### PR TITLE
Change the type of milliSecondsOfLastJDUpdate to qint64

### DIFF
--- a/src/core/StelCore.hpp
+++ b/src/core/StelCore.hpp
@@ -809,7 +809,7 @@ private:
 	double presetSkyTime;
 	QTime initTodayTime;
 	QString startupTimeMode;
-	double milliSecondsOfLastJDUpdate;    // Time in seconds when the time rate or time last changed
+	qint64 milliSecondsOfLastJDUpdate;    // Time in milliseconds when the time rate or time last changed
 	double jdOfLastJDUpdate;         // JD when the time rate or time last changed
 
 	QString currentTimeZone;	


### PR DESCRIPTION
The getter and setter of milliSecondsOfLastJDUpdate are in qint64, no need for the variable itself to be double. Also update the comment.