### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/src/core/StelCore.cpp
+++ b/src/core/StelCore.cpp
@@ -2280,10 +2280,10 @@ QString StelCore::getCurrentDeltaTAlgorithmDescription(void) const
 			description = q_("This solution by S. Islam, M. Sadiq and M. S. Qureshi, based on Meeus & Simons (2000), was published in article <em>Error Minimization of Polynomial Approximation of DeltaT</em> (%1) and revisited by Sana Islam in 2013.").arg("<a href='http://www.ias.ac.in/article/fulltext/joaa/029/03-04/0363-0366'>2008</a>").append(getCurrentDeltaTAlgorithmValidRangeDescription(jd, &marker));
 			break;
 		case KhalidSultanaZaidi:
-			description = q_("This polynomial approximation with 0.6 seconds of accuracy by M. Khalid, Mariam Sultana and Faheem Zaidi was published in <em>Delta T: Polynomial Approximation of Time Period 1620-2013</em> (%1).").arg("<a href='http://dx.doi.org/10.1155/2014/480964'>2014</a>").append(getCurrentDeltaTAlgorithmValidRangeDescription(jd, &marker));
+			description = q_("This polynomial approximation with 0.6 seconds of accuracy by M. Khalid, Mariam Sultana and Faheem Zaidi was published in <em>Delta T: Polynomial Approximation of Time Period 1620-2013</em> (%1).").arg("<a href='https://doi.org/10.1155/2014/480964'>2014</a>").append(getCurrentDeltaTAlgorithmValidRangeDescription(jd, &marker));
 			break;
 		case StephensonMorrisonHohenkerk2016: // PRIMARY SOURCE, SEEMS VERY IMPORTANT
-			description = q_("This solution by F. R. Stephenson, L. V. Morrison and C. Y. Hohenkerk (2016) was published in <em>Measurement of the Earth’s rotation: 720 BC to AD 2015</em> (%1). Outside of the named range (modelled with a spline fit) it provides values from an approximate parabola.").arg("<a href='http://dx.doi.org/10.1098/rspa.2016.0404'>2016</a>").append(getCurrentDeltaTAlgorithmValidRangeDescription(jd, &marker));
+			description = q_("This solution by F. R. Stephenson, L. V. Morrison and C. Y. Hohenkerk (2016) was published in <em>Measurement of the Earth’s rotation: 720 BC to AD 2015</em> (%1). Outside of the named range (modelled with a spline fit) it provides values from an approximate parabola.").arg("<a href='https://doi.org/10.1098/rspa.2016.0404'>2016</a>").append(getCurrentDeltaTAlgorithmValidRangeDescription(jd, &marker));
 			break;
 		case Custom:
 			description = q_("This is a quadratic formula for calculation of %1T with coefficients defined by the user.").arg(QChar(0x0394));

--- a/src/core/StelUtils.hpp
+++ b/src/core/StelUtils.hpp
@@ -639,7 +639,7 @@ namespace StelUtils
 	//! Implementation of polinomial approximation of time period 1620-2013 for DeltaT by M. Khalid, Mariam Sultana and Faheem Zaidi (2014).
 	//! Source: Delta T: Polynomial Approximation of Time Period 1620-2013
 	//! Journal of Astrophysics, Vol. 2014, Article ID 480964
-	//! http://dx.doi.org/10.1155/2014/480964
+	//! https://doi.org/10.1155/2014/480964
 	//! @param jDay the date and time expressed as a Julian day
 	//! @return Delta-T in seconds
 	double getDeltaTByKhalidSultanaZaidi(const double jDay);
@@ -648,7 +648,7 @@ namespace StelUtils
 	//! Implementation of a spline approximation for time period -720-2016.0 for DeltaT by Stephenson, Morrison and Hohenkerk (2016).
 	//! Source: Measurement of the Earth’s rotation: 720 BC to AD 2015
 	//! Proc. R. Soc. A 472: 20160404.
-	//! http://dx.doi.org/10.1098/rspa.2016.0404
+	//! https://doi.org/10.1098/rspa.2016.0404
 	//! @param jDay the date and time expressed as a Julian day
 	//! @return Delta-T in seconds. For times outside the limits, return result from the fitting parabola.
 	double getDeltaTByStephensonMorrisonHohenkerk2016(const double jDay);

--- a/src/core/planetsephems/precession.h
+++ b/src/core/planetsephems/precession.h
@@ -25,12 +25,12 @@ extern "C" {
 //! Precession modelled from:
 //! J. Vondrák, N. Capitaine, and P. Wallace: New precession expressions, valid for long time intervals
 //! A&A (Astronomy&Astrophysics) 534, A22 (2011)
-//! DOI: http://dx.doi.org/10.1051/0004-6361/201117274
+//! DOI: https://doi.org/10.1051/0004-6361/201117274
 //!    with correction from
 //! J. Vondrak, N. Capitaine, P. Wallace
 //! New precession expressions, valid for long time intervals (Corrigendum)
 //! A&A 541, C1 (2012)
-//! DOI: http://dx.doi.org/10.1051/0004-6361/201117274e
+//! DOI: https://doi.org/10.1051/0004-6361/201117274e
 //!
 //! This paper describes a precession model valid for +/-200.000 years from J2000.0 and consistent with P03 precession accepted as IAU2006 Precession.
 //! Some better understanding of the angles can be found in:


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old links with the `dx` subdomain continue to work.

So, there is no urgent need to do anything, but nonetheless, I'd like to suggest to hereby update all static DOI links.

Cheers!