### PR TITLE
Hires screenshot

### DIFF
--- a/guide/app_config_ini.tex
+++ b/guide/app_config_ini.tex
@@ -502,11 +502,14 @@ date\_display\_format & string & date display format: can be \emph{system\_defau
 \begin{tabularx}{\textwidth}{l|l|X}\toprule
 \emph{ID}                 & \emph{Type} & \emph{Description}\\\midrule
 invert\_screenshots\_colors & bool   & If \emph{true}, Stellarium will saving the screenshorts with inverted colors.\\%\midrule
-restore\_defaults           & bool   & If \emph{true}, Stellarium will restore default settings at startup. 
-                                       This is equivalent to calling Stellarium with the \command{--restore-defaults} option.\\%\midrule
 screenshot\_dir             & string & Path for saving screenshots\\%\midrule
+screenshot\_custom\_size    & bool   & \emph{true} if you want to specify particular dimensions next:\\
+screenshot\_custom\_width   & int    & custom width of screenshots. Max.\ available size is hardware dependent!\\
+screenshot\_custom\_height  & int    & custom height of screenshots. Max.\ available size is hardware dependent!\\\midrule
 version                     & string & Version of Stellarium. This parameter may be used to detect necessary changes in config.ini file, do not edit.\\%\midrule
 use\_separate\_output\_file & bool   & Set to \emph{true} if you want to create a new file for script output for each start of Stellarium\\%\midrule
+restore\_defaults           & bool   & If \emph{true}, Stellarium will restore default settings at startup. 
+                                       This is equivalent to calling Stellarium with the \command{--restore-defaults} option.\\%\midrule
 ignore\_opengl\_warning     & bool   & Set to \emph{true} if you don't want to see OpenGL warnings for each start of Stellarium.\\%\midrule
 check\_requirements         & bool   & Set to \emph{false} if you want to disable and permanently ignore checking hardware requirements at startup. 
                                        Expect problems if hardware is below requirements!\\

--- a/guide/ch_interface.tex
+++ b/guide/ch_interface.tex
@@ -272,8 +272,14 @@ If your screen is too narrow to show all buttons, you may have to choose your op
 \item[Indication for mount mode] You can activate the short display of a message when switching type of used mount.
 \end{description}
 
-\noindent In addition, you can set the directory where screenshots will be stored, 
-and you can download more star catalogs on this tab.
+\noindent In addition, you can set the directory where screenshots
+will be stored, and \newFeature{0.18.1} also whether you want
+screenshots sized like Stellarium's window or some other, likely
+larger size. The maximum possible size depends on your
+hardware. $4096\times4096$ should be possible on most PCs, others may
+even create $16384\times16384$ images.
+
+Another button allows you to download more star catalogs on this tab.
 
 \subsection{The Scripts Tab}
 \label{sec:gui:scripts}

--- a/src/StelMainView.cpp
+++ b/src/StelMainView.cpp
@@ -1431,15 +1431,15 @@ void StelMainView::doScreenshot(void)
 		{
 			context->functions()->initializeOpenGLFunctions();
 			//qDebug() << "initializeOpenGLFunctions()...";
-
+#ifndef Q_OS_MAC
 			// Make sure we have enough free GPU memory!
 			GLint freeGLmemory;
 			context->functions()->glGetIntegerv(GL_GPU_MEMORY_INFO_CURRENT_AVAILABLE_VIDMEM_NVX, &freeGLmemory);
-			qCDebug(mainview)<<"Free GPU memory:" << freeGLmemory << "kB -- we ask for " << customScreenshotWidth*customScreenshotHeight*4 / 1024 <<"kB";
+			qCDebug(mainview)<<"Free GPU memory:" << freeGLmemory << "kB -- we ask for " << customScreenshotWidth*customScreenshotHeight*8 / 1024 <<"kB";
 			GLint freeGLmemoryAMD[4];
 			context->functions()->glGetIntegerv(GL_RENDERBUFFER_FREE_MEMORY_ATI, freeGLmemoryAMD);
-			qCDebug(mainview)<<"Free GPU memory (AMD version):" << (uint)freeGLmemoryAMD[1]/1024 << "+" << (uint)freeGLmemoryAMD[3]/1024 << " of " << (uint)freeGLmemoryAMD[0]/1024 << "+" << (uint)freeGLmemoryAMD[2]/1024 << "kB -- we ask for " << customScreenshotWidth*customScreenshotHeight*4 / 1024 <<"kB";
-
+			qCDebug(mainview)<<"Free GPU memory (AMD version):" << (uint)freeGLmemoryAMD[1]/1024 << "+" << (uint)freeGLmemoryAMD[3]/1024 << " of " << (uint)freeGLmemoryAMD[0]/1024 << "+" << (uint)freeGLmemoryAMD[2]/1024 << "kB -- we ask for " << customScreenshotWidth*customScreenshotHeight*8 / 1024 <<"kB";
+#endif
 
 			GLint texSize,viewportSize[2],rbSize;
 			context->functions()->glGetIntegerv(GL_MAX_TEXTURE_SIZE, &texSize);

--- a/src/StelMainView.hpp
+++ b/src/StelMainView.hpp
@@ -51,6 +51,9 @@ class StelMainView : public QGraphicsView
 	Q_PROPERTY(bool fullScreen                 READ isFullScreen                  WRITE setFullScreen                 NOTIFY fullScreenChanged)
 	Q_PROPERTY(bool flagInvertScreenShotColors READ getFlagInvertScreenShotColors WRITE setFlagInvertScreenShotColors NOTIFY flagInvertScreenShotColorsChanged)
 	Q_PROPERTY(bool flagOverwriteScreenshots   READ getFlagOverwriteScreenShots   WRITE setFlagOverwriteScreenShots   NOTIFY flagOverwriteScreenshotsChanged)
+	Q_PROPERTY(bool flagUseCustomScreenshotSize READ getFlagUseCustomScreenshotSize WRITE setFlagUseCustomScreenshotSize NOTIFY flagUseCustomScreenshotSizeChanged)
+	Q_PROPERTY(int  customScreenshotWidth      READ getCustomScreenshotWidth      WRITE setCustomScreenshotWidth      NOTIFY customScreenshotWidthChanged)
+	Q_PROPERTY(int  customScreenshotHeight     READ getCustomScreenshotHeight     WRITE setCustomScreenshotHeight     NOTIFY customScreenshotHeightChanged)
 	Q_PROPERTY(bool flagUseButtonsBackground   READ getFlagUseButtonsBackground   WRITE setFlagUseButtonsBackground   NOTIFY flagUseButtonsBackgroundChanged)
 	Q_PROPERTY(bool flagCursorTimeout          READ getFlagCursorTimeout          WRITE setFlagCursorTimeout          NOTIFY flagCursorTimeoutChanged)
 	Q_PROPERTY(double cursorTimeout            READ getCursorTimeout              WRITE setCursorTimeout              NOTIFY cursorTimeoutChanged)
@@ -131,6 +134,19 @@ public slots:
 	//! Set whether existing files are overwritten when saving screenshot
 	void setFlagOverwriteScreenShots(bool b) {flagOverwriteScreenshots=b; emit flagOverwriteScreenshotsChanged(b);}
 
+	//! Get whether custom size should be used for screenshots
+	bool getFlagUseCustomScreenshotSize() const {return flagUseCustomScreenshotSize;}
+	//! Set whether custom size should be used for screenshots
+	void setFlagUseCustomScreenshotSize(bool b) {flagUseCustomScreenshotSize=b; emit flagUseCustomScreenshotSizeChanged(b);}
+	//! Get custom screenshot width
+	int getCustomScreenshotWidth() const {return customScreenshotWidth;}
+	//! Set whether custom size should be used for screenshots
+	void setCustomScreenshotWidth(int width) {customScreenshotWidth=width; emit customScreenshotWidthChanged(width);}
+	//! Get custom screenshot height
+	int getCustomScreenshotHeight() const {return customScreenshotHeight;}
+	//! Set whether custom size should be used for screenshots
+	void setCustomScreenshotHeight(int height) {customScreenshotHeight=height; emit customScreenshotHeightChanged(height);}
+
 	//! Get the state of the mouse cursor timeout flag
 	bool getFlagCursorTimeout() {return flagCursorTimeout;}
 	//! Get the state of the mouse cursor timeout flag
@@ -168,9 +184,9 @@ public slots:
 	//! Get the state of the flag of usage background for GUI buttons
 	bool getFlagUseButtonsBackground() { return flagUseButtonsBackground; }
 
-	//! Set the sky background color. (Actually forwards to the StelRootItem.)  Everything else than black creates an work of art!
+	//! Set the sky background color. (Actually forwards to the StelRootItem.)  Everything else than black creates a work of art!
 	void setSkyBackgroundColor(Vec3f color);
-	//! Get the sky background color. (Actually retrieves from the StelRootItem.)  Everything else than black creates an work of art!
+	//! Get the sky background color. (Actually retrieves from the StelRootItem.)  Everything else than black creates a work of art!
 	Vec3f getSkyBackgroundColor();
 
 protected:
@@ -200,6 +216,10 @@ signals:
 	void updateIconsRequested();
 	void flagInvertScreenShotColorsChanged(bool b);
 	void flagOverwriteScreenshotsChanged(bool b);
+	void flagUseCustomScreenshotSizeChanged(bool use);
+	void customScreenshotWidthChanged(int width);
+	void customScreenshotHeightChanged(int height);
+
 	void flagUseButtonsBackgroundChanged(bool b);
 	void skyBackgroundColorChanged(Vec3f color);
 	void flagCursorTimeoutChanged(bool b);
@@ -255,6 +275,9 @@ private:
 	bool updateQueued;
 	bool flagInvertScreenShotColors;
 	bool flagOverwriteScreenshots; //! if set to true, screenshot is named exactly screenShotPrefix.png and overwrites existing file
+	bool flagUseCustomScreenshotSize; //! if true, the next 2 values are observed for screenshots.
+	int customScreenshotWidth;            //! used when flagCustomResolutionScreenshots==true
+	int customScreenshotHeight;           //! used when flagCustomResolutionScreenshots==true
 
 	QString screenShotPrefix;
 	QString screenShotDir;

--- a/src/StelMainView.hpp
+++ b/src/StelMainView.hpp
@@ -51,9 +51,11 @@ class StelMainView : public QGraphicsView
 	Q_PROPERTY(bool fullScreen                 READ isFullScreen                  WRITE setFullScreen                 NOTIFY fullScreenChanged)
 	Q_PROPERTY(bool flagInvertScreenShotColors READ getFlagInvertScreenShotColors WRITE setFlagInvertScreenShotColors NOTIFY flagInvertScreenShotColorsChanged)
 	Q_PROPERTY(bool flagOverwriteScreenshots   READ getFlagOverwriteScreenShots   WRITE setFlagOverwriteScreenShots   NOTIFY flagOverwriteScreenshotsChanged)
+#ifndef USE_OLD_QGLWIDGET
 	Q_PROPERTY(bool flagUseCustomScreenshotSize READ getFlagUseCustomScreenshotSize WRITE setFlagUseCustomScreenshotSize NOTIFY flagUseCustomScreenshotSizeChanged)
 	Q_PROPERTY(int  customScreenshotWidth      READ getCustomScreenshotWidth      WRITE setCustomScreenshotWidth      NOTIFY customScreenshotWidthChanged)
 	Q_PROPERTY(int  customScreenshotHeight     READ getCustomScreenshotHeight     WRITE setCustomScreenshotHeight     NOTIFY customScreenshotHeightChanged)
+#endif
 	Q_PROPERTY(bool flagUseButtonsBackground   READ getFlagUseButtonsBackground   WRITE setFlagUseButtonsBackground   NOTIFY flagUseButtonsBackgroundChanged)
 	Q_PROPERTY(bool flagCursorTimeout          READ getFlagCursorTimeout          WRITE setFlagCursorTimeout          NOTIFY flagCursorTimeoutChanged)
 	Q_PROPERTY(double cursorTimeout            READ getCursorTimeout              WRITE setCursorTimeout              NOTIFY cursorTimeoutChanged)
@@ -134,6 +136,7 @@ public slots:
 	//! Set whether existing files are overwritten when saving screenshot
 	void setFlagOverwriteScreenShots(bool b) {flagOverwriteScreenshots=b; emit flagOverwriteScreenshotsChanged(b);}
 
+#ifndef USE_OLD_QGLWIDGET
 	//! Get whether custom size should be used for screenshots
 	bool getFlagUseCustomScreenshotSize() const {return flagUseCustomScreenshotSize;}
 	//! Set whether custom size should be used for screenshots
@@ -146,7 +149,10 @@ public slots:
 	int getCustomScreenshotHeight() const {return customScreenshotHeight;}
 	//! Set whether custom size should be used for screenshots
 	void setCustomScreenshotHeight(int height) {customScreenshotHeight=height; emit customScreenshotHeightChanged(height);}
-
+	//! Get screenshot magnification. This should be used by StarMgr, text drawing and other elements which may
+	//! want to enlarge their output in screenshots to keep them visible.
+	float getCustomScreenshotMagnification() {return customScreenshotMagnification;}
+#endif
 	//! Get the state of the mouse cursor timeout flag
 	bool getFlagCursorTimeout() {return flagCursorTimeout;}
 	//! Get the state of the mouse cursor timeout flag
@@ -275,10 +281,12 @@ private:
 	bool updateQueued;
 	bool flagInvertScreenShotColors;
 	bool flagOverwriteScreenshots; //! if set to true, screenshot is named exactly screenShotPrefix.png and overwrites existing file
+#ifndef USE_OLD_QGLWIDGET
 	bool flagUseCustomScreenshotSize; //! if true, the next 2 values are observed for screenshots.
 	int customScreenshotWidth;            //! used when flagCustomResolutionScreenshots==true
 	int customScreenshotHeight;           //! used when flagCustomResolutionScreenshots==true
-
+	float customScreenshotMagnification;  //! tracks the magnification factor customScreenshotHeight/NormalWindowHeight
+#endif
 	QString screenShotPrefix;
 	QString screenShotDir;
 

--- a/src/core/StelHips.hpp
+++ b/src/core/StelHips.hpp
@@ -74,10 +74,10 @@ public:
 	//! Render the survey.
 	//! @param sPainter the painter to use.
 	//! @param angle total visible angle of the survey in radians. This is used to optimize the rendering of planet
-	//         surveys.  Should be set to 2 pi for sky surveys.
+	//!         surveys.  Should be set to 2 pi for sky surveys.
 	//! @param callback if set this will be called for each visible tile, and the callback should do it rendering
-	//         itself.  If set to NULL, the function will draw the tiles using the default shader.
-	void draw(StelPainter* sPainter, double angle = 2 * M_PI, DrawCallback callback = nullptr);
+	//!         itself.  If set to Q_NULLPTR, the function will draw the tiles using the default shader.
+	void draw(StelPainter* sPainter, double angle = 2.0 * M_PI, DrawCallback callback = Q_NULLPTR);
 
 	//! Return the source URL of the survey.
 	const QString& getUrl() const {return url;}

--- a/src/core/StelPainter.hpp
+++ b/src/core/StelPainter.hpp
@@ -205,9 +205,9 @@ public:
 	//! @param stacks: number of horizontal segments ("latitude zones")
 	//! @param orientInside: 1 to have normals point inside, e.g. for Milky Way, Zodiacal Light, etc.
 	//! @param flipTexture: if texture should be mapped to inside of sphere, e.g. Milky Way.
-	//! @param topAngle GZ: new parameter. An opening angle [radians] at top of the sphere. Useful if there is an empty
+	//! @param topAngle: An opening angle [radians] at top of the sphere. Useful if there is an empty
 	//!        region around the top pole, like North Galactic Pole.
-	//! @param bottomAngle GZ: new parameter. An opening angle [radians] at bottom of the sphere. Useful if there is an empty
+	//! @param bottomAngle: An opening angle [radians] at bottom of the sphere. Useful if there is an empty
 	//!        region around the bottom pole, like South Galactic Pole.
 	static StelVertexArray computeSphereNoLight(float radius, float oneMinusOblateness, int slices, int stacks,
                             int orientInside = 0, bool flipTexture = false,

--- a/src/core/StelSkyDrawer.cpp
+++ b/src/core/StelSkyDrawer.cpp
@@ -29,6 +29,9 @@
 #include "StelUtils.hpp"
 #include "StelMovementMgr.hpp"
 #include "StelPainter.hpp"
+#ifndef USE_OLD_QGLWIDGET
+#include "StelMainView.hpp"
+#endif
 
 #include "StelModuleMgr.hpp"
 #include "LandscapeMgr.hpp"
@@ -344,7 +347,9 @@ bool StelSkyDrawer::computeRCMag(float mag, RCMag* rcMag) const
 {
 	rcMag->radius = eye->adaptLuminanceScaledLn(pointSourceMagToLnLuminance(mag), starRelativeScale*1.40f/2.f);
 	rcMag->radius *=starLinearScale;
-
+#ifndef USE_OLD_QGLWIDGET
+	rcMag->radius *=StelMainView::getInstance().getCustomScreenshotMagnification();
+#endif
 	// Use now statically min_rmag = 0.5, because higher and too small values look bad
 	if (rcMag->radius < 0.3f)
 	{

--- a/src/gui/ConfigurationDialog.cpp
+++ b/src/gui/ConfigurationDialog.cpp
@@ -319,12 +319,19 @@ void ConfigurationDialog::createDialogContent()
 	connect(ui->screenshotDirEdit, SIGNAL(editingFinished()), this, SLOT(selectScreenshotDir()));
 	connect(ui->screenshotBrowseButton, SIGNAL(clicked()), this, SLOT(browseForScreenshotDir()));
 	connectBoolProperty(ui->invertScreenShotColorsCheckBox, "MainView.flagInvertScreenShotColors");
+#ifdef USE_OLD_QGLWIDGET
+	ui->useCustomScreenshotSizeCheckBox->setEnabled(false);
+	ui->useCustomScreenshotSizeCheckBox->hide();
+	ui->customScreenshotWidthLineEdit->hide();
+	ui->label_times->hide();
+	ui->customScreenshotHeightLineEdit->hide();
+#else
 	connectBoolProperty(ui->useCustomScreenshotSizeCheckBox, "MainView.flagUseCustomScreenshotSize");
-	ui->customScreenshotWidthLineEdit->setValidator(new QIntValidator(16, 32768));
-	ui->customScreenshotHeightLineEdit->setValidator(new QIntValidator(16, 32768));
+	ui->customScreenshotWidthLineEdit->setValidator(new QIntValidator(16, 16384));
+	ui->customScreenshotHeightLineEdit->setValidator(new QIntValidator(16, 16384));
 	connectIntProperty(ui->customScreenshotWidthLineEdit, "MainView.customScreenshotWidth");
 	connectIntProperty(ui->customScreenshotHeightLineEdit, "MainView.customScreenshotHeight");
-
+#endif
 	connectBoolProperty(ui->autoEnableAtmosphereCheckBox, "LandscapeMgr.flagAtmosphereAutoEnabling");
 	connectBoolProperty(ui->autoChangeLandscapesCheckBox, "LandscapeMgr.flagLandscapeAutoSelection");
 

--- a/src/gui/ConfigurationDialog.cpp
+++ b/src/gui/ConfigurationDialog.cpp
@@ -61,6 +61,20 @@
 #include <QDir>
 #include <QDesktopWidget>
 
+//! Simple helper extension class which can guarantee int inputs in a useful range.
+class MinMaxIntValidator: public QIntValidator
+{
+public:
+	MinMaxIntValidator(int min, int max, QObject *parent=Q_NULLPTR):
+		QIntValidator(min, max, parent){}
+
+	virtual void fixup(QString &input) const
+	{
+		int allowed=qBound(bottom(), input.toInt(), top());
+		input.setNum(allowed);
+	}
+};
+
 ConfigurationDialog::ConfigurationDialog(StelGui* agui, QObject* parent)
 	: StelDialog("Configuration", parent)
 	, isDownloadingStarCatalog(false)
@@ -225,10 +239,8 @@ void ConfigurationDialog::createDialogContent()
 
 	// TODO: convert to properties
 	ui->enableKeysNavigationCheckBox->setChecked(mvmgr->getFlagEnableMoveKeys() || mvmgr->getFlagEnableZoomKeys());
-	//ui->enableMouseNavigationCheckBox->setChecked(mvmgr->getFlagEnableMouseNavigation());
 	connect(ui->enableKeysNavigationCheckBox, SIGNAL(toggled(bool)), mvmgr, SLOT(setFlagEnableMoveKeys(bool)));
 	connect(ui->enableKeysNavigationCheckBox, SIGNAL(toggled(bool)), mvmgr, SLOT(setFlagEnableZoomKeys(bool)));
-	//connect(ui->enableMouseNavigationCheckBox, SIGNAL(toggled(bool)), mvmgr, SLOT(setFlagEnableMouseNavigation(bool)));
 	connectBoolProperty(ui->enableMouseNavigationCheckBox,  "StelMovementMgr.flagEnableMouseNavigation");
 
 	connect(ui->fixedDateTimeCurrentButton, SIGNAL(clicked()), this, SLOT(setFixedDateTimeToCurrent()));
@@ -327,8 +339,8 @@ void ConfigurationDialog::createDialogContent()
 	ui->customScreenshotHeightLineEdit->hide();
 #else
 	connectBoolProperty(ui->useCustomScreenshotSizeCheckBox, "MainView.flagUseCustomScreenshotSize");
-	ui->customScreenshotWidthLineEdit->setValidator(new QIntValidator(16, 16384));
-	ui->customScreenshotHeightLineEdit->setValidator(new QIntValidator(16, 16384));
+	ui->customScreenshotWidthLineEdit->setValidator(new MinMaxIntValidator(128, 16384, this));
+	ui->customScreenshotHeightLineEdit->setValidator(new MinMaxIntValidator(128, 16384, this));
 	connectIntProperty(ui->customScreenshotWidthLineEdit, "MainView.customScreenshotWidth");
 	connectIntProperty(ui->customScreenshotHeightLineEdit, "MainView.customScreenshotHeight");
 #endif
@@ -897,7 +909,10 @@ void ConfigurationDialog::saveAllSettings()
 	conf->setValue("gui/mouse_cursor_timeout",			StelMainView::getInstance().getCursorTimeout());
 
 	conf->setValue("main/screenshot_dir",				StelFileMgr::getScreenshotDir());
-	conf->setValue("main/invert_screenshots_colors",		StelMainView::getInstance().getFlagInvertScreenShotColors());
+	conf->setValue("main/invert_screenshots_colors",		propMgr->getStelPropertyValue("MainView.flagInvertScreenShotColors").toBool());
+	conf->setValue("main/screenshot_custom_size",			propMgr->getStelPropertyValue("MainView.flagUseCustomScreenshotSize").toBool());
+	conf->setValue("main/screenshot_custom_width",			propMgr->getStelPropertyValue("MainView.customScreenshotWidth").toInt());
+	conf->setValue("main/screenshot_custom_height",			propMgr->getStelPropertyValue("MainView.customScreenshotHeight").toInt());
 
 	int screenNum = qApp->desktop()->screenNumber(&StelMainView::getInstance());
 	conf->setValue("video/screen_number", screenNum);

--- a/src/gui/ConfigurationDialog.cpp
+++ b/src/gui/ConfigurationDialog.cpp
@@ -320,8 +320,8 @@ void ConfigurationDialog::createDialogContent()
 	connect(ui->screenshotBrowseButton, SIGNAL(clicked()), this, SLOT(browseForScreenshotDir()));
 	connectBoolProperty(ui->invertScreenShotColorsCheckBox, "MainView.flagInvertScreenShotColors");
 	connectBoolProperty(ui->useCustomScreenshotSizeCheckBox, "MainView.flagUseCustomScreenshotSize");
-	ui->customScreenshotWidthLineEdit->setInputMask("00009");
-	ui->customScreenshotHeightLineEdit->setInputMask("00009");
+	ui->customScreenshotWidthLineEdit->setValidator(new QIntValidator(16, 32768));
+	ui->customScreenshotHeightLineEdit->setValidator(new QIntValidator(16, 32768));
 	connectIntProperty(ui->customScreenshotWidthLineEdit, "MainView.customScreenshotWidth");
 	connectIntProperty(ui->customScreenshotHeightLineEdit, "MainView.customScreenshotHeight");
 

--- a/src/gui/ConfigurationDialog.cpp
+++ b/src/gui/ConfigurationDialog.cpp
@@ -319,6 +319,11 @@ void ConfigurationDialog::createDialogContent()
 	connect(ui->screenshotDirEdit, SIGNAL(editingFinished()), this, SLOT(selectScreenshotDir()));
 	connect(ui->screenshotBrowseButton, SIGNAL(clicked()), this, SLOT(browseForScreenshotDir()));
 	connectBoolProperty(ui->invertScreenShotColorsCheckBox, "MainView.flagInvertScreenShotColors");
+	connectBoolProperty(ui->useCustomScreenshotSizeCheckBox, "MainView.flagUseCustomScreenshotSize");
+	ui->customScreenshotWidthLineEdit->setInputMask("00009");
+	ui->customScreenshotHeightLineEdit->setInputMask("00009");
+	connectIntProperty(ui->customScreenshotWidthLineEdit, "MainView.customScreenshotWidth");
+	connectIntProperty(ui->customScreenshotHeightLineEdit, "MainView.customScreenshotHeight");
 
 	connectBoolProperty(ui->autoEnableAtmosphereCheckBox, "LandscapeMgr.flagAtmosphereAutoEnabling");
 	connectBoolProperty(ui->autoChangeLandscapesCheckBox, "LandscapeMgr.flagLandscapeAutoSelection");

--- a/src/gui/StelDialog.hpp
+++ b/src/gui/StelDialog.hpp
@@ -30,6 +30,7 @@
 class QAbstractButton;
 class QComboBox;
 class QSpinBox;
+class QLineEdit;
 class QDoubleSpinBox;
 class QSlider;
 class StelAction;
@@ -115,6 +116,12 @@ protected:
 	//! Helper function to connect a checkbox to the given StelAction
 	static void connectCheckBox(QAbstractButton *checkBox, StelAction* action);
 
+	//! Helper function to connect a QLineEdit to an integer StelProperty.
+	//! @note This method also works with flag/enum types (TODO. Does it?)
+	//! You should call something like setInputMask("009") for a 3-place numerical field.
+	//! @warning If the action with \c propName is invalid/unregistered, or cannot be converted
+	//! to the required datatype, the application will crash
+	static void connectIntProperty(QLineEdit* lineEdit, const QString& propName);
 	//! Helper function to connect a QSpinBox to an integer StelProperty.
 	//! @note This method also works with flag/enum types
 	//! @warning If the action with \c propName is invalid/unregistered, or cannot be converted

--- a/src/gui/StelDialog_p.hpp
+++ b/src/gui/StelDialog_p.hpp
@@ -62,6 +62,21 @@ private:
 };
 
 
+//! A StelPropertyProxy that works with QLineEdit widgets.
+//! When the property changes, the widget's value is updated, while preventing widget signals to be sent.
+//! This avoids emitting the valueChanged() signal, which would unnecessarily set the property value again, which may lead to problems.
+class QLineEditStelPropertyConnectionHelper : public StelPropertyProxy
+{
+	Q_OBJECT
+public:
+	QLineEditStelPropertyConnectionHelper(StelProperty* prop,QLineEdit* edit);
+
+protected slots:
+	virtual void onPropertyChanged(const QVariant& value) Q_DECL_OVERRIDE;
+private:
+	QLineEdit* edit;
+};
+
 //! A StelPropertyProxy that works with QSpinBox widgets.
 //! When the property changes, the widget's value is updated, while preventing widget signals to be sent.
 //! This avoids emitting the valueChanged() signal, which would unnecessarily set the property value again, which may lead to problems.

--- a/src/gui/StelGui.cpp
+++ b/src/gui/StelGui.cpp
@@ -559,6 +559,10 @@ void StelGui::update()
 	if (getAction("actionShow_Hips_Surveys")->isChecked() != flag)
 		getAction("actionShow_Hips_Surveys")->setChecked(flag);
 
+	flag = propMgr->getProperty("ToastMgr.surveyDisplayed")->getValue().toBool();
+	if (getAction("actionShow_Toast_Survey")->isChecked() != flag)
+		getAction("actionShow_Toast_Survey")->setChecked(flag);
+
 	flag = propMgr->getProperty("GridLinesMgr.equatorJ2000GridDisplayed")->getValue().toBool();
 	if (getAction("actionShow_Equatorial_J2000_Grid")->isChecked() != flag)
 		getAction("actionShow_Equatorial_J2000_Grid")->setChecked(flag);
@@ -888,7 +892,7 @@ void StelGui::setFlagShowConstellationBoundariesButton(bool b)
 }
 
 // Define whether the button toggling DSS images should be visible
-// TODO: This is now Hips. Decide what to do with TOAST/DSS-only, and rename methods accordingly.
+// We keep Toast even though HiPS is now available: We have a local Toast option better suited for offline operation!
 void StelGui::setFlagShowDSSButton(bool b)
 {
 	if (b!=flagShowDSSButton)
@@ -915,7 +919,6 @@ void StelGui::setFlagShowDSSButton(bool b)
 }
 
 // Define whether the button toggling HiPS images should be visible
-// TODO: This is now Hips. Decide what to do with TOAST/DSS-only, and rename methods accordingly.
 void StelGui::setFlagShowHiPSButton(bool b)
 {
 	if (b!=flagShowHiPSButton)

--- a/src/gui/StelGuiItems.cpp
+++ b/src/gui/StelGuiItems.cpp
@@ -927,9 +927,8 @@ void BottomStelBar::buttonHoverChanged(bool b)
 	StelMainView::getInstance().thereWasAnEvent();
 }
 
-StelBarsPath::StelBarsPath(QGraphicsItem* parent) : QGraphicsPathItem(parent)
+StelBarsPath::StelBarsPath(QGraphicsItem* parent) : QGraphicsPathItem(parent), roundSize(6)
 {
-	roundSize = 6;
 	QPen aPen(QColor::fromRgbF(0.7,0.7,0.7,0.5));
 	aPen.setWidthF(1.);
 	setBrush(QBrush(QColor::fromRgbF(0.22, 0.22, 0.23, 0.2)));

--- a/src/gui/configurationDialog.ui
+++ b/src/gui/configurationDialog.ui
@@ -1914,7 +1914,7 @@
            </widget>
           </item>
           <item>
-           <widget class="QGroupBox" name="groupBox_3">
+           <widget class="QGroupBox" name="groupBox_Screenshots">
             <property name="title">
              <string>Screenshots</string>
             </property>
@@ -1959,11 +1959,86 @@
               </layout>
              </item>
              <item>
-              <widget class="QCheckBox" name="invertScreenShotColorsCheckBox">
-               <property name="text">
-                <string>Invert colors</string>
+              <layout class="QHBoxLayout" name="horizontalLayout_ScreenshotCustom">
+               <property name="topMargin">
+                <number>0</number>
                </property>
-              </widget>
+               <item>
+                <widget class="QCheckBox" name="invertScreenShotColorsCheckBox">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="text">
+                  <string>Invert colors</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <spacer name="horizontalSpacer_screenshots">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               <item>
+                <widget class="QCheckBox" name="useCustomScreenshotSizeCheckBox">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="text">
+                  <string>Custom size</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLineEdit" name="customScreenshotWidthLineEdit">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLabel" name="label_times">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="toolTip">
+                  <string notr="true"/>
+                 </property>
+                 <property name="text">
+                  <string notr="true">x</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLineEdit" name="customScreenshotHeightLineEdit">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                </widget>
+               </item>
+              </layout>
              </item>
             </layout>
            </widget>


### PR DESCRIPTION
To continue #102: This is not finished yet, but I am a bit stuck, maybe @guillaumechereau or @xalioth can share some insight. 

I want to make high-resolution screenshots. The various parts of the scene, gui, projection, etc. have to be resized, and certainly I have overlooked something again. I cannot make the button bars appear in the low edge of the screen. Also I don't like the hackish projection parameter patching, is there a more elegant solution?

These hi-res screenshots would be nice to have. I think it is acceptable to have small dialog windows and small text, usually these big images are intended for text/guiless poster prints. Panoramas 16384 pixels wide? No problem on better machines.  Or at least FullHD screenshots on netbooks. Maybe text should be resized? I have not played with the effect of pixelRatio, maybe this helps here? 