### PR TITLE
Include sys/socket.h for AF_INET

### DIFF
--- a/src/external/libindi/libs/indibase/baseclient.cpp
+++ b/src/external/libindi/libs/indibase/baseclient.cpp
@@ -42,6 +42,7 @@
 #include <netdb.h>
 #include <unistd.h>
 #include <sys/types.h>
+#include <sys/socket.h>
 #include <netinet/in.h>
 #define net_read read
 #define net_write write


### PR DESCRIPTION
OpenBSD needs this header otherwise build will fail with
undeclared identifiers (AF_INET, SOL_SOCKET, etc).