### PR TITLE
issue103

### DIFF
--- a/src/gui/LocationDialog.cpp
+++ b/src/gui/LocationDialog.cpp
@@ -79,6 +79,11 @@ void LocationDialog::createDialogContent()
 	// We try to directly connect to the observer slots as much as we can
 	ui->setupUi(dialog);
 
+	//enable resizability
+	ui->mapLabel->setMinimumSize(0,0);
+	ui->mapLabel->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Ignored);
+	ui->mapLabel->setScaledContents(false);
+
 	connect(&StelApp::getInstance(), SIGNAL(languageChanged()), this, SLOT(retranslate()));
 	// Init the SpinBox entries
 	ui->longitudeSpinBox->setDisplayFormat(AngleSpinBox::DMSSymbols);
@@ -174,6 +179,7 @@ void LocationDialog::handleDialogSizeChanged(QSizeF size)
 {
 	StelDialog::handleDialogSizeChanged(size);
 	StelLocation loc = locationFromFields();
+	resizePixmap();
 	ui->mapLabel->setCursorPos(loc.longitude, loc.latitude);
 }
 
@@ -307,7 +313,7 @@ void LocationDialog::setMapForLocation(const StelLocation& loc)
 	if (lastPlanet==loc.planetName)
 		return;
 
-	QPixmap pixmap;
+	//QPixmap pixmap;
 	// Try to set the proper planet map image
 	if (loc.planetName=="Earth")
 	{
@@ -329,18 +335,25 @@ void LocationDialog::setMapForLocation(const StelLocation& loc)
 			pixmap = QPixmap(path);
 		}
 	}
-	StelCore * core = StelApp::getInstance().getCore();
-	pixmap.setDevicePixelRatio(core->getCurrentStelProjectorParams().devicePixelsPerPixel);
+	//StelCore * core = StelApp::getInstance().getCore();
+	//pixmap.setDevicePixelRatio(core->getCurrentStelProjectorParams().devicePixelsPerPixel);
 	ui->mapLabel->setPixmap(pixmap);
+	resizePixmap();
 	ui->mapLabel->setCursorPos(loc.longitude, loc.latitude);
 	// For caching
 	lastPlanet = loc.planetName;
 }
 
+void LocationDialog::resizePixmap()
+{
+	int w = ui->mapLabel->width();
+	int h = ui->mapLabel->height();
+	ui->mapLabel->setPixmap(pixmap.scaled(w,h,Qt::KeepAspectRatio,Qt::SmoothTransformation));
+}
+
 void LocationDialog::populatePlanetList()
 {
 	Q_ASSERT(ui->planetNameComboBox);
-
 	QComboBox* planets = ui->planetNameComboBox;
 	SolarSystem* ssystem = GETSTELMODULE(SolarSystem);
 	QList<PlanetP> ss = ssystem->getAllPlanets();

--- a/src/gui/LocationDialog.hpp
+++ b/src/gui/LocationDialog.hpp
@@ -46,6 +46,8 @@ protected:
 	//! Initialize the dialog widgets and connect the signals/slots
 	virtual void createDialogContent();
 	Ui_locationDialogForm* ui;
+
+	void resizePixmap();
 	
 private:
 	//! Set the values of all the fields from a location info
@@ -152,6 +154,8 @@ private:
 	QStringListModel* allModel;
 	QStringListModel* pickedModel;
 	QSortFilterProxyModel *proxyModel;
+
+	QPixmap pixmap;
 
 	//! Updates the check state and the enabled/disabled status.
 	void updateDefaultLocationControls(bool currentIsDefault);

--- a/src/gui/MapLabel.cpp
+++ b/src/gui/MapLabel.cpp
@@ -35,14 +35,30 @@ MapLabel::~MapLabel()
 
 void MapLabel::setCursorPos(double longitude, double latitude)
 {
-	const int x = (int)((longitude+180.)/360.*size().width());
-	const int y = (int)((latitude-90.)/-180.*size().height());
+	const int offsetX = (width() - pixmap()->width())/2;
+	const int offsetY = (height() - pixmap()->height())/2;
+	const int x = ((int)((longitude+180.)/360.*pixmap()->size().width())) + offsetX;
+	const int y = ((int)((latitude-90.)/-180.*pixmap()->size().height())) + offsetY;
 	cursor->move(x-cursor->size().width()/2, y-cursor->size().height()/2);
 }
 
 void MapLabel::mousePressEvent(QMouseEvent* event)
 {
-	const double lon = ((double)event->pos().x())/size().width()*360.-180.;
+	/*const double lon = ((double)event->pos().x())/size().width()*360.-180.;
 	const double lat = 90.-((double)event->pos().y())/size().height()*180.;
+	emit(positionChanged(lon, lat));*/
+
+	const int offsetX = (width() - pixmap()->width())/2;
+	const int offsetY = (height() - pixmap()->height())/2;
+
+	const int posX = event->pos().x();
+	const int posY = event->pos().y();
+
+	if((unsigned)(posX-offsetX) > (unsigned)pixmap()->width() || (unsigned)(posY-offsetY) > (unsigned)pixmap()->height())
+	{
+		return;
+	}
+	const double lon = ((double)(posX-offsetX))/pixmap()->size().width()*360.-180.;
+	const double lat = 90.-((double)(posY-offsetY))/pixmap()->size().height()*180.;
 	emit(positionChanged(lon, lat));
 }

--- a/src/gui/StelDialog.cpp
+++ b/src/gui/StelDialog.cpp
@@ -70,6 +70,7 @@ void StelDialog::setVisible(bool v)
 	if (v)
 	{
 		QSize screenSize = StelMainView::getInstance().size();
+		QSize maxSize = 0.8*screenSize;
 		if (dialog)
 		{
 			dialog->show();
@@ -84,6 +85,11 @@ void StelDialog::setVisible(bool v)
 				newPos.setY(screenSize.height() - dialog->size().height());
 			if (newPos != dialog->pos())
 				proxy->setPos(newPos);
+			QSizeF newSize = proxy->size();
+			if (newSize.width() >= maxSize.width())
+				newSize.setWidth(maxSize.width());
+			if (newSize.height() >= maxSize.height())
+				newSize.setHeight(maxSize.height());
 		}
 		else
 		{
@@ -162,6 +168,10 @@ void StelDialog::setVisible(bool v)
 			{
 				//qDebug() << confNameSize << ": resize to " << storedSizeString;
 				proxy->resize(qMax((qreal)newX, proxy->size().width()), qMax((qreal)newY, proxy->size().height()));
+			}
+			if(proxy->size().width() > maxSize.width() || proxy->size().height() > maxSize.height())
+			{
+				proxy->resize(maxSize);
 			}
 			handleDialogSizeChanged(proxy->size()); // This may trigger internal updates in subclasses. E.g. LocationPanel location arrow.
 


### PR DESCRIPTION
StelDialog class now limits the maximum size to 0.8x screen size.
LocationDialog is now resizable, the aspect ratio of the LocationMap is preserved.

Maybe the resizing of the pixmap should be implemented in MapLabel class by overriding resizeEvent?
Would it be better to draw the map cursor directly on the pixmap through QPainter instead of a separate label in order to avoid the jumping while resizing?