### PR TITLE
Fix fullscreen toggle on macos

### DIFF
--- a/src/gui/StelGui.cpp
+++ b/src/gui/StelGui.cpp
@@ -364,6 +364,7 @@ void StelGui::init(QGraphicsWidget *atopLevelGraphicsWidget)
 	pxmapOn = QPixmap(":/graphicGui/btFullScreen-on.png");
 	pxmapOff = QPixmap(":/graphicGui/btFullScreen-off.png");
 	b = new StelButton(Q_NULLPTR, pxmapOn, pxmapOff, pxmapGlow32x32, "actionSet_Full_Screen_Global");
+	b->setTriggerOnRelease(true);
 	skyGui->buttonBar->addButton(b, "060-othersGroup");
 
 	pxmapOn = QPixmap(":/graphicGui/btTimeRewind-on.png");

--- a/src/gui/StelGuiItems.cpp
+++ b/src/gui/StelGuiItems.cpp
@@ -177,8 +177,11 @@ void StelButton::mousePressEvent(QGraphicsSceneMouseEvent* event)
 	QGraphicsItem::mousePressEvent(event);
 	event->accept();
 	setChecked(toggleChecked(checked));
-	emit(toggled(checked));
-	emit(triggered());
+	if (!triggerOnRelease)
+	{
+		emit(toggled(checked));
+		emit(triggered());
+	}
 }
 
 void StelButton::hoverEnterEvent(QGraphicsSceneHoverEvent*)
@@ -205,6 +208,11 @@ void StelButton::mouseReleaseEvent(QGraphicsSceneMouseEvent*)
 
 	if (flagChangeFocus) // true if button is on bottom bar
 		StelMainView::getInstance().focusSky(); // Change the focus after clicking on button
+	if (triggerOnRelease)
+	{
+		emit(toggled(checked));
+		emit(triggered());
+	}
 }
 
 void StelButton::updateIcon()

--- a/src/gui/StelGuiItems.hpp
+++ b/src/gui/StelGuiItems.hpp
@@ -123,6 +123,10 @@ public:
 	//! left buttons call panels which receive focus after button press, so those should be configured with b=false)
 	void setFocusOnSky(bool b) { flagChangeFocus=b; }
 
+	//! Configure the button to trigger its action when the mouse click
+	//! is released (by default buttons trigger on press event).
+	void setTriggerOnRelease(bool b) { triggerOnRelease = b;}
+
 signals:
 	//! Triggered when the button state changes
 	void toggled(bool);
@@ -170,6 +174,7 @@ private:
 	bool isTristate_;
 	double opacity;
 	double hoverOpacity;
+	bool triggerOnRelease = false;
 };
 
 // The button bar on the left containing windows toggle buttons


### PR DESCRIPTION
The problem was that the mouse press event triggers the fullscreen
switch, and the mouse release event is then lost by Qt.  So the user has
to click once on the screen so that the mouse event get processed
properly again.

The fix is was to configure the fullscreen button to trigger on mouse
release event instead of mouse press.  This changes the behavior a
little bit.