### PR TITLE
Turn on /MP and /DEBUG:FASTLINK on VS2015+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,6 +150,15 @@ IF(WIN32)
           # C4351: "new" behaviour, member array default initialization. Required since at least C++98, but funny MSVC throws a warning.
           # C4996: deprecated POSIX names (used in zlib)
           SET(STEL_MSVC_FLAGS "/wd4244 /wd4305 /wd4351 /wd4996")
+          IF(MSVC_VERSION GREATER 1700)
+               SET(STEL_MSVC_FLAGS "${STEL_MSVC_FLAGS} /MP")
+
+               FOREACH(flag_var
+                    CMAKE_EXE_LINKER_FLAGS_DEBUG CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO
+                    CMAKE_SHARED_LINKER_FLAGS_DEBUG CMAKE_SHARED_LINKER_FLAGS_RELWITHDEBINFO)
+                    SET(${flag_var} "${${flag_var}} /DEBUG:FASTLINK")
+               ENDFOREACH()
+          ENDIF()
           SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${STEL_MSVC_FLAGS}")
           SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${STEL_MSVC_FLAGS}")
           # Additional defines:


### PR DESCRIPTION
Use options of MSVC to speed up building. Job time in appveyor is reduced from ~12 mins to ~9.5 mins. On my machine, the building is about 3x faster.