### PR TITLE
Merge gz_planetSpeed

### DIFF
--- a/src/StelMainView.hpp
+++ b/src/StelMainView.hpp
@@ -47,7 +47,13 @@ class StelMainView : public QGraphicsView
 	friend class StelGraphicsScene;
 	friend class NightModeGraphicsEffect;
 	Q_OBJECT
-	Q_PROPERTY(bool fullScreen READ isFullScreen WRITE setFullScreen NOTIFY fullScreenChanged)
+	Q_PROPERTY(bool fullScreen                 READ isFullScreen                  WRITE setFullScreen                 NOTIFY fullScreenChanged)
+	Q_PROPERTY(bool flagInvertScreenShotColors READ getFlagInvertScreenShotColors WRITE setFlagInvertScreenShotColors NOTIFY flagInvertScreenShotColorsChanged)
+	Q_PROPERTY(bool flagOverwriteScreenshots   READ getFlagOverwriteScreenShots   WRITE setFlagOverwriteScreenShots   NOTIFY flagOverwriteScreenshotsChanged)
+	Q_PROPERTY(bool flagUseButtonsBackground   READ getFlagUseButtonsBackground   WRITE setFlagUseButtonsBackground   NOTIFY flagUseButtonsBackgroundChanged)
+	Q_PROPERTY(bool flagCursorTimeout          READ getFlagCursorTimeout          WRITE setFlagCursorTimeout          NOTIFY flagCursorTimeoutChanged)
+	Q_PROPERTY(double cursorTimeout            READ getCursorTimeout              WRITE setCursorTimeout              NOTIFY cursorTimeoutChanged)
+
 
 public:
 	//! Contains some basic info about the OpenGL context used
@@ -117,21 +123,21 @@ public slots:
 	//! Get whether colors are inverted when saving screenshot
 	bool getFlagInvertScreenShotColors() const {return flagInvertScreenShotColors;}
 	//! Set whether colors should be inverted when saving screenshot
-	void setFlagInvertScreenShotColors(bool b) {flagInvertScreenShotColors=b;}
+	void setFlagInvertScreenShotColors(bool b) {flagInvertScreenShotColors=b; emit flagInvertScreenShotColorsChanged(b);}
 
 	//! Get whether existing files are overwritten when saving screenshot
 	bool getFlagOverwriteScreenShots() const {return flagOverwriteScreenshots;}
 	//! Set whether existing files are overwritten when saving screenshot
-	void setFlagOverwriteScreenShots(bool b) {flagOverwriteScreenshots=b;}
+	void setFlagOverwriteScreenShots(bool b) {flagOverwriteScreenshots=b; emit flagOverwriteScreenshotsChanged(b);}
 
 	//! Get the state of the mouse cursor timeout flag
 	bool getFlagCursorTimeout() {return flagCursorTimeout;}
 	//! Get the mouse cursor timeout in seconds
-	float getCursorTimeout() const {return cursorTimeout;}
+	double getCursorTimeout() const {return cursorTimeout;}
 	//! Get the state of the mouse cursor timeout flag
-	void setFlagCursorTimeout(bool b) {flagCursorTimeout=b;}
+	void setFlagCursorTimeout(bool b) {flagCursorTimeout=b; emit flagCursorTimeoutChanged(b);}
 	//! Set the mouse cursor timeout in seconds
-	void setCursorTimeout(float t) {cursorTimeout=t;}
+	void setCursorTimeout(double t) {cursorTimeout=t; emit cursorTimeoutChanged(t);}
 
 	//! Set the minimum frames per second. Usually this minimum will be switched to after there are no
 	//! user events for some seconds to save power. However, if can be useful to set this to a high
@@ -157,7 +163,7 @@ public slots:
 	bool needsMaxFPS() const;
 
 	//! Set the state of the flag of usage background for GUI buttons
-	void setFlagUseButtonsBackground(bool b) { flagUseButtonsBackground=b; }
+	void setFlagUseButtonsBackground(bool b) { flagUseButtonsBackground=b; emit flagUseButtonsBackgroundChanged(b); }
 	//! Get the state of the flag of usage background for GUI buttons
 	bool getFlagUseButtonsBackground() { return flagUseButtonsBackground; }
 
@@ -170,6 +176,8 @@ protected:
 	//! Handle window resized events, and change the size of the underlying
 	//! QGraphicsScene to be the same
 	virtual void resizeEvent(QResizeEvent* event) Q_DECL_OVERRIDE;
+//	//! Wake up mouse cursor (if it was hidden)
+//	virtual void mouseMoveEvent(QMouseEvent *event) Q_DECL_OVERRIDE;
 signals:
 	//! emitted when saveScreenShot is requested with saveScreenShot().
 	//! doScreenshot() does the actual work (it has to do it in the main
@@ -184,6 +192,11 @@ signals:
 	void reloadShadersRequested();
 
 	void updateIconsRequested();
+	void flagInvertScreenShotColorsChanged(bool b);
+	void flagOverwriteScreenshotsChanged(bool b);
+	void flagUseButtonsBackgroundChanged(bool b);
+	void flagCursorTimeoutChanged(bool b);
+	void cursorTimeoutChanged(double t);
 
 private slots:
 	// Do the actual screenshot generation in the main thread with this method.
@@ -200,6 +213,8 @@ private slots:
 private:
 	//! The graphics scene notifies us when a draw finished, so that we can queue the next one
 	void drawEnded();
+	//! hide mouse cursor after some time if configured.
+	void handleMouseCursorTimeout(const double now);
 	//! Returns the desired OpenGL format settings,
 	//! on desktop this corresponds to a GL 2.1 context,
 	//! with 32bit RGBA buffer and 24/8 depth/stencil buffer
@@ -237,8 +252,8 @@ private:
 	QString screenShotPrefix;
 	QString screenShotDir;
 
-	// Number of second before the mouse cursor disappears
-	float cursorTimeout;
+	// Number of seconds before the mouse cursor disappears
+	double cursorTimeout;
 	bool flagCursorTimeout;
 
 	bool flagUseButtonsBackground;

--- a/src/core/StelApp.cpp
+++ b/src/core/StelApp.cpp
@@ -439,6 +439,10 @@ void StelApp::init(QSettings* conf)
 	planetLocationMgr = new StelLocationMgr();
 	actionMgr = new StelActionMgr();
 
+	// register non-modules for StelProperty tracking
+	propMgr->registerObject(this);
+	propMgr->registerObject(mainWin);
+
 	// Stel Object Data Base manager
 	stelObjectMgr = new StelObjectMgr();
 	stelObjectMgr->init();
@@ -878,17 +882,29 @@ void StelApp::setVisionModeNight(bool b)
 
 void StelApp::setFlagShowDecimalDegrees(bool b)
 {
-	flagShowDecimalDegrees = b;
+	if (flagShowDecimalDegrees!=b)
+	{
+		flagShowDecimalDegrees = b;
+		emit flagShowDecimalDegreesChanged(b);
+	}
 }
 
 void StelApp::setFlagUseFormattingOutput(bool b)
 {
-	flagUseFormattingOutput = b;
+	if (flagUseFormattingOutput!=b)
+	{
+		flagUseFormattingOutput = b;
+		emit flagUseFormattingOutputChanged(b);
+	}
 }
 
 void StelApp::setFlagUseCCSDesignation(bool b)
 {
-	flagUseCCSDesignation = b;
+	if (flagUseCCSDesignation!=b)
+	{
+		flagUseCCSDesignation = b;
+		emit flagUseCCSDesignationChanged(b);
+	}
 }
 
 // Update translations and font for sky everywhere in the program

--- a/src/core/StelApp.hpp
+++ b/src/core/StelApp.hpp
@@ -69,6 +69,10 @@ class StelApp : public QObject
 {
 	Q_OBJECT
 	Q_PROPERTY(bool nightMode READ getVisionModeNight WRITE setVisionModeNight NOTIFY visionNightModeChanged)
+	Q_PROPERTY(bool flagShowDecimalDegrees  READ getFlagShowDecimalDegrees  WRITE setFlagShowDecimalDegrees  NOTIFY flagShowDecimalDegreesChanged)
+	Q_PROPERTY(bool flagUseAzimuthFromSouth READ getFlagSouthAzimuthUsage   WRITE setFlagSouthAzimuthUsage   NOTIFY flagUseAzimuthFromSouthChanged)
+	Q_PROPERTY(bool flagUseCCSDesignation   READ getFlagUseCCSDesignation   WRITE setFlagUseCCSDesignation   NOTIFY flagUseCCSDesignationChanged)
+	Q_PROPERTY(bool flagUseFormattingOutput READ getFlagUseFormattingOutput WRITE setFlagUseFormattingOutput NOTIFY flagUseFormattingOutputChanged)
 
 public:
 	friend class StelAppGraphicsWidget;
@@ -237,7 +241,7 @@ public slots:
 	//! Set flag for using calculation of azimuth from south towards west (instead north towards east)
 	bool getFlagSouthAzimuthUsage() const { return flagUseAzimuthFromSouth; }
 	//! Get flag for using calculation of azimuth from south towards west (instead north towards east)
-	void setFlagSouthAzimuthUsage(bool use) { flagUseAzimuthFromSouth=use; }
+	void setFlagSouthAzimuthUsage(bool use) { flagUseAzimuthFromSouth=use; emit flagUseAzimuthFromSouthChanged(use);}
 	
 	//! Set flag for using of formatting output for coordinates
 	void setFlagUseFormattingOutput(bool b);
@@ -278,6 +282,10 @@ public slots:
 	void quit();
 signals:
 	void visionNightModeChanged(bool);
+	void flagShowDecimalDegreesChanged(bool);
+	void flagUseAzimuthFromSouthChanged(bool);
+	void flagUseCCSDesignationChanged(bool);
+	void flagUseFormattingOutputChanged(bool);
 	void colorSchemeChanged(const QString&);
 	void languageChanged();
 

--- a/src/core/StelMovementMgr.hpp
+++ b/src/core/StelMovementMgr.hpp
@@ -41,6 +41,10 @@ class StelMovementMgr : public StelModule
 		   READ getFlagTracking
 		   WRITE setFlagTracking
 		   NOTIFY flagTrackingChanged)
+	Q_PROPERTY(bool flagIndicationMountMode
+		   READ getFlagIndicationMountMode
+		   WRITE setFlagIndicationMountMode
+		   NOTIFY flagIndicationMountModeChanged)
 
 	//The targets of viewport offset animation
 	Q_PROPERTY(float viewportHorizontalOffsetTarget
@@ -182,7 +186,7 @@ public slots:
 	//! Get the state of flag for indication of mount mode
 	bool getFlagIndicationMountMode() const {return flagIndicationMountMode;}
 	//! Set the state of flag for indication of mount mode
-	void setFlagIndicationMountMode(bool b) { flagIndicationMountMode=b; }
+	void setFlagIndicationMountMode(bool b) { flagIndicationMountMode=b; emit flagIndicationMountModeChanged(b); }
 
 	//! Move the view to a specified J2000 position.
 	//! @param aim The position to move to expressed as a vector.
@@ -309,6 +313,7 @@ signals:
 	//! Emitted when the tracking property changes
 	void flagTrackingChanged(bool b);
 	void equatorialMountChanged(bool b);
+	void flagIndicationMountModeChanged(bool b);
 
 	void flagAutoZoomOutResetsDirectionChanged(bool b);
 

--- a/src/core/StelObject.hpp
+++ b/src/core/StelObject.hpp
@@ -54,18 +54,19 @@ public:
 		AltAzi			= 0x00000020, //!< The position (Altitude/Azimuth)
 		Distance		= 0x00000040, //!< Info about an object's distance
 		Size			= 0x00000080, //!< Info about an object's size
-		Extra			= 0x00000100, //!< Derived class-specific extra fields
-		HourAngle		= 0x00000200, //!< The hour angle + DE (of date)
-		AbsoluteMagnitude	= 0x00000400, //!< The absolute magnitude
-		GalacticCoord		= 0x00000800, //!< The galactic position
-		SupergalacticCoord	= 0x00001000, //!< The supergalactic position
-		ObjectType		= 0x00002000, //!< The type of the object (star, planet, etc.)
-		EclipticCoordJ2000	= 0x00004000, //!< The ecliptic position (J2000.0 ref) [+ XYZ of VSOP87A (used mainly for debugging, not public)]
-		EclipticCoordOfDate	= 0x00008000, //!< The ecliptic position (of date)
-		IAUConstellation        = 0x00010000, //!< Three-letter constellation code (And, Boo, Cas, ...)
-		SiderealTime		= 0x00020000, //!< Mean and Apparent Sidereal Time
-		NoFont			= 0x00040000,
-		PlainText		= 0x00080000,  //!< Strip HTML tags from output
+		Velocity                = 0x00000100, //!< Info about object's velocity
+		Extra			= 0x00000200, //!< Derived class-specific extra fields
+		HourAngle		= 0x00000400, //!< The hour angle + DE (of date)
+		AbsoluteMagnitude	= 0x00000800, //!< The absolute magnitude
+		GalacticCoord		= 0x00001000, //!< The galactic position
+		SupergalacticCoord	= 0x00002000, //!< The supergalactic position
+		ObjectType		= 0x00004000, //!< The type of the object (star, planet, etc.)
+		EclipticCoordJ2000	= 0x00008000, //!< The ecliptic position (J2000.0 ref) [+ XYZ of VSOP87A (used mainly for debugging, not public)]
+		EclipticCoordOfDate	= 0x00010000, //!< The ecliptic position (of date)
+		IAUConstellation        = 0x00020000, //!< Three-letter constellation code (And, Boo, Cas, ...)
+		SiderealTime		= 0x00040000, //!< Mean and Apparent Sidereal Time
+		NoFont			= 0x00080000,
+		PlainText		= 0x00100000,  //!< Strip HTML tags from output
 // TODO GZ
 //		RaDecJ2000Planetocentric  = 0x00020000, //!< The planetocentric equatorial position (J2000 ref) [Mostly to compare with almanacs]
 //		RaDecOfDatePlanetocentric = 0x00040000  //!< The planetocentric equatorial position (of date)
@@ -75,7 +76,7 @@ public:
 	Q_DECLARE_FLAGS(InfoStringGroup, InfoStringGroupFlags)
 
 	//! A pre-defined set of specifiers for the getInfoString flags argument to getInfoString
-	static const InfoStringGroupFlags AllInfo = (InfoStringGroupFlags)(Name|CatalogNumber|Magnitude|RaDecJ2000|RaDecOfDate|AltAzi|Distance|Size|Extra|HourAngle|
+	static const InfoStringGroupFlags AllInfo = (InfoStringGroupFlags)(Name|CatalogNumber|Magnitude|RaDecJ2000|RaDecOfDate|AltAzi|Distance|Size|Velocity|Extra|HourAngle|
 									   AbsoluteMagnitude|GalacticCoord|SupergalacticCoord|ObjectType|EclipticCoordJ2000|
 									   EclipticCoordOfDate|IAUConstellation|SiderealTime);
 	//! A pre-defined set of specifiers for the getInfoString flags argument to getInfoString

--- a/src/core/modules/Comet.cpp
+++ b/src/core/modules/Comet.cpp
@@ -366,12 +366,6 @@ void Comet::update(int deltaTime)
 	{
 		lastJDEtail=dateJDE;
 
-		// The CometOrbit is in fact available in userDataPtr!
-		CometOrbit* orbit=(CometOrbit*)orbitPtr;
-		Q_ASSERT(orbit);
-		if (!orbit->objectDateValid(dateJDE)) return; // out of useful date range. This should allow having hundreds of comet elements.
-
-		eclipticVelocity=orbit->getVelocity();
 		if (orbit->getUpdateTails()){
 			// Compute lengths and orientations from orbit object, but only if required.
 			tailFactors=getComaDiameterAndTailLengthAU();

--- a/src/core/modules/Comet.cpp
+++ b/src/core/modules/Comet.cpp
@@ -187,6 +187,7 @@ QString Comet::getInfoString(const StelCore *core, const InfoStringGroup &flags)
 			oss << QString("%1: %2").arg(q_("Absolute Magnitude")).arg(absoluteMagnitude, 0, 'f', 2) << "<br>";
 	}
 
+
 	oss << getCommonInfoString(core, flags);
 
 	// TRANSLATORS: Unit of measure for distance - kilometers
@@ -231,6 +232,18 @@ QString Comet::getInfoString(const StelCore *core, const InfoStringGroup &flags)
 		oss << QString("%1: %2%3 (%4 %5)").arg(q_("Distance"), distAU, au, distKM, useKM ? km : Mkm) << "<br />";
 	}
 
+	if (flags&Velocity)
+	{
+		QString kms = qc_("km/s", "speed");
+
+		Vec3d orbitalVel=getEclipticVelocity();
+		double orbVel=orbitalVel.length();
+		if (orbVel>0.)
+		{ // AU/d * km/AU /24
+			oss << QString("%1: %2 %3").arg(q_("Velocity")).arg(orbVel* AU/86400., 0, 'f', 3).arg(kms) << "<br />";
+		}
+	}
+
 	if (flags&Extra)
 	{
 		// If semi-major axis not zero then calculate and display orbital period for comet in days
@@ -241,10 +254,10 @@ QString Comet::getInfoString(const StelCore *core, const InfoStringGroup &flags)
 			oss << QString("%1: %2 a").arg(q_("Sidereal period"), QString::number(siderealPeriod/365.25, 'f', 3)) << "<br />";
 		}
 
-		// TRANSLATORS: Unit of measure for speed - kilometers per second
-		QString kms = qc_("km/s", "speed");
-		// GZ: Add speed. I don't know where else to place that bit of information.
-		oss << QString("%1: %2 %3").arg(q_("Speed"), QString::number(((CometOrbit*)orbitPtr)->getVelocity().length()*AU/86400.0, 'f', 3), kms) << "<br />";
+//		// TRANSLATORS: Unit of measure for speed - kilometers per second
+//		QString kms = qc_("km/s", "speed");
+//		// GZ: Add speed. I don't know where else to place that bit of information.
+//		oss << QString("%1: %2 %3").arg(q_("Speed"), QString::number(((CometOrbit*)orbitPtr)->getVelocity().length()*AU/86400.0, 'f', 3), kms) << "<br />";
 
 		const Vec3d& observerHelioPos = core->getObserverHeliocentricEclipticPos();
 		const double elongation = getElongation(observerHelioPos);
@@ -358,6 +371,7 @@ void Comet::update(int deltaTime)
 		Q_ASSERT(orbit);
 		if (!orbit->objectDateValid(dateJDE)) return; // out of useful date range. This should allow having hundreds of comet elements.
 
+		eclipticVelocity=orbit->getVelocity();
 		if (orbit->getUpdateTails()){
 			// Compute lengths and orientations from orbit object, but only if required.
 			tailFactors=getComaDiameterAndTailLengthAU();
@@ -434,7 +448,8 @@ void Comet::update(int deltaTime)
 	float gasMagFactor=qMin(0.9f*aLum, 0.7f);
 	float dustMagFactor=qMin(dustTailBrightnessFactor*aLum, 0.7f);
 
-	Vec3f gasColor(0.15f*gasMagFactor,0.35f*gasMagFactor,0.6f*gasMagFactor); // Orig color 0.15/0.15/0.6
+	// TODO: Maybe make gas color distance dependent? (various typical ingredients outgas at different temperatures...)
+	Vec3f gasColor(0.15f*gasMagFactor,0.35f*gasMagFactor,0.6f*gasMagFactor); // Orig color 0.15/0.15/0.6.
 	Vec3f dustColor(dustMagFactor, dustMagFactor,0.6f*dustMagFactor);
 
 	if (withAtmosphere)

--- a/src/core/modules/MinorPlanet.cpp
+++ b/src/core/modules/MinorPlanet.cpp
@@ -302,6 +302,23 @@ QString MinorPlanet::getInfoString(const StelCore *core, const InfoStringGroup &
 		oss << QString("%1: %2%3 (%4 %5)").arg(q_("Distance"), distAU, au, distKM, km) << "<br />";
 	}
 
+	if (flags&Velocity)
+	{
+		// TRANSLATORS: Unit of measure for speed - kilometers per second
+		QString kms = qc_("km/s", "speed");
+
+		Vec3d orbitalVel=getEclipticVelocity();
+		double orbVel=orbitalVel.length();
+		if (orbVel>0.)
+		{ // AU/d * km/AU /24
+			double orbVelKms=orbVel* AU/86400.;
+			oss << QString("%1: %2 %3").arg(q_("Orbital Velocity")).arg(orbVelKms, 0, 'f', 3).arg(kms) << "<br />";
+			double helioVel=getHeliocentricEclipticVelocity().length(); // just in case we have asteroid moons!
+			if (helioVel!=orbVel)
+			oss << QString("%1: %2 %3").arg(q_("Heliocentric velocity")).arg(helioVel* AU/86400., 0, 'f', 3).arg(kms) << "<br />";
+		}
+	}
+
 	double angularSize = 2.*getAngularSize(core)*M_PI/180.;
 	if (flags&Size && angularSize>=4.8e-7)
 	{

--- a/src/core/modules/Orbit.cpp
+++ b/src/core/modules/Orbit.cpp
@@ -251,6 +251,7 @@ CometOrbit::CometOrbit(double pericenterDistance,
 
 void CometOrbit::positionAtTimevInVSOP87Coordinates(double JDE, double *v, bool updateVelocityVector)
 {
+	Q_UNUSED(updateVelocityVector);
 	JDE -= t0;
 	double rCosNu,rSinNu;
 	if (e < 1.0) InitEll(q,n,e,JDE,rCosNu,rSinNu); // Laguerre-Conway seems stable enough to go for <1.0.
@@ -261,16 +262,17 @@ void CometOrbit::positionAtTimevInVSOP87Coordinates(double JDE, double *v, bool 
 	}
 	else InitPar(q,n,JDE,rCosNu,rSinNu);
 	double p0,p1,p2, s0, s1, s2;
-	Init3D(i,Om,w,rCosNu,rSinNu,p0,p1,p2, s0, s1, s2, updateVelocityVector, e, q);
+	//Init3D(i,Om,w,rCosNu,rSinNu,p0,p1,p2, s0, s1, s2, updateVelocityVector, e, q);
+	Init3D(i,Om,w,rCosNu,rSinNu,p0,p1,p2, s0, s1, s2, true, e, q);
 	v[0] = rotateToVsop87[0]*p0 + rotateToVsop87[1]*p1 + rotateToVsop87[2]*p2;
 	v[1] = rotateToVsop87[3]*p0 + rotateToVsop87[4]*p1 + rotateToVsop87[5]*p2;
 	v[2] = rotateToVsop87[6]*p0 + rotateToVsop87[7]*p1 + rotateToVsop87[8]*p2;
 
-	if (updateVelocityVector)
-	{
+	//if (updateVelocityVector)
+	//{
 		rdot.set(s0, s1, s2);
 		updateTails=true;
-	}
+	//}
 }
 
 
@@ -459,6 +461,7 @@ Vec3d EllipticalOrbit::positionAtE(const double E) const
 	}
 	else if (eccentricity > 1.0) // N.B. This is odd at least: elliptical must have ecc<1!
 	{
+		Q_ASSERT(0); // We should never come here!
 		double a = pericenterDistance / (1.0 - eccentricity);
 		x = -a * (eccentricity - cosh(E));
 		z = -a * std::sqrt(eccentricity * eccentricity - 1) * -sinh(E);
@@ -466,6 +469,7 @@ Vec3d EllipticalOrbit::positionAtE(const double E) const
 	else
 	{
 		// TODO: Handle parabolic orbits
+		Q_ASSERT(0); // We should never come here!
 		x = 0.0;
 		z = 0.0;
 	}
@@ -487,22 +491,6 @@ Vec3d EllipticalOrbit::positionAtTime(const double JDE) const
 	return positionAtE(E);
 }
 
-//void EllipticalOrbit::positionAtTime(double JDE, double * X, double * Y, double * Z) const
-//{
-//	Vec3d pos = positionAtTime(JDE);
-//	*X=pos[2];
-//	*Y=pos[0];
-//	*Z=pos[1];
-//}
-
-//void EllipticalOrbit::positionAtTimev(double JDE, double* v)
-//{
-//	Vec3d pos = positionAtTime(JDE);
-//	v[0]=pos[2];
-//	v[1]=pos[0];
-//	v[2]=pos[1];
-//}
-
 void EllipticalOrbit::positionAtTimevInVSOP87Coordinates(const double JDE, double* v) const
 {
 	Vec3d pos = positionAtTime(JDE);
@@ -516,21 +504,23 @@ double EllipticalOrbit::getPeriod() const
 	return period;
 }
 
-
+/* Found undocumented and unused in pre-0.17.
+// return apocenter distance
 double EllipticalOrbit::getBoundingRadius() const
 {
 	// TODO: watch out for unbounded parabolic and hyperbolic orbits
 	return pericenterDistance * ((1.0 + eccentricity) / (1.0 - eccentricity));
 }
-
-
+*/
+/*
+ * Found undocumented and unused pre-0.17.
 void EllipticalOrbit::sample(double, double, int nSamples, OrbitSampleProc& proc) const
 {
 	double dE = 2. * M_PI / (double) nSamples;
 	for (int i = 0; i < nSamples; i++)
 		proc.sample(positionAtE(dE * i));
 }
-
+*/
 /*
  * Stuff found unused and deactivated pre-0.15
 Vec3d CachingOrbit::positionAtTime(double JDE) const

--- a/src/core/modules/Orbit.hpp
+++ b/src/core/modules/Orbit.hpp
@@ -56,8 +56,8 @@ public:
 	// Original one
 	Vec3d positionAtTime(const double JDE) const;
 	double getPeriod() const;
-	double getBoundingRadius() const;
-	virtual void sample(double, double, int, OrbitSampleProc&) const;
+	// double getBoundingRadius() const; // Return apoapsis distance. UNUSED!
+	// virtual void sample(double, double, int, OrbitSampleProc&) const; //UNDOCUMENTED & UNUSED
 
 private:
 	//! returns eccentric anomaly E for Mean anomaly M

--- a/src/core/modules/Orbit.hpp
+++ b/src/core/modules/Orbit.hpp
@@ -98,6 +98,7 @@ public:
 	void setUpdateTails(const bool update){ updateTails=update; }
 	//! return speed value [AU/d] last computed by positionAtTimevInVSOP87Coordinates(JDE, v, true)
 	Vec3d getVelocity() const { return rdot; }
+	void getVelocity(double *vel) const { vel[0]=rdot[0]; vel[1]=rdot[1]; vel[2]=rdot[2];}
 	double getSemimajorAxis() const { return (e==1. ? 0. : q / (1.-e)); }
 	double getEccentricity() const { return e; }
 	bool objectDateValid(const double JDE) const { return (fabs(t0-JDE)<orbitGood); }

--- a/src/core/modules/Planet.cpp
+++ b/src/core/modules/Planet.cpp
@@ -197,6 +197,7 @@ Planet::Planet(const QString& englishName,
 	  radius(radius),
 	  oneMinusOblateness(1.0-oblateness),
 	  eclipticPos(0.,0.,0.),
+	  eclipticVelocity(0.,0.,0.),
 	  haloColor(halocolor),
 	  absoluteMagnitude(-99.0f),
 	  albedo(albedo),
@@ -487,6 +488,26 @@ QString Planet::getInfoString(const StelCore* core, const InfoStringGroup& flags
 		oss << QString("%1: %2%3 (%4 %5)").arg(q_("Distance"), distAU, au, distKM, km) << "<br />";
 	}
 
+	if (flags&Velocity)
+	{
+		// TRANSLATORS: Unit of measure for speed - kilometers per second
+		QString kms = qc_("km/s", "speed");
+
+		Vec3d orbitalVel=getEclipticVelocity();
+		double orbVel=orbitalVel.length();
+		if (orbVel>0.)
+		{ // AU/d * km/AU /24
+			double orbVelKms=orbVel* AU/86400.;
+			if (englishName=="moon")
+				orbVelKms=orbVel;
+			oss << QString("%1: %2 %3").arg(q_("Velocity")).arg(orbVelKms, 0, 'f', 3).arg(kms) << "<br />";
+			double helioVel=getHeliocentricEclipticVelocity().length();
+			if (helioVel!=orbVel)
+			oss << QString("%1: %2 %3").arg(q_("Heliocentric velocity")).arg(helioVel* AU/86400., 0, 'f', 3).arg(kms) << "<br />";
+		}
+	}
+
+
 	double angularSize = 2.*getAngularSize(core)*M_PI/180.;
 	if (flags&Size && angularSize>=4.8e-7)
 	{
@@ -649,6 +670,9 @@ QVariantMap Planet::getInfoMap(const StelCore *core) const
 		map.insert("elongation-deg", StelUtils::radToDecDegStr(elongation));
 		map.insert("type", getPlanetTypeString()); // replace existing "type=Planet" by something more detailed.
 		// TBD: Is there ANY reason to keep "type"="Planet" and add a "ptype"=getPlanetTypeString() field?
+		map.insert("velocity", getEclipticVelocity().toString());
+		map.insert("heliocentric-velocity", getHeliocentricEclipticVelocity().toString());
+
 	}
 
 	return map;
@@ -738,7 +762,7 @@ void Planet::computePositionWithoutOrbits(const double dateJDE)
 {
 	if (fabs(lastJDE-dateJDE)>deltaJDE)
 	{
-		coordFunc(dateJDE, eclipticPos, orbitPtr);
+		coordFunc(dateJDE, eclipticPos, eclipticVelocity, orbitPtr);
 		lastJDE = dateJDE;
 	}
 }
@@ -851,11 +875,11 @@ void Planet::computePosition(const double dateJDE)
 					computeTransMatrix(calc_date-core->computeDeltaT(calc_date)/86400.0, calc_date);
 					if (osculatingFunc)
 					{
-						(*osculatingFunc)(dateJDE,calc_date,eclipticPos);
+						(*osculatingFunc)(dateJDE,calc_date,eclipticPos, eclipticVelocity);
 					}
 					else
 					{
-						coordFunc(calc_date, eclipticPos, orbitPtr);
+						coordFunc(calc_date, eclipticPos, eclipticVelocity, orbitPtr);
 					}
 					orbitP[d] = eclipticPos;
 					orbit[d] = getHeliocentricEclipticPos();
@@ -881,11 +905,11 @@ void Planet::computePosition(const double dateJDE)
 
 					computeTransMatrix(calc_date-core->computeDeltaT(calc_date)/86400.0, calc_date);
 					if (osculatingFunc) {
-						(*osculatingFunc)(dateJDE,calc_date,eclipticPos);
+						(*osculatingFunc)(dateJDE,calc_date,eclipticPos, eclipticVelocity);
 					}
 					else
 					{
-						coordFunc(calc_date, eclipticPos, orbitPtr);
+						coordFunc(calc_date, eclipticPos, eclipticVelocity, orbitPtr);
 					}
 					orbitP[d] = eclipticPos;
 					orbit[d] = getHeliocentricEclipticPos();
@@ -910,11 +934,11 @@ void Planet::computePosition(const double dateJDE)
 				computeTransMatrix(calc_date-core->computeDeltaT(calc_date)/86400.0, calc_date);
 				if (osculatingFunc)
 				{
-					(*osculatingFunc)(dateJDE,calc_date,eclipticPos);
+					(*osculatingFunc)(dateJDE,calc_date,eclipticPos, eclipticVelocity);
 				}
 				else
 				{
-					coordFunc(calc_date, eclipticPos, orbitPtr);
+					coordFunc(calc_date, eclipticPos, eclipticVelocity, orbitPtr);
 				}
 				orbitP[d] = eclipticPos;
 				orbit[d] = getHeliocentricEclipticPos();
@@ -926,7 +950,7 @@ void Planet::computePosition(const double dateJDE)
 
 
 		// calculate actual Planet position
-		coordFunc(dateJDE, eclipticPos, orbitPtr);
+		coordFunc(dateJDE, eclipticPos, eclipticVelocity, orbitPtr);
 
 		lastJDE = dateJDE;
 
@@ -934,7 +958,7 @@ void Planet::computePosition(const double dateJDE)
 	else if (fabs(lastJDE-dateJDE)>deltaJDE)
 	{
 		// calculate actual Planet position
-		coordFunc(dateJDE, eclipticPos, orbitPtr);
+		coordFunc(dateJDE, eclipticPos, eclipticVelocity, orbitPtr);
 		if (orbitFader.getInterstate()>0.000001)
 			for( int d=0; d<ORBIT_SEGMENTS; d++ )
 				orbit[d]=getHeliocentricPos(orbitP[d]);
@@ -1131,6 +1155,23 @@ void Planet::setHeliocentricEclipticPos(const Vec3d &pos)
 			p = p->parent;
 		}
 	}
+}
+// Return heliocentric velocity of planet.
+Vec3d Planet::getHeliocentricEclipticVelocity() const
+{
+	// Note: using shared copies is too slow here.  So we use direct access
+	// instead.
+	Vec3d vel = eclipticVelocity;
+	const Planet* pp = parent.data();
+	if (pp)
+	{
+		while (pp->parent.data())
+		{
+			vel += pp->eclipticVelocity;
+			pp = pp->parent.data();
+		}
+	}
+	return vel;
 }
 
 // Compute the distance to the given position in heliocentric coordinate (in AU)

--- a/src/core/modules/Planet.cpp
+++ b/src/core/modules/Planet.cpp
@@ -500,10 +500,10 @@ QString Planet::getInfoString(const StelCore* core, const InfoStringGroup& flags
 			double orbVelKms=orbVel* AU/86400.;
 			if (englishName=="moon")
 				orbVelKms=orbVel;
-			oss << QString("%1: %2 %3").arg(q_("Velocity")).arg(orbVelKms, 0, 'f', 3).arg(kms) << "<br />";
+			oss << QString("%1: %2 %3").arg(q_("Orbital Velocity")).arg(orbVelKms, 0, 'f', 3).arg(kms) << "<br />";
 			double helioVel=getHeliocentricEclipticVelocity().length();
 			if (helioVel!=orbVel)
-			oss << QString("%1: %2 %3").arg(q_("Heliocentric velocity")).arg(helioVel* AU/86400., 0, 'f', 3).arg(kms) << "<br />";
+			oss << QString("%1: %2 %3").arg(q_("Heliocentric Velocity")).arg(helioVel* AU/86400., 0, 'f', 3).arg(kms) << "<br />";
 		}
 	}
 

--- a/src/core/modules/SolarSystem.cpp
+++ b/src/core/modules/SolarSystem.cpp
@@ -403,7 +403,7 @@ void ellipticalOrbitPosFunc(double jd,double xyz[3], double xyzdot[3], void* orb
 void cometOrbitPosFunc(double jd,double xyz[3], double xyzdot[3], void* orbitPtr)
 {
 	static_cast<CometOrbit*>(orbitPtr)->positionAtTimevInVSOP87Coordinates(jd, xyz, true);
-	xyzdot=static_cast<CometOrbit*>(orbitPtr)->getVelocity();
+	static_cast<CometOrbit*>(orbitPtr)->getVelocity(xyzdot);
 }
 
 // Init and load the solar system data (2 files)

--- a/src/core/modules/SolarSystem.cpp
+++ b/src/core/modules/SolarSystem.cpp
@@ -394,13 +394,16 @@ void SolarSystem::drawPointer(const StelCore* core)
 	}
 }
 
-void ellipticalOrbitPosFunc(double jd,double xyz[3], void* userDataPtr)
+void ellipticalOrbitPosFunc(double jd,double xyz[3], double xyzdot[3], void* orbitPtr)
 {
-	static_cast<EllipticalOrbit*>(userDataPtr)->positionAtTimevInVSOP87Coordinates(jd, xyz);
+	static_cast<EllipticalOrbit*>(orbitPtr)->positionAtTimevInVSOP87Coordinates(jd, xyz);
+	// TODO: Implement a way to retrieve velocities.
+	xyzdot[0]=xyzdot[1]=xyzdot[2]=0.0;
 }
-void cometOrbitPosFunc(double jd,double xyz[3], void* userDataPtr)
+void cometOrbitPosFunc(double jd,double xyz[3], double xyzdot[3], void* orbitPtr)
 {
-	static_cast<CometOrbit*>(userDataPtr)->positionAtTimevInVSOP87Coordinates(jd, xyz);
+	static_cast<CometOrbit*>(orbitPtr)->positionAtTimevInVSOP87Coordinates(jd, xyz, true);
+	xyzdot=static_cast<CometOrbit*>(orbitPtr)->getVelocity();
 }
 
 // Init and load the solar system data (2 files)
@@ -638,9 +641,8 @@ bool SolarSystem::loadPlanets(const QString& filePath)
 			if (pericenterDistance <= 0.0) {
 				semi_major_axis = pd.value(secname+"/orbit_SemiMajorAxis",-1e100).toDouble();
 				if (semi_major_axis <= -1e100) {
-					qDebug() << "ERROR: " << englishName
+					qDebug() << "ERROR loading " << englishName
 						 << ": you must provide orbit_PericenterDistance or orbit_SemiMajorAxis";
-					//abort();
 					continue;
 				} else {
 					semi_major_axis /= AU;
@@ -692,12 +694,8 @@ bool SolarSystem::loadPlanets(const QString& filePath)
 			}
 
 			// when the parent is the sun use ecliptic rather than sun equator:
-			const double parentRotObliquity = parent->getParent()
-											  ? parent->getRotObliquity(2451545.0)
-											  : 0.0;
-			const double parent_rot_asc_node = parent->getParent()
-											  ? parent->getRotAscendingNode()
-											  : 0.0;
+			const double parentRotObliquity  = parent->getParent() ? parent->getRotObliquity(2451545.0) : 0.0;
+			const double parent_rot_asc_node = parent->getParent() ? parent->getRotAscendingNode()      : 0.0;
 			double parent_rot_j2000_longitude = 0.0;
 			if (parent->getParent()) {
 				const double c_obl = cos(parentRotObliquity);
@@ -714,16 +712,16 @@ bool SolarSystem::loadPlanets(const QString& filePath)
 			}
 
 			// Create an elliptical orbit
-			EllipticalOrbit *orb = new EllipticalOrbit(pericenterDistance,
-								   eccentricity,
-								   inclination,
-								   ascending_node,
-								   arg_of_pericenter,
-								   mean_anomaly,
-								   period,
-								   epoch,
-								   parentRotObliquity,
-								   parent_rot_asc_node,
+			EllipticalOrbit *orb = new EllipticalOrbit(pericenterDistance,     // [AU]
+								   eccentricity,           // 0..>1, but practically only 0..1
+								   inclination,            // [radians]
+								   ascending_node,         // [radians]
+								   arg_of_pericenter,      // [radians]
+								   mean_anomaly,           // [radians]
+								   period,                 // [days]
+								   epoch,                  // [JDE]
+								   parentRotObliquity,     // [radians]
+								   parent_rot_asc_node,    // [radians]
 								   parent_rot_j2000_longitude);
 			orbits.push_back(orb);
 

--- a/src/core/planetsephems/EphemWrapper.hpp
+++ b/src/core/planetsephems/EphemWrapper.hpp
@@ -26,7 +26,7 @@ Foundation, Inc., 51 Franklin Street, Suite 500, Boston, MA  02110-1335, USA.
  * - DE431
  *
  * Extending the old stellplanet-class, this updated version now
- * includes access to DE430 and DE431 for a more precise, yet storage-space intensive solution.
+ * includes access to DE430 and DE431 for a more accurate, yet storage-space intensive solution.
  */
 
 #ifndef _EPHEMWRAPPER_HPP_
@@ -44,51 +44,51 @@ public:
 };
 
 // These functions have an unused void pointer to be compatible to PosFuncType in SolarSystem and Planet classes.
-void get_sun_helio_coordsv(double jd,double xyz[3], void*);
-void get_mercury_helio_coordsv(double jd,double xyz[3], void*);
-void get_venus_helio_coordsv(double jd,double xyz[3], void*);
-void get_earth_helio_coordsv(double jd,double xyz[3], void*);
-void get_mars_helio_coordsv(double jd,double xyz[3], void*);
-void get_jupiter_helio_coordsv(double jd,double xyz[3], void*);
-void get_saturn_helio_coordsv(double jd,double xyz[3], void*);
-void get_uranus_helio_coordsv(double jd,double xyz[3], void*);
-void get_neptune_helio_coordsv(double jd,double xyz[3], void*);
-void get_pluto_helio_coordsv(double jd,double xyz[3], void*);
+void get_sun_helio_coordsv(double jd,double xyz[3], double xyzdot[3], void*);
+void get_mercury_helio_coordsv(double jd,double xyz[3], double xyzdot[3], void*);
+void get_venus_helio_coordsv(double jd,double xyz[3], double xyzdot[3], void*);
+void get_earth_helio_coordsv(double jd,double xyz[3], double xyzdot[3], void*);
+void get_mars_helio_coordsv(double jd,double xyz[3], double xyzdot[3], void*);
+void get_jupiter_helio_coordsv(double jd,double xyz[3], double xyzdot[3], void*);
+void get_saturn_helio_coordsv(double jd,double xyz[3], double xyzdot[3], void*);
+void get_uranus_helio_coordsv(double jd,double xyz[3], double xyzdot[3], void*);
+void get_neptune_helio_coordsv(double jd,double xyz[3], double xyzdot[3], void*);
+void get_pluto_helio_coordsv(double jd,double xyz[3], double xyzdot[3], void*);
 
-void get_mercury_helio_osculating_coords(double jd0,double jd,double xyz[3]);
-void get_venus_helio_osculating_coords(double jd0,double jd,double xyz[3]);
-void get_earth_helio_osculating_coords(double jd0,double jd,double xyz[3]);
-void get_mars_helio_osculating_coords(double jd0,double jd,double xyz[3]);
-void get_jupiter_helio_osculating_coords(double jd0,double jd,double xyz[3]);
-void get_saturn_helio_osculating_coords(double jd0,double jd,double xyz[3]);
-void get_uranus_helio_osculating_coords(double jd0,double jd,double xyz[3]);
-void get_neptune_helio_osculating_coords(double jd0,double jd,double xyz[3]);
-void get_pluto_helio_osculating_coords(double jd0,double jd,double xyz[3]);
+void get_mercury_helio_osculating_coords(double jd0,double jd,double xyz[3], double xyzdot[3]);
+void get_venus_helio_osculating_coords(double jd0,double jd,double xyz[3], double xyzdot[3]);
+void get_earth_helio_osculating_coords(double jd0,double jd,double xyz[3], double xyzdot[3]);
+void get_mars_helio_osculating_coords(double jd0,double jd,double xyz[3], double xyzdot[3]);
+void get_jupiter_helio_osculating_coords(double jd0,double jd,double xyz[3], double xyzdot[3]);
+void get_saturn_helio_osculating_coords(double jd0,double jd,double xyz[3], double xyzdot[3]);
+void get_uranus_helio_osculating_coords(double jd0,double jd,double xyz[3], double xyzdot[3]);
+void get_neptune_helio_osculating_coords(double jd0,double jd,double xyz[3], double xyzdot[3]);
+void get_pluto_helio_osculating_coords(double jd0,double jd,double xyz[3], double xyzdot[3]);
 
-void get_lunar_parent_coordsv(double jde, double xyz[3], void*);
+void get_lunar_parent_coordsv(double jde, double xyz[3], double xyzdot[3], void*);
 
-void get_phobos_parent_coordsv(double jd,double xyz[3], void*);
-void get_deimos_parent_coordsv(double jd,double xyz[3], void*);
+void get_phobos_parent_coordsv(double jd,double xyz[3], double xyzdot[3], void*);
+void get_deimos_parent_coordsv(double jd,double xyz[3], double xyzdot[3], void*);
 
-void get_io_parent_coordsv(double jd,double xyz[3], void*);
-void get_europa_parent_coordsv(double jd,double xyz[3], void*);
-void get_ganymede_parent_coordsv(double jd,double xyz[3], void*);
-void get_callisto_parent_coordsv(double jd,double xyz[3], void*);
+void get_io_parent_coordsv(double jd,double xyz[3], double xyzdot[3], void*);
+void get_europa_parent_coordsv(double jd,double xyz[3], double xyzdot[3], void*);
+void get_ganymede_parent_coordsv(double jd,double xyz[3], double xyzdot[3], void*);
+void get_callisto_parent_coordsv(double jd,double xyz[3], double xyzdot[3], void*);
 
-void get_mimas_parent_coordsv(double jd,double xyz[3], void*);
-void get_enceladus_parent_coordsv(double jd,double xyz[3], void*);
-void get_tethys_parent_coordsv(double jd,double xyz[3], void*);
-void get_dione_parent_coordsv(double jd,double xyz[3], void*);
-void get_rhea_parent_coordsv(double jd,double xyz[3], void*);
-void get_titan_parent_coordsv(double jd,double xyz[3], void*);
-void get_hyperion_parent_coordsv(double jd,double xyz[3], void*);
-void get_iapetus_parent_coordsv(double jd,double xyz[3], void*);
+void get_mimas_parent_coordsv(double jd,double xyz[3], double xyzdot[3], void*);
+void get_enceladus_parent_coordsv(double jd,double xyz[3], double xyzdot[3], void*);
+void get_tethys_parent_coordsv(double jd,double xyz[3], double xyzdot[3], void*);
+void get_dione_parent_coordsv(double jd,double xyz[3], double xyzdot[3], void*);
+void get_rhea_parent_coordsv(double jd,double xyz[3], double xyzdot[3], void*);
+void get_titan_parent_coordsv(double jd,double xyz[3], double xyzdot[3], void*);
+void get_hyperion_parent_coordsv(double jd,double xyz[3], double xyzdot[3], void*);
+void get_iapetus_parent_coordsv(double jd,double xyz[3], double xyzdot[3], void*);
 
-void get_miranda_parent_coordsv(double jd,double xyz[3], void*);
-void get_ariel_parent_coordsv(double jd,double xyz[3], void*);
-void get_umbriel_parent_coordsv(double jd,double xyz[3], void*);
-void get_titania_parent_coordsv(double jd,double xyz[3], void*);
-void get_oberon_parent_coordsv(double jd,double xyz[3], void*);
+void get_miranda_parent_coordsv(double jd,double xyz[3], double xyzdot[3], void*);
+void get_ariel_parent_coordsv(double jd,double xyz[3], double xyzdot[3], void*);
+void get_umbriel_parent_coordsv(double jd,double xyz[3], double xyzdot[3], void*);
+void get_titania_parent_coordsv(double jd,double xyz[3], double xyzdot[3], void*);
+void get_oberon_parent_coordsv(double jd,double xyz[3], double xyzdot[3], void*);
 
 #endif // _EPHEMWRAPPER_HPP_
 

--- a/src/core/planetsephems/de430.cpp
+++ b/src/core/planetsephems/de430.cpp
@@ -36,8 +36,10 @@ THE SOFTWARE.
 
 static void * ephem;
 
-static Vec3d tempECL = Vec3d(0,0,0);
-static Vec3d tempICRF = Vec3d(0,0,0);
+static Vec3d tempECLpos = Vec3d(0,0,0);
+static Vec3d tempECLspd = Vec3d(0,0,0);
+static Vec3d tempICRFpos = Vec3d(0,0,0);
+static Vec3d tempICRFspd = Vec3d(0,0,0);
 static char nams[JPL_MAX_N_CONSTANTS][6];
 static double vals[JPL_MAX_N_CONSTANTS];
 static double tempXYZ[6];
@@ -79,7 +81,7 @@ bool GetDe430Coor(const double jde, const int planet_id, double * xyz, const int
     if(initDone)
     {
 	// This may return some error code!
-	int jplresult=jpl_pleph(ephem, jde, planet_id, centralBody_id, tempXYZ, 0);
+	int jplresult=jpl_pleph(ephem, jde, planet_id, centralBody_id, tempXYZ, 1);
 
 	switch (jplresult)
 	{
@@ -111,18 +113,25 @@ bool GetDe430Coor(const double jde, const int planet_id, double * xyz, const int
 			break;
 	}
 
-	jpl_pleph(ephem, jde, planet_id, centralBody_id, tempXYZ, 0);
+	// Why do we duplicate this?
+	// jpl_pleph(ephem, jde, planet_id, centralBody_id, tempXYZ, 0);
 
-        tempICRF = Vec3d(tempXYZ[0], tempXYZ[1], tempXYZ[2]);
+	tempICRFpos =   Vec3d(tempXYZ[0], tempXYZ[1], tempXYZ[2]);
+	tempICRFspd =   Vec3d(tempXYZ[3], tempXYZ[4], tempXYZ[5]);
 	#ifdef UNIT_TEST
-	tempECL = matJ2000ToVsop87 * tempICRF;
+	tempECLpos = matJ2000ToVsop87 * tempICRFpos;
+	tempECLspd = matJ2000ToVsop87 * tempICRFspd;
 	#else
-        tempECL = StelCore::matJ2000ToVsop87 * tempICRF;
+	tempECLpos = StelCore::matJ2000ToVsop87 * tempICRFpos;
+	tempECLspd = StelCore::matJ2000ToVsop87 * tempICRFspd;
 	#endif
 
-        xyz[0] = tempECL[0];
-        xyz[1] = tempECL[1];
-        xyz[2] = tempECL[2];
+	xyz[0] = tempECLpos[0];
+	xyz[1] = tempECLpos[1];
+	xyz[2] = tempECLpos[2];
+	xyz[3] = tempECLspd[0];
+	xyz[4] = tempECLspd[1];
+	xyz[5] = tempECLspd[2];
 	return true;
     }
     return false;

--- a/src/core/planetsephems/de431.cpp
+++ b/src/core/planetsephems/de431.cpp
@@ -37,8 +37,10 @@ THE SOFTWARE.
 
 static void * ephem;
    
-static Vec3d tempECL = Vec3d(0,0,0);
-static Vec3d tempICRF = Vec3d(0,0,0);
+static Vec3d tempECLpos = Vec3d(0,0,0);
+static Vec3d tempECLspd = Vec3d(0,0,0);
+static Vec3d tempICRFpos = Vec3d(0,0,0);
+static Vec3d tempICRFspd = Vec3d(0,0,0);
 static char nams[JPL_MAX_N_CONSTANTS][6];
 static double vals[JPL_MAX_N_CONSTANTS];
 static double tempXYZ[6];
@@ -80,7 +82,7 @@ bool GetDe431Coor(const double jde, const int planet_id, double * xyz, const int
     if(initDone)
     {
 	// This may return some error code!
-	int jplresult=jpl_pleph(ephem, jde, planet_id, centralBody_id, tempXYZ, 0);
+	int jplresult=jpl_pleph(ephem, jde, planet_id, centralBody_id, tempXYZ, 1);
 
 	switch (jplresult)
 	{
@@ -112,16 +114,22 @@ bool GetDe431Coor(const double jde, const int planet_id, double * xyz, const int
 			break;
 	}
 
-        tempICRF = Vec3d(tempXYZ[0], tempXYZ[1], tempXYZ[2]);
+	tempICRFpos = Vec3d(tempXYZ[0], tempXYZ[1], tempXYZ[2]);
+	tempICRFspd = Vec3d(tempXYZ[3], tempXYZ[4], tempXYZ[5]);
 	#ifdef UNIT_TEST
-	tempECL = matJ2000ToVsop87 * tempICRF;
+	tempECLpos = matJ2000ToVsop87 * tempICRFpos;
+	tempECLspd = matJ2000ToVsop87 * tempICRFspd;
 	#else
-        tempECL = StelCore::matJ2000ToVsop87 * tempICRF;
+	tempECLpos = StelCore::matJ2000ToVsop87 * tempICRFpos;
+	tempECLspd = StelCore::matJ2000ToVsop87 * tempICRFspd;
 	#endif
 
-        xyz[0] = tempECL[0];
-        xyz[1] = tempECL[1];
-        xyz[2] = tempECL[2];
+	xyz[0] = tempECLpos[0];
+	xyz[1] = tempECLpos[1];
+	xyz[2] = tempECLpos[2];
+	xyz[3] = tempECLspd[0];
+	xyz[4] = tempECLspd[1];
+	xyz[5] = tempECLspd[2];
 	return true;
     }
     return false;

--- a/src/core/planetsephems/elliptic_to_rectangular.c
+++ b/src/core/planetsephems/elliptic_to_rectangular.c
@@ -116,7 +116,7 @@ EllipticToRectangular(const double a,const double n,
     xyz[1] = x1 * rdg + y1 * rtq;
     xyz[2] = (-x1 * elem[5] + y1 * elem[4]) * dwho;
 
-/*
+// /* GZ 2017-11: Re-enable these lines, they seem to be velocity!
     const double rsam1 = -elem[2]*cLe - elem[3]*sLe;
     const double h = a*n / (1.0 + rsam1);
     const double vx1 = h * (-sLe - psi*rsam1*elem[3]);
@@ -125,7 +125,7 @@ EllipticToRectangular(const double a,const double n,
     xyz[3] = vx1 * rtp + vy1 * rdg;
     xyz[4] = vx1 * rdg + vy1 * rtq;
     xyz[5] = (-vx1 * elem[5] + vy1 * elem[4]) * dwho;
-*/
+// */
   }
 }
 

--- a/src/core/planetsephems/elliptic_to_rectangular.h
+++ b/src/core/planetsephems/elliptic_to_rectangular.h
@@ -65,6 +65,11 @@ extern "C" {
    e = excentricity
    
    Units are suspected to be: Julian days, AU, rad
+
+   Results:
+   xyz[0,1,2]=Position [AU]
+   xyz[3,4,5]=Velocity [AU/d]
+
 */
 
 void EllipticToRectangularN(double mu,const double elem[6],double dt,

--- a/src/core/planetsephems/gust86.c
+++ b/src/core/planetsephems/gust86.c
@@ -438,13 +438,16 @@ static double gust86_elem_2[GUST86_DIM];
 static double gust86_jd0 = -1e100;
 static double gust86_elem[GUST86_DIM];
 
-void GetGust86Coor(const double jd,const int body,double *xyz) {
-  GetGust86OsculatingCoor(jd,jd,body,xyz);
+void GetGust86Coor(const double jd, const int body, double *xyz, double *xyzdot) {
+	double xyz6[6];
+	GetGust86OsculatingCoor(jd,jd,body,xyz6);
+	xyz[0]   =xyz6[0]; xyz[1]   =xyz6[1]; xyz[2]   =xyz6[2];
+	xyzdot[0]=xyz6[3]; xyzdot[1]=xyz6[4]; xyzdot[2]=xyz6[5];
 }
 
 void GetGust86OsculatingCoor(const double jd0,const double jd,
                              const int body,double *xyz) {
-  double x[3];
+  double x[6];
   if (jd0 != gust86_jd0) {
     const double t0 = jd0 - 2444239.5;
     gust86_jd0 = jd0;
@@ -465,4 +468,8 @@ void GetGust86OsculatingCoor(const double jd0,const double jd,
   xyz[0] = GUST86toVsop87[0]*x[0]+GUST86toVsop87[1]*x[1]+GUST86toVsop87[2]*x[2];
   xyz[1] = GUST86toVsop87[3]*x[0]+GUST86toVsop87[4]*x[1]+GUST86toVsop87[5]*x[2];
   xyz[2] = GUST86toVsop87[6]*x[0]+GUST86toVsop87[7]*x[1]+GUST86toVsop87[8]*x[2];
+  // GZ Updated to a 6-vector
+  xyz[3] = GUST86toVsop87[0]*x[3]+GUST86toVsop87[1]*x[4]+GUST86toVsop87[2]*x[5];
+  xyz[4] = GUST86toVsop87[3]*x[3]+GUST86toVsop87[4]*x[4]+GUST86toVsop87[5]*x[5];
+  xyz[5] = GUST86toVsop87[6]*x[3]+GUST86toVsop87[7]*x[4]+GUST86toVsop87[8]*x[5];
 }

--- a/src/core/planetsephems/gust86.h
+++ b/src/core/planetsephems/gust86.h
@@ -60,7 +60,7 @@ extern "C" {
 #define GUST86_TITANIA   3
 #define GUST86_OBERON    4
 
-void GetGust86Coor(const double jd, const int body, double *xyz);
+void GetGust86Coor(const double jd, const int body, double *xyz, double *xyzdot);
   /* Return the rectangular coordinates of the given satellite
      and the given julian date jd expressed in dynamical time (TAI+32.184s).
      The origin of the xyz-coordinates is the center of the planet.
@@ -91,6 +91,7 @@ void GetGust86Coor(const double jd, const int body, double *xyz);
      
 void GetGust86OsculatingCoor(const double jd0, const double jd, const int body, double *xyz);
   /* The oculating orbit of epoch jd0, evaluated at jd, is returned.
+   * xyz is a 6-vector (position&speed)
   */
 
 #ifdef __cplusplus

--- a/src/core/planetsephems/l1.c
+++ b/src/core/planetsephems/l1.c
@@ -997,13 +997,16 @@ static void CalcUglyStaticL1Elem(double t,double elem[6]) {
   CalcL1Elem(t,ugly_static_parameter_body,elem);
 }
 
-void GetL1Coor(double jd,int body,double *xyz) {
-  GetL1OsculatingCoor(jd,jd,body,xyz);
+void GetL1Coor(double jd, int body, double *xyz, double *xyzdot) {
+	double xyz6[6];
+	GetL1OsculatingCoor(jd,jd,body,xyz6);
+	xyz[0]   =xyz6[0]; xyz[1]   =xyz6[1]; xyz[2]   =xyz6[2];
+	xyzdot[0]=xyz6[3]; xyzdot[1]=xyz6[4]; xyzdot[2]=xyz6[5];
 }
 
 void GetL1OsculatingCoor(const double jd0,const double jd,
                          const int body,double *xyz) {
-  double x[3];
+  double x[6];
   if (jd0 != l1_jd0[body]) {
     const double t0 = jd0 - 2433282.5;
     l1_jd0[body] = jd0;
@@ -1018,4 +1021,8 @@ void GetL1OsculatingCoor(const double jd0,const double jd,
   xyz[0] = L1toVsop87[0]*x[0]+L1toVsop87[1]*x[1]+L1toVsop87[2]*x[2];
   xyz[1] = L1toVsop87[3]*x[0]+L1toVsop87[4]*x[1]+L1toVsop87[5]*x[2];
   xyz[2] = L1toVsop87[6]*x[0]+L1toVsop87[7]*x[1]+L1toVsop87[8]*x[2];
+  // GZ Pure guesswork. I hope these make sense...
+  xyz[3] = L1toVsop87[0]*x[3]+L1toVsop87[1]*x[4]+L1toVsop87[2]*x[5];
+  xyz[4] = L1toVsop87[3]*x[3]+L1toVsop87[4]*x[4]+L1toVsop87[5]*x[5];
+  xyz[5] = L1toVsop87[6]*x[3]+L1toVsop87[7]*x[4]+L1toVsop87[8]*x[5];
 }

--- a/src/core/planetsephems/l1.h
+++ b/src/core/planetsephems/l1.h
@@ -56,12 +56,14 @@ extern "C" {
 #define L1_GANYMEDE      2
 #define L1_CALLISTO      3
 
-void GetL1Coor(double jd,int body,double *xyz);
+void GetL1Coor(double jd,int body,double *xyz, double *xyzdot);
   /* Return the rectangular coordinates of the given satellite
      and the given julian date jd expressed in dynamical time (TAI+32.184s).
      The origin of the xyz-coordinates is the center of the planet.
      The reference frame is "dynamical equinox and ecliptic J2000",
      which is the reference frame in VSOP87 and VSOP87A.
+
+     GZ2017-11: added xyzdot, now last 2 parameters should be 3-vectors of position and speed.
 
      WARNING! Due to static internal variables, this function is not reentrant and not parallelizable!
   */
@@ -69,6 +71,7 @@ void GetL1Coor(double jd,int body,double *xyz);
 void GetL1OsculatingCoor(const double jd0,const double jd, const int body,double *xyz);
 
   /* The oculating orbit of epoch jd0, evaluated at jd, is returned.
+     GZ2017-11: xyz now is a 6-vector of position and speed.
   */
 
 

--- a/src/core/planetsephems/marssat.c
+++ b/src/core/planetsephems/marssat.c
@@ -428,13 +428,16 @@ static void CalcAllMarsSatElem(double t,double elem[12]) {
 
 static double mars_sat_to_vsop87[9];
 
-void GetMarsSatCoor(double jd,int body,double *xyz) {
-  GetMarsSatOsculatingCoor(jd,jd,body,xyz);
+void GetMarsSatCoor(double jd,int body,double *xyz, double *xyzdot) {
+	double xyz6[6];
+	GetMarsSatOsculatingCoor(jd,jd,body,xyz6);
+	xyz[0]   =xyz6[0]; xyz[1]   =xyz6[1]; xyz[2]   =xyz6[2];
+	xyzdot[0]=xyz6[3]; xyzdot[1]=xyz6[4]; xyzdot[2]=xyz6[5];
 }
 
 void GetMarsSatOsculatingCoor(const double jd0,const double jd,
                               const int body,double *xyz) {
-  double x[3];
+  double x[6];
   if (jd0 != marssat_jd0) {
     const double t0 = jd0 - 2451545.0 + 6491.5;
     marssat_jd0 = jd0;
@@ -445,8 +448,7 @@ void GetMarsSatOsculatingCoor(const double jd0,const double jd,
                              &t_2,marssat_elem_2);
     GenerateMarsSatToVSOP87(t0,mars_sat_to_vsop87);
   }
-  EllipticToRectangularA(mars_sat_bodies[body].mu,marssat_elem+(body*6),
-                         jd-jd0,x);
+  EllipticToRectangularA(mars_sat_bodies[body].mu,marssat_elem+(body*6),jd-jd0,x);
   xyz[0] = mars_sat_to_vsop87[0]*x[0]
          + mars_sat_to_vsop87[1]*x[1]
          + mars_sat_to_vsop87[2]*x[2];
@@ -456,6 +458,16 @@ void GetMarsSatOsculatingCoor(const double jd0,const double jd,
   xyz[2] = mars_sat_to_vsop87[6]*x[0]
          + mars_sat_to_vsop87[7]*x[1]
          + mars_sat_to_vsop87[8]*x[2];
+  // GZ This is a guess, based on the structure of other operations...
+  xyz[3] = mars_sat_to_vsop87[0]*x[3]
+	 + mars_sat_to_vsop87[1]*x[4]
+	 + mars_sat_to_vsop87[2]*x[5];
+  xyz[4] = mars_sat_to_vsop87[3]*x[3]
+	 + mars_sat_to_vsop87[4]*x[4]
+	 + mars_sat_to_vsop87[5]*x[5];
+  xyz[5] = mars_sat_to_vsop87[6]*x[3]
+	 + mars_sat_to_vsop87[7]*x[4]
+	 + mars_sat_to_vsop87[8]*x[5];
 /*
   printf("%d %18.9lf %15.12lf %15.12lf %15.12lf\n",
          body,jd,xyz[0],xyz[1],xyz[2]);

--- a/src/core/planetsephems/marssat.h
+++ b/src/core/planetsephems/marssat.h
@@ -58,8 +58,8 @@ extern "C" {
 #define MARS_SAT_PHOBOS 0
 #define MARS_SAT_DEIMOS 1
 
-void GetMarsSatCoor(double jd,int body,double *xyz);
-  /* Return the rectangular coordinates of the given satellite
+void GetMarsSatCoor(double jd, int body, double *xyz, double *xyzdot);
+  /* Return the rectangular coordinates and speed of the given satellite
      and the given julian date jd expressed in dynamical time (TAI+32.184s).
      The origin of the xyz-coordinates is the center of the planet.
      The reference frame is "dynamical equinox and ecliptic J2000",
@@ -68,6 +68,7 @@ void GetMarsSatCoor(double jd,int body,double *xyz);
 
 void GetMarsSatOsculatingCoor(const double jd0, const double jd, const int body,double *xyz);
   /* The oculating orbit of epoch jd0, evatuated at jd, is returned.
+   * xyz is a 6-vector
   */
 
 #ifdef __cplusplus

--- a/src/core/planetsephems/tass17.c
+++ b/src/core/planetsephems/tass17.c
@@ -3163,14 +3163,17 @@ void CalcAllTass17Elem(const double t,double elem[TASS17_DIM])
 	for (body=0;body<=7;body++) CalcTass17Elem(t,lon,body,elem+(body*6));
 }
 
-void GetTass17Coor(double jd,int body,double *xyz)
+void GetTass17Coor(double jd,int body,double *xyz, double *xyzdot)
 {
-	GetTass17OsculatingCoor(jd,jd,body,xyz);
+	double xyz6[6];
+	GetTass17OsculatingCoor(jd,jd,body,xyz6);
+	xyz[0]   =xyz6[0]; xyz[1]   =xyz6[1]; xyz[2]   =xyz6[2];
+	xyzdot[0]=xyz6[3]; xyzdot[1]=xyz6[4]; xyzdot[2]=xyz6[5];
 }
 
 void GetTass17OsculatingCoor(const double jd0,const double jd, const int body,double *xyz)
 {
-	double x[3];
+	double x[6];
 	if (jd0 != tass17_jd0)
 	{
 		const double t0 = jd0 - 2444240.0;
@@ -3192,6 +3195,10 @@ void GetTass17OsculatingCoor(const double jd0,const double jd, const int body,do
 	xyz[0] = TASS17toVSOP87[0]*x[0]+TASS17toVSOP87[1]*x[1]+TASS17toVSOP87[2]*x[2];
 	xyz[1] = TASS17toVSOP87[3]*x[0]+TASS17toVSOP87[4]*x[1]+TASS17toVSOP87[5]*x[2];
 	xyz[2] = TASS17toVSOP87[6]*x[0]+TASS17toVSOP87[7]*x[1]+TASS17toVSOP87[8]*x[2];
+	// GZ Updated to a 6-vector including speed...
+	xyz[3] = TASS17toVSOP87[0]*x[3]+TASS17toVSOP87[1]*x[4]+TASS17toVSOP87[2]*x[5];
+	xyz[4] = TASS17toVSOP87[3]*x[3]+TASS17toVSOP87[4]*x[4]+TASS17toVSOP87[5]*x[5];
+	xyz[5] = TASS17toVSOP87[6]*x[3]+TASS17toVSOP87[7]*x[4]+TASS17toVSOP87[8]*x[5];
 }
 
 

--- a/src/core/planetsephems/tass17.h
+++ b/src/core/planetsephems/tass17.h
@@ -66,7 +66,9 @@ extern "C" {
 #define TASS17_HYPERION  7
 #define TASS17_IAPETUS   6
 
-void GetTass17Coor(double jd,int body,double *xyz);
+// xyz and xyzdot are 3-vectors (position&speed)
+void GetTass17Coor(double jd, int body, double *xyz, double *xyzdot);
+// xyz is a 6-vector (position&speed)
 void GetTass17OsculatingCoor(const double jd0,const double jd, const int body,double *xyz);
 
 #ifdef __cplusplus

--- a/src/core/planetsephems/vsop87.c
+++ b/src/core/planetsephems/vsop87.c
@@ -137338,8 +137338,7 @@ void GetVsop87Coor(double jd,int body,double *xyz) {
   GetVsop87OsculatingCoor(jd,jd,body,xyz);
 }
 
-void GetVsop87OsculatingCoor(const double jd0,const double jd,
-							 const int body,double *xyz) {
+void GetVsop87OsculatingCoor(const double jd0,const double jd,const int body,double *xyz) {
   if (jd0 != vsop87_jd0) {
 	const double t0 = (jd0 - 2451545.0) / 365250.0;
 	vsop87_jd0 = jd0;

--- a/src/gui/ConfigurationDialog.cpp
+++ b/src/gui/ConfigurationDialog.cpp
@@ -195,11 +195,9 @@ void ConfigurationDialog::createDialogContent()
 	// Additional settings for selected object info
 	connectBoolProperty(ui->checkBoxUMSurfaceBrightness, "NebulaMgr.flagSurfaceBrightnessArcsecUsage");
 	connectBoolProperty(ui->checkBoxUMShortNotationSurfaceBrightness, "NebulaMgr.flagSurfaceBrightnessShortNotationUsage");
-	ui->checkBoxUseFormattingOutput->setChecked(StelApp::getInstance().getFlagUseFormattingOutput());
-	connect(ui->checkBoxUseFormattingOutput, SIGNAL(toggled(bool)), this, SLOT(updateSettingFormattingOutput(bool)));
-	ui->checkBoxUseCCSDesignations->setChecked(StelApp::getInstance().getFlagUseCCSDesignation());
-	connect(ui->checkBoxUseCCSDesignations, SIGNAL(toggled(bool)), this, SLOT(updateSettingCCSDesignations(bool)));
-	
+	connectBoolProperty(ui->checkBoxUseFormattingOutput, "StelApp.flagUseFormattingOutput");
+	connectBoolProperty(ui->checkBoxUseCCSDesignations,  "StelApp.flagUseCCSDesignation");
+
 	connect(ui->noSelectedInfoRadio, SIGNAL(released()), this, SLOT(setNoSelectedInfo()));
 	connect(ui->allSelectedInfoRadio, SIGNAL(released()), this, SLOT(setAllSelectedInfo()));
 	connect(ui->briefSelectedInfoRadio, SIGNAL(released()), this, SLOT(setBriefSelectedInfo()));
@@ -223,6 +221,7 @@ void ConfigurationDialog::createDialogContent()
 	ui->fixedDateTimeEdit->setDateTime(StelUtils::jdToQDateTime(core->getPresetSkyTime()));
 	connect(ui->fixedDateTimeEdit, SIGNAL(dateTimeChanged(QDateTime)), core, SLOT(setPresetSkyTime(QDateTime)));
 
+	// TODO: convert to properties
 	ui->enableKeysNavigationCheckBox->setChecked(mvmgr->getFlagEnableMoveKeys() || mvmgr->getFlagEnableZoomKeys());
 	ui->enableMouseNavigationCheckBox->setChecked(mvmgr->getFlagEnableMouseNavigation());
 	connect(ui->enableKeysNavigationCheckBox, SIGNAL(toggled(bool)), mvmgr, SLOT(setFlagEnableMoveKeys(bool)));
@@ -284,46 +283,31 @@ void ConfigurationDialog::createDialogContent()
 	connect(ui->diskViewportCheckbox, SIGNAL(toggled(bool)), this, SLOT(setDiskViewport(bool)));
 	connectBoolProperty(ui->autoZoomResetsDirectionCheckbox, "StelMovementMgr.flagAutoZoomOutResetsDirection");
 
-	ui->showFlipButtonsCheckbox->setChecked(gui->getFlagShowFlipButtons());
-	connect(ui->showFlipButtonsCheckbox, SIGNAL(toggled(bool)), gui, SLOT(setFlagShowFlipButtons(bool)));
+	connectBoolProperty(ui->showFlipButtonsCheckbox,                   "StelGui.flagShowFlipButtons");
+	connectBoolProperty(ui->showNebulaBgButtonCheckbox,                "StelGui.flagShowNebulaBackgroundButton");
+	connectBoolProperty(ui->showToastSurveyButtonCheckbox,             "StelGui.flagShowToastSurveyButton");
+	connectBoolProperty(ui->showBookmarksButtonCheckBox,               "StelGui.flagShowBookmarksButton");
+	connectBoolProperty(ui->showICRSGridButtonCheckBox,                "StelGui.flagShowICRSGridButton");
+	connectBoolProperty(ui->showGalacticGridButtonCheckBox,            "StelGui.flagShowGalacticGridButton");
+	connectBoolProperty(ui->showEclipticGridButtonCheckBox,            "StelGui.flagShowEclipticGridButton");
+	connectBoolProperty(ui->showConstellationBoundariesButtonCheckBox, "StelGui.flagShowConstellationBoundariesButton");
 
-	ui->showNebulaBgButtonCheckbox->setChecked(gui->getFlagShowNebulaBackgroundButton());
-	connect(ui->showNebulaBgButtonCheckbox, SIGNAL(toggled(bool)), gui, SLOT(setFlagShowNebulaBackgroundButton(bool)));
+	//ui->decimalDegreeCheckBox->setChecked(StelApp::getInstance().getFlagShowDecimalDegrees());
+	//connect(ui->decimalDegreeCheckBox, SIGNAL(toggled(bool)), gui, SLOT(setFlagShowDecimalDegrees(bool)));
+	// TODO: Make sure to remove this setter function, rather listen to StelApp's signal. 
+	connectBoolProperty(ui->decimalDegreeCheckBox, "StelApp.flagShowDecimalDegrees");
 
-	ui->showToastSurveyButtonCheckbox->setChecked(gui->getFlagShowToastSurveyButton());
-	connect(ui->showToastSurveyButtonCheckbox, SIGNAL(toggled(bool)), gui, SLOT(setFlagShowToastSurveyButton(bool)));
+	connectBoolProperty(ui->azimuthFromSouthcheckBox, "StelApp.flagUseAzimuthFromSouth");
 
-	ui->showBookmarksButtonCheckBox->setChecked(gui->getFlagShowBookmarksButton());
-	connect(ui->showBookmarksButtonCheckBox, SIGNAL(toggled(bool)), gui, SLOT(setFlagShowBookmarksButton(bool)));
-
-	ui->showICRSGridButtonCheckBox->setChecked(gui->getFlagShowICRSGridButton());
-	connect(ui->showICRSGridButtonCheckBox, SIGNAL(toggled(bool)), gui, SLOT(setFlagShowICRSGridButton(bool)));
-
-	ui->showGalacticGridButtonCheckBox->setChecked(gui->getFlagShowGalacticGridButton());
-	connect(ui->showGalacticGridButtonCheckBox, SIGNAL(toggled(bool)), gui, SLOT(setFlagShowGalacticGridButton(bool)));
-
-	ui->showEclipticGridButtonCheckBox->setChecked(gui->getFlagShowEclipticGridButton());
-	connect(ui->showEclipticGridButtonCheckBox, SIGNAL(toggled(bool)), gui, SLOT(setFlagShowEclipticGridButton(bool)));
-
-	ui->showConstellationBoundariesButtonCheckBox->setChecked(gui->getFlagShowConstellationBoundariesButton());
-	connect(ui->showConstellationBoundariesButtonCheckBox, SIGNAL(toggled(bool)), gui, SLOT(setFlagShowConstellationBoundariesButton(bool)));
-
-	ui->decimalDegreeCheckBox->setChecked(StelApp::getInstance().getFlagShowDecimalDegrees());
-	connect(ui->decimalDegreeCheckBox, SIGNAL(toggled(bool)), gui, SLOT(setFlagShowDecimalDegrees(bool)));
-	ui->azimuthFromSouthcheckBox->setChecked(StelApp::getInstance().getFlagSouthAzimuthUsage());
-	connect(ui->azimuthFromSouthcheckBox, SIGNAL(toggled(bool)), this, SLOT(updateStartPointForAzimuth(bool)));
-
-	ui->mouseTimeoutCheckbox->setChecked(StelMainView::getInstance().getFlagCursorTimeout());
-	ui->mouseTimeoutSpinBox->setValue(StelMainView::getInstance().getCursorTimeout());
-	connect(ui->mouseTimeoutCheckbox, SIGNAL(clicked()), this, SLOT(cursorTimeOutChanged()));
-	connect(ui->mouseTimeoutCheckbox, SIGNAL(toggled(bool)), this, SLOT(cursorTimeOutChanged()));
-	connect(ui->mouseTimeoutSpinBox, SIGNAL(valueChanged(double)), this, SLOT(cursorTimeOutChanged(double)));
-
-	ui->useButtonsBackgroundCheckBox->setChecked(StelMainView::getInstance().getFlagUseButtonsBackground());
-	connect(ui->useButtonsBackgroundCheckBox, SIGNAL(toggled(bool)), this, SLOT(usageButtonsBackgroundChanged(bool)));
-
-	ui->indicationMountModeCheckBox->setChecked(mvmgr->getFlagIndicationMountMode());
-	connect(ui->indicationMountModeCheckBox, SIGNAL(toggled(bool)), mvmgr, SLOT(setFlagIndicationMountMode(bool)));
+	//ui->mouseTimeoutCheckbox->setChecked(StelMainView::getInstance().getFlagCursorTimeout());
+	//ui->mouseTimeoutSpinBox->setValue(StelMainView::getInstance().getCursorTimeout());
+	//connect(ui->mouseTimeoutCheckbox, SIGNAL(clicked()), this, SLOT(cursorTimeOutChanged()));
+	//connect(ui->mouseTimeoutCheckbox, SIGNAL(toggled(bool)), this, SLOT(cursorTimeOutChanged()));
+	//connect(ui->mouseTimeoutSpinBox, SIGNAL(valueChanged(double)), this, SLOT(cursorTimeOutChanged(double)));
+	connectBoolProperty(ui->mouseTimeoutCheckbox, "MainView.flagCursorTimeout");
+	connectDoubleProperty(ui->mouseTimeoutSpinBox, "MainView.cursorTimeout");
+	connectBoolProperty(ui->useButtonsBackgroundCheckBox, "MainView.flagUseButtonsBackground");
+	connectBoolProperty(ui->indicationMountModeCheckBox, "StelMovementMgr.flagIndicationMountMode");
 
 	// General Option Save
 	connect(ui->saveViewDirAsDefaultPushButton, SIGNAL(clicked()), this, SLOT(saveCurrentViewDirSettings()));
@@ -334,9 +318,7 @@ void ConfigurationDialog::createDialogContent()
 	ui->screenshotDirEdit->setText(StelFileMgr::getScreenshotDir());
 	connect(ui->screenshotDirEdit, SIGNAL(textChanged(QString)), this, SLOT(selectScreenshotDir(QString)));
 	connect(ui->screenshotBrowseButton, SIGNAL(clicked()), this, SLOT(browseForScreenshotDir()));
-
-	ui->invertScreenShotColorsCheckBox->setChecked(StelMainView::getInstance().getFlagInvertScreenShotColors());
-	connect(ui->invertScreenShotColorsCheckBox, SIGNAL(toggled(bool)), &StelMainView::getInstance(), SLOT(setFlagInvertScreenShotColors(bool)));
+	connectBoolProperty(ui->invertScreenShotColorsCheckBox, "MainView.flagInvertScreenShotColors");
 
 	connectBoolProperty(ui->autoEnableAtmosphereCheckBox, "LandscapeMgr.flagAtmosphereAutoEnabling");
 	connectBoolProperty(ui->autoChangeLandscapesCheckBox, "LandscapeMgr.flagLandscapeAutoSelection");
@@ -519,6 +501,8 @@ void ConfigurationDialog::setSelectedInfoFromCheckBoxes()
 		flags |= StelObject::AltAzi;
 	if (ui->checkBoxDistance->isChecked())
 		flags |= StelObject::Distance;
+	if (ui->checkBoxVelocity->isChecked())
+		flags |= StelObject::Velocity;
 	if (ui->checkBoxSize->isChecked())
 		flags |= StelObject::Size;
 	if (ui->checkBoxExtra->isChecked())
@@ -542,32 +526,32 @@ void ConfigurationDialog::setSelectedInfoFromCheckBoxes()
 }
 
 
-void ConfigurationDialog::updateStartPointForAzimuth(bool b)
-{
-	StelApp::getInstance().setFlagSouthAzimuthUsage(b);
-}
+//void ConfigurationDialog::updateStartPointForAzimuth(bool b)
+//{
+//	StelApp::getInstance().setFlagSouthAzimuthUsage(b);
+//}
 
-void ConfigurationDialog::updateSettingFormattingOutput(bool b)
-{
-	StelApp::getInstance().setFlagUseFormattingOutput(b);
-}
+//void ConfigurationDialog::updateSettingFormattingOutput(bool b)
+//{
+//	StelApp::getInstance().setFlagUseFormattingOutput(b);
+//}
 
-void ConfigurationDialog::updateSettingCCSDesignations(bool b)
-{
-	StelApp::getInstance().setFlagUseCCSDesignation(b);
-}
+//void ConfigurationDialog::updateSettingCCSDesignations(bool b)
+//{
+//	StelApp::getInstance().setFlagUseCCSDesignation(b);
+//}
 
-void ConfigurationDialog::cursorTimeOutChanged()
-{
-	StelMainView::getInstance().setFlagCursorTimeout(ui->mouseTimeoutCheckbox->isChecked());
-	StelMainView::getInstance().setCursorTimeout(ui->mouseTimeoutSpinBox->value());
-}
+//void ConfigurationDialog::cursorTimeOutChanged()
+//{
+//	StelMainView::getInstance().setFlagCursorTimeout(ui->mouseTimeoutCheckbox->isChecked());
+//	StelMainView::getInstance().setCursorTimeout(ui->mouseTimeoutSpinBox->value());
+//}
 
-void ConfigurationDialog::usageButtonsBackgroundChanged(bool b)
-{
-	StelMainView::getInstance().setFlagUseButtonsBackground(b);
-	emit StelMainView::getInstance().updateIconsRequested();
-}
+//void ConfigurationDialog::usageButtonsBackgroundChanged(bool b)
+//{
+//	StelMainView::getInstance().setFlagUseButtonsBackground(b);
+//	emit StelMainView::getInstance().updateIconsRequested();
+//}
 
 void ConfigurationDialog::browseForScreenshotDir()
 {
@@ -848,6 +832,8 @@ void ConfigurationDialog::saveAllSettings()
 		               (bool) (flags &  StelObject::AltAzi));
 		conf->setValue("flag_show_distance",
 		               (bool) (flags & StelObject::Distance));
+		conf->setValue("flag_show_velocity",
+			       (bool) (flags & StelObject::Velocity));
 		conf->setValue("flag_show_size",
 		               (bool) (flags & StelObject::Size));
 		conf->setValue("flag_show_extra",
@@ -1428,6 +1414,7 @@ void ConfigurationDialog::updateSelectedInfoCheckBoxes()
 	ui->checkBoxHourAngle->setChecked(flags & StelObject::HourAngle);
 	ui->checkBoxAltAz->setChecked(flags & StelObject::AltAzi);
 	ui->checkBoxDistance->setChecked(flags & StelObject::Distance);
+	ui->checkBoxVelocity->setChecked(flags & StelObject::Velocity);
 	ui->checkBoxSize->setChecked(flags & StelObject::Size);
 	ui->checkBoxExtra->setChecked(flags & StelObject::Extra);
 	ui->checkBoxGalacticCoordinates->setChecked(flags & StelObject::GalacticCoord);

--- a/src/gui/ConfigurationDialog.hpp
+++ b/src/gui/ConfigurationDialog.hpp
@@ -90,13 +90,6 @@ private slots:
 	void showShortcutsWindow();
 	void setDiskViewport(bool);
 	void setSphericMirror(bool);
-	void cursorTimeOutChanged();
-	void cursorTimeOutChanged(double) {cursorTimeOutChanged();}
-	void usageButtonsBackgroundChanged(bool b);
-
-	void updateStartPointForAzimuth(bool b);
-	void updateSettingFormattingOutput(bool b);
-	void updateSettingCCSDesignations(bool b);
 
 	void newStarCatalogData();
 	void downloadStars();

--- a/src/gui/SearchDialog.cpp
+++ b/src/gui/SearchDialog.cpp
@@ -146,6 +146,7 @@ SearchDialog::SearchDialog(QObject* parent)
 	useLockPosition = conf->value("search/flag_lock_position", true).toBool();
 	simbadServerUrl = conf->value("search/simbad_server_url", DEF_SIMBAD_URL).toString();
 	setCurrentCoordinateSystemKey(conf->value("search/coordinate_system", "equatorialJ2000").toString());
+	connect(&StelApp::getInstance(), SIGNAL(flagShowDecimalDegreesChanged(bool)), this, SLOT(populateCoordinateAxis()));
 }
 
 SearchDialog::~SearchDialog()
@@ -223,7 +224,7 @@ void SearchDialog::populateCoordinateSystemsList()
 
 void SearchDialog::populateCoordinateAxis()
 {
-	bool withDecimalDegree = StelApp::getInstance().getFlagShowDecimalDegrees();;
+	bool withDecimalDegree = StelApp::getInstance().getFlagShowDecimalDegrees();
 	bool xnormal = true;
 
 	ui->AxisXSpinBox->setDecimals(2);

--- a/src/gui/SkyGui.cpp
+++ b/src/gui/SkyGui.cpp
@@ -72,6 +72,8 @@ InfoPanel::InfoPanel(QGraphicsItem* parent) : QGraphicsTextItem("", parent),
 			infoTextFilters |= StelObject::AltAzi;
 		if (conf->value("flag_show_distance", false).toBool())
 			infoTextFilters |= StelObject::Distance;
+		if (conf->value("flag_show_velocity", false).toBool())
+			infoTextFilters |= StelObject::Velocity;
 		if (conf->value("flag_show_size", false).toBool())
 			infoTextFilters |= StelObject::Size;
 		if (conf->value("flag_show_extra", false).toBool())

--- a/src/gui/StelGui.cpp
+++ b/src/gui/StelGui.cpp
@@ -119,6 +119,7 @@ StelGui::StelGui()
   #endif
 
 {
+	setObjectName("StelGui");
 	// QPixmapCache::setCacheLimit(30000); ?
 }
 
@@ -245,6 +246,8 @@ void StelGui::init(QGraphicsWidget *atopLevelGraphicsWidget)
 	connect(scriptMgr, SIGNAL(scriptRunning()), this, SLOT(scriptStarted()));
 	connect(scriptMgr, SIGNAL(scriptStopped()), this, SLOT(scriptStopped()));
 #endif
+	// Put StelGui under the StelProperty system (simpler and more consistent GUI)
+	StelApp::getInstance().getStelPropertyManager()->registerObject(this);
 
 	///////////////////////////////////////////////////////////////////////////
 	//// QGraphicsView based GUI
@@ -699,6 +702,7 @@ void StelGui::setFlagShowFlipButtons(bool b)
 	if (initDone) {
 		skyGui->updateBarsPos();
 	}
+	emit flagShowFlipButtonsChanged(b);
 }
 
 // Define whether the button toggling nebulae backround images should be visible
@@ -720,6 +724,7 @@ void StelGui::setFlagShowNebulaBackgroundButton(bool b)
 	if (initDone) {
 		skyGui->updateBarsPos();
 	}
+	emit flagShowNebulaBackgroundButtonChanged(b);
 }
 
 // Define whether the button toggling bookmarks should be visible
@@ -741,6 +746,7 @@ void StelGui::setFlagShowBookmarksButton(bool b)
 	if (initDone) {
 		skyGui->updateBarsPos();
 	}
+	emit flagShowBookmarksButtonChanged(b);
 }
 
 // Define whether the button toggling ICRS grid should be visible
@@ -762,6 +768,7 @@ void StelGui::setFlagShowICRSGridButton(bool b)
 	if (initDone) {
 		skyGui->updateBarsPos();
 	}
+	emit flagShowICRSGridButtonChanged(b);
 }
 
 // Define whether the button toggling galactic grid should be visible
@@ -783,6 +790,7 @@ void StelGui::setFlagShowGalacticGridButton(bool b)
 	if (initDone) {
 		skyGui->updateBarsPos();
 	}
+	emit flagShowGalacticGridButtonChanged(b);
 }
 
 // Define whether the button toggling ecliptic grid should be visible
@@ -825,6 +833,7 @@ void StelGui::setFlagShowConstellationBoundariesButton(bool b)
 	if (initDone) {
 		skyGui->updateBarsPos();
 	}
+	emit flagShowConstellationBoundariesButtonChanged(b);
 }
 
 // Define whether the button toggling TOAST survey images should be visible
@@ -843,16 +852,7 @@ void StelGui::setFlagShowToastSurveyButton(bool b)
 		getButtonBar()->hideButton("actionShow_Toast_Survey");
 	}
 	flagShowToastSurveyButton = b;
-}
-
-void StelGui::setFlagShowDecimalDegrees(bool b)
-{
-	StelApp::getInstance().setFlagShowDecimalDegrees(b);
-	if (searchDialog->visible())
-	{
-		// Update format of input fields if Search Dialog is open
-		searchDialog->populateCoordinateAxis();		
-	}
+	emit flagShowToastSurveyButtonChanged(b);
 }
 
 void StelGui::setVisible(bool b)
@@ -997,6 +997,7 @@ void StelGui::scriptStopped()
 void StelGui::setGuiVisible(bool b)
 {
 	setVisible(b);
+	emit visibleChanged(b);
 }
 
 StelAction* StelGui::getAction(const QString& actionName)

--- a/src/gui/StelGui.hpp
+++ b/src/gui/StelGui.hpp
@@ -56,6 +56,14 @@ class StelGui : public QObject, public StelGuiBase
 	Q_PROPERTY(bool visible READ getVisible WRITE setVisible NOTIFY visibleChanged)
 	Q_PROPERTY(bool autoHideHorizontalButtonBar READ getAutoHideHorizontalButtonBar WRITE setAutoHideHorizontalButtonBar NOTIFY autoHideHorizontalButtonBarChanged)
 	Q_PROPERTY(bool autoHideVerticalButtonBar READ getAutoHideVerticalButtonBar WRITE setAutoHideVerticalButtonBar NOTIFY autoHideVerticalButtonBarChanged)
+	Q_PROPERTY(bool flagShowFlipButtons READ getFlagShowFlipButtons WRITE setFlagShowFlipButtons NOTIFY flagShowFlipButtonsChanged)
+	Q_PROPERTY(bool flagShowNebulaBackgroundButton READ getFlagShowNebulaBackgroundButton WRITE setFlagShowNebulaBackgroundButton NOTIFY flagShowNebulaBackgroundButtonChanged)
+	Q_PROPERTY(bool flagShowToastSurveyButton READ getFlagShowToastSurveyButton WRITE setFlagShowToastSurveyButton NOTIFY  flagShowToastSurveyButtonChanged)
+	Q_PROPERTY(bool flagShowBookmarksButton READ getFlagShowBookmarksButton WRITE setFlagShowBookmarksButton NOTIFY flagShowBookmarksButtonChanged)
+	Q_PROPERTY(bool flagShowICRSGridButton READ getFlagShowICRSGridButton WRITE setFlagShowICRSGridButton NOTIFY flagShowICRSGridButtonChanged)
+	Q_PROPERTY(bool flagShowGalacticGridButton READ getFlagShowGalacticGridButton WRITE setFlagShowGalacticGridButton NOTIFY flagShowGalacticGridButtonChanged )
+	Q_PROPERTY(bool flagShowEclipticGridButton READ getFlagShowEclipticGridButton WRITE setFlagShowEclipticGridButton NOTIFY flagShowEclipticGridButtonChanged )
+	Q_PROPERTY(bool flagShowConstellationBoundariesButton READ getFlagShowConstellationBoundariesButton WRITE setFlagShowConstellationBoundariesButton NOTIFY flagShowConstellationBoundariesButtonChanged )
 
 public:
 	friend class ViewDialog;
@@ -85,30 +93,6 @@ public:
 	//! Get the SkyGui instance (useful for adding other interface elements).
 	//! It will return a valid object only if called after init().
 	class SkyGui* getSkyGui() const;
-	
-	//! Get whether the buttons toggling image flip are visible
-	bool getFlagShowFlipButtons() const;
-	
-	//! Get whether the button toggling nebulae background is visible
-	bool getFlagShowNebulaBackgroundButton() const;
-
-	//! Get whether the button toggling TOAST survey is visible
-	bool getFlagShowToastSurveyButton() const;
-
-	//! Get whether the button toggling bookmarks is visible
-	bool getFlagShowBookmarksButton() const;
-
-	//! Get whether the button toggling ICRS grid is visible
-	bool getFlagShowICRSGridButton() const;
-
-	//! Get whether the button toggling galactic grid is visible
-	bool getFlagShowGalacticGridButton() const;
-
-	//! Get whether the button toggling ecliptic grid is visible
-	bool getFlagShowEclipticGridButton() const;
-
-	//! Get whether the button toggling constellation boundaries is visible
-	bool getFlagShowConstellationBoundariesButton() const;
 
 	//! returns true if the gui has completed init process.
 	bool initComplete(void) const;
@@ -134,29 +118,43 @@ public:
 public slots:
 	//! Define whether the buttons toggling image flip should be visible
 	void setFlagShowFlipButtons(bool b);
-	
+	//! Get whether the buttons toggling image flip are visible
+	bool getFlagShowFlipButtons() const;
+
 	//! Define whether the button toggling nebulae background should be visible
 	void setFlagShowNebulaBackgroundButton(bool b);
+	//! Get whether the button toggling nebulae background is visible
+	bool getFlagShowNebulaBackgroundButton() const;
 
 	//! Define whether the button toggling TOAST survey should be visible
 	void setFlagShowToastSurveyButton(bool b);
+	//! Get whether the button toggling TOAST survey is visible
+	bool getFlagShowToastSurveyButton() const;
 
 	//! Define whether the button toggling bookmarks should be visible
 	void setFlagShowBookmarksButton(bool b);
+	//! Get whether the button toggling bookmarks is visible
+	bool getFlagShowBookmarksButton() const;
 
 	//! Define whether the button toggling ICRS grid should be visible
 	void setFlagShowICRSGridButton(bool b);
+	//! Get whether the button toggling ICRS grid is visible
+	bool getFlagShowICRSGridButton() const;
 
 	//! Define whether the button toggling galactic grid should be visible
 	void setFlagShowGalacticGridButton(bool b);
+	//! Get whether the button toggling galactic grid is visible
+	bool getFlagShowGalacticGridButton() const;
 
 	//! Define whether the button toggling ecliptic grid should be visible
 	void setFlagShowEclipticGridButton(bool b);
+	//! Get whether the button toggling ecliptic grid is visible
+	bool getFlagShowEclipticGridButton() const;
 
 	//! Define whether the button toggling constellation boundaries should be visible
 	void setFlagShowConstellationBoundariesButton(bool b);
-
-	void setFlagShowDecimalDegrees(bool b);
+	//! Get whether the button toggling constellation boundaries is visible
+	bool getFlagShowConstellationBoundariesButton() const;
 
 	//! Get the auto-hide status of the horizontal toolbar.
 	bool getAutoHideHorizontalButtonBar() const;
@@ -194,6 +192,14 @@ signals:
 	void visibleChanged(bool b);
 	void autoHideHorizontalButtonBarChanged(bool b);
 	void autoHideVerticalButtonBarChanged(bool b);
+	void flagShowFlipButtonsChanged(bool b);
+	void flagShowNebulaBackgroundButtonChanged(bool b);
+	void flagShowToastSurveyButtonChanged(bool b);
+	void flagShowBookmarksButtonChanged(bool b);
+	void flagShowICRSGridButtonChanged(bool b);
+	void flagShowGalacticGridButtonChanged(bool b);
+	void flagShowEclipticGridButtonChanged(bool b);
+	void flagShowConstellationBoundariesButtonChanged(bool b);
 
 private slots:
 	void reloadStyle();

--- a/src/gui/configurationDialog.ui
+++ b/src/gui/configurationDialog.ui
@@ -613,10 +613,10 @@
                </attribute>
               </widget>
              </item>
-             <item row="3" column="1">
-              <widget class="QCheckBox" name="checkBoxSupergalacticCoordinates">
+             <item row="1" column="0">
+              <widget class="QCheckBox" name="checkBoxCatalogNumbers">
                <property name="text">
-                <string>Supergalactic coordinates</string>
+                <string>Catalog number(s)</string>
                </property>
                <attribute name="buttonGroup">
                 <string notr="true">buttonGroupDisplayedFields</string>
@@ -624,29 +624,6 @@
               </widget>
              </item>
              <item row="7" column="0">
-              <widget class="QCheckBox" name="checkBoxType">
-               <property name="toolTip">
-                <string>The type of the object (star, planet, etc.)</string>
-               </property>
-               <property name="text">
-                <string>Type</string>
-               </property>
-               <attribute name="buttonGroup">
-                <string notr="true">buttonGroupDisplayedFields</string>
-               </attribute>
-              </widget>
-             </item>
-             <item row="1" column="1">
-              <widget class="QCheckBox" name="checkBoxAbsoluteMag">
-               <property name="text">
-                <string>Absolute magnitude</string>
-               </property>
-               <attribute name="buttonGroup">
-                <string notr="true">buttonGroupDisplayedFields</string>
-               </attribute>
-              </widget>
-             </item>
-             <item row="5" column="0">
               <widget class="QCheckBox" name="checkBoxEclipticCoordsOfDate">
                <property name="toolTip">
                 <string>Ecliptic coordinates, equinox of date (only for Earth)</string>
@@ -659,56 +636,10 @@
                </attribute>
               </widget>
              </item>
-             <item row="6" column="0">
-              <widget class="QCheckBox" name="checkBoxSize">
-               <property name="toolTip">
-                <string>Angular or physical size</string>
-               </property>
+             <item row="0" column="0">
+              <widget class="QCheckBox" name="checkBoxName">
                <property name="text">
-                <string>Size</string>
-               </property>
-               <attribute name="buttonGroup">
-                <string notr="true">buttonGroupDisplayedFields</string>
-               </attribute>
-              </widget>
-             </item>
-             <item row="5" column="1">
-              <widget class="QCheckBox" name="checkBoxAltAz">
-               <property name="toolTip">
-                <string>Horizontal coordinates</string>
-               </property>
-               <property name="text">
-                <string>Azimuth/Altitude</string>
-               </property>
-               <attribute name="buttonGroup">
-                <string notr="true">buttonGroupDisplayedFields</string>
-               </attribute>
-              </widget>
-             </item>
-             <item row="1" column="0">
-              <widget class="QCheckBox" name="checkBoxCatalogNumbers">
-               <property name="text">
-                <string>Catalog number(s)</string>
-               </property>
-               <attribute name="buttonGroup">
-                <string notr="true">buttonGroupDisplayedFields</string>
-               </attribute>
-              </widget>
-             </item>
-             <item row="6" column="1">
-              <widget class="QCheckBox" name="checkBoxDistance">
-               <property name="text">
-                <string>Distance</string>
-               </property>
-               <attribute name="buttonGroup">
-                <string notr="true">buttonGroupDisplayedFields</string>
-               </attribute>
-              </widget>
-             </item>
-             <item row="2" column="1">
-              <widget class="QCheckBox" name="checkBoxGalacticCoordinates">
-               <property name="text">
-                <string>Galactic coordinates</string>
+                <string>Name</string>
                </property>
                <attribute name="buttonGroup">
                 <string notr="true">buttonGroupDisplayedFields</string>
@@ -728,17 +659,7 @@
                </attribute>
               </widget>
              </item>
-             <item row="0" column="0">
-              <widget class="QCheckBox" name="checkBoxName">
-               <property name="text">
-                <string>Name</string>
-               </property>
-               <attribute name="buttonGroup">
-                <string notr="true">buttonGroupDisplayedFields</string>
-               </attribute>
-              </widget>
-             </item>
-             <item row="4" column="0">
+             <item row="6" column="0">
               <widget class="QCheckBox" name="checkBoxEclipticCoordsJ2000">
                <property name="toolTip">
                 <string>Ecliptic coordinates, equinox J2000.0</string>
@@ -751,7 +672,17 @@
                </attribute>
               </widget>
              </item>
-             <item row="4" column="1">
+             <item row="8" column="0">
+              <widget class="QCheckBox" name="checkBoxGalacticCoordinates">
+               <property name="text">
+                <string>Galactic coordinates</string>
+               </property>
+               <attribute name="buttonGroup">
+                <string notr="true">buttonGroupDisplayedFields</string>
+               </attribute>
+              </widget>
+             </item>
+             <item row="4" column="0">
               <widget class="QCheckBox" name="checkBoxHourAngle">
                <property name="toolTip">
                 <string>Equatorial coordinates, equinox of date</string>
@@ -764,7 +695,66 @@
                </attribute>
               </widget>
              </item>
-             <item row="0" column="1">
+             <item row="9" column="0">
+              <widget class="QCheckBox" name="checkBoxSupergalacticCoordinates">
+               <property name="text">
+                <string>Supergalactic coordinates</string>
+               </property>
+               <attribute name="buttonGroup">
+                <string notr="true">buttonGroupDisplayedFields</string>
+               </attribute>
+              </widget>
+             </item>
+             <item row="5" column="0">
+              <widget class="QCheckBox" name="checkBoxAltAz">
+               <property name="toolTip">
+                <string>Horizontal coordinates</string>
+               </property>
+               <property name="text">
+                <string>Azimuth/Altitude</string>
+               </property>
+               <attribute name="buttonGroup">
+                <string notr="true">buttonGroupDisplayedFields</string>
+               </attribute>
+              </widget>
+             </item>
+             <item row="4" column="1">
+              <widget class="QCheckBox" name="checkBoxSize">
+               <property name="toolTip">
+                <string>Angular or physical size</string>
+               </property>
+               <property name="text">
+                <string>Size</string>
+               </property>
+               <attribute name="buttonGroup">
+                <string notr="true">buttonGroupDisplayedFields</string>
+               </attribute>
+              </widget>
+             </item>
+             <item row="3" column="1">
+              <widget class="QCheckBox" name="checkBoxType">
+               <property name="toolTip">
+                <string>The type of the object (star, planet, etc.)</string>
+               </property>
+               <property name="text">
+                <string>Type</string>
+               </property>
+               <attribute name="buttonGroup">
+                <string notr="true">buttonGroupDisplayedFields</string>
+               </attribute>
+              </widget>
+             </item>
+             <item row="2" column="1">
+              <widget class="QCheckBox" name="checkBoxAbsoluteMag">
+               <property name="text">
+                <string>Absolute magnitude</string>
+               </property>
+               <attribute name="buttonGroup">
+                <string notr="true">buttonGroupDisplayedFields</string>
+               </attribute>
+              </widget>
+             </item>
+             <item row="1" column="1">
               <widget class="QCheckBox" name="checkBoxVisualMag">
                <property name="text">
                 <string>Visual magnitude</string>
@@ -774,13 +764,40 @@
                </attribute>
               </widget>
              </item>
-             <item row="8" column="0">
+             <item row="0" column="1">
               <widget class="QCheckBox" name="checkBoxConstellation">
                <property name="toolTip">
                 <string>3-letter IAU constellation abbreviation</string>
                </property>
                <property name="text">
                 <string>Constellation</string>
+               </property>
+               <attribute name="buttonGroup">
+                <string notr="true">buttonGroupDisplayedFields</string>
+               </attribute>
+              </widget>
+             </item>
+             <item row="5" column="1">
+              <widget class="QCheckBox" name="checkBoxVelocity">
+               <property name="text">
+                <string>Velocity</string>
+               </property>
+              </widget>
+             </item>
+             <item row="6" column="1">
+              <widget class="QCheckBox" name="checkBoxDistance">
+               <property name="text">
+                <string>Distance</string>
+               </property>
+               <attribute name="buttonGroup">
+                <string notr="true">buttonGroupDisplayedFields</string>
+               </attribute>
+              </widget>
+             </item>
+             <item row="7" column="1">
+              <widget class="QCheckBox" name="checkBoxSiderealTime">
+               <property name="text">
+                <string>Sidereal time</string>
                </property>
                <attribute name="buttonGroup">
                 <string notr="true">buttonGroupDisplayedFields</string>
@@ -794,16 +811,6 @@
                </property>
                <property name="text">
                 <string>Additional information</string>
-               </property>
-               <attribute name="buttonGroup">
-                <string notr="true">buttonGroupDisplayedFields</string>
-               </attribute>
-              </widget>
-             </item>
-             <item row="7" column="1">
-              <widget class="QCheckBox" name="checkBoxSiderealTime">
-               <property name="text">
-                <string>Sidereal time</string>
                </property>
                <attribute name="buttonGroup">
                 <string notr="true">buttonGroupDisplayedFields</string>
@@ -2102,16 +2109,9 @@
   <tabstop>saveSettingsAsDefaultPushButton</tabstop>
   <tabstop>restoreDefaultsButton</tabstop>
   <tabstop>checkBoxName</tabstop>
-  <tabstop>checkBoxVisualMag</tabstop>
   <tabstop>checkBoxCatalogNumbers</tabstop>
-  <tabstop>checkBoxAbsoluteMag</tabstop>
   <tabstop>checkBoxRaDecJ2000</tabstop>
-  <tabstop>checkBoxGalacticCoordinates</tabstop>
-  <tabstop>checkBoxSupergalacticCoordinates</tabstop>
   <tabstop>checkBoxRaDecOfDate</tabstop>
-  <tabstop>checkBoxSize</tabstop>
-  <tabstop>checkBoxDistance</tabstop>
-  <tabstop>checkBoxType</tabstop>
   <tabstop>checkBoxEclipticCoordsJ2000</tabstop>
   <tabstop>checkBoxEclipticCoordsOfDate</tabstop>
   <tabstop>enableKeysNavigationCheckBox</tabstop>


### PR DESCRIPTION
IMPORTED FROM: https://code.launchpad.net/~stellarium/stellarium/gz_planetSpeed/+merge/333965

--------
@gzotti 

This branch is actually just one commit. I re-activated the velocity computations from the various ephemerides and added an eclipticalVelocity field to the Planet class. We will require velocity for aberration correction which will follow in another branch past 0.17.0, so this re-discovery is a first step.

The current solution requires a few copying operations from a local six-element "buffer" array to the object's Vec3ds. Not sure if this could be simplified in any way. Any ideas from the C++ gurus? Store a 6-array and just use Vec3d in the get/set methods? But then those need the copying.

I don't have velocities in our lunar ELP82 and in the EllipticalOrbit class, so these objects (our Moon and small moons of outer planets) currently only deliver zero speed. The latter class could be entirely removed IMHO, and CometOrbit could take over as "KeplerOrbit" class, solving the 2-body problem with either orbital elements or state vector (JDE&position&speed). This could allow interplanetary spaceflight or "orbital observers with propulsion control", but needs again a larger change in the ssystem_*.ini files, so will come only after 0.17.