### PR TITLE
Make sure that splash screen shows up immediately

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -51,6 +51,7 @@
 #include <QTextStream>
 #include <QTranslator>
 #include <QNetworkDiskCache>
+#include <QThread>
 
 #include <clocale>
 
@@ -107,6 +108,28 @@ void clearCache()
 	cacheMgr->setCacheDirectory(StelFileMgr::getCacheDir());
 	cacheMgr->clear(); // Removes all items from the cache.
 }
+
+class SplashScreen : public QSplashScreen
+{
+    bool painted=false;
+    void paintEvent(QPaintEvent* e) override
+    {
+        QSplashScreen::paintEvent(e);
+        painted=true;
+    }
+public:
+    SplashScreen(QPixmap const& pixmap)
+        : QSplashScreen(pixmap)
+    {}
+    void ensureFirstPaint() const
+    {
+        while(!painted)
+        {
+            QThread::usleep(1000);
+            qApp->processEvents();
+        }
+    }
+};
 
 // Main stellarium procedure
 int main(int argc, char **argv)
@@ -168,10 +191,10 @@ int main(int argc, char **argv)
 	StelFileMgr::init();
 
 	QPixmap pixmap(StelFileMgr::findFile("data/splash.png"));
-	QSplashScreen splash(pixmap);
+	SplashScreen splash(pixmap);
 	splash.show();
 	splash.showMessage(StelUtils::getApplicationVersion() , Qt::AlignLeft, Qt::white);
-	app.processEvents();
+	splash.ensureFirstPaint();
 
 	// Log command line arguments.
 	QString argStr;


### PR DESCRIPTION
We want the splash screen to show its image right after it's show()ed. But on Linux X11 paint event often doesn't come until ~30 ms passes, or sometimes more, so that `app.processEvents();` doesn't show anything. In this case, from user's point of view, the splash screen is created at the same time as main window, which is useless. Thus it's better to make sure that paintEvent handler has been called, and only then to proceed with initialization.