### PR TITLE
A revision of Czech skyculture translations.

### DIFF
--- a/po/stellarium-skycultures/cs.po
+++ b/po/stellarium-skycultures/cs.po
@@ -8263,7 +8263,7 @@ msgstr "Kříž"
 #: skycultures/chinese/constellation_names.eng.fab:214
 #: skycultures/chinese/star_names.fab:3125
 msgid "Excrement"
-msgstr "Výkal";
+msgstr "Výkal"
 
 #: skycultures/chinese/constellation_names.eng.fab:215
 msgid "Municipal Office"

--- a/po/stellarium-skycultures/cs.po
+++ b/po/stellarium-skycultures/cs.po
@@ -91,7 +91,7 @@ msgstr "Deimos"
 #: skycultures/translations.fab:48
 msgctxt "moon"
 msgid "Phobos"
-msgstr "Phobos"
+msgstr "Fobos"
 
 #. TRANSLATORS: Moon of Jupiter (JI)
 #. TRANSLATORS: https://en.wikipedia.org/wiki/Io_(moon)
@@ -119,7 +119,7 @@ msgstr "Ganymed"
 #: skycultures/translations.fab:62
 msgctxt "moon"
 msgid "Callisto"
-msgstr "Callisto"
+msgstr "Kallisto"
 
 #. TRANSLATORS: Moon of Jupiter (JV)
 #. TRANSLATORS: https://en.wikipedia.org/wiki/Amalthea_(moon)
@@ -1073,13 +1073,13 @@ msgstr ""
 #: skycultures/translations.fab:493
 msgctxt "comet"
 msgid "Great Comet of 1680 (C/1680 V1)"
-msgstr ""
+msgstr "Velká kometa roku 1680 (C/1680 V1)"
 
 #. TRANSLATORS: Name of supernova SN 1572A
 #. TRANSLATORS: https://en.wikipedia.org/wiki/SN_1572
 #: skycultures/translations.fab:504
 msgid "Tycho's Supernova"
-msgstr "Tychova supernova"
+msgstr "Tychonova supernova"
 
 #. TRANSLATORS: Name of supernova SN 1604A
 #. TRANSLATORS: https://en.wikipedia.org/wiki/Kepler%27s_Supernova
@@ -1825,7 +1825,7 @@ msgstr ""
 
 #: nebulae/default/names.dat:43
 msgid "String of Pearls"
-msgstr ""
+msgstr "Řetízek perel"
 
 #: nebulae/default/names.dat:44 nebulae/default/names.dat:45
 #: nebulae/default/names.dat:46 nebulae/default/names.dat:47
@@ -1838,7 +1838,7 @@ msgstr "47 Tuc"
 
 #: nebulae/default/names.dat:49
 msgid "NGC 128 group"
-msgstr ""
+msgstr "Skupina NGC 128"
 
 #: nebulae/default/names.dat:50
 msgid "Giant Squid Galaxy"
@@ -1854,15 +1854,15 @@ msgstr ""
 
 #: nebulae/default/names.dat:53
 msgid "Andromeda Galaxy"
-msgstr "Galaxie Andromeda"
+msgstr "Galaxie v Andromedě"
 
 #: nebulae/default/names.dat:54
 msgid "Andromeda Nebula"
-msgstr ""
+msgstr "Mlhovina v Andromedě"
 
 #: nebulae/default/names.dat:55
 msgid "Great Nebula in Andromeda"
-msgstr ""
+msgstr "Velká mlhovina v Andromedě"
 
 #: nebulae/default/names.dat:56
 msgid "Sailboat Cluster"
@@ -1890,7 +1890,7 @@ msgstr ""
 
 #: nebulae/default/names.dat:62
 msgid "Sculptor Galaxy"
-msgstr "Galaxie Sochař"
+msgstr "Galaxie v Sochaři"
 
 #: nebulae/default/names.dat:63
 msgid "Silver Coin Galaxy"
@@ -1938,7 +1938,7 @@ msgstr ""
 
 #: nebulae/default/names.dat:74
 msgid "Mirach's Ghost"
-msgstr "Mirachův duch"
+msgstr "Duch Mirachu"
 
 #: nebulae/default/names.dat:75
 msgid "Lost Pearl Galaxy"
@@ -1954,7 +1954,7 @@ msgstr ""
 
 #: nebulae/default/names.dat:78
 msgid "Owl Cluster"
-msgstr ""
+msgstr "Hvězdokupa Sova"
 
 #: nebulae/default/names.dat:79
 msgid "E.T. Cluster"
@@ -1991,7 +1991,7 @@ msgstr ""
 
 #: nebulae/default/names.dat:87 nebulae/default/names.dat:91
 msgid "Little Dumbbell Nebula"
-msgstr ""
+msgstr "Mlhovina Malá činka"
 
 #: nebulae/default/names.dat:88
 msgid "Cork Nebula"
@@ -2216,7 +2216,7 @@ msgstr "Struveho ztracená mlhovina"
 
 #: nebulae/default/names.dat:146
 msgid "Struve's Nebula"
-msgstr ""
+msgstr "Struveho mlhovina"
 
 #: nebulae/default/names.dat:147 nebulae/default/names.dat:148
 msgid "Hind's Variable Nebula"
@@ -2290,11 +2290,11 @@ msgstr ""
 
 #: nebulae/default/names.dat:170
 msgid "Great Orion Nebula"
-msgstr ""
+msgstr "Velká mlhovina v Orionu"
 
 #: nebulae/default/names.dat:171
 msgid "Orion Nebula"
-msgstr "Mlhovina Oriona"
+msgstr "Mlhovina v Orionu"
 
 #: nebulae/default/names.dat:172
 msgid "Orion A"
@@ -2386,7 +2386,7 @@ msgstr ""
 
 #: nebulae/default/names.dat:195
 msgid "Tarantula Nebula"
-msgstr ""
+msgstr "Mlhovina Tarantule"
 
 #: nebulae/default/names.dat:196
 msgid "Great Looped Nebula"
@@ -2488,7 +2488,7 @@ msgstr "Hvězdokupa Vánoční stromeček"
 
 #: nebulae/default/names.dat:224 nebulae/default/names.dat:879
 msgid "Cone Nebula"
-msgstr ""
+msgstr "Kuželová mlhovina"
 
 #: nebulae/default/names.dat:225
 msgid "Head Hunter Cluster"
@@ -2528,7 +2528,7 @@ msgstr ""
 
 #: nebulae/default/names.dat:236
 msgid "Hourglass Planetary Nebula"
-msgstr ""
+msgstr "Mlhovina Přesýpací hodiny"
 
 #: nebulae/default/names.dat:237
 msgid "Crimson Butterfly Nebula"
@@ -2712,7 +2712,7 @@ msgstr "Polarissima Australis"
 
 #: nebulae/default/names.dat:284
 msgid "Praesepe"
-msgstr "Praesepe"
+msgstr "Jesličky"
 
 #: nebulae/default/names.dat:285
 msgid "Manger"
@@ -2720,7 +2720,7 @@ msgstr ""
 
 #: nebulae/default/names.dat:286
 msgid "Golden-Eye Cluster"
-msgstr ""
+msgstr "Hvězdokupa Zlaté oko"
 
 #: nebulae/default/names.dat:287
 msgid "Pac-Man Cluster"
@@ -2745,7 +2745,7 @@ msgstr ""
 #: nebulae/default/names.dat:292 nebulae/default/names.dat:308
 #: nebulae/default/names.dat:483
 msgid "Spindle Galaxy"
-msgstr "Galaxie hřídele"
+msgstr "Vřetenová galaxie"
 
 #: nebulae/default/names.dat:293
 msgid "Pencil Nebula"
@@ -2753,7 +2753,7 @@ msgstr ""
 
 #: nebulae/default/names.dat:294
 msgid "Herschel's Ray Nebula"
-msgstr ""
+msgstr "Mlhovina Herschelův paprsek"
 
 #: nebulae/default/names.dat:295
 msgid "NGC 2769 Group"
@@ -2765,11 +2765,11 @@ msgstr "Továrna na supernovy"
 
 #: nebulae/default/names.dat:297
 msgid "Tiger's Eye Galaxy"
-msgstr ""
+msgstr "Galaxie Tygří oko"
 
 #: nebulae/default/names.dat:298
 msgid "The Penguin Galaxy"
-msgstr ""
+msgstr "Galaxie Tučňák"
 
 #: nebulae/default/names.dat:299
 msgid "The Egg Galaxy"
@@ -2781,7 +2781,7 @@ msgstr "Bodeho galaxie"
 
 #: nebulae/default/names.dat:301 nebulae/default/names.dat:305
 msgid "Bode's Nebula"
-msgstr ""
+msgstr "Bodeho mlhovina"
 
 #: nebulae/default/names.dat:302
 msgid "The Great Spiral"
@@ -2789,7 +2789,7 @@ msgstr ""
 
 #: nebulae/default/names.dat:303
 msgid "Cigar Galaxy"
-msgstr "Galaxie doutníku"
+msgstr "Doutníková galaxie"
 
 #: nebulae/default/names.dat:304
 msgid "Ursa Major A"
@@ -2805,7 +2805,7 @@ msgstr ""
 
 #: nebulae/default/names.dat:309
 msgid "Spindle Nebula"
-msgstr ""
+msgstr "Vřetenová mlhovina"
 
 #: nebulae/default/names.dat:310
 msgid "Eight-Burst Planetary Nebula"
@@ -2830,7 +2830,7 @@ msgstr ""
 #: nebulae/default/names.dat:315 nebulae/default/names.dat:316
 #: nebulae/default/names.dat:318 nebulae/default/names.dat:319
 msgid "Leo Quartet"
-msgstr ""
+msgstr "Kvartet ve Lvu"
 
 #: nebulae/default/names.dat:317
 msgid "NGC 3190 Group"
@@ -2842,11 +2842,11 @@ msgstr ""
 
 #: nebulae/default/names.dat:321
 msgid "Ghost of Jupiter Nebula"
-msgstr ""
+msgstr "Mlhovina Duch Jupiteru"
 
 #: nebulae/default/names.dat:322
 msgid "Eye Nebula"
-msgstr ""
+msgstr "Mlhovina Oko"
 
 #: nebulae/default/names.dat:323
 msgid "Gem Cluster"
@@ -2862,7 +2862,7 @@ msgstr ""
 
 #: nebulae/default/names.dat:326 nebulae/default/names.dat:331
 msgid "Keyhole Nebula"
-msgstr ""
+msgstr "Mlhovina Klíčová dírka"
 
 #: nebulae/default/names.dat:327
 msgid "The Gabriela Mistral Nebula"
@@ -2914,7 +2914,7 @@ msgstr "Ambartsumianův uzel"
 
 #: nebulae/default/names.dat:340
 msgid "The Guitar"
-msgstr ""
+msgstr "Kytara"
 
 #: nebulae/default/names.dat:341
 msgid "Statue of Liberty Nebula"
@@ -2935,7 +2935,7 @@ msgstr ""
 #: nebulae/default/names.dat:345 nebulae/default/names.dat:346
 #: nebulae/default/names.dat:348
 msgid "Leo Triplet"
-msgstr "Trojice v souhvězdí Lva"
+msgstr "Trojice ve Lvu"
 
 #: nebulae/default/names.dat:347
 msgid "Hamburger Galaxy"
@@ -2966,7 +2966,7 @@ msgstr ""
 
 #: nebulae/default/names.dat:360
 msgid "Blue planetary"
-msgstr "Modrá planetka"
+msgstr "Modrá planetárka"
 
 #: nebulae/default/names.dat:361
 msgid "The Southerner"
@@ -3080,7 +3080,7 @@ msgstr "Oči"
 
 #: nebulae/default/names.dat:395 nebulae/default/names.dat:397
 msgid "Copeland's Eyes"
-msgstr ""
+msgstr "Copelandovy oči"
 
 #: nebulae/default/names.dat:400
 msgid "Virgo Galaxy"
@@ -3092,11 +3092,11 @@ msgstr "Panna A"
 
 #: nebulae/default/names.dat:402
 msgid "Smoking gun"
-msgstr ""
+msgstr "Kouřící pistole"
 
 #: nebulae/default/names.dat:403 nebulae/default/names.dat:448
 msgid "Cocoon Galaxy"
-msgstr ""
+msgstr "Galaxie Zámotek"
 
 #: nebulae/default/names.dat:404
 msgid "Shapley-Ames 2"
@@ -3104,7 +3104,7 @@ msgstr ""
 
 #: nebulae/default/names.dat:405
 msgid "Lost Galaxy"
-msgstr ""
+msgstr "Ztracená galaxie"
 
 #: nebulae/default/names.dat:406
 msgid "Hairy Eyebrow Galaxy"
@@ -3112,7 +3112,7 @@ msgstr ""
 
 #: nebulae/default/names.dat:407
 msgid "The Lost Galaxy of Copeland"
-msgstr ""
+msgstr "Ztracená Copelandova galaxie"
 
 #: nebulae/default/names.dat:408
 msgid "Koi Fish Galaxy"
@@ -3120,15 +3120,15 @@ msgstr ""
 
 #: nebulae/default/names.dat:409
 msgid "Needle Galaxy"
-msgstr ""
+msgstr "Galaxie Jehla"
 
 #: nebulae/default/names.dat:410
 msgid "Berenice's Hair Clip"
-msgstr ""
+msgstr "Bereničina sponka"
 
 #: nebulae/default/names.dat:411
 msgid "Flying Saucer Galaxy"
-msgstr ""
+msgstr "Galaxie Létající talíř"
 
 #: nebulae/default/names.dat:412 nebulae/default/names.dat:414
 msgid "Siamese Twins"
@@ -3201,7 +3201,7 @@ msgstr "Supervětrná galaxie"
 
 #: nebulae/default/names.dat:432
 msgid "Mice Galaxies"
-msgstr ""
+msgstr "Galaxie Myši"
 
 #: nebulae/default/names.dat:433
 msgid "Vinyl LP Galaxy"
@@ -3221,7 +3221,7 @@ msgstr "Šperkovnice"
 
 #: nebulae/default/names.dat:437
 msgid "Herschel's Jewel Box"
-msgstr ""
+msgstr "Herschelova šperkovnice"
 
 #: nebulae/default/names.dat:438
 msgid "κ Cru Cluster"
@@ -3289,7 +3289,7 @@ msgstr ""
 
 #: nebulae/default/names.dat:455
 msgid "ω Cen Cluster"
-msgstr ""
+msgstr "Hvězdokupa ω Cen"
 
 #: nebulae/default/names.dat:456
 msgid "Spiral Planetary Nebula"
@@ -3445,7 +3445,7 @@ msgstr ""
 
 #: nebulae/default/names.dat:503
 msgid "Hercules Globular Cluster"
-msgstr ""
+msgstr "Kulová hvězdokupa v Herkulovi"
 
 #: nebulae/default/names.dat:504
 msgid "Great Hercules Cluster"
@@ -3457,7 +3457,7 @@ msgstr ""
 
 #: nebulae/default/names.dat:506
 msgid "Turtle Nebula"
-msgstr ""
+msgstr "Mlhovina Želva"
 
 #: nebulae/default/names.dat:507
 msgid "Prize Comet Globular Cluster"
@@ -3497,7 +3497,7 @@ msgstr "Čtvercová mlhovina"
 
 #: nebulae/default/names.dat:517
 msgid "Exclamation Mark Nebula"
-msgstr ""
+msgstr "Mlhovina Vykřičník"
 
 #: nebulae/default/names.dat:518
 msgid "Cat's Paw Nebula"
@@ -3521,7 +3521,7 @@ msgstr ""
 
 #: nebulae/default/names.dat:523
 msgid "Ghost of Mars Nebula"
-msgstr ""
+msgstr "Mlhovina Duch Marsu"
 
 #: nebulae/default/names.dat:524
 msgid "Tonantzintla 1"
@@ -3598,7 +3598,7 @@ msgstr ""
 
 #: nebulae/default/names.dat:545
 msgid "Cat's Eye Nebula"
-msgstr ""
+msgstr "Mlhovina Kočičí oko"
 
 #: nebulae/default/names.dat:546 nebulae/default/names.dat:671
 msgid "Sunflower Nebula"
@@ -3606,7 +3606,7 @@ msgstr ""
 
 #: nebulae/default/names.dat:547
 msgid "Snail Nebula"
-msgstr ""
+msgstr "Mlhovina Hlemýžď"
 
 #: nebulae/default/names.dat:550
 msgid "Blue Racquetball Nebula"
@@ -3642,7 +3642,7 @@ msgstr ""
 
 #: nebulae/default/names.dat:558
 msgid "Omega Nebula"
-msgstr ""
+msgstr "Mlhovina Omega"
 
 #: nebulae/default/names.dat:559
 msgid "Swan Nebula"
@@ -3758,7 +3758,7 @@ msgstr ""
 
 #: nebulae/default/names.dat:590
 msgid "Son of M76"
-msgstr ""
+msgstr "Syn M76"
 
 #: nebulae/default/names.dat:591 nebulae/default/names.dat:594
 msgid "Snowball Nebula"
@@ -3766,7 +3766,7 @@ msgstr ""
 
 #: nebulae/default/names.dat:592
 msgid "Ghost of the Moon Nebula"
-msgstr ""
+msgstr "Mlhovina Duch Měsíce"
 
 #: nebulae/default/names.dat:593
 msgid "Incredible Shrinking Nebula"
@@ -3806,7 +3806,7 @@ msgstr ""
 
 #: nebulae/default/names.dat:604
 msgid "Barnard's Galaxy"
-msgstr "Barnardova Galaxie"
+msgstr "Barnardova galaxie"
 
 #: nebulae/default/names.dat:605
 msgid "Hubble X"
@@ -3814,7 +3814,7 @@ msgstr ""
 
 #: nebulae/default/names.dat:606
 msgid "Blinking planetary"
-msgstr "Blikající planetka"
+msgstr "Blikající planetárka"
 
 #: nebulae/default/names.dat:607
 msgid "Poodle Cluster"
@@ -3934,7 +3934,7 @@ msgstr ""
 
 #: nebulae/default/names.dat:636
 msgid "Cirrus Nebula"
-msgstr ""
+msgstr "Mlhovina Řasy"
 
 #: nebulae/default/names.dat:637
 msgid "Witch's Broom Nebula"
@@ -3944,7 +3944,7 @@ msgstr ""
 #: nebulae/default/names.dat:643 nebulae/default/names.dat:645
 #: nebulae/default/names.dat:847
 msgid "Veil Nebula"
-msgstr "Mlhovina Koště čarodějnice"
+msgstr "Mlhovina Řasy"
 
 #: nebulae/default/names.dat:639
 msgid "Fleming's Triangular Wisp"
@@ -3968,7 +3968,7 @@ msgstr ""
 
 #: nebulae/default/names.dat:647
 msgid "North America Nebula"
-msgstr ""
+msgstr "Mlhovina Severní Amerika"
 
 #: nebulae/default/names.dat:648
 msgid "Fetus Nebula"
@@ -3980,11 +3980,11 @@ msgstr ""
 
 #: nebulae/default/names.dat:650
 msgid "Saturn Nebula"
-msgstr "Mlhovina Saturnu"
+msgstr "Mlhovina Saturn"
 
 #: nebulae/default/names.dat:651
 msgid "Iris Nebula"
-msgstr ""
+msgstr "Mlhovina Kosatec"
 
 #: nebulae/default/names.dat:652
 msgid "Cheeseburger Nebula"
@@ -3992,7 +3992,7 @@ msgstr ""
 
 #: nebulae/default/names.dat:653 nebulae/default/names.dat:837
 msgid "Burnham's Nebula"
-msgstr ""
+msgstr "Burnhamova mlhovina"
 
 #: nebulae/default/names.dat:654
 msgid "Pink Pillow Nebula"
@@ -4020,7 +4020,7 @@ msgstr ""
 
 #: nebulae/default/names.dat:660
 msgid "Jellyfish Cluster"
-msgstr ""
+msgstr "Mlhovina Chobotnice"
 
 #: nebulae/default/names.dat:661
 msgid "Small Cluster Nebula"
@@ -4110,7 +4110,7 @@ msgstr ""
 #: nebulae/default/names.dat:686 nebulae/default/names.dat:687
 #: nebulae/default/names.dat:689 nebulae/default/names.dat:691
 msgid "Grus Quartet"
-msgstr "Kvartet galaxií v Jeřábovi"
+msgstr "Kvartet v Jeřábovi"
 
 #: nebulae/default/names.dat:688 nebulae/default/names.dat:690
 #: nebulae/default/names.dat:692
@@ -4159,7 +4159,7 @@ msgstr ""
 
 #: nebulae/default/names.dat:704
 msgid "Crab Cluster"
-msgstr ""
+msgstr "Krabí hvězdokupa"
 
 #: nebulae/default/names.dat:705
 msgid "Screaming Skull Cluster"
@@ -4171,11 +4171,11 @@ msgstr ""
 
 #: nebulae/default/names.dat:707
 msgid "Bond's Galaxy"
-msgstr ""
+msgstr "Bondova galaxie"
 
 #: nebulae/default/names.dat:708
 msgid "The Little Sombrero Galaxy"
-msgstr ""
+msgstr "Galaxie Malé sombrero"
 
 #: nebulae/default/names.dat:709
 msgid "Electric Arc Galaxy"
@@ -4215,7 +4215,7 @@ msgstr ""
 
 #: nebulae/default/names.dat:719
 msgid "Spider Nebula"
-msgstr ""
+msgstr "Mlhovina Pavouk"
 
 #: nebulae/default/names.dat:720
 msgid "Spirograph Nebula"
@@ -4231,7 +4231,7 @@ msgstr ""
 
 #: nebulae/default/names.dat:723
 msgid "Jellyfish Nebula"
-msgstr ""
+msgstr "Mlhovina Chobotnice"
 
 #: nebulae/default/names.dat:724
 msgid "Gemini A"
@@ -4424,7 +4424,7 @@ msgstr ""
 
 #: nebulae/default/names.dat:774
 msgid "Southern Integral Sign"
-msgstr "Jižní znaménko integrálu"
+msgstr "Jižní integrál"
 
 #: nebulae/default/names.dat:777
 msgid "Hourglass Region"
@@ -4448,7 +4448,7 @@ msgstr "Plejády"
 
 #: nebulae/default/names.dat:782
 msgid "Seven Sisters"
-msgstr ""
+msgstr "Sedm sester"
 
 #: nebulae/default/names.dat:783
 msgid "Subaru"
@@ -4472,7 +4472,7 @@ msgstr ""
 
 #: nebulae/default/names.dat:788
 msgid "Coma Berenices Cluster"
-msgstr ""
+msgstr "Kupa ve Vlasech Bereniky"
 
 #: nebulae/default/names.dat:789
 msgid "Ariadne's Hair"
@@ -4496,7 +4496,7 @@ msgstr ""
 
 #: nebulae/default/names.dat:794
 msgid "Taurus Poniatovii Cluster"
-msgstr ""
+msgstr "Hvězdokupa Býk Poniatowského"
 
 #: nebulae/default/names.dat:795
 msgid "Taurus Dark Cloud Nebula"
@@ -4557,7 +4557,7 @@ msgstr "Hyády"
 
 #: nebulae/default/names.dat:818
 msgid "Coalsack Nebula"
-msgstr ""
+msgstr "Mlhovina Pytel uhlí"
 
 #: nebulae/default/names.dat:819
 msgid "Orion Cluster"
@@ -4597,7 +4597,7 @@ msgstr ""
 
 #: nebulae/default/names.dat:828
 msgid "Ursa Major Cluster"
-msgstr "Hvězdokupa ve Velké medvědici"
+msgstr "Kupa ve Velké medvědici"
 
 #: nebulae/default/names.dat:829
 msgid "Antares Cluster"
@@ -4605,7 +4605,7 @@ msgstr ""
 
 #: nebulae/default/names.dat:830
 msgid "Coathanger"
-msgstr ""
+msgstr "Pytel uhlí"
 
 #: nebulae/default/names.dat:831
 msgid "Al Sufi's Cluster"
@@ -4633,7 +4633,7 @@ msgstr ""
 
 #: nebulae/default/names.dat:838
 msgid "T Tauri Nebula"
-msgstr ""
+msgstr "Mlhovina T Tauri"
 
 #: nebulae/default/names.dat:839
 msgid "Orion Loop Nebula"
@@ -4645,11 +4645,11 @@ msgstr ""
 
 #: nebulae/default/names.dat:841
 msgid "Green Ring Nebula"
-msgstr "Mlhovina zelené oko"
+msgstr "Mlhovina Zelené oko"
 
 #: nebulae/default/names.dat:843
 msgid "Little Cocoon Nebula"
-msgstr ""
+msgstr "Mlhovina Malý zámotek"
 
 #: nebulae/default/names.dat:844
 msgid "Cygnus Star Cloud"
@@ -5119,7 +5119,7 @@ msgstr ""
 #: nebulae/default/names.dat:972 nebulae/default/names.dat:973
 #: nebulae/default/names.dat:974
 msgid "Zwicky's Triplet"
-msgstr ""
+msgstr "Zwickyho triplet"
 
 #: nebulae/default/names.dat:975
 msgid "Hercules A"
@@ -5135,7 +5135,7 @@ msgstr ""
 
 #: nebulae/default/names.dat:978
 msgid "Kowal's Object"
-msgstr ""
+msgstr "Kowalův objekt"
 
 #: nebulae/default/names.dat:979
 msgid "Aquarius Dwarf Galaxy"
@@ -5147,7 +5147,7 @@ msgstr ""
 
 #: nebulae/default/names.dat:981
 msgid "McLeish's Object"
-msgstr "Mcleishův objekt"
+msgstr "McLeishův objekt"
 
 #: nebulae/default/names.dat:982
 msgid "Shapley-Ames 6"
@@ -5548,7 +5548,7 @@ msgstr "Severní koruna"
 #: skycultures/arabic/constellation_names.eng.fab:19
 #: skycultures/romanian/constellation_names.eng.fab:18
 msgid "The Raven"
-msgstr "Havra"
+msgstr "Havran"
 
 #: skycultures/arabic/constellation_names.eng.fab:20
 msgid "The Great Cup"
@@ -5631,7 +5631,7 @@ msgstr "Jižní velryba"
 
 #: skycultures/arabic/constellation_names.eng.fab:39
 msgid "The Arrow"
-msgstr "Šip"
+msgstr "Šíp"
 
 #: skycultures/arabic/constellation_names.eng.fab:40
 #: skycultures/romanian/constellation_names.eng.fab:37
@@ -5654,7 +5654,7 @@ msgstr "Trojúhelník"
 
 #: skycultures/arabic/constellation_names.eng.fab:44
 msgid "The Greater Bear"
-msgstr "Větší mědvěd"
+msgstr "Větší medvěd"
 
 #: skycultures/arabic/constellation_names.eng.fab:45
 msgid "The Lesser Bear"
@@ -5678,7 +5678,7 @@ msgstr "Šelma"
 
 #: skycultures/arabic/star_names.fab:1
 msgid "Horse navel"
-msgstr "Pupík koně"
+msgstr "Pupek koně"
 
 #: skycultures/arabic/star_names.fab:2
 msgid "Tinted palm"
@@ -5710,11 +5710,11 @@ msgstr "Konec řeky"
 
 #: skycultures/arabic/star_names.fab:9
 msgid "Belly of Cetus"
-msgstr "Cetův pupík"
+msgstr "Pupek velryby"
 
 #: skycultures/arabic/star_names.fab:10
 msgid "The triangle - The first companionable"
-msgstr "Trojúhelník - První družná"
+msgstr "Trojúhelník - První z družiny"
 
 #: skycultures/arabic/star_names.fab:11
 msgid "The second sign"
@@ -5806,7 +5806,7 @@ msgstr "Stolička"
 
 #: skycultures/arabic/star_names.fab:34
 msgid "Heel of the Reins holder"
-msgstr "Pata držitele oteží"
+msgstr "Pata držitele otěží"
 
 #: skycultures/arabic/star_names.fab:35
 msgid "The camels quenching their thirst"
@@ -5850,7 +5850,7 @@ msgstr "Rameno obra"
 
 #: skycultures/arabic/star_names.fab:45
 msgid "Shoulder of Reins holder"
-msgstr "Rameno držitele oteží"
+msgstr "Rameno držitele otěží"
 
 #: skycultures/arabic/star_names.fab:46
 msgid "Forward foot"
@@ -5940,7 +5940,7 @@ msgstr "Severní osel"
 
 #: skycultures/arabic/star_names.fab:68
 msgid "Southern donkey"
-msgstr "JIžní osel"
+msgstr "Jižní osel"
 
 #: skycultures/arabic/star_names.fab:69
 msgid "The claw"
@@ -6044,7 +6044,7 @@ msgstr "Zátoka"
 
 #: skycultures/arabic/star_names.fab:94
 msgid "The lion Liver"
-msgstr "Játro lva"
+msgstr "Játra lva"
 
 #: skycultures/arabic/star_names.fab:95
 msgid "Vine-harvestress"
@@ -6194,7 +6194,7 @@ msgstr "Žihadlo"
 
 #: skycultures/arabic/star_names.fab:131
 msgid "Second one of the bier daughters"
-msgstr "Dráuhá z dcer már"
+msgstr "Druhá z dcer már"
 
 #: skycultures/arabic/star_names.fab:132
 msgid "The raised tail"
@@ -6294,7 +6294,7 @@ msgstr "Druhá šťastná hvězda vraha"
 
 #: skycultures/arabic/star_names.fab:157
 msgid "The breast - one of the cavalry's"
-msgstr "Prso - jeden z kavalerie"
+msgstr "Prso - jeden z kavalérie"
 
 #: skycultures/arabic/star_names.fab:158
 msgid "One of the sitting's"
@@ -6310,7 +6310,7 @@ msgstr "Ocas slepice"
 
 #: skycultures/arabic/star_names.fab:161
 msgid "The wing- one of the cavalry's"
-msgstr "Křídlo - jeden z kavalerie"
+msgstr "Křídlo - jeden z kavalérie"
 
 #: skycultures/arabic/star_names.fab:162
 msgid "One of swallower luck"
@@ -6318,7 +6318,7 @@ msgstr "Jeden ze štěstí polykače"
 
 #: skycultures/arabic/star_names.fab:163
 msgid "Part of the horse"
-msgstr "Čast koně"
+msgstr "Část koně"
 
 #: skycultures/arabic/star_names.fab:164
 msgid "The right forearm"
@@ -6330,7 +6330,7 @@ msgstr "Druhý z Alfirka"
 
 #: skycultures/arabic/star_names.fab:166
 msgid "One of the Luck of lucks"
-msgstr "Jedne ze štěstí všeho štěstí"
+msgstr "Jedno ze štěstí všeho štěstí"
 
 #: skycultures/arabic/star_names.fab:167
 msgid "One of the Nashira luck"
@@ -6398,7 +6398,7 @@ msgstr "Záda velkého koně"
 
 #: skycultures/arabic/star_names.fab:183
 msgid "Fourth one of Alkalaes"
-msgstr "Čtrtý z Alkalaes"
+msgstr "Čtvrtý z Alkalaes"
 
 #: skycultures/arabic/star_names.fab:184
 msgid "Third one of Alkalaes"
@@ -6458,7 +6458,7 @@ msgstr "Třetí ze sedících"
 
 #: skycultures/arabic/star_names.fab:198
 msgid "Second one of the cavalry's"
-msgstr "Druhý z kavalerie"
+msgstr "Druhý z kavalérie"
 
 #: skycultures/arabic/star_names.fab:199
 msgid "The shining"
@@ -6506,7 +6506,7 @@ msgstr "Druhý z andironu"
 
 #: skycultures/arabic/star_names.fab:210
 msgid "Third one of the andiron's"
-msgstr "Třet z andironu"
+msgstr "Třetí z andironu"
 
 #: skycultures/arabic/star_names.fab:211
 msgid "The forth incantation"
@@ -7495,7 +7495,7 @@ msgstr "Duchové"
 
 #: skycultures/chinese/constellation_names.eng.fab:8
 msgid "Winnowing Basket"
-msgstr "Prosívací košík"
+msgstr "Sklízecí koš"
 
 #: skycultures/chinese/constellation_names.eng.fab:9
 #: skycultures/japanese_moon_stations/constellation_names.eng.fab:2
@@ -7527,11 +7527,11 @@ msgstr "Okovy"
 
 #: skycultures/chinese/constellation_names.eng.fab:15
 msgid "Hairy Head"
-msgstr ""
+msgstr "Vlasatá hlava"
 
 #: skycultures/chinese/constellation_names.eng.fab:16
 msgid "Ox"
-msgstr "Vůl"
+msgstr "Býk"
 
 #: skycultures/chinese/constellation_names.eng.fab:17
 msgid "Girl"
@@ -7543,19 +7543,19 @@ msgstr "Ležení"
 
 #: skycultures/chinese/constellation_names.eng.fab:19
 msgid "Supreme Palace Right Wall"
-msgstr ""
+msgstr "Pravá zeď Vrchního paláce"
 
 #: skycultures/chinese/constellation_names.eng.fab:20
 msgid "Supreme Palace Left Wall"
-msgstr ""
+msgstr "Levá zeď Vrchního paláce"
 
 #: skycultures/chinese/constellation_names.eng.fab:21
 msgid "Heavenly Market Right Wall"
-msgstr ""
+msgstr "Pravá zeď Nebeského trhu"
 
 #: skycultures/chinese/constellation_names.eng.fab:22
 msgid "Heavenly Market Left Wall"
-msgstr ""
+msgstr "Levá zeď Nebeského trhu"
 
 #: skycultures/chinese/constellation_names.eng.fab:23
 msgid "Rooftop"
@@ -7600,31 +7600,31 @@ msgstr "Válečný vůz"
 
 #: skycultures/chinese/constellation_names.eng.fab:32
 msgid "Purple Forbidden Right Wall"
-msgstr ""
+msgstr "Pravá zeď Zakázaného města"
 
 #: skycultures/chinese/constellation_names.eng.fab:33
 msgid "Purple Forbidden Left Wall"
-msgstr ""
+msgstr "Levá zeď Zakázaného města"
 
 #: skycultures/chinese/constellation_names.eng.fab:34
 msgid "Turtle Beak"
-msgstr ""
+msgstr "Želví zobák"
 
 #: skycultures/chinese/constellation_names.eng.fab:35
 msgid "Eight Kinds of Crops"
-msgstr ""
+msgstr "Osm druhů plodin"
 
 #: skycultures/chinese/constellation_names.eng.fab:36
 msgid "Net for Catching Birds"
-msgstr ""
+msgstr "Síť pro chytání ptáků"
 
 #: skycultures/chinese/constellation_names.eng.fab:37
 msgid "Rotten Gourd"
-msgstr ""
+msgstr "Shnilá tykev"
 
 #: skycultures/chinese/constellation_names.eng.fab:38
 msgid "Decayed Mortar"
-msgstr ""
+msgstr "Rozpadlý moždíř"
 
 #: skycultures/chinese/constellation_names.eng.fab:39
 #: skycultures/korean/constellation_names.eng.fab:219
@@ -7637,12 +7637,12 @@ msgstr "Severní řeka"
 
 #: skycultures/chinese/constellation_names.eng.fab:41
 msgid "Northern Pole"
-msgstr ""
+msgstr "Severní pól"
 
 #: skycultures/chinese/constellation_names.eng.fab:42
 #: skycultures/chinese/star_names.fab:2212
 msgid "North Gate of the Military Camp"
-msgstr ""
+msgstr "Severní brána vojenského ležení"
 
 #: skycultures/chinese/constellation_names.eng.fab:43
 msgid "River Turtle"
@@ -7650,11 +7650,11 @@ msgstr "Říční želva"
 
 #: skycultures/chinese/constellation_names.eng.fab:44
 msgid "Persia"
-msgstr ""
+msgstr "Persie"
 
 #: skycultures/chinese/constellation_names.eng.fab:46
 msgid "Textile Ruler"
-msgstr ""
+msgstr "Krejčovský metr"
 
 #: skycultures/chinese/constellation_names.eng.fab:47
 msgid "Banner of Three Stars"
@@ -7673,57 +7673,57 @@ msgstr "Bič"
 
 #: skycultures/chinese/constellation_names.eng.fab:50
 msgid "Royal Guards"
-msgstr ""
+msgstr "Královské stráže"
 
 #: skycultures/chinese/constellation_names.eng.fab:51
 msgid "Big Yard for Chariots"
-msgstr ""
+msgstr "Velký dvůr pro vozy"
 
 #: skycultures/chinese/constellation_names.eng.fab:52
 msgid "Chariots and Cavalry"
-msgstr ""
+msgstr "Vozy a jízda"
 
 #: skycultures/chinese/constellation_names.eng.fab:53
 msgid "Commodity Market"
-msgstr ""
+msgstr "Trh se zbožím"
 
 #: skycultures/chinese/constellation_names.eng.fab:54
 msgid "Hay"
-msgstr ""
+msgstr "Seno"
 
 #: skycultures/chinese/constellation_names.eng.fab:55
 msgid "Pestle (In Winnowing Basket Mansion)"
-msgstr ""
+msgstr "Palička (v dómu Sklízecího koše)"
 
 #: skycultures/chinese/constellation_names.eng.fab:56
 msgid "Pestle (In Rooftop Mansion)"
-msgstr ""
+msgstr "Palička (v dómu Střechy)"
 
 #: skycultures/chinese/constellation_names.eng.fab:57
 msgid "Changsha (Vassal of Chariot)"
-msgstr ""
+msgstr "Changsha (podřízená Vozu)"
 
 #: skycultures/chinese/constellation_names.eng.fab:58
 msgid "Guest House"
-msgstr ""
+msgstr "Dům pro hosty"
 
 #: skycultures/chinese/constellation_names.eng.fab:59
 msgid "Retinue (In Room Mansion)"
-msgstr ""
+msgstr "Dvořané (v dómu Místnosti)"
 
 #: skycultures/chinese/constellation_names.eng.fab:60
 #: skycultures/chinese/star_names.fab:458
 msgid "Retinue (In Supreme Palace Enclosure)"
-msgstr ""
+msgstr "Dvořané (ve Vrchním paláci)"
 
 #: skycultures/chinese/constellation_names.eng.fab:61
 #: skycultures/chinese/star_names.fab:1117
 msgid "Great Horn"
-msgstr ""
+msgstr "Velký roh"
 
 #: skycultures/chinese/constellation_names.eng.fab:62
 msgid "Chief Judge"
-msgstr ""
+msgstr "Vrchní soudce"
 
 #: skycultures/chinese/constellation_names.eng.fab:63
 #: skycultures/korean/constellation_names.eng.fab:116
@@ -7732,16 +7732,16 @@ msgstr "Mauzoleum"
 
 #: skycultures/chinese/constellation_names.eng.fab:64
 msgid "Celestial Temple"
-msgstr ""
+msgstr "Nebeský chrám"
 
 #: skycultures/chinese/constellation_names.eng.fab:66
 msgid "Mattress of the Emperor"
-msgstr ""
+msgstr "Panovníkovo lože"
 
 #: skycultures/chinese/constellation_names.eng.fab:67
 #: skycultures/chinese/star_names.fab:674
 msgid "Emperor's Seat"
-msgstr ""
+msgstr "Panovníkův trůn"
 
 #: skycultures/chinese/constellation_names.eng.fab:68
 msgid "Eastern Door"
@@ -7749,23 +7749,23 @@ msgstr "Východní dveře"
 
 #: skycultures/chinese/constellation_names.eng.fab:69
 msgid "Dipper for Liquids"
-msgstr ""
+msgstr "Naběračka pro kapalné"
 
 #: skycultures/chinese/constellation_names.eng.fab:70
 msgid "Trials"
-msgstr ""
+msgstr "Soudy"
 
 #: skycultures/chinese/constellation_names.eng.fab:71
 msgid "Send Armed Forces To Suppress (Vassal of Three Stars)"
-msgstr ""
+msgstr "Ozbrojené síly poslané potlačit (podřízené Třem hvězdám)"
 
 #: skycultures/chinese/constellation_names.eng.fab:72
 msgid "Punishment"
-msgstr ""
+msgstr "Trest"
 
 #: skycultures/chinese/constellation_names.eng.fab:73
 msgid "Flying Fish"
-msgstr ""
+msgstr "Létající ryba"
 
 #: skycultures/chinese/constellation_names.eng.fab:75
 msgid "Tomb (Vassal of Rooftop)"
@@ -7773,37 +7773,37 @@ msgstr ""
 
 #: skycultures/chinese/constellation_names.eng.fab:76
 msgid "Axe"
-msgstr ""
+msgstr "Sekyra"
 
 #: skycultures/chinese/constellation_names.eng.fab:77
 msgid "Sickle"
-msgstr ""
+msgstr "Srp"
 
 #: skycultures/chinese/constellation_names.eng.fab:78
 msgid "Basket for Mulberry Leaves"
-msgstr ""
+msgstr "Koš morušových listů"
 
 #: skycultures/chinese/constellation_names.eng.fab:79
 msgid "White Patched Nearby"
-msgstr ""
+msgstr "Bílé záplaty poblíž"
 
 #: skycultures/chinese/constellation_names.eng.fab:81
 #: skycultures/chinese/star_names.fab:2385
 msgid "Auxiliary Road"
-msgstr ""
+msgstr "Pomocná cesta"
 
 #: skycultures/chinese/constellation_names.eng.fab:82
 #: skycultures/chinese/star_names.fab:1377
 msgid "Fu Yue"
-msgstr ""
+msgstr "Fu Yue"
 
 #: skycultures/chinese/constellation_names.eng.fab:83
 msgid "Roofing"
-msgstr ""
+msgstr "Krytina"
 
 #: skycultures/chinese/constellation_names.eng.fab:84
 msgid "Canopy Support (Vassal of Canopy of the Emperor)"
-msgstr ""
+msgstr "Podložka baldachýnu (podřízená Baldachýnu panovníka)"
 
 #: skycultures/chinese/constellation_names.eng.fab:85
 msgid "Flying Corridor"
@@ -7811,15 +7811,15 @@ msgstr "Letecký koridor"
 
 #: skycultures/chinese/constellation_names.eng.fab:86
 msgid "Celestial Lance"
-msgstr ""
+msgstr "Nebeské kopí"
 
 #: skycultures/chinese/constellation_names.eng.fab:87
 msgid "Curved Array"
-msgstr ""
+msgstr "Zvlněné pole"
 
 #: skycultures/chinese/constellation_names.eng.fab:88
 msgid "Lock (Vassal of Room)"
-msgstr ""
+msgstr "Zámek (podřízený Místnosti)"
 
 #: skycultures/chinese/constellation_names.eng.fab:89
 #: skycultures/korean/constellation_names.eng.fab:47
@@ -7828,7 +7828,7 @@ msgstr "Pes"
 
 #: skycultures/chinese/constellation_names.eng.fab:90
 msgid "Territory of Dog"
-msgstr ""
+msgstr "Území psa"
 
 #: skycultures/chinese/constellation_names.eng.fab:91
 msgid "Coiled Thong"
@@ -7836,97 +7836,97 @@ msgstr "Svinutý řemen"
 
 #: skycultures/chinese/constellation_names.eng.fab:92
 msgid "Beacon Fire"
-msgstr ""
+msgstr "Oheň majáku"
 
 #: skycultures/chinese/constellation_names.eng.fab:93
 #: skycultures/tukano/constellation_names.eng.fab:10
 msgid "Tortoise"
-msgstr ""
+msgstr "Želva"
 
 #: skycultures/chinese/constellation_names.eng.fab:94
 msgid "Sea and Mountain"
-msgstr ""
+msgstr "Moře a hory"
 
 #: skycultures/chinese/constellation_names.eng.fab:96
 msgid "Sea Rock"
-msgstr ""
+msgstr "Skála v moři"
 
 #: skycultures/chinese/constellation_names.eng.fab:98
 msgid "Military Gate"
-msgstr ""
+msgstr "Vojenská brána"
 
 #: skycultures/chinese/constellation_names.eng.fab:100
 msgid "Drum at the River"
-msgstr ""
+msgstr "Buben na řece"
 
 #: skycultures/chinese/constellation_names.eng.fab:101
 msgid "Crane"
-msgstr ""
+msgstr "Jeřáb"
 
 #: skycultures/chinese/constellation_names.eng.fab:103
 msgid "Railings"
-msgstr ""
+msgstr "Zábradlí"
 
 #: skycultures/chinese/constellation_names.eng.fab:104
 #: skycultures/chinese/star_names.fab:677
 msgid "Astrologer"
-msgstr ""
+msgstr "Astrolog"
 
 #: skycultures/chinese/constellation_names.eng.fab:105
 msgid "Bow and Arrow"
-msgstr ""
+msgstr "Luk a šíp"
 
 #: skycultures/chinese/constellation_names.eng.fab:106
 msgid "Dipper for Solids"
-msgstr ""
+msgstr "Naběračka pro pevné"
 
 #: skycultures/chinese/constellation_names.eng.fab:107
 #: skycultures/chinese/star_names.fab:609
 msgid "Emperor's Bodyguard"
-msgstr ""
+msgstr "Císařova osobní stráž"
 
 #: skycultures/chinese/constellation_names.eng.fab:108
 msgid "Good Gourd"
-msgstr "Zdravá tykev"
+msgstr "Dobrá tykev"
 
 #: skycultures/chinese/constellation_names.eng.fab:109
 msgid "Canopy of the Emperor"
-msgstr ""
+msgstr "Baldachýn panovníka"
 
 #: skycultures/chinese/constellation_names.eng.fab:110
 msgid "Eunuch Official"
-msgstr ""
+msgstr "Úředník eunuchů"
 
 #: skycultures/chinese/constellation_names.eng.fab:111
 msgid "Firebird"
-msgstr ""
+msgstr "Ohnivák"
 
 #: skycultures/chinese/constellation_names.eng.fab:113
 #: skycultures/chinese/dso_names.fab:2
 msgid "Cumulative Corpses"
-msgstr ""
+msgstr "Hrobka"
 
 #: skycultures/chinese/constellation_names.eng.fab:114
 #: skycultures/chinese/star_names.fab:2592
 msgid "Heap of Corpses"
-msgstr ""
+msgstr "Kupa mrtvol"
 
 #: skycultures/chinese/constellation_names.eng.fab:115
 msgid "Stored water"
-msgstr ""
+msgstr "Uchovaná voda"
 
 #: skycultures/chinese/constellation_names.eng.fab:116
 #: skycultures/chinese/star_names.fab:3216
 msgid "Pile of Firewood"
-msgstr ""
+msgstr "Dřevěná hranice"
 
 #: skycultures/chinese/constellation_names.eng.fab:117
 msgid "Group of Soldiers"
-msgstr ""
+msgstr "Skupina vojáků"
 
 #: skycultures/chinese/constellation_names.eng.fab:118
 msgid "White Patches Attached"
-msgstr ""
+msgstr "Bílé záplaty připojené"
 
 #: skycultures/chinese/constellation_names.eng.fab:120
 msgid "Establishment"
@@ -7934,46 +7934,46 @@ msgstr "Sídlo"
 
 #: skycultures/chinese/constellation_names.eng.fab:121
 msgid "Clepsydra Terrace"
-msgstr ""
+msgstr "Terasa s Klepsydrami"
 
 #: skycultures/chinese/constellation_names.eng.fab:122
 #: skycultures/chinese/star_names.fab:1285
 msgid "Door Bolt"
-msgstr ""
+msgstr "Petlice"
 
 #: skycultures/chinese/constellation_names.eng.fab:123
 msgid "Goldfish"
-msgstr ""
+msgstr "Zlatá rybka"
 
 #: skycultures/chinese/constellation_names.eng.fab:125
 #: skycultures/chinese/star_names.fab:1027
 msgid "Recommending Virtuous Men"
-msgstr ""
+msgstr "Doporučující čestný muž"
 
 #: skycultures/chinese/constellation_names.eng.fab:126
 #: skycultures/chinese/star_names.fab:3213
 msgid "Accumulated Water"
-msgstr ""
+msgstr "Nahromaděná voda"
 
 #: skycultures/chinese/constellation_names.eng.fab:127
 msgid "Nine Water Wells"
-msgstr ""
+msgstr "Devět vodních studní"
 
 #: skycultures/chinese/constellation_names.eng.fab:129
 msgid "Nine Senior Officers"
-msgstr ""
+msgstr "Devět starších důstojníků"
 
 #: skycultures/chinese/constellation_names.eng.fab:130
 msgid "Imperial Military Flag"
-msgstr ""
+msgstr "Císařská váleční vlajka"
 
 #: skycultures/chinese/constellation_names.eng.fab:131
 msgid "Interpreters of Nine Dialects"
-msgstr ""
+msgstr "Vykladači devíti nářečí"
 
 #: skycultures/chinese/constellation_names.eng.fab:132
 msgid "Banner of Wine Shop"
-msgstr ""
+msgstr "Tabule obchodu s vínem"
 
 #: skycultures/chinese/constellation_names.eng.fab:133
 #: skycultures/korean/constellation_names.eng.fab:80
@@ -7987,16 +7987,16 @@ msgstr "Svinutý jazyk"
 
 #: skycultures/chinese/constellation_names.eng.fab:135
 msgid "Military Well"
-msgstr ""
+msgstr "Vojenská studna"
 
 #: skycultures/chinese/constellation_names.eng.fab:136
 #: skycultures/chinese/star_names.fab:2388
 msgid "Southern Military Gate"
-msgstr ""
+msgstr "Jižní vojenská brána"
 
 #: skycultures/chinese/constellation_names.eng.fab:137
 msgid "Market for Soldiers"
-msgstr ""
+msgstr "Trh pro vojáky"
 
 #: skycultures/chinese/constellation_names.eng.fab:138
 #: skycultures/chinese/star_names.fab:1395
@@ -8006,15 +8006,15 @@ msgstr "Plevy"
 
 #: skycultures/chinese/constellation_names.eng.fab:139
 msgid "Boats and Lake"
-msgstr ""
+msgstr "Lodě a jezero"
 
 #: skycultures/chinese/constellation_names.eng.fab:140
 msgid "Peafowl"
-msgstr ""
+msgstr "Páv"
 
 #: skycultures/chinese/constellation_names.eng.fab:142
 msgid "Crying"
-msgstr ""
+msgstr "Plačící"
 
 #: skycultures/chinese/constellation_names.eng.fab:143
 msgid "Arsenal"
@@ -8023,11 +8023,11 @@ msgstr "Zbrojnice"
 #: skycultures/chinese/constellation_names.eng.fab:144
 #: skycultures/chinese/star_names.fab:543
 msgid "Captain of the Bodyguards"
-msgstr ""
+msgstr "Velitel tělesné stráže"
 
 #: skycultures/chinese/constellation_names.eng.fab:145
 msgid "Officers of the Imperial Guard"
-msgstr ""
+msgstr "Důstojníci císařské stráže"
 
 #: skycultures/chinese/constellation_names.eng.fab:146
 #: skycultures/chinese/star_names.fab:3323
@@ -8037,23 +8037,23 @@ msgstr "Stařec"
 
 #: skycultures/chinese/constellation_names.eng.fab:147
 msgid "Thunder and Lightning"
-msgstr ""
+msgstr "Hrom a blesk"
 
 #: skycultures/chinese/constellation_names.eng.fab:148
 msgid "Line of Ramparts"
-msgstr ""
+msgstr "Řada opevnění"
 
 #: skycultures/chinese/constellation_names.eng.fab:149
 msgid "Resting Palace (Vassal of Encampment)"
-msgstr ""
+msgstr "Odpočinkový palác (podřízený Ležení)"
 
 #: skycultures/chinese/constellation_names.eng.fab:150
 msgid "Jade Ornament on Ladies' Wear"
-msgstr ""
+msgstr "Nefritová ozdoba na oděvu ženy"
 
 #: skycultures/chinese/constellation_names.eng.fab:151
 msgid "Pearls on Ladies' Wear"
-msgstr ""
+msgstr "Perly na oděvu ženy"
 
 #: skycultures/chinese/constellation_names.eng.fab:152
 #: skycultures/korean/constellation_names.eng.fab:121
@@ -8062,39 +8062,39 @@ msgstr "Brousek"
 
 #: skycultures/chinese/constellation_names.eng.fab:153
 msgid "Jewel Market"
-msgstr ""
+msgstr "Trh s klenoty"
 
 #: skycultures/chinese/constellation_names.eng.fab:154
 msgid "Astronomical Observatory"
-msgstr ""
+msgstr "Astronomická observatoř"
 
 #: skycultures/chinese/constellation_names.eng.fab:155
 msgid "Six Jia"
-msgstr ""
+msgstr "Šest Jia"
 
 #: skycultures/chinese/constellation_names.eng.fab:156
 msgid "Network of Dykes"
-msgstr ""
+msgstr "Síť hrází"
 
 #: skycultures/chinese/constellation_names.eng.fab:157
 msgid "Horse's Abdomen"
-msgstr ""
+msgstr "Břicho koně"
 
 #: skycultures/chinese/constellation_names.eng.fab:159
 msgid "Horse's Tail"
-msgstr ""
+msgstr "Oháňka koně"
 
 #: skycultures/chinese/constellation_names.eng.fab:161
 msgid "Bee"
-msgstr ""
+msgstr "Včela"
 
 #: skycultures/chinese/constellation_names.eng.fab:163
 msgid "The Hall of Glory"
-msgstr ""
+msgstr "Síň slávy"
 
 #: skycultures/chinese/constellation_names.eng.fab:164
 msgid "Southern Boat"
-msgstr ""
+msgstr "Jižní loď"
 
 #: skycultures/chinese/constellation_names.eng.fab:166
 msgid "South River"
@@ -8102,11 +8102,11 @@ msgstr "Jižní řeka"
 
 #: skycultures/chinese/constellation_names.eng.fab:167
 msgid "Dongou"
-msgstr ""
+msgstr "Dongou"
 
 #: skycultures/chinese/constellation_names.eng.fab:169
 msgid "Southern Gate"
-msgstr ""
+msgstr "Jižní brána"
 
 #: skycultures/chinese/constellation_names.eng.fab:170
 #: skycultures/korean/constellation_names.eng.fab:224
@@ -8115,15 +8115,15 @@ msgstr "Vnitřní kuchyně"
 
 #: skycultures/chinese/constellation_names.eng.fab:171
 msgid "Inner Steps"
-msgstr ""
+msgstr "Vnitřní schody"
 
 #: skycultures/chinese/constellation_names.eng.fab:172
 msgid "High Judge"
-msgstr ""
+msgstr "Vysoký soudce"
 
 #: skycultures/chinese/constellation_names.eng.fab:173
 msgid "Inner Screen"
-msgstr ""
+msgstr "Vnitřní zástěna"
 
 #: skycultures/chinese/constellation_names.eng.fab:174
 msgid "Imperial Passageway"
@@ -8131,12 +8131,12 @@ msgstr "Císařská cesta"
 
 #: skycultures/chinese/constellation_names.eng.fab:175
 msgid "Bird's Beak"
-msgstr ""
+msgstr "Zobák ptáka"
 
 #: skycultures/chinese/constellation_names.eng.fab:177
 #: skycultures/chinese/star_names.fab:1505
 msgid "Peasant"
-msgstr ""
+msgstr "Rolník"
 
 #: skycultures/chinese/constellation_names.eng.fab:178
 msgid "Woman's Bed"
@@ -8145,7 +8145,7 @@ msgstr "Postel ženy"
 #: skycultures/chinese/constellation_names.eng.fab:179
 #: skycultures/chinese/star_names.fab:65
 msgid "Female Protocol"
-msgstr ""
+msgstr "Protokol ženy"
 
 #: skycultures/chinese/constellation_names.eng.fab:180
 msgid "Thunderbolt"
@@ -8153,11 +8153,11 @@ msgstr "Blesk"
 
 #: skycultures/chinese/constellation_names.eng.fab:181
 msgid "Judging"
-msgstr ""
+msgstr "Soud"
 
 #: skycultures/chinese/constellation_names.eng.fab:182
 msgid "Flat Road"
-msgstr ""
+msgstr "Rovná cesta"
 
 #: skycultures/chinese/constellation_names.eng.fab:183
 msgid "Screen"
@@ -8169,7 +8169,7 @@ msgstr "Sedm Excelencí"
 
 #: skycultures/chinese/constellation_names.eng.fab:185
 msgid "House for Musical Instruments"
-msgstr ""
+msgstr "Dům hudebních nástrojů"
 
 #: skycultures/chinese/constellation_names.eng.fab:187
 msgid "Imperial Guards"
@@ -8178,19 +8178,19 @@ msgstr "Císařské stráže"
 #: skycultures/chinese/constellation_names.eng.fab:188
 #: skycultures/chinese/star_names.fab:1264
 msgid "Chariots and Cavalry General"
-msgstr ""
+msgstr "Generál vozů a jízdy"
 
 #: skycultures/chinese/constellation_names.eng.fab:189
 msgid "Weeping"
-msgstr ""
+msgstr "Pláč"
 
 #: skycultures/chinese/constellation_names.eng.fab:190
 msgid "Celestial Cereals"
-msgstr ""
+msgstr "Nebeské obilí"
 
 #: skycultures/chinese/constellation_names.eng.fab:192
 msgid "Green Hill"
-msgstr ""
+msgstr "Zelený vrch"
 
 #: skycultures/chinese/constellation_names.eng.fab:193
 msgid "Palace Gate"
@@ -8198,20 +8198,20 @@ msgstr "Palácová brána"
 
 #: skycultures/chinese/constellation_names.eng.fab:194
 msgid "Humans"
-msgstr ""
+msgstr "Lidé"
 
 #: skycultures/chinese/constellation_names.eng.fab:195
 #: skycultures/chinese/star_names.fab:1311
 msgid "Solar Star"
-msgstr ""
+msgstr "Sluneční hvězda"
 
 #: skycultures/chinese/constellation_names.eng.fab:196
 msgid "Three Excellencies (In Supreme Palace Enclosure)"
-msgstr ""
+msgstr "Tři Excelence (ve Vrchním paláci)"
 
 #: skycultures/chinese/constellation_names.eng.fab:197
 msgid "Three Excellencies (In Purple Forbidden Enclosure)"
-msgstr ""
+msgstr "Tři Excelence (v Zakázaném městě)"
 
 #: skycultures/chinese/constellation_names.eng.fab:198
 #: skycultures/egyptian/constellation_names.eng.fab:8
@@ -8220,7 +8220,7 @@ msgstr "Trojúhelník"
 
 #: skycultures/chinese/constellation_names.eng.fab:200
 msgid "Three Top Instructors"
-msgstr ""
+msgstr "Tři hlavní učitelé"
 
 #: skycultures/chinese/constellation_names.eng.fab:201
 #: skycultures/korean/constellation_names.eng.fab:197
@@ -8229,45 +8229,45 @@ msgstr "Tři schody"
 
 #: skycultures/chinese/constellation_names.eng.fab:202
 msgid "Royal Secretary"
-msgstr ""
+msgstr "Králův sekretář"
 
 #: skycultures/chinese/constellation_names.eng.fab:203
 msgid "Junior Officers"
-msgstr ""
+msgstr "Nižší úředníci"
 
 #: skycultures/chinese/constellation_names.eng.fab:204
 msgid "Snake's Abdomen"
-msgstr ""
+msgstr "Břicho hada"
 
 #: skycultures/chinese/constellation_names.eng.fab:206
 msgid "Snake's Head"
-msgstr ""
+msgstr "Hlava hada"
 
 #: skycultures/chinese/constellation_names.eng.fab:208
 msgid "Snake's Tail"
-msgstr ""
+msgstr "Ocas hada"
 
 #: skycultures/chinese/constellation_names.eng.fab:210
 msgid "Changing Room (Vassal of Tail)"
-msgstr ""
+msgstr "Převlékací kabina (podřízená Ocasu)"
 
 #: skycultures/chinese/constellation_names.eng.fab:211
 msgid "Twelve States"
-msgstr ""
+msgstr "Dvanáct zemí"
 
 #: skycultures/chinese/constellation_names.eng.fab:212
 #: skycultures/macedonian/constellation_names.eng.fab:10
 msgid "Cross"
-msgstr ""
+msgstr "Kříž"
 
 #: skycultures/chinese/constellation_names.eng.fab:214
 #: skycultures/chinese/star_names.fab:3125
 msgid "Excrement"
-msgstr ""
+msgstr "Výkal";
 
 #: skycultures/chinese/constellation_names.eng.fab:215
 msgid "Municipal Office"
-msgstr ""
+msgstr "Městský úřad"
 
 #: skycultures/chinese/constellation_names.eng.fab:216
 #: skycultures/korean/constellation_names.eng.fab:262
@@ -8276,35 +8276,35 @@ msgstr "Kleštěnec"
 
 #: skycultures/chinese/constellation_names.eng.fab:217
 msgid "Official for Irrigation"
-msgstr ""
+msgstr "Úředník pro zavlažování"
 
 #: skycultures/chinese/constellation_names.eng.fab:218
 msgid "Crooked Running Water"
-msgstr ""
+msgstr "Klikatící se vodní tok"
 
 #: skycultures/chinese/constellation_names.eng.fab:220
 msgid "Water Level"
-msgstr ""
+msgstr "Hladina vody"
 
 #: skycultures/chinese/constellation_names.eng.fab:221
 msgid "Deified Judge of Right and Wrong"
-msgstr ""
+msgstr "Božský soudce dobra a zla"
 
 #: skycultures/chinese/constellation_names.eng.fab:222
 msgid "Deity in Charge of Monsters"
-msgstr ""
+msgstr "Božstvo ve službách monster"
 
 #: skycultures/chinese/constellation_names.eng.fab:223
 msgid "Deified Judge of Rank"
-msgstr ""
+msgstr "Božský soudce řádu"
 
 #: skycultures/chinese/constellation_names.eng.fab:224
 msgid "Deified Judge of Life"
-msgstr ""
+msgstr "Božský soudce života"
 
 #: skycultures/chinese/constellation_names.eng.fab:225
 msgid "Deified Judge of Disaster and Good Fortune"
-msgstr ""
+msgstr "Božský soudce pohrom a štěstí"
 
 #: skycultures/chinese/constellation_names.eng.fab:226
 msgid "Four Channels"
@@ -8312,21 +8312,21 @@ msgstr "Čtyři kanály"
 
 #: skycultures/chinese/constellation_names.eng.fab:227
 msgid "Four Advisors"
-msgstr ""
+msgstr "Čtyři rádci"
 
 #: skycultures/chinese/constellation_names.eng.fab:228
 msgid "Grandson"
-msgstr ""
+msgstr "Vnuk"
 
 #: skycultures/chinese/constellation_names.eng.fab:229
 #: skycultures/chinese/star_names.fab:280
 msgid "Guard of the Sun"
-msgstr ""
+msgstr "Stráž Slunce"
 
 #: skycultures/chinese/constellation_names.eng.fab:230
 #: skycultures/chinese/star_names.fab:202
 msgid "First Great One"
-msgstr ""
+msgstr "První Velký"
 
 #: skycultures/chinese/constellation_names.eng.fab:231
 #: skycultures/chinese/star_names.fab:6 skycultures/chinese/star_names.fab:455
@@ -8337,228 +8337,228 @@ msgstr "Korunní princ"
 #: skycultures/chinese/constellation_names.eng.fab:232
 #: skycultures/chinese/star_names.fab:284
 msgid "Royals"
-msgstr ""
+msgstr "Královská rodina"
 
 #: skycultures/chinese/constellation_names.eng.fab:233
 msgid "Flying Serpent"
-msgstr ""
+msgstr "Létající had"
 
 #: skycultures/chinese/constellation_names.eng.fab:234
 #: skycultures/chinese/star_names.fab:2686
 msgid "Celestial Concave"
-msgstr ""
+msgstr "Nebeská klenba"
 
 #: skycultures/chinese/constellation_names.eng.fab:235
 msgid "Celestial Flail"
-msgstr ""
+msgstr "Nebeský cep"
 
 #: skycultures/chinese/constellation_names.eng.fab:236
 msgid "Market Officer"
-msgstr "Úředník"
+msgstr "Obchodní úředník"
 
 #: skycultures/chinese/constellation_names.eng.fab:237
 msgid "Square Celestial Granary"
-msgstr ""
+msgstr "Čtvercový nebeský "
 
 #: skycultures/chinese/constellation_names.eng.fab:238
 #: skycultures/chinese/star_names.fab:2708
 msgid "Celestial Slander"
-msgstr ""
+msgstr "Nebeská pomluva"
 
 #: skycultures/chinese/constellation_names.eng.fab:239
 msgid "Celestial Kitchen"
-msgstr ""
+msgstr "Nebeská kuchyně"
 
 #: skycultures/chinese/constellation_names.eng.fab:240
 msgid "Celestial Boat"
-msgstr ""
+msgstr "Nebeská loď"
 
 #: skycultures/chinese/constellation_names.eng.fab:241
 msgid "Celestial Bed"
-msgstr ""
+msgstr "Nebeská postel"
 
 #: skycultures/chinese/constellation_names.eng.fab:242
 msgid "Great General of Heaven"
-msgstr ""
+msgstr "Velký generál nebes"
 
 #: skycultures/chinese/constellation_names.eng.fab:243
 msgid "Celestial Drumstick"
-msgstr ""
+msgstr "Nebeská palička"
 
 #: skycultures/chinese/constellation_names.eng.fab:244
 msgid "Celestial Spokes"
-msgstr ""
+msgstr "Nebeský výplet"
 
 #: skycultures/chinese/constellation_names.eng.fab:245
 #: skycultures/chinese/star_names.fab:2209
 msgid "Materials for Making Tents"
-msgstr ""
+msgstr "Látky pro výrobu stanů"
 
 #: skycultures/chinese/constellation_names.eng.fab:246
 msgid "Celestial High Terrace"
-msgstr ""
+msgstr "Nebeská vysoká terasa"
 
 #: skycultures/chinese/constellation_names.eng.fab:247
 msgid "Celestial Hook"
-msgstr ""
+msgstr "Nebeský hák"
 
 #: skycultures/chinese/constellation_names.eng.fab:248
 msgid "Celestial Dog"
-msgstr ""
+msgstr "Nebeský pes"
 
 #: skycultures/chinese/constellation_names.eng.fab:249
 #: skycultures/chinese/star_names.fab:2894
 msgid "Celestial Pass"
-msgstr ""
+msgstr "Nebeský průchod"
 
 #: skycultures/chinese/constellation_names.eng.fab:250
 #: skycultures/chinese/star_names.fab:43
 msgid "Great Emperor of Heaven"
-msgstr ""
+msgstr "Velký vládce nebes"
 
 #: skycultures/chinese/constellation_names.eng.fab:251
 msgid "Celestial Pier"
-msgstr ""
+msgstr "Nebeské molo"
 
 #: skycultures/chinese/constellation_names.eng.fab:252
 msgid "Celestial Pigsty"
-msgstr ""
+msgstr "Nebeský vepřín"
 
 #: skycultures/chinese/constellation_names.eng.fab:253
 msgid "Celestial Cock"
-msgstr ""
+msgstr "Nebeský kohout"
 
 #: skycultures/chinese/constellation_names.eng.fab:254
 #: skycultures/chinese/star_names.fab:3440
 msgid "Judge for Estimating the Age of Animals"
-msgstr ""
+msgstr "Soudce pro určování věku zvířat"
 
 #: skycultures/chinese/constellation_names.eng.fab:255
 msgid "Celestial Discipline"
-msgstr ""
+msgstr "Nebeská kázeň"
 
 #: skycultures/chinese/constellation_names.eng.fab:256
 msgid "Celestial River"
-msgstr ""
+msgstr "Nebeská řeka"
 
 #: skycultures/chinese/constellation_names.eng.fab:257
 msgid "Celestial Street"
-msgstr ""
+msgstr "Nebeská ulice"
 
 #: skycultures/chinese/constellation_names.eng.fab:258
 msgid "Celestial Tally"
-msgstr ""
+msgstr "Nebeská tabulka"
 
 #: skycultures/chinese/constellation_names.eng.fab:259
 msgid "Celestial Ford"
-msgstr ""
+msgstr "Nebeský brod"
 
 #: skycultures/chinese/constellation_names.eng.fab:260
 msgid "Celestial Stable"
-msgstr ""
+msgstr "Nebeský chlév"
 
 #: skycultures/chinese/constellation_names.eng.fab:261
 #: skycultures/chinese/star_names.fab:3297
 msgid "Celestial Wolf"
-msgstr ""
+msgstr "Nebeský vlk"
 
 #: skycultures/chinese/constellation_names.eng.fab:262
 msgid "Celestial Prison"
-msgstr ""
+msgstr "Nebeské vězení"
 
 #: skycultures/chinese/constellation_names.eng.fab:263
 msgid "Celestial Ramparts"
-msgstr ""
+msgstr "Nebeské hradby"
 
 #: skycultures/chinese/constellation_names.eng.fab:264
 msgid "Judge for Nobility"
-msgstr ""
+msgstr "Soudce pro šlechtu"
 
 #: skycultures/chinese/constellation_names.eng.fab:265
 msgid "Celestial Foodstuff"
-msgstr ""
+msgstr "Nebeská potrava"
 
 #: skycultures/chinese/constellation_names.eng.fab:266
 msgid "Celestial Gate"
-msgstr ""
+msgstr "Nebeská brána"
 
 #: skycultures/chinese/constellation_names.eng.fab:267
 msgid "Celestial Money"
-msgstr ""
+msgstr "Nebeské peníze"
 
 #: skycultures/chinese/constellation_names.eng.fab:268
 msgid "Celestial Spear"
-msgstr ""
+msgstr "Nebeské kopí"
 
 #: skycultures/chinese/constellation_names.eng.fab:269
 msgid "Circular Celestial Granary"
-msgstr ""
+msgstr "Kruhová nebeská sýpka"
 
 #: skycultures/chinese/constellation_names.eng.fab:270
 #: skycultures/chinese/star_names.fab:1228
 msgid "Celestial Milk"
-msgstr ""
+msgstr "Nebeské mléko"
 
 #: skycultures/chinese/constellation_names.eng.fab:271
 msgid "Celestial Earth God's Temple"
-msgstr ""
+msgstr "Nebeský chrám boha Země"
 
 #: skycultures/chinese/constellation_names.eng.fab:272
 msgid "Celestial Farmland (In Horn Mansion)"
-msgstr ""
+msgstr "Nebeské pole (v dómu Rohu)"
 
 #: skycultures/chinese/constellation_names.eng.fab:273
 msgid "Celestial Farmland (In Ox Mansion)"
-msgstr ""
+msgstr "Nebeské pole (v dómu Býka)"
 
 #: skycultures/chinese/constellation_names.eng.fab:274
 msgid "Celestial Premier"
-msgstr ""
+msgstr "Nebeský první ministr"
 
 #: skycultures/chinese/constellation_names.eng.fab:275
 #: skycultures/chinese/star_names.fab:199
 msgid "Celestial Great One"
-msgstr ""
+msgstr "Nebeský Velký"
 
 #: skycultures/chinese/constellation_names.eng.fab:276
 msgid "Celestial Yin Force"
-msgstr ""
+msgstr "Nebeská síla Jin"
 
 #: skycultures/chinese/constellation_names.eng.fab:277
 msgid "Ricks of Grain"
-msgstr ""
+msgstr "Kupky zrní"
 
 #: skycultures/chinese/constellation_names.eng.fab:279
 msgid "Celestial Spring"
-msgstr ""
+msgstr "Nebeský potok"
 
 #: skycultures/chinese/constellation_names.eng.fab:280
 msgid "Celestial Orchard"
-msgstr ""
+msgstr "Nebeský sad"
 
 #: skycultures/chinese/constellation_names.eng.fab:281
 msgid "Celestial Meadows"
-msgstr ""
+msgstr "Nebeská louka"
 
 #: skycultures/chinese/constellation_names.eng.fab:282
 msgid "Celestial Keyhole"
-msgstr ""
+msgstr "Nebeská klíčová dírka"
 
 #: skycultures/chinese/constellation_names.eng.fab:283
 msgid "Celestial Pillar"
-msgstr ""
+msgstr "Nebeský sloup"
 
 #: skycultures/chinese/constellation_names.eng.fab:284
 msgid "Celestial Wine Cup"
-msgstr ""
+msgstr "Hrnek nebeského vína"
 
 #: skycultures/chinese/constellation_names.eng.fab:285
 msgid "Butcher's Shops"
-msgstr ""
+msgstr "Řeznictví"
 
 #: skycultures/chinese/constellation_names.eng.fab:286
 msgid "Official for Earthworks and Buildings"
-msgstr ""
+msgstr "Úředník pro zemní práce a stavby"
 
 #: skycultures/chinese/constellation_names.eng.fab:287
 #: skycultures/korean/constellation_names.eng.fab:88
@@ -8568,7 +8568,7 @@ msgstr "Úředník pro materiální zásoby"
 #: skycultures/chinese/constellation_names.eng.fab:288
 #: skycultures/chinese/star_names.fab:2440
 msgid "Master of Constructions"
-msgstr ""
+msgstr "Vedoucí staveb"
 
 #: skycultures/chinese/constellation_names.eng.fab:289
 #: skycultures/korean/constellation_names.eng.fab:179
@@ -8581,15 +8581,15 @@ msgstr "Vnější oplocení"
 
 #: skycultures/chinese/constellation_names.eng.fab:291
 msgid "Wang Liang"
-msgstr ""
+msgstr "Wang Liang"
 
 #: skycultures/chinese/constellation_names.eng.fab:292
 msgid "Master of Constructions (In Legs Mansion)"
-msgstr ""
+msgstr "Vedoucí staveb (v dómu Nohou)"
 
 #: skycultures/chinese/constellation_names.eng.fab:294
 msgid "Administrative Center"
-msgstr ""
+msgstr "Úřední středisko"
 
 #: skycultures/chinese/constellation_names.eng.fab:295
 msgid "Five Chariots"
@@ -8597,15 +8597,15 @@ msgstr "Pět vozů"
 
 #: skycultures/chinese/constellation_names.eng.fab:296
 msgid "Interior Seats of the Five Emperors"
-msgstr ""
+msgstr "Vnitřní trůny pěti císařů"
 
 #: skycultures/chinese/constellation_names.eng.fab:297
 msgid "Seats of the Five Emperors"
-msgstr ""
+msgstr "Trůny pěti císařů"
 
 #: skycultures/chinese/constellation_names.eng.fab:298
 msgid "Five Feudal Kings"
-msgstr ""
+msgstr "Pět feudálních králů"
 
 #: skycultures/chinese/constellation_names.eng.fab:299
 #: skycultures/korean/constellation_names.eng.fab:159
@@ -8618,34 +8618,34 @@ msgstr "Západní dveře"
 
 #: skycultures/chinese/constellation_names.eng.fab:301
 msgid "Xi Zhong"
-msgstr ""
+msgstr "Xi Zhong"
 
 #: skycultures/chinese/constellation_names.eng.fab:302
 msgid "Pool of Harmony"
-msgstr ""
+msgstr "Studnice souladu"
 
 #: skycultures/chinese/constellation_names.eng.fab:303
 #: skycultures/chinese/star_names.fab:267
 msgid "Prime Minister"
-msgstr ""
+msgstr "První ministr"
 
 #: skycultures/chinese/constellation_names.eng.fab:304
 #: skycultures/western_rey/constellation_names.eng.fab:8
 msgid "Little Dipper"
-msgstr ""
+msgstr "Malá naběračka"
 
 #: skycultures/chinese/constellation_names.eng.fab:306
 #: skycultures/chinese/star_names.fab:461
 msgid "Officer of Honour"
-msgstr ""
+msgstr "Vyznamenaný důstojník"
 
 #: skycultures/chinese/constellation_names.eng.fab:307
 msgid "Temple"
-msgstr ""
+msgstr "Chrám"
 
 #: skycultures/chinese/constellation_names.eng.fab:308
 msgid "Xuanyuan"
-msgstr "Xuanyuan"
+msgstr "Žlutý úředník"
 
 #: skycultures/chinese/constellation_names.eng.fab:309
 #: skycultures/chinese/star_names.fab:258
@@ -8654,33 +8654,33 @@ msgstr ""
 
 #: skycultures/chinese/constellation_names.eng.fab:310
 msgid "Battle Axe (Vassal of Well)"
-msgstr ""
+msgstr "Bojová sekera (podřízená Studni)"
 
 #: skycultures/chinese/constellation_names.eng.fab:311
 msgid "Gate of Yang"
-msgstr ""
+msgstr "Brána Jang"
 
 #: skycultures/chinese/constellation_names.eng.fab:312
 #: skycultures/chinese/star_names.fab:3294
 msgid "Wild Cockerel"
-msgstr ""
+msgstr "Divoký kohoutek"
 
 #: skycultures/chinese/constellation_names.eng.fab:313
 #: skycultures/chinese/star_names.fab:667
 msgid "Usher to the Court"
-msgstr ""
+msgstr "Uvaděč k soudu"
 
 #: skycultures/chinese/constellation_names.eng.fab:314
 msgid "Exotic Bird"
-msgstr ""
+msgstr "Exotický pták"
 
 #: skycultures/chinese/constellation_names.eng.fab:316
 msgid "Hidden Virtue"
-msgstr ""
+msgstr "Skrytá ctnost"
 
 #: skycultures/chinese/constellation_names.eng.fab:317
 msgid "Official in Charge of Pasturing"
-msgstr ""
+msgstr "Úředník zodpovědný za pastviny"
 
 #: skycultures/chinese/constellation_names.eng.fab:318
 #: skycultures/korean/constellation_names.eng.fab:57
@@ -8689,7 +8689,7 @@ msgstr "Pravý prapor"
 
 #: skycultures/chinese/constellation_names.eng.fab:319
 msgid "Right Conductor"
-msgstr ""
+msgstr "Pravý průvodce"
 
 #: skycultures/chinese/constellation_names.eng.fab:320
 #: skycultures/chinese/dso_names.fab:6
@@ -8699,7 +8699,7 @@ msgstr "Ryba"
 
 #: skycultures/chinese/constellation_names.eng.fab:321
 msgid "Palace Guard"
-msgstr ""
+msgstr "Stráž paláce"
 
 #: skycultures/chinese/constellation_names.eng.fab:322
 msgid "Jade Well"
@@ -8708,20 +8708,20 @@ msgstr "Nefritová studna"
 #: skycultures/chinese/constellation_names.eng.fab:323
 #: skycultures/chinese/star_names.fab:3556
 msgid "Maids-in-waiting"
-msgstr ""
+msgstr "Čekající služebné"
 
 #: skycultures/chinese/constellation_names.eng.fab:324
 #: skycultures/chinese/star_names.fab:2689
 msgid "Lunar Star"
-msgstr ""
+msgstr "Měsíční hvězda"
 
 #: skycultures/chinese/constellation_names.eng.fab:325
 msgid "Whisper (Vassal of Net)"
-msgstr ""
+msgstr "Šepot (podřízený Síti)"
 
 #: skycultures/chinese/constellation_names.eng.fab:326
 msgid "Cloud and Rain"
-msgstr ""
+msgstr "Oblak a déšť"
 
 #: skycultures/chinese/constellation_names.eng.fab:327
 msgid "Zaofu"
@@ -8729,32 +8729,32 @@ msgstr "Zaofu"
 
 #: skycultures/chinese/constellation_names.eng.fab:328
 msgid "Long Wall"
-msgstr ""
+msgstr "Dlouhá zeď"
 
 #: skycultures/chinese/constellation_names.eng.fab:329
 msgid "Grandfather"
-msgstr ""
+msgstr "Děd"
 
 #: skycultures/chinese/constellation_names.eng.fab:330
 #: skycultures/chinese/star_names.fab:1225
 msgid "Twinkling Indicator"
-msgstr ""
+msgstr "Blikající ukazatel"
 
 #: skycultures/chinese/constellation_names.eng.fab:331
 msgid "Assistant (Vassal of Northern Dipper)"
-msgstr ""
+msgstr "Pomocník (podřízený Severní naběračky)"
 
 #: skycultures/chinese/constellation_names.eng.fab:332
 msgid "Executions"
-msgstr ""
+msgstr "Popravy"
 
 #: skycultures/chinese/constellation_names.eng.fab:333
 msgid "Battle Chariots"
-msgstr ""
+msgstr "Bojové vozy"
 
 #: skycultures/chinese/constellation_names.eng.fab:334
 msgid "Right linchpin (Vassal of Chariot)"
-msgstr ""
+msgstr "Pravý zákolník (podřízený Vozu)"
 
 #: skycultures/chinese/constellation_names.eng.fab:335
 #: skycultures/chinese/star_names.fab:1631
@@ -8763,28 +8763,28 @@ msgstr "Přadlena"
 
 #: skycultures/chinese/constellation_names.eng.fab:336
 msgid "Left linchpin (Vassal of Chariot)"
-msgstr ""
+msgstr "Levý zákolník (podřízený Vozu)"
 
 #: skycultures/chinese/constellation_names.eng.fab:337
 msgid "Tripod of the Zhou"
-msgstr ""
+msgstr "Trojnožka Zhoua"
 
 #: skycultures/chinese/constellation_names.eng.fab:338
 msgid "Feudal Kings"
-msgstr ""
+msgstr "Feudální králové"
 
 #: skycultures/chinese/constellation_names.eng.fab:339
 msgid "Pillars (In Net Mansion)"
-msgstr ""
+msgstr "Sloupy (v dómu Sítě)"
 
 #: skycultures/chinese/constellation_names.eng.fab:340
 msgid "Pillars (In Horn Mansion)"
-msgstr ""
+msgstr "Sloupy (v dómu Rohu)"
 
 #: skycultures/chinese/constellation_names.eng.fab:341
 #: skycultures/chinese/star_names.fab:69
 msgid "Official of Royal Archives"
-msgstr ""
+msgstr "Úředník Královských archivů"
 
 #: skycultures/chinese/constellation_names.eng.fab:342
 #: skycultures/korean/constellation_names.eng.fab:172
@@ -8793,19 +8793,19 @@ msgstr "Syn"
 
 #: skycultures/chinese/constellation_names.eng.fab:343
 msgid "Patriarchal Clan"
-msgstr ""
+msgstr "Patriarchální klan"
 
 #: skycultures/chinese/constellation_names.eng.fab:344
 msgid "Official of Religious Ceremonies"
-msgstr ""
+msgstr "Úředník pro náboženské obřady"
 
 #: skycultures/chinese/constellation_names.eng.fab:345
 msgid "Official for the Royal Clan"
-msgstr ""
+msgstr "Úředník pro Královský klan"
 
 #: skycultures/chinese/constellation_names.eng.fab:346
 msgid "Official in Charge of the Forest"
-msgstr ""
+msgstr "Úředník zodpovědný za lesy"
 
 #: skycultures/chinese/constellation_names.eng.fab:347
 #: skycultures/korean/constellation_names.eng.fab:54
@@ -8814,11 +8814,11 @@ msgstr "Levý prapor"
 
 #: skycultures/chinese/constellation_names.eng.fab:348
 msgid "Left Conductor"
-msgstr ""
+msgstr "Levý průvodce"
 
 #: skycultures/chinese/constellation_names.eng.fab:349
 msgid "Seat Flags"
-msgstr ""
+msgstr "Vlajky trůnu"
 
 #: skycultures/chinese/star_names.fab:5
 msgid "Northern Pole I"
@@ -21636,13 +21636,13 @@ msgstr "Vodní hvězdy"
 #: skycultures/western/star_names.fab:160
 #: skycultures/western_rey/star_names.fab:32
 msgid "Procyon"
-msgstr "Procyon"
+msgstr "Prokyon"
 
 #: skycultures/egyptian/star_names.fab:2
 #: skycultures/western/star_names.fab:141
 #: skycultures/western_rey/star_names.fab:36
 msgid "Sirius"
-msgstr "Sirius"
+msgstr "Sírius"
 
 #. TRANSLATORS: Native name of the Sun in Egyptian culture (English: God of
 #. Sun)
@@ -22975,7 +22975,7 @@ msgstr "Zbrojnice"
 
 #: skycultures/korean/constellation_names.eng.fab:104
 msgid "Southern Gate of Emperator"
-msgstr "Jižní brána emperátora"
+msgstr "Jižní brána císaře"
 
 #: skycultures/korean/constellation_names.eng.fab:105
 msgid "Outer Folding Screen"
@@ -22991,7 +22991,7 @@ msgstr "Architekt"
 
 #: skycultures/korean/constellation_names.eng.fab:108
 msgid "Emperator"
-msgstr "Emperátor"
+msgstr "Císař"
 
 #: skycultures/korean/constellation_names.eng.fab:109
 msgid "Watchtower"
@@ -23028,7 +23028,7 @@ msgstr "Hromada mrtvol"
 
 #: skycultures/korean/constellation_names.eng.fab:118
 msgid "Stomach of Tiger"
-msgstr "Tigrův žaludek"
+msgstr "Žaludek tygra"
 
 #: skycultures/korean/constellation_names.eng.fab:119
 msgid "Store of Millet for"
@@ -23115,7 +23115,7 @@ msgstr "Vlajka císaře"
 
 #: skycultures/korean/constellation_names.eng.fab:144
 msgid "Nine Territory"
-msgstr "Deváte teritorium"
+msgstr "Devátá oblast"
 
 #: skycultures/korean/constellation_names.eng.fab:145
 msgid "Garden of Sky"
@@ -23337,7 +23337,7 @@ msgstr "Tři ministři"
 
 #: skycultures/korean/constellation_names.eng.fab:210
 msgid "Officer for Audience"
-msgstr "Úředník pro díváky"
+msgstr "Úředník pro diváky"
 
 #: skycultures/korean/constellation_names.eng.fab:211
 msgid "Grave Front"
@@ -23438,7 +23438,7 @@ msgstr "Most tvořený jednou kládou"
 
 #: skycultures/korean/constellation_names.eng.fab:239
 msgid "Great Emperor"
-msgstr "Velkýcísař"
+msgstr "Velký císař"
 
 #: skycultures/korean/constellation_names.eng.fab:240
 msgid "Officer for Opinion"
@@ -24607,7 +24607,7 @@ msgstr "Rigel"
 #: skycultures/western/star_names.fab:68
 #: skycultures/western_rey/star_names.fab:31
 msgid "Capella"
-msgstr "Capella"
+msgstr "Kapella"
 
 #: skycultures/romanian/star_names.fab:49
 msgid "Alnath"
@@ -25402,7 +25402,7 @@ msgstr "Azelfafage"
 #: skycultures/romanian/star_names.fab:211
 #: skycultures/western/star_names.fab:220
 msgid "The Garnet Star"
-msgstr "Garnetova hvězda"
+msgstr "Granátová hvězda"
 
 #: skycultures/romanian/star_names.fab:212
 #: skycultures/western/star_names.fab:617
@@ -25841,7 +25841,7 @@ msgstr "Lodní kýl"
 #: skycultures/western/constellation_names.eng.fab:15
 #: skycultures/western_rey/constellation_names.eng.fab:15
 msgid "Cassiopeia"
-msgstr "Kasiopea"
+msgstr "Kasiopeja"
 
 #: skycultures/western/constellation_names.eng.fab:16
 #: skycultures/western_rey/constellation_names.eng.fab:168
@@ -26076,7 +26076,7 @@ msgstr "Malíř"
 #: skycultures/western/constellation_names.eng.fab:63
 #: skycultures/western_rey/constellation_names.eng.fab:57
 msgid "Perseus"
-msgstr "Perseus"
+msgstr "Perzeus"
 
 #: skycultures/western/constellation_names.eng.fab:64
 #: skycultures/western_rey/constellation_names.eng.fab:127
@@ -26169,7 +26169,7 @@ msgstr "Býk"
 #: skycultures/western/constellation_names.eng.fab:82
 #: skycultures/western_rey/constellation_names.eng.fab:188
 msgid "Telescopium"
-msgstr "Teleskop"
+msgstr "Dalekohled"
 
 #: skycultures/western/constellation_names.eng.fab:83
 #: skycultures/western_rey/constellation_names.eng.fab:186
@@ -26204,72 +26204,72 @@ msgstr "Plachty"
 #: skycultures/western/asterism_names.eng.fab:2
 msgctxt "asterism"
 msgid "Great Diamond"
-msgstr ""
+msgstr "Velký diamant"
 
 #: skycultures/western/asterism_names.eng.fab:3
 msgctxt "asterism"
 msgid "Spring Triangle"
-msgstr ""
+msgstr "Jarní trojúhelník"
 
 #: skycultures/western/asterism_names.eng.fab:4
 msgctxt "asterism"
 msgid "Summer Triangle"
-msgstr ""
+msgstr "Letní trojúhelník"
 
 #: skycultures/western/asterism_names.eng.fab:5
 msgctxt "asterism"
 msgid "Great Square of Pegasus"
-msgstr ""
+msgstr "Pegasův čtverec"
 
 #: skycultures/western/asterism_names.eng.fab:6
 msgctxt "asterism"
 msgid "Winter Triangle"
-msgstr ""
+msgstr "Zimní trojúhelník"
 
 #: skycultures/western/asterism_names.eng.fab:7
 msgctxt "asterism"
 msgid "Winter Hexagon (Winter Circle)"
-msgstr ""
+msgstr "Zimní šestiúhelník"
 
 #: skycultures/western/asterism_names.eng.fab:9
 msgctxt "asterism"
 msgid "Northern Cross"
-msgstr ""
+msgstr "Severní kříž"
 
 #: skycultures/western/asterism_names.eng.fab:10
 msgctxt "asterism"
 msgid "W"
-msgstr ""
+msgstr "W"
 
 #: skycultures/western/asterism_names.eng.fab:11
 msgctxt "asterism"
 msgid "Keystone"
-msgstr ""
+msgstr "Klenák"
 
 #: skycultures/western/asterism_names.eng.fab:12
 msgctxt "asterism"
 msgid "Butterfly"
-msgstr ""
+msgstr "Motýl"
 
 #: skycultures/western/asterism_names.eng.fab:13
 msgctxt "asterism"
 msgid "Kite"
-msgstr ""
+msgstr "Papírový drak"
 
 #: skycultures/western/asterism_names.eng.fab:14
 msgctxt "asterism"
 msgid "Sail"
-msgstr ""
+msgstr "Plachta"
 
 #: skycultures/western/asterism_names.eng.fab:15
 msgctxt "asterism"
 msgid "Seven Stars Row"
-msgstr ""
+msgstr "Řada sedmi hvězd"
 
 #: skycultures/western/asterism_names.eng.fab:16
 msgctxt "asterism"
 msgid "Coathanger"
-msgstr ""
+msgstr "Ramínko na šaty"
 
 #: skycultures/western/asterism_names.eng.fab:18
 msgctxt "asterism"
@@ -26279,147 +26279,147 @@ msgstr "Velký vůz"
 #: skycultures/western/asterism_names.eng.fab:19
 msgctxt "asterism"
 msgid "Little Dipper"
-msgstr ""
+msgstr "Malý vůz"
 
 #: skycultures/western/asterism_names.eng.fab:20
 msgctxt "asterism"
 msgid "The Pointers"
-msgstr ""
+msgstr "Ukazatelé"
 
 #: skycultures/western/asterism_names.eng.fab:21
 msgctxt "asterism"
 msgid "Dragon Head"
-msgstr ""
+msgstr "Hlava draka"
 
 #: skycultures/western/asterism_names.eng.fab:22
 msgctxt "asterism"
 msgid "Head of Medusa Gorgon"
-msgstr ""
+msgstr "Hlava medúzy"
 
 #: skycultures/western/asterism_names.eng.fab:23
 msgctxt "asterism"
 msgid "Goatlings"
-msgstr ""
+msgstr "Kůzlata"
 
 #: skycultures/western/asterism_names.eng.fab:24
 msgctxt "asterism"
 msgid "The Y in Aquarius (The Urn)"
-msgstr ""
+msgstr "Y ve Vodnáři"
 
 #: skycultures/western/asterism_names.eng.fab:25
 msgctxt "asterism"
 msgid "Orion's Belt"
-msgstr ""
+msgstr "Pás Oriona"
 
 #: skycultures/western/asterism_names.eng.fab:26
 msgctxt "asterism"
 msgid "Orion's Sword"
-msgstr ""
+msgstr "Meč Oriona"
 
 #: skycultures/western/asterism_names.eng.fab:27
 msgctxt "asterism"
 msgid "Orion's Shield"
-msgstr ""
+msgstr "Štít Oriona"
 
 #: skycultures/western/asterism_names.eng.fab:28
 msgctxt "asterism"
 msgid "Orion's Cudgel"
-msgstr ""
+msgstr "Kyj Oriona"
 
 #: skycultures/western/asterism_names.eng.fab:29
 msgctxt "asterism"
 msgid "Head of Whale"
-msgstr ""
+msgstr "Hlava velryby"
 
 #: skycultures/western/asterism_names.eng.fab:30
 msgctxt "asterism"
 msgid "Head of Serpent"
-msgstr ""
+msgstr "Hlava hada"
 
 #: skycultures/western/asterism_names.eng.fab:31
 msgctxt "asterism"
 msgid "Head of Hydra"
-msgstr ""
+msgstr "Hlava hydry"
 
 #: skycultures/western/asterism_names.eng.fab:32
 msgctxt "asterism"
 msgid "Teapot"
-msgstr ""
+msgstr "Konvice"
 
 #: skycultures/western/asterism_names.eng.fab:33
 msgctxt "asterism"
 msgid "Terebellum"
-msgstr ""
+msgstr "Terebellum"
 
 #: skycultures/western/asterism_names.eng.fab:34
 msgctxt "asterism"
 msgid "Egyptian Cross"
-msgstr ""
+msgstr "Egyptský kříž"
 
 #: skycultures/western/asterism_names.eng.fab:35
 msgctxt "asterism"
 msgid "False Cross"
-msgstr ""
+msgstr "Falešný kříž"
 
 #: skycultures/western/asterism_names.eng.fab:36
 msgctxt "asterism"
 msgid "Sickle"
-msgstr ""
+msgstr "Srp"
 
 #: skycultures/western/asterism_names.eng.fab:37
 msgctxt "asterism"
 msgid "Diamond Cross"
-msgstr ""
+msgstr "Diamantový kříž"
 
 #: skycultures/western/asterism_names.eng.fab:38
 msgctxt "asterism"
 msgid "Circlet"
-msgstr ""
+msgstr "Čelenka"
 
 #: skycultures/western/asterism_names.eng.fab:40
 msgctxt "asterism"
 msgid "Davis' Dog"
-msgstr ""
+msgstr "Davisův pes"
 
 #: skycultures/western/asterism_names.eng.fab:41
 msgctxt "asterism"
 msgid "Honores Friderici"
-msgstr ""
+msgstr "Pocta Fridrichovi"
 
 #: skycultures/western/asterism_names.eng.fab:42
 msgctxt "asterism"
 msgid "Engagement ring of Polaris"
-msgstr ""
+msgstr "Zásnubní prsten Polárky"
 
 #: skycultures/western/asterism_names.eng.fab:44
 msgctxt "asterism"
 msgid "Kemble's Cascade"
-msgstr ""
+msgstr "Kembleho kaskáda"
 
 #: skycultures/western/asterism_names.eng.fab:45
 msgctxt "asterism"
 msgid "Kemble's Kite"
-msgstr ""
+msgstr "Kembleho drak"
 
 #: skycultures/western/asterism_names.eng.fab:46
 msgctxt "asterism"
 msgid "Mini-Cassiopeia (Kemble 2)"
-msgstr ""
+msgstr "Miniaturní Kasiopeja (Kemble 2)"
 
 #: skycultures/western/asterism_names.eng.fab:47
 msgctxt "asterism"
 msgid "Napoleon's Hat"
-msgstr ""
+msgstr "Napoleonův klobouk"
 
 #: skycultures/western/asterism_names.eng.fab:48
 msgctxt "asterism"
 msgid "The Hercules Keystone"
-msgstr ""
+msgstr "Herkulův klenák"
 
 #: skycultures/western/asterism_names.eng.fab:49
 msgctxt "asterism"
 msgid "Pouring Cup"
-msgstr ""
+msgstr "Vylévaný hrnek"
 
 #: skycultures/western/star_names.fab:4
 msgid "Sirrah"
@@ -27207,15 +27207,15 @@ msgstr "Besselova hvězda"
 
 #: skycultures/western/star_names.fab:321
 msgid "Piazzi's Flying Star"
-msgstr ""
+msgstr "Piazziho letící hvězda"
 
 #: skycultures/western/star_names.fab:323
 msgid "Campbell’s Hydrogen Star"
-msgstr ""
+msgstr "Campbellova vodíková hvězda"
 
 #: skycultures/western/star_names.fab:324
 msgid "Revenant of the Swan"
-msgstr ""
+msgstr "Zmrtvýchvstání Labutě"
 
 #: skycultures/western/star_names.fab:325
 msgid "Permanent nova"
@@ -27476,7 +27476,7 @@ msgstr ""
 #: skycultures/western/star_names.fab:420
 #: skycultures/western_rey/star_names.fab:29
 msgid "Castor"
-msgstr "Castor"
+msgstr "Kastor"
 
 #: skycultures/western/star_names.fab:421
 msgid "Apollo"
@@ -27737,7 +27737,7 @@ msgstr ""
 
 #: skycultures/western/star_names.fab:521
 msgid "Hind's Crimson Star"
-msgstr "Hidnova rudá hvězda"
+msgstr "Hindova karmínová hvězda"
 
 #: skycultures/western/star_names.fab:522
 msgid "Kursi al Jabbar"
@@ -27862,7 +27862,7 @@ msgstr ""
 
 #: skycultures/western/star_names.fab:561
 msgid "Plaskett's Star"
-msgstr ""
+msgstr "Plaskettova hvězda"
 
 #: skycultures/western/star_names.fab:564
 msgid "Polaris Australis"
@@ -27935,7 +27935,7 @@ msgstr ""
 
 #: skycultures/western/star_names.fab:598
 msgid "Trapezium"
-msgstr ""
+msgstr "Trapez"
 
 #: skycultures/western/star_names.fab:599
 msgid "Mizan Batil II"
@@ -28115,7 +28115,7 @@ msgstr ""
 
 #: skycultures/western/star_names.fab:668
 msgid "van Maanen's Star"
-msgstr ""
+msgstr "van Maanenova hvězda"
 
 #: skycultures/western/star_names.fab:669
 msgid "van Maanen 2"
@@ -28566,7 +28566,7 @@ msgstr ""
 #: skycultures/western/star_names.fab:841
 #: skycultures/western_rey/star_names.fab:8
 msgid "Alcor"
-msgstr "Alcor"
+msgstr "Alkor"
 
 #: skycultures/western/star_names.fab:842
 msgid "Groombridge 1830"
@@ -28574,11 +28574,11 @@ msgstr ""
 
 #: skycultures/western/star_names.fab:843
 msgid "Flying Star"
-msgstr ""
+msgstr "Letící hvězda"
 
 #: skycultures/western/star_names.fab:844
 msgid "Runaway Star"
-msgstr ""
+msgstr "Prchající hvězda"
 
 #: skycultures/western/star_names.fab:847
 msgid "Taiyangshou"
@@ -28666,7 +28666,7 @@ msgstr ""
 
 #: skycultures/western/star_names.fab:869
 msgid "Polaris"
-msgstr "Polaris"
+msgstr "Polárka"
 
 #: skycultures/western/star_names.fab:870
 msgid "Alrucaba"
@@ -28800,17 +28800,17 @@ msgstr "Velký vůz"
 
 #: skycultures/western_rey/constellation_names.eng.fab:7
 msgid "Pointers"
-msgstr ""
+msgstr "Ukazatelé"
 
 #: skycultures/western_rey/constellation_names.eng.fab:9
 msgid "Guardians"
-msgstr ""
+msgstr "Strážci"
 
 #: skycultures/western_rey/constellation_names.eng.fab:11
 #: skycultures/western_rey/constellation_names.eng.fab:39
 #: skycultures/western_rey/constellation_names.eng.fab:90
 msgid "feet"
-msgstr ""
+msgstr "chodidla"
 
 #: skycultures/western_rey/constellation_names.eng.fab:12
 #: skycultures/western_rey/constellation_names.eng.fab:20
@@ -28842,12 +28842,12 @@ msgstr "hlava"
 #: skycultures/western_rey/constellation_names.eng.fab:157
 #: skycultures/western_rey/constellation_names.eng.fab:166
 msgid "tail"
-msgstr ""
+msgstr "ocas"
 
 #: skycultures/western_rey/constellation_names.eng.fab:21
 #: skycultures/western_rey/constellation_names.eng.fab:22
 msgid "paws"
-msgstr ""
+msgstr "tlapy"
 
 #: skycultures/western_rey/constellation_names.eng.fab:30
 #: skycultures/western_rey/constellation_names.eng.fab:101
@@ -28858,7 +28858,7 @@ msgstr "tělo"
 
 #: skycultures/western_rey/constellation_names.eng.fab:32
 msgid "pipe"
-msgstr ""
+msgstr "hůl"
 
 #: skycultures/western_rey/constellation_names.eng.fab:37
 #: skycultures/western_rey/constellation_names.eng.fab:38
@@ -28869,67 +28869,67 @@ msgstr ""
 #: skycultures/western_rey/constellation_names.eng.fab:153
 #: skycultures/western_rey/constellation_names.eng.fab:158
 msgid "wing"
-msgstr ""
+msgstr "křídlo"
 
 #: skycultures/western_rey/constellation_names.eng.fab:40
 msgid "outstretched neck"
-msgstr ""
+msgstr "krk"
 
 #: skycultures/western_rey/constellation_names.eng.fab:44
 #: skycultures/western_rey/constellation_names.eng.fab:76
 msgid "club"
-msgstr ""
+msgstr "kyj"
 
 #: skycultures/western_rey/constellation_names.eng.fab:45
 msgid "Keystone"
-msgstr ""
+msgstr "Klenák"
 
 #: skycultures/western_rey/constellation_names.eng.fab:50
 msgid "the chain"
-msgstr ""
+msgstr "řetěz"
 
 #: skycultures/western_rey/constellation_names.eng.fab:51
 msgid "Great Square"
-msgstr ""
+msgstr "Velký čtverec"
 
 #: skycultures/western_rey/constellation_names.eng.fab:63
 #: skycultures/western_rey/constellation_names.eng.fab:64
 msgid "horn"
-msgstr ""
+msgstr "roh"
 
 #: skycultures/western_rey/constellation_names.eng.fab:75
 msgid "belt"
-msgstr ""
+msgstr "pás"
 
 #: skycultures/western_rey/constellation_names.eng.fab:77
 msgid "shield"
-msgstr ""
+msgstr "štít"
 
 #: skycultures/western_rey/constellation_names.eng.fab:83
 msgid "Hydra's head"
-msgstr ""
+msgstr "Hlava hydry"
 
 #: skycultures/western_rey/constellation_names.eng.fab:87
 msgid "Hydra's tail"
-msgstr ""
+msgstr "Ocas hydry"
 
 #: skycultures/western_rey/constellation_names.eng.fab:93
 msgid "bill"
-msgstr ""
+msgstr "zobák"
 
 #: skycultures/western_rey/constellation_names.eng.fab:94
 #: skycultures/western_rey/constellation_names.eng.fab:105
 #: skycultures/western_rey/constellation_names.eng.fab:106
 msgid "foot"
-msgstr ""
+msgstr "chodidlo"
 
 #: skycultures/western_rey/constellation_names.eng.fab:97
 msgid "Serpens Cauda"
-msgstr ""
+msgstr "Hlava hada"
 
 #: skycultures/western_rey/constellation_names.eng.fab:98
 msgid "Serpens Caput"
-msgstr ""
+msgstr "Ocas hada"
 
 #: skycultures/western_rey/constellation_names.eng.fab:103
 #: skycultures/western_rey/constellation_names.eng.fab:104
@@ -28937,75 +28937,75 @@ msgstr ""
 #: skycultures/western_rey/constellation_names.eng.fab:170
 #: skycultures/western_rey/constellation_names.eng.fab:171
 msgid "arm"
-msgstr ""
+msgstr "ruka"
 
 #: skycultures/western_rey/constellation_names.eng.fab:108
 msgid "claws"
-msgstr ""
+msgstr "klepeta"
 
 #: skycultures/western_rey/constellation_names.eng.fab:110
 msgid "cat's eyes"
-msgstr ""
+msgstr "kočičí oko"
 
 #: skycultures/western_rey/constellation_names.eng.fab:123
 msgid "skirt"
-msgstr ""
+msgstr "sukně"
 
 #: skycultures/western_rey/constellation_names.eng.fab:124
 msgid "the bow"
-msgstr ""
+msgstr "luk"
 
 #: skycultures/western_rey/constellation_names.eng.fab:131
 msgid "vessel"
-msgstr ""
+msgstr "nádoba"
 
 #: skycultures/western_rey/constellation_names.eng.fab:138
 msgid "Northern Fish"
-msgstr ""
+msgstr "Severní ryba"
 
 #: skycultures/western_rey/constellation_names.eng.fab:139
 msgid "Circlet"
-msgstr ""
+msgstr "Náramek"
 
 #: skycultures/western_rey/constellation_names.eng.fab:146
 msgid "False Cross"
-msgstr ""
+msgstr "Falešný kříž"
 
 #: skycultures/western_rey/constellation_names.eng.fab:148
 msgid "figurehead"
-msgstr ""
+msgstr "galionová figura"
 
 #: skycultures/western_rey/constellation_names.eng.fab:150
 msgid "transom"
-msgstr ""
+msgstr "zrcadlo"
 
 #: skycultures/western_rey/constellation_names.eng.fab:167
 msgid "ears"
-msgstr ""
+msgstr "oči"
 
 #: skycultures/western_rey/constellation_names.eng.fab:173
 msgid "front legs"
-msgstr ""
+msgstr "přední nohy"
 
 #: skycultures/western_rey/constellation_names.eng.fab:174
 msgid "hind legs"
-msgstr ""
+msgstr "zadní nohy"
 
 #: skycultures/western_rey/constellation_names.eng.fab:180
 msgid "Fly"
-msgstr ""
+msgstr "Moucha"
 
 #: skycultures/western_rey/constellation_names.eng.fab:183
 msgid "eyes"
-msgstr ""
+msgstr "oči"
 
 #: skycultures/western_rey/star_names.fab:5
 msgid "Pole Star"
-msgstr ""
+msgstr "Polárka"
 
 #: skycultures/western_rey/star_names.fab:49
 msgid "Tau Ceti"
-msgstr ""
+msgstr "Tau Ceti"
 
 #: skycultures/western_rey/star_names.fab:50
 msgid "Knot"
@@ -29013,8 +29013,8 @@ msgstr "Uzel"
 
 #: skycultures/western_rey/star_names.fab:56
 msgid "Alpha Centauri"
-msgstr ""
+msgstr "Alfa Centauri"
 
 #: skycultures/western_rey/star_names.fab:57
 msgid "Beta Centauri"
-msgstr ""
+msgstr "Beta Centauri"


### PR DESCRIPTION
Dear developers,

I beg to submit a revision of Czech skyculture translations, which includes:

  i) corrected spelling (I simply used a spellchecker);

 ii) improved language in some cases to sound Czech perfectly;
     (e.g. Tychova -> Tychonova, Mlhovina v Orionu)

iii) several nebulae were assigned/changed names to match
     Czech/Slovak books (Hlad etal. 1988, Pittich & Kalmančok 1981).

 iv) completed Chinese constellations ("uff");

  v) one major constellation was changed (Teleskop -> Dalekohled),
     which is indeed a Czech original word; several others now have
     Czech spelling ('K' instead of 'C');

 vi) completed western asterisms and Rey's parts of constellations.

May I kindly ask you to consider these changes, please?

Clear skies, Miroslav Broz
