### PR TITLE
Ignore warning C4819 in MSVC.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,7 +149,7 @@ IF(WIN32)
           # C4305: type truncation
           # C4351: "new" behaviour, member array default initialization. Required since at least C++98, but funny MSVC throws a warning.
           # C4996: deprecated POSIX names (used in zlib)
-          SET(STEL_MSVC_FLAGS "/wd4244 /wd4305 /wd4351 /wd4996")
+          SET(STEL_MSVC_FLAGS "/wd4244 /wd4305 /wd4351 /wd4819 /wd4996")
           SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${STEL_MSVC_FLAGS}")
           SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${STEL_MSVC_FLAGS}")
           # Additional defines:


### PR DESCRIPTION
The locale of my computer is set as Chinese. Building Stellarium with MSVC resulting a lot of warning C4819:

> The file contains a character that cannot be represented in the current code page (936). Save the file in Unicode format to prevent data loss.

Turn off C4819 to ignore this problem.



