### PR TITLE
C++11 auto to replace complicated hand written types.

### DIFF
--- a/plugins/RemoteControl/src/APIController.cpp
+++ b/plugins/RemoteControl/src/APIController.cpp
@@ -38,9 +38,9 @@ APIController::~APIController()
 
 void APIController::update(double deltaTime)
 {
-	for(ServiceMap::iterator it = m_serviceMap.begin();it!=m_serviceMap.end();++it)
+	for (auto& service : m_serviceMap)
 	{
-		(*it)->update(deltaTime);
+		service->update(deltaTime);
 	}
 }
 
@@ -89,7 +89,7 @@ void APIController::service(HttpRequest &request, HttpResponse &response)
 	}
 
 	//try to find service
-	ServiceMap::iterator it = m_serviceMap.find(serviceString);
+	auto it = m_serviceMap.find(serviceString);
 	if(it!=m_serviceMap.end())
 	{
 		RemoteControlServiceInterface* sv = *it;
@@ -149,7 +149,7 @@ void APIController::service(HttpRequest &request, HttpResponse &response)
 	{
 		response.setStatus(400,"Bad Request");
 		QString str(QStringLiteral("Unknown service: '%1'\n\nAvailable services:\n").arg(QString::fromUtf8(pathWithoutPrefix)));
-		for(ServiceMap::iterator it = m_serviceMap.begin();it!=m_serviceMap.end();++it)
+		for (auto it = m_serviceMap.begin(); it != m_serviceMap.end(); ++it)
 		{
 			str.append(QString::fromUtf8(it.key()));
 			str.append("\n");

--- a/plugins/RemoteControl/src/LocationSearchService.cpp
+++ b/plugins/RemoteControl/src/LocationSearchService.cpp
@@ -71,10 +71,10 @@ void LocationSearchService::get(const QByteArray& operation, const APIParameters
 		//use a regexp in wildcard mode, the app does the same
 		QRegExp exp(term,Qt::CaseInsensitive, QRegExp::Wildcard);
 
-		for(QList<QString>::const_iterator it = list.begin();it!=list.end();++it)
+		for(const auto& str : list)
 		{
-			if(it->contains(exp))
-				results.append(*it);
+			if (str.contains(exp))
+				results.append(str);
 		}
 
 		response.writeJSON(QJsonDocument(results));

--- a/plugins/RemoteControl/src/MainService.cpp
+++ b/plugins/RemoteControl/src/MainService.cpp
@@ -729,9 +729,8 @@ QJsonObject MainService::getPropertyChangesSinceID(int changeId)
 			//this is either the initial state (-2) or
 			//something is "broken", probably from an existing web interface that reconnected after restart
 			//force a full reload
-			const StelPropertyMgr::StelPropertyMap& map = propMgr->getPropertyMap();
-			for(StelPropertyMgr::StelPropertyMap::const_iterator it = map.constBegin();
-			    it!=map.constEnd();++it)
+			const auto& map = propMgr->getPropertyMap();
+			for (auto it = map.constBegin(); it != map.constEnd(); ++it)
 			{
 				changes.insert(it.key(), QJsonValue::fromVariant((*it)->getValue()));
 			}
@@ -744,9 +743,8 @@ QJsonObject MainService::getPropertyChangesSinceID(int changeId)
 		{
 			//this is either the initial state (-2) or
 			//"broken" state again, force full reload
-			const StelPropertyMgr::StelPropertyMap& map = propMgr->getPropertyMap();
-			for(StelPropertyMgr::StelPropertyMap::const_iterator it = map.constBegin();
-			    it!=map.constEnd();++it)
+			const auto& map = propMgr->getPropertyMap();
+			for (auto it = map.constBegin(); it != map.constEnd(); ++it)
 			{
 				changes.insert(it.key(), QJsonValue::fromVariant((*it)->getValue()));
 			}

--- a/plugins/RemoteControl/src/ObjectService.cpp
+++ b/plugins/RemoteControl/src/ObjectService.cpp
@@ -163,8 +163,7 @@ void ObjectService::get(const QByteArray& operation, const APIParameters &parame
 			StelObjectMgr* omgr = GETSTELMODULE(StelObjectMgr);
 			StelObjectP obj = omgr->searchByName(name);
 			QVariantMap infoMap=StelObjectMgr::getObjectInfo(obj);
-			QVariantMap::const_iterator i;
-			for (i=infoMap.constBegin(); i!=infoMap.constEnd(); ++i)
+			for (auto i = infoMap.constBegin(); i != infoMap.constEnd(); ++i)
 				infoObj.insert(i.key(), i.value().toString());
 
 			// We make use of 2 extra values for linked applications. These govern sky brightness and can be used for ambient settings.

--- a/plugins/RemoteControl/src/StelPropertyService.cpp
+++ b/plugins/RemoteControl/src/StelPropertyService.cpp
@@ -42,9 +42,8 @@ void StelPropertyService::get(const QByteArray& operation, const APIParameters &
 	{
 		QJsonObject rootObj;
 
-		const StelPropertyMgr::StelPropertyMap& map = propMgr->getPropertyMap();
-		for(StelPropertyMgr::StelPropertyMap::const_iterator it = map.constBegin();
-		    it!=map.constEnd();++it)
+		const auto& map = propMgr->getPropertyMap();
+		for (auto it = map.constBegin(); it != map.constEnd(); ++it)
 		{
 			QJsonObject item;
 			const StelProperty* prop = *it;

--- a/plugins/RemoteSync/src/SyncClientHandlers.cpp
+++ b/plugins/RemoteSync/src/SyncClientHandlers.cpp
@@ -233,13 +233,13 @@ bool ClientSelectionHandler::handleMessage(QDataStream &stream, SyncProtocol::tP
 	//this might cause problems if 2 objects of different types have the same name!
 	QList<StelObjectP> selection;
 
-	for(QList< QPair<QString,QString> >::iterator it = msg.selectedObjects.begin(); it!=msg.selectedObjects.end();++it)
+	for (const auto& selectedObject : msg.selectedObjects)
 	{
-		StelObjectP obj = objMgr->searchByID(it->first, it->second);
+		StelObjectP obj = objMgr->searchByID(selectedObject.first, selectedObject.second);
 		if(obj)
 			selection.append(obj);
 		else
-			qWarning()<<"Object not found"<<it->first<<it->second;
+			qWarning() << "Object not found" << selectedObject.first << selectedObject.second;
 	}
 
 	if(selection.isEmpty())

--- a/plugins/RemoteSync/src/SyncServer.cpp
+++ b/plugins/RemoteSync/src/SyncServer.cpp
@@ -107,9 +107,8 @@ void SyncServer::broadcastMessage(const SyncMessage &msg)
 		return;
 	}
 
-	for(tClientList::iterator it = clients.begin();it!=clients.end();++it)
+	for (auto* client : clients)
 	{
-		SyncRemotePeer* client = *it;
 		if(client->isAuthenticated())
 		{
 			client->writeData(broadcastBuffer,size);
@@ -134,7 +133,7 @@ void SyncServer::stop()
 		}
 		senderList.clear();
 
-		for(tClientList::iterator it = clients.begin();it!=clients.end(); )
+		for (auto it = clients.begin(); it!=clients.end();)
 		{
 			//this may cause disconnected signal, which will remove the client
 			SyncRemotePeer* peer = *it;
@@ -167,9 +166,9 @@ void SyncServer::timerEvent(QTimerEvent *evt)
 void SyncServer::checkTimeouts()
 {
 	//iterate over the connected clients
-	for(tClientList::iterator it = clients.begin(); it!=clients.end(); ++it)
+	for (auto* client : clients)
 	{
-		(*it)->checkTimeout();
+		client->checkTimeout();
 	}
 }
 

--- a/plugins/RemoteSync/src/SyncServerEventSenders.cpp
+++ b/plugins/RemoteSync/src/SyncServerEventSenders.cpp
@@ -99,9 +99,9 @@ Selection SelectionEventSender::constructMessage()
 	//(StelObject::getType does not correspond directly to StelObjectModule::getName)
 	//even then, some objects (e.g. Nebulas) dont seem to have a name at all!
 
-	for (QList<StelObjectP>::const_iterator iter=selObj.constBegin();iter!=selObj.constEnd();++iter)
+	for (const auto& obj : selObj)
 	{
-		msg.selectedObjects.append(qMakePair((*iter)->getType(), (*iter)->getID()));
+		msg.selectedObjects.append(qMakePair(obj->getType(), obj->getID()));
 	}
 
 	return msg;

--- a/plugins/Satellites/src/Satellites.cpp
+++ b/plugins/Satellites/src/Satellites.cpp
@@ -1520,13 +1520,12 @@ void Satellites::updateSatellites(TleDataHash& newTleSets)
 	
 	// Only those not in the loaded collection have remained
 	// (autoAddEnabled is not checked, because it's already in the flags)
-	QHash<QString, TleData>::const_iterator i;
-	for (i = newTleSets.begin(); i != newTleSets.end(); ++i)
+	for (const auto& tleData : newTleSets)
 	{
-		if (i.value().addThis)
+		if (tleData.addThis)
 		{
 			// Add the satellite...
-			if (add(i.value()))
+			if (add(tleData))
 				addedCount++;
 		}
 	}
@@ -1958,8 +1957,7 @@ IridiumFlaresPredictionList Satellites::getIridiumFlaresPrediction()
 		ssystem->getEarth()->computePosition(predictionJD);
 		pcore->update(0);
 
-		QMap<SatelliteP,SatDataStruct>::iterator i = iridiums.begin();
-		while (i != iridiums.end())
+		for (auto i = iridiums.begin(); i != iridiums.end(); ++i)
 		{
 			if ( i.value().nextJD<=predictionJD)
 			{
@@ -2033,7 +2031,6 @@ IridiumFlaresPredictionList Satellites::getIridiumFlaresPrediction()
 				if (nextJD>i.value().nextJD)
 					nextJD = i.value().nextJD;
 			}
-			++i;
 		}
 		predictionJD = nextJD;
 	}

--- a/plugins/Scenery3d/src/Polyhedron.cpp
+++ b/plugins/Scenery3d/src/Polyhedron.cpp
@@ -102,7 +102,7 @@ void Polyhedron::intersect(const Plane &p)
 	QVector<Vec3f> intersectionPoints;
 
 	//Iterate over this polyhedron's polygons
-	for(QVector<SPolygon>::iterator it = polygons.begin(); it != polygons.end();)
+	for (auto it = polygons.begin(); it != polygons.end();)
 	{
 		//Retrive the polygon and intersect it with the specified plane, save the intersection points
 		(*it).intersect(p, intersectionPoints);

--- a/plugins/Scenery3d/src/Scenery3dRemoteControlService.cpp
+++ b/plugins/Scenery3d/src/Scenery3dRemoteControlService.cpp
@@ -63,7 +63,7 @@ void Scenery3dRemoteControlService::get(const QByteArray &operation, const APIPa
 
 		QJsonObject obj;
 
-		for(QMap<QString,QString>::const_iterator it = map.constBegin(); it!=map.constEnd();++it)
+		for (auto it = map.constBegin(); it != map.constEnd(); ++it)
 		{
 			obj.insert(it.value(), StelTranslator::globalTranslator->qtranslate(it.key()));
 		}

--- a/plugins/Scenery3d/src/ShaderManager.cpp
+++ b/plugins/Scenery3d/src/ShaderManager.cpp
@@ -119,10 +119,10 @@ void ShaderMgr::clearCache()
 
 	//iterate over the shaderContentCache - this contains the same amount of shaders as actually exist!
 	//the shaderCache could contain duplicate entries
-	for(t_ShaderContentCache::iterator it = m_shaderContentCache.begin();it!=m_shaderContentCache.end();++it)
+	for (auto* shader : m_shaderContentCache)
 	{
-		if((*it))
-			delete (*it);
+		if (shader)
+			delete shader;
 	}
 
 	m_shaderCache.clear();
@@ -132,7 +132,7 @@ void ShaderMgr::clearCache()
 
 QOpenGLShaderProgram* ShaderMgr::findOrLoadShader(uint flags)
 {
-	t_ShaderCache::iterator it = m_shaderCache.find(flags);
+	auto it = m_shaderCache.find(flags);
 
 	// This may also return Q_NULLPTR if the load failed.
 	//We wait until user explictly forces shader reload until we try again to avoid spamming errors.
@@ -321,7 +321,7 @@ bool ShaderMgr::preprocessShader(const QString &fileName, const uint flags, QByt
 			lineStream>>word;
 
 			//try to find it in our flags list
-			t_FeatureFlagStrings::iterator it = featureFlagsStrings.find(word);
+			auto it = featureFlagsStrings.find(word);
 			if(it!=featureFlagsStrings.end())
 			{
 				bool val = it.value() & flags;
@@ -461,7 +461,7 @@ void ShaderMgr::buildUniformCache(QOpenGLShaderProgram &program)
 
 		GLint loc = program.uniformLocation(str);
 
-		t_UniformStrings::iterator it = uniformStrings.find(str);
+		auto it = uniformStrings.find(str);
 
 		// This may also return Q_NULLPTR if the load failed.
 		//We wait until user explictly forces shader reload until we try again to avoid spamming errors.

--- a/plugins/Scenery3d/src/ShaderManager.hpp
+++ b/plugins/Scenery3d/src/ShaderManager.hpp
@@ -277,7 +277,7 @@ QOpenGLShaderProgram* ShaderMgr::getTextureShader()
 
 GLint ShaderMgr::uniformLocation(const QOpenGLShaderProgram *shad, UNIFORM uni)
 {
-	t_UniformCache::iterator it = m_uniformCache.find(shad);
+	auto it = m_uniformCache.find(shad);
 	if(it!=m_uniformCache.end())
 	{
 		return it.value().value(uni,-1);

--- a/plugins/TelescopeControl/src/TelescopeControl.cpp
+++ b/plugins/TelescopeControl/src/TelescopeControl.cpp
@@ -236,8 +236,8 @@ void TelescopeControl::deinit()
 	//Destroy all clients first in order to avoid displaying a TCP error
 	deleteAllTelescopes();
 
-	QHash<int, QProcess*>::const_iterator iterator = telescopeServerProcess.constBegin();
-	while(iterator != telescopeServerProcess.constEnd())
+	for (auto iterator = telescopeServerProcess.constBegin(); iterator != telescopeServerProcess.constEnd();
+		 ++iterator)
 	{
 		int slotNumber = iterator.key();
 #ifdef Q_OS_WIN
@@ -248,8 +248,6 @@ void TelescopeControl::deinit()
 		telescopeServerProcess[slotNumber]->waitForFinished();
 		delete telescopeServerProcess[slotNumber];
 		qDebug() << "[TelescopeControl] deinit(): Server process at slot" << slotNumber << "terminated successfully.";
-
-		++iterator;
 	}
 
 	//TODO: Decide if it should be saved on change
@@ -453,15 +451,13 @@ void TelescopeControl::communicate(void)
 {
 	if (!telescopeClients.empty())
 	{
-		QMap<int, TelescopeClientP>::const_iterator telescope = telescopeClients.constBegin();
-		while (telescope != telescopeClients.end())
+		for (auto telescope = telescopeClients.constBegin(); telescope != telescopeClients.constEnd(); ++telescope)
 		{
 			logAtSlot(telescope.key());//If there's no log, it will be ignored
 			if(telescope.value()->prepareCommunication())
 			{
 				telescope.value()->performCommunication();
 			}
-			telescope++;
 		}
 	}
 }
@@ -1192,11 +1188,9 @@ bool TelescopeControl::stopAllTelescopes()
 
 	if (!telescopeClients.empty())
 	{
-		QMap<int, TelescopeClientP>::const_iterator telescope = telescopeClients.constBegin();
-		while (telescope != telescopeClients.end())
+		for (auto telescope = telescopeClients.constBegin(); telescope != telescopeClients.constEnd(); ++telescope)
 		{
 			allStoppedSuccessfully = allStoppedSuccessfully && stopTelescopeAtSlot(telescope.key());
-			telescope++;
 		}
 	}
 

--- a/src/core/OctahedronPolygon.cpp
+++ b/src/core/OctahedronPolygon.cpp
@@ -284,13 +284,13 @@ void OctahedronPolygon::projectOnOctahedron(QVarLengthArray<QVector<SubContour>,
 
 	for (int i=0;i<8;++i)
 	{
-		for (QVector<SubContour>::Iterator iter=subs[i].begin();iter!=subs[i].end();++iter)
+		for (auto& sub : subs[i])
 		{
-			for (SubContour::Iterator v=iter->begin();v!=iter->end();++v)
+			for (auto& v : sub)
 			{
 				// Project on the face with aperture = 90 deg
-				v->vertex *= 1./(sideDirections[i]*v->vertex);
-				v->vertex[2]=0.;
+				v.vertex *= 1./(sideDirections[i]*v.vertex);
+				v.vertex[2]=0.;
 				// May want to add offsets after that to map TOAST projection
 			}
 		}

--- a/src/core/StelLocationMgr.cpp
+++ b/src/core/StelLocationMgr.cpp
@@ -477,9 +477,9 @@ StelLocationMgr::StelLocationMgr(const LocationList &locations)
 
 void StelLocationMgr::setLocations(const LocationList &locations)
 {
-	for(LocationList::const_iterator it = locations.constBegin();it!=locations.constEnd();++it)
+	for (const auto& loc : locations)
 	{
-		this->locations.insert(it->getID(),*it);
+		this->locations.insert(loc.getID(), loc);
 	}
 
 	emit locationListChanged();
@@ -530,10 +530,8 @@ LocationMap StelLocationMgr::loadCitiesBin(const QString& fileName)
 	// Sanity checks: It seems we must translate timezone names. Quite a number on Windows, but also still some on Linux.
 	QList<QByteArray> availableTimeZoneList=QTimeZone::availableTimeZoneIds();
 	QStringList unknownTZlist;
-	QMap<QString, StelLocation>::iterator i=res.begin();
-	while (i!=res.end())
+	for (auto& loc : res)
 	{
-		StelLocation loc=i.value();
 		if ((loc.ianaTimeZone!="LMST") &&  (loc.ianaTimeZone!="LTST") && ( ! availableTimeZoneList.contains(loc.ianaTimeZone.toUtf8())) )
 		{
 			// TZ name which is currently unknown to Qt detected. See if we can translate it, if not: complain to qDebug().
@@ -541,7 +539,6 @@ LocationMap StelLocationMgr::loadCitiesBin(const QString& fileName)
 			if (availableTimeZoneList.contains(fixTZname.toUtf8()))
 			{
 				loc.ianaTimeZone=fixTZname;
-				i.value() = loc;
 			}
 			else
 			{
@@ -549,17 +546,14 @@ LocationMap StelLocationMgr::loadCitiesBin(const QString& fileName)
 				unknownTZlist.append(loc.ianaTimeZone);
 			}
 		}
-		++i;
 	}
 	if (unknownTZlist.length()>0)
 	{
 		unknownTZlist.removeDuplicates();
 		qDebug() << "StelLocationMgr::loadCitiesBin(): Summary of unknown TimeZones:";
-		QStringList::const_iterator t=unknownTZlist.begin();
-		while (t!=unknownTZlist.end())
+		for (const auto& tz : unknownTZlist)
 		{
-			qDebug() << *t;
-			++t;
+			qDebug() << tz;
 		}
 		qDebug() << "Please report these timezone names (this logfile) to the Stellarium developers.";
 		// Note to developers: Fill those names and replacements to the map above.
@@ -649,7 +643,7 @@ static float parseAngle(const QString& s, bool* ok)
 
 const StelLocation StelLocationMgr::locationForString(const QString& s) const
 {
-	QMap<QString, StelLocation>::const_iterator iter = locations.find(s);
+	auto iter = locations.find(s);
 	if (iter!=locations.end())
 	{
 		return iter.value();
@@ -746,7 +740,7 @@ bool StelLocationMgr::saveUserLocation(const StelLocation& loc)
 // If the location comes from the base read only list, it cannot be deleted
 bool StelLocationMgr::canDeleteUserLocation(const QString& id) const
 {
-	QMap<QString, StelLocation>::const_iterator iter=locations.find(id);
+	auto iter=locations.find(id);
 
 	// If it's not known at all there is a problem
 	if (iter==locations.end())

--- a/src/core/StelModuleMgr.cpp
+++ b/src/core/StelModuleMgr.cpp
@@ -198,9 +198,8 @@ void StelModuleMgr::setPluginLoadAtStartup(const QString& key, bool b)
 *************************************************************************/
 void StelModuleMgr::generateCallingLists()
 {
-	QMap<StelModule::StelModuleActionName, QList<StelModule*> >::iterator mc;
 	// For each actions (e.g. "draw", "update", etc..)
-	for(mc=callOrders.begin();mc!=callOrders.end();++mc)
+	for (auto mc = callOrders.begin(); mc != callOrders.end(); ++mc)
 	{
 		// Flush previous call orders
 		mc.value().clear();
@@ -287,7 +286,7 @@ QList<StelModuleMgr::PluginDescriptor> StelModuleMgr::getPluginsList()
 	QSettings* conf = StelApp::getInstance().getSettings();
 	Q_ASSERT(conf);
 	conf->beginGroup("plugins_load_at_startup");
-	for (QMap<QString, StelModuleMgr::PluginDescriptor>::Iterator iter=pluginDescriptorList.begin();iter!=pluginDescriptorList.end();++iter)
+	for (auto iter = pluginDescriptorList.begin(); iter != pluginDescriptorList.end(); ++iter)
 	{
 		bool startByDefault = iter.value().info.startByDefault;
 		iter->loadAtStartup = conf->value(iter.key(), startByDefault).toBool();

--- a/src/core/StelOBJ.cpp
+++ b/src/core/StelOBJ.cpp
@@ -379,7 +379,7 @@ bool StelOBJ::parseFace(const ParseParams& params, const V3Vec& posList, const V
 		}
 
 		//check if the vertex is already in the vertex cache
-		VertexCache::const_iterator it = vertCache.find(v);
+		auto it = vertCache.find(v);
 		if(it!=vertCache.end())
 		{
 			//cache hit, reuse index

--- a/src/core/StelObjectMgr.cpp
+++ b/src/core/StelObjectMgr.cpp
@@ -274,7 +274,7 @@ StelObjectP StelObjectMgr::searchByName(const QString &name) const
 
 StelObjectP StelObjectMgr::searchByID(const QString &type, const QString &id) const
 {
-	QMap<QString, StelObjectModule*>::const_iterator it = typeToModuleMap.constFind(type);
+	auto it = typeToModuleMap.constFind(type);
 	if(it!=typeToModuleMap.constEnd())
 	{
 		return (*it)->searchByID(id);;
@@ -442,10 +442,10 @@ bool StelObjectMgr::setSelectedObject(const QList<StelObjectP>& objs, StelModule
 QList<StelObjectP> StelObjectMgr::getSelectedObject(const QString& type)
 {
 	QList<StelObjectP> result;
-	for (QList<StelObjectP>::iterator iter=lastSelectedObjects.begin();iter!=lastSelectedObjects.end();++iter)
+	for (const auto& obj : lastSelectedObjects)
 	{
-		if ((*iter)->getType()==type)
-			result.push_back(*iter);
+		if (obj->getType() == type)
+			result.push_back(obj);
 	}
 	return result;
 }

--- a/src/core/StelSkyDrawer.cpp
+++ b/src/core/StelSkyDrawer.cpp
@@ -891,14 +891,14 @@ void StelSkyDrawer::initColorTableFromConfigFile(QSettings* conf)
 		for (int i=0;i<128;i++)
 		{
 			const float bV = StelSkyDrawer::indexToBV(i);
-			std::map<float,Vec3f>::const_iterator greater(color_map.upper_bound(bV));
+			auto greater = color_map.upper_bound(bV);
 			if (greater == color_map.begin())
 			{
 				colorTable[i] = greater->second;
 			}
 			else
 			{
-				std::map<float,Vec3f>::const_iterator less(greater);--less;
+				auto less = greater;--less;
 				if (greater == color_map.end())
 				{
 					colorTable[i] = less->second;

--- a/src/core/StelSkyImageTile.cpp
+++ b/src/core/StelSkyImageTile.cpp
@@ -93,7 +93,7 @@ void StelSkyImageTile::draw(StelCore* core, StelPainter& sPainter, float)
 
 	// Draw in the good order
 	sPainter.setBlending(true, GL_ONE, GL_ONE);
-	QMap<double, StelSkyImageTile*>::Iterator i = result.end();
+	auto i = result.end();
 	while (i!=result.begin())
 	{
 		--i;
@@ -506,15 +506,15 @@ void StelSkyImageTile::loadFromQVariantMap(const QVariantMap& map)
 	// This is a list of URLs to the child tiles or a list of already loaded map containing child information
 	// (in this later case, the StelSkyImageTile objects will be created later)
 	subTilesUrls = map.value("subTiles").toList();
-	for (QVariantList::Iterator i=subTilesUrls.begin(); i!=subTilesUrls.end();++i)
+	for (auto& variant : subTilesUrls)
 	{
-		if (i->type()==QVariant::Map)
+		if (variant.type() == QVariant::Map)
 		{
 			// Check if the JSON object is a reference, i.e. if it contains a $ref key
-			QVariantMap m = i->toMap();
+			QVariantMap m = variant.toMap();
 			if (m.size()==1 && m.contains("$ref"))
 			{
-				*i=QString(m["$ref"].toString());
+				variant = QString(m["$ref"].toString());
 			}
 		}
 	}

--- a/src/core/StelSkyPolygon.cpp
+++ b/src/core/StelSkyPolygon.cpp
@@ -62,7 +62,7 @@ void StelSkyPolygon::draw(StelCore* core, StelPainter& sPainter, float)
 
 	// Draw in the good order
 	sPainter.setBlending(true, GL_ONE, GL_ONE);
-	QMap<double, StelSkyPolygon*>::Iterator i = result.end();
+	auto i = result.end();
 	while (i!=result.begin())
 	{
 		--i;

--- a/src/core/StelSphericalIndex.hpp
+++ b/src/core/StelSphericalIndex.hpp
@@ -236,11 +236,11 @@ private:
 				}
 
 				// If we have children and one of them contains the element, store it in a sub-level
-				for (QVector<Node>::iterator iter = node.children.begin(); iter!=node.children.end(); ++iter)
+				for (auto& child : node.children)
 				{
-					if (((SphericalRegion*)&(iter->triangle))->contains(el.obj->getRegion().data()))
+					if (((SphericalRegion*)&(child.triangle))->contains(el.obj->getRegion().data()))
 					{
-						insert(*iter, el, level+1);
+						insert(child, el, level + 1);
 						return;
 					}
 				}

--- a/src/core/StelTextureMgr.cpp
+++ b/src/core/StelTextureMgr.cpp
@@ -139,7 +139,7 @@ StelTextureSP StelTextureMgr::createTexture(const QImage &image, const StelTextu
 
 StelTextureSP StelTextureMgr::wrapperForGLTexture(GLuint texId)
 {
-	IdMap::iterator it = idMap.find(texId);
+	auto it = idMap.find(texId);
 	if(it!=idMap.end())
 	{
 		//find out if it is valid
@@ -174,7 +174,7 @@ StelTextureSP StelTextureMgr::wrapperForGLTexture(GLuint texId)
 
 StelTextureSP StelTextureMgr::lookupCache(const QString &file)
 {
-	TexCache::iterator it = textureCache.find(file);
+	auto it = textureCache.find(file);
 	if(it!=textureCache.end())
 	{
 		//find out if it is valid

--- a/src/core/StelVideoMgr.cpp
+++ b/src/core/StelVideoMgr.cpp
@@ -748,10 +748,9 @@ void StelVideoMgr::handleMetaDataChanged()
 		if (verbose)
 			qDebug() << "StelVideoMgr: " << id << ":  Following metadata are available:";
 		QStringList metadataList=videoObjects[id]->player->availableMetaData();
-		QStringList::const_iterator mdIter;
-		for (mdIter=metadataList.constBegin(); mdIter!=metadataList.constEnd(); ++mdIter)
+		for (const auto& md : metadataList)
 		{
-			QString key=(*mdIter).toLocal8Bit().constData();
+			QString key = md.toLocal8Bit().constData();
 			if (verbose)
 				qDebug() << "\t" << key << "==>" << videoObjects[id]->player->metaData(key);
 
@@ -798,8 +797,7 @@ void StelVideoMgr::handleMetaDataChanged(const QString & key, const QVariant & v
 // update() has only to deal with the faders in all videos, and (re)set positions and sizes of video windows.
 void StelVideoMgr::update(double deltaTime)
 {
-	QMap<QString, VideoPlayer*>::const_iterator voIter;
-	for (voIter=videoObjects.constBegin(); voIter!=videoObjects.constEnd(); ++voIter)
+	for (auto voIter = videoObjects.constBegin(); voIter != videoObjects.constEnd(); ++voIter)
 	{
 		QMediaPlayer::MediaStatus mediaStatus = (*voIter)->player->mediaStatus();
 		QString id=voIter.key();

--- a/src/core/TrailGroup.cpp
+++ b/src/core/TrailGroup.cpp
@@ -66,16 +66,16 @@ void TrailGroup::draw(StelCore* core, StelPainter* sPainter)
 void TrailGroup::update()
 {
 	times.append(StelApp::getInstance().getCore()->getJDE());
-	for (QList<Trail>::Iterator iter=allTrails.begin();iter!=allTrails.end();++iter)
+	for (auto& trail : allTrails)
 	{
-		iter->posHistory.append(j2000ToTrailNative*iter->stelObject->getJ2000EquatorialPos(StelApp::getInstance().getCore()));
+		trail.posHistory.append(j2000ToTrailNative * trail.stelObject->getJ2000EquatorialPos(StelApp::getInstance().getCore()));
 	}
 	if (StelApp::getInstance().getCore()->getJDE()-times.at(0)>timeExtent)
 	{
 		times.pop_front();
-		for (QList<Trail>::Iterator iter=allTrails.begin();iter!=allTrails.end();++iter)
+		for (auto& trail : allTrails)
 		{
-			iter->posHistory.pop_front();
+			trail.posHistory.pop_front();
 		}
 	}
 }
@@ -95,8 +95,8 @@ void TrailGroup::addObject(const StelObjectP& obj, const Vec3f* col)
 void TrailGroup::reset()
 {
 	times.clear();
-	for (QList<Trail>::Iterator iter=allTrails.begin();iter!=allTrails.end();++iter)
+	for (auto& trail : allTrails)
 	{
-		iter->posHistory.clear();
+		trail.posHistory.clear();
 	}
 }

--- a/src/core/modules/AsterismMgr.cpp
+++ b/src/core/modules/AsterismMgr.cpp
@@ -62,11 +62,9 @@ AsterismMgr::AsterismMgr(StarMgr *_hip_stars)
 
 AsterismMgr::~AsterismMgr()
 {
-	std::vector<Asterism *>::iterator iter;
-
-	for (iter = asterisms.begin(); iter != asterisms.end(); iter++)
+	for (auto* asterism : asterisms)
 	{
-		delete(*iter);
+		delete asterism;
 	}
 }
 
@@ -244,9 +242,8 @@ void AsterismMgr::loadLines(const QString &fileName)
 	in.seek(0);
 
 	// delete existing data, if any
-	vector < Asterism * >::iterator iter;
-	for (iter = asterisms.begin(); iter != asterisms.end(); ++iter)
-		delete(*iter);
+	for (auto* asterism : asterisms)
+		delete asterism;
 
 	asterisms.clear();
 	Asterism *aster = Q_NULLPTR;
@@ -307,11 +304,10 @@ void AsterismMgr::drawLines(StelPainter& sPainter, const StelCore* core) const
 	sPainter.setLineSmooth(true);
 
 	const SphericalCap& viewportHalfspace = sPainter.getProjector()->getBoundingCap();
-	vector < Asterism * >::const_iterator iter;
-	for (iter = asterisms.begin(); iter != asterisms.end(); ++iter)
+	for (auto* asterism : asterisms)
 	{
-		if ((*iter)->isAsterism())
-			(*iter)->drawOptim(sPainter, core, viewportHalfspace);
+		if (asterism->isAsterism())
+			asterism->drawOptim(sPainter, core, viewportHalfspace);
 	}
 	if (asterismLineThickness>1)
 		sPainter.setLineWidth(1); // restore line thickness
@@ -330,11 +326,10 @@ void AsterismMgr::drawRayHelpers(StelPainter& sPainter, const StelCore* core) co
 	sPainter.setLineSmooth(true);
 
 	const SphericalCap& viewportHalfspace = sPainter.getProjector()->getBoundingCap();
-	vector < Asterism * >::const_iterator iter;
-	for (iter = asterisms.begin(); iter != asterisms.end(); ++iter)
+	for (auto* asterism : asterisms)
 	{
-		if (!(*iter)->isAsterism())
-			(*iter)->drawOptim(sPainter, core, viewportHalfspace);
+		if (!asterism->isAsterism())
+			asterism->drawOptim(sPainter, core, viewportHalfspace);
 	}
 	if (rayHelperThickness>1)
 		sPainter.setLineWidth(1); // restore line thickness
@@ -348,24 +343,22 @@ void AsterismMgr::drawNames(StelPainter& sPainter) const
 		return;
 
 	sPainter.setBlending(true);
-	vector < Asterism * >::const_iterator iter;
-	for (iter = asterisms.begin(); iter != asterisms.end(); iter++)
+	for (auto* asterism : asterisms)
 	{
-		if (!(*iter)->flagAsterism) continue;
+		if (!asterism->flagAsterism) continue;
 		// Check if in the field of view
-		if (sPainter.getProjector()->projectCheck((*iter)->XYZname, (*iter)->XYname))
-			(*iter)->drawName(sPainter);
+		if (sPainter.getProjector()->projectCheck(asterism->XYZname, asterism->XYname))
+			asterism->drawName(sPainter);
 	}
 }
 
 Asterism *AsterismMgr::isStarIn(const StelObject* s) const
 {
-	vector < Asterism * >::const_iterator iter;
-	for (iter = asterisms.begin(); iter != asterisms.end(); ++iter)
+	for (auto* asterism : asterisms)
 	{
-		if ((*iter)->isStarIn(s))
+		if (asterism->isStarIn(s))
 		{
-			return (*iter);
+			return asterism;
 		}
 	}
 	return Q_NULLPTR;
@@ -373,11 +366,10 @@ Asterism *AsterismMgr::isStarIn(const StelObject* s) const
 
 Asterism* AsterismMgr::findFromAbbreviation(const QString& abbreviation) const
 {
-	vector < Asterism * >::const_iterator iter;
-	for (iter = asterisms.begin(); iter != asterisms.end(); ++iter)
+	for (auto* asterism : asterisms)
 	{
-		if ((*iter)->abbreviation.compare(abbreviation, Qt::CaseInsensitive) == 0)
-			return (*iter);
+		if (asterism->abbreviation.compare(abbreviation, Qt::CaseInsensitive) == 0)
+			return asterism;
 	}
 	return Q_NULLPTR;
 }
@@ -395,10 +387,9 @@ void AsterismMgr::loadNames(const QString& namesFile)
 	if (asterisms.empty()) return;
 
 	// clear previous names
-	vector < Asterism * >::const_iterator iter;
-	for (iter = asterisms.begin(); iter != asterisms.end(); ++iter)
+	for (auto* asterism : asterisms)
 	{
-		(*iter)->englishName.clear();
+		asterism->englishName.clear();
 	}
 
 	// Open file
@@ -471,21 +462,19 @@ void AsterismMgr::loadNames(const QString& namesFile)
 void AsterismMgr::updateI18n()
 {
 	const StelTranslator& trans = StelApp::getInstance().getLocaleMgr().getSkyTranslator();
-	vector < Asterism * >::const_iterator iter;
-	for (iter = asterisms.begin(); iter != asterisms.end(); ++iter)
+	for (auto* asterism : asterisms)
 	{
-		(*iter)->nameI18 = trans.qtranslate((*iter)->englishName, (*iter)->context);
+		asterism->nameI18 = trans.qtranslate(asterism->englishName, asterism->context);
 	}
 }
 
 // update faders
 void AsterismMgr::update(double deltaTime)
 {
-	vector < Asterism * >::const_iterator iter;
 	const int delta = (int)(deltaTime*1000);
-	for (iter = asterisms.begin(); iter != asterisms.end(); ++iter)
+	for (auto* asterism : asterisms)
 	{
-		(*iter)->update(delta);
+		asterism->update(delta);
 	}
 }
 
@@ -494,10 +483,9 @@ void AsterismMgr::setFlagLines(const bool displayed)
 	if(linesDisplayed != displayed)
 	{
 		linesDisplayed = displayed;
-		vector < Asterism * >::const_iterator iter;
-		for (iter = asterisms.begin(); iter != asterisms.end(); ++iter)
+		for (auto* asterism : asterisms)
 		{
-			(*iter)->setFlagLines(linesDisplayed);
+			asterism->setFlagLines(linesDisplayed);
 		}
 		emit linesDisplayedChanged(displayed);
 	}
@@ -513,10 +501,9 @@ void AsterismMgr::setFlagRayHelpers(const bool displayed)
 	if(rayHelpersDisplayed != displayed)
 	{
 		rayHelpersDisplayed = displayed;
-		vector < Asterism * >::const_iterator iter;
-		for (iter = asterisms.begin(); iter != asterisms.end(); ++iter)
+		for (auto* asterism : asterisms)
 		{
-			(*iter)->setFlagRayHelpers(rayHelpersDisplayed);
+			asterism->setFlagRayHelpers(rayHelpersDisplayed);
 		}
 		emit rayHelpersDisplayedChanged(displayed);
 	}
@@ -532,9 +519,8 @@ void AsterismMgr::setFlagLabels(const bool displayed)
 	if (namesDisplayed != displayed)
 	{
 		namesDisplayed = displayed;
-		vector < Asterism * >::const_iterator iter;
-		for (iter = asterisms.begin(); iter != asterisms.end(); ++iter)
-			(*iter)->setFlagLabels(namesDisplayed);
+		for (auto* asterism : asterisms)
+			asterism->setFlagLabels(namesDisplayed);
 
 		emit namesDisplayedChanged(displayed);
 	}
@@ -549,11 +535,10 @@ StelObjectP AsterismMgr::searchByNameI18n(const QString& nameI18n) const
 {
 	QString objw = nameI18n.toUpper();
 
-	vector <Asterism*>::const_iterator iter;
-	for (iter = asterisms.begin(); iter != asterisms.end(); ++iter)
+	for (auto* asterism : asterisms)
 	{
-		QString objwcap = (*iter)->nameI18.toUpper();
-		if (objwcap==objw) return *iter;
+		QString objwcap = asterism->nameI18.toUpper();
+		if (objwcap == objw) return asterism;
 	}
 	return Q_NULLPTR;
 }
@@ -561,14 +546,13 @@ StelObjectP AsterismMgr::searchByNameI18n(const QString& nameI18n) const
 StelObjectP AsterismMgr::searchByName(const QString& name) const
 {
 	QString objw = name.toUpper();
-	vector <Asterism*>::const_iterator iter;
-	for (iter = asterisms.begin(); iter != asterisms.end(); ++iter)
+	for (auto* asterism : asterisms)
 	{
-		QString objwcap = (*iter)->englishName.toUpper();
-		if (objwcap==objw) return *iter;
+		QString objwcap = asterism->englishName.toUpper();
+		if (objwcap == objw) return asterism;
 
-		objwcap = (*iter)->abbreviation.toUpper();
-		if (objwcap==objw) return *iter;
+		objwcap = asterism->abbreviation.toUpper();
+		if (objwcap == objw) return asterism;
 	}
 	return Q_NULLPTR;
 }
@@ -581,10 +565,9 @@ QStringList AsterismMgr::listMatchingObjects(const QString& objPrefix, int maxNb
 		return result;
 	}
 
-	vector<Asterism*>::const_iterator iter;
-	for (iter = asterisms.begin(); iter != asterisms.end(); ++iter)
+	for (auto* asterism : asterisms)
 	{
-		QString name = inEnglish ? (*iter)->getEnglishName() : (*iter)->getNameI18n();
+		QString name = inEnglish ? asterism->getEnglishName() : asterism->getNameI18n();
 		if (!matchObjectName(name, objPrefix, useStartOfWords))
 		{
 			continue;
@@ -625,10 +608,9 @@ QStringList AsterismMgr::listAllObjects(bool inEnglish) const
 
 StelObjectP AsterismMgr::searchByID(const QString &id) const
 {
-	vector <Asterism*>::const_iterator iter;
-	for (iter = asterisms.begin(); iter != asterisms.end(); ++iter)
+	for (auto* asterism : asterisms)
 	{
-		if ((*iter)->getID() == id) return *iter;
+		if (asterism->getID() == id) return asterism;
 	}
 	return Q_NULLPTR;
 }

--- a/src/core/modules/ConstellationMgr.cpp
+++ b/src/core/modules/ConstellationMgr.cpp
@@ -70,19 +70,15 @@ ConstellationMgr::ConstellationMgr(StarMgr *_hip_stars)
 
 ConstellationMgr::~ConstellationMgr()
 {
-	std::vector<Constellation *>::iterator iter;
-
-	for (iter = constellations.begin(); iter != constellations.end(); iter++)
+	for (auto* constellation : constellations)
 	{
-		delete(*iter);
+		delete constellation;
 	}
 
-	vector<vector<Vec3d> *>::iterator iter1;
-	for (iter1 = allBoundarySegments.begin(); iter1 != allBoundarySegments.end(); ++iter1)
+	for (auto* segment : allBoundarySegments)
 	{
-		delete (*iter1);
+		delete segment;
 	}
-	allBoundarySegments.clear();
 }
 
 void ConstellationMgr::init()
@@ -403,9 +399,8 @@ void ConstellationMgr::loadLinesAndArt(const QString &fileName, const QString &a
 	in.seek(0);
 
 	// delete existing data, if any
-	vector < Constellation * >::iterator iter;
-	for (iter = constellations.begin(); iter != constellations.end(); ++iter)
-		delete(*iter);
+	for (auto* constellation : constellations)
+		delete constellation;
 
 	constellations.clear();
 	Constellation *cons = Q_NULLPTR;
@@ -596,11 +591,10 @@ void ConstellationMgr::drawArt(StelPainter& sPainter) const
 	sPainter.setBlending(true, GL_ONE, GL_ONE);
 	sPainter.setCullFace(true);
 
-	vector < Constellation * >::const_iterator iter;
 	SphericalRegionP region = sPainter.getProjector()->getViewportConvexPolygon();
-	for (iter = constellations.begin(); iter != constellations.end(); ++iter)
+	for (auto* constellation : constellations)
 	{
-		(*iter)->drawArtOptim(sPainter, *region);
+		constellation->drawArtOptim(sPainter, *region);
 	}
 
 	sPainter.setCullFace(false);
@@ -615,10 +609,9 @@ void ConstellationMgr::drawLines(StelPainter& sPainter, const StelCore* core) co
 	sPainter.setLineSmooth(true);
 
 	const SphericalCap& viewportHalfspace = sPainter.getProjector()->getBoundingCap();
-	vector < Constellation * >::const_iterator iter;
-	for (iter = constellations.begin(); iter != constellations.end(); ++iter)
+	for (auto* constellation : constellations)
 	{
-		(*iter)->drawOptim(sPainter, core, viewportHalfspace);
+		constellation->drawOptim(sPainter, core, viewportHalfspace);
 	}
 	if (constellationLineThickness>1)
 		sPainter.setLineWidth(1); // restore line thickness
@@ -629,24 +622,22 @@ void ConstellationMgr::drawLines(StelPainter& sPainter, const StelCore* core) co
 void ConstellationMgr::drawNames(StelPainter& sPainter) const
 {
 	sPainter.setBlending(true);
-	vector < Constellation * >::const_iterator iter;
-	for (iter = constellations.begin(); iter != constellations.end(); iter++)
+	for (auto* constellation : constellations)
 	{
 		// Check if in the field of view
-		if (sPainter.getProjector()->projectCheck((*iter)->XYZname, (*iter)->XYname))
-			(*iter)->drawName(sPainter, constellationDisplayStyle);
+		if (sPainter.getProjector()->projectCheck(constellation->XYZname, constellation->XYname))
+			constellation->drawName(sPainter, constellationDisplayStyle);
 	}
 }
 
 Constellation *ConstellationMgr::isStarIn(const StelObject* s) const
 {
-	vector < Constellation * >::const_iterator iter;
-	for (iter = constellations.begin(); iter != constellations.end(); ++iter)
+	for (auto* constellation : constellations)
 	{
 		// Check if the star is in one of the constellation
-		if ((*iter)->isStarIn(s))
+		if (constellation->isStarIn(s))
 		{
-			return (*iter);
+			return constellation;
 		}
 	}
 	return Q_NULLPTR;
@@ -657,17 +648,16 @@ Constellation* ConstellationMgr::findFromAbbreviation(const QString& abbreviatio
 	// search in uppercase only
 	//QString tname = abbreviation.toUpper();
 
-	vector < Constellation * >::const_iterator iter;
-	for (iter = constellations.begin(); iter != constellations.end(); ++iter)
+	for (auto* constellation : constellations)
 	{
-		//if ((*iter)->abbreviation.toUpper() == tname)
-		if ((*iter)->abbreviation.compare(abbreviation, Qt::CaseInsensitive) == 0)
+		//if (constellation->abbreviation.toUpper() == tname)
+		if (constellation->abbreviation.compare(abbreviation, Qt::CaseInsensitive) == 0)
 		{
-			//if ((*iter)->abbreviation != abbreviation)
-			//	qDebug() << "ConstellationMgr::findFromAbbreviation: not a perfect match, but sufficient:" << (*iter)->abbreviation << "vs." << abbreviation;
-			return (*iter);
+			//if (constellation->abbreviation != abbreviation)
+			//	qDebug() << "ConstellationMgr::findFromAbbreviation: not a perfect match, but sufficient:" << constellation->abbreviation << "vs." << abbreviation;
+			return constellation;
 		}
-		//else qDebug() << "Comparison mismatch: " << abbreviation << "vs." << (*iter)->abbreviation;
+		//else qDebug() << "Comparison mismatch: " << abbreviation << "vs." << constellation->abbreviation;
 	}
 	return Q_NULLPTR;
 }
@@ -684,10 +674,9 @@ void ConstellationMgr::loadNames(const QString& namesFile)
 	if (constellations.empty()) return;
 
 	// clear previous names
-	vector < Constellation * >::const_iterator iter;
-	for (iter = constellations.begin(); iter != constellations.end(); ++iter)
+	for (auto* constellation : constellations)
 	{
-		(*iter)->englishName.clear();
+		constellation->englishName.clear();
 	}
 
 	// Open file
@@ -775,12 +764,11 @@ void ConstellationMgr::loadSeasonalRules(const QString& rulesFile)
 		flag = false;
 
 	// clear previous names
-	vector < Constellation * >::const_iterator iter;
-	for (iter = constellations.begin(); iter != constellations.end(); ++iter)
+	for (auto* constellation : constellations)
 	{
-		(*iter)->beginSeason = 1;
-		(*iter)->endSeason = 12;
-		(*iter)->seasonalRuleEnabled = flag;
+		constellation->beginSeason = 1;
+		constellation->endSeason = 12;
+		constellation->seasonalRuleEnabled = flag;
 	}
 
 	// Current starlore didn't support the seasonal rules
@@ -850,10 +838,9 @@ void ConstellationMgr::loadSeasonalRules(const QString& rulesFile)
 void ConstellationMgr::updateI18n()
 {
 	const StelTranslator& trans = StelApp::getInstance().getLocaleMgr().getSkyTranslator();
-	vector < Constellation * >::const_iterator iter;
-	for (iter = constellations.begin(); iter != constellations.end(); ++iter)
+	for (auto* constellation : constellations)
 	{
-		(*iter)->nameI18 = trans.qtranslate((*iter)->englishName, (*iter)->context);
+		constellation->nameI18 = trans.qtranslate(constellation->englishName, constellation->context);
 	}
 }
 
@@ -864,11 +851,10 @@ void ConstellationMgr::update(double deltaTime)
 	double fov = StelApp::getInstance().getCore()->getMovementMgr()->getCurrentFov();
 	Constellation::artIntensityFovScale = qBound(0.0,(fov - artIntensityMinimumFov) / (artIntensityMaximumFov - artIntensityMinimumFov),1.0);
 
-	vector < Constellation * >::const_iterator iter;
 	const int delta = (int)(deltaTime*1000);
-	for (iter = constellations.begin(); iter != constellations.end(); ++iter)
+	for (auto* constellation : constellations)
 	{
-		(*iter)->update(delta);
+		constellation->update(delta);
 	}
 }
 
@@ -878,10 +864,9 @@ void ConstellationMgr::setArtIntensity(const float intensity)
 	{
 		artIntensity = intensity;
 
-		vector < Constellation * >::const_iterator iter;
-		for (iter = constellations.begin(); iter != constellations.end(); ++iter)
+		for (auto* constellation : constellations)
 		{
-			(*iter)->artOpacity = artIntensity;
+			constellation->artOpacity = artIntensity;
 		}
 
 		emit artIntensityChanged(intensity);
@@ -919,10 +904,9 @@ void ConstellationMgr::setArtFadeDuration(const float duration)
 	{
 		artFadeDuration = duration;
 
-		vector < Constellation * >::const_iterator iter;
-		for (iter = constellations.begin(); iter != constellations.end(); ++iter)
+		for (auto* constellation : constellations)
 		{
-			(*iter)->artFader.setDuration((int) (duration * 1000.f));
+			constellation->artFader.setDuration((int)(duration * 1000.f));
 		}
 		emit artFadeDurationChanged(duration);
 	}
@@ -938,20 +922,18 @@ void ConstellationMgr::setFlagLines(const bool displayed)
 	if(linesDisplayed != displayed)
 	{
 		linesDisplayed = displayed;
-		if (selected.begin() != selected.end()  && isolateSelected)
+		if (!selected.empty() && isolateSelected)
 		{
-			vector < Constellation * >::const_iterator iter;
-			for (iter = selected.begin(); iter != selected.end(); ++iter)
+			for (auto* constellation : selected)
 			{
-				(*iter)->setFlagLines(linesDisplayed);
+				constellation->setFlagLines(linesDisplayed);
 			}
 		}
 		else
 		{
-			vector < Constellation * >::const_iterator iter;
-			for (iter = constellations.begin(); iter != constellations.end(); ++iter)
+			for (auto* constellation : constellations)
 			{
-				(*iter)->setFlagLines(linesDisplayed);
+				constellation->setFlagLines(linesDisplayed);
 			}
 		}
 		emit linesDisplayedChanged(displayed);
@@ -968,20 +950,18 @@ void ConstellationMgr::setFlagBoundaries(const bool displayed)
 	if (boundariesDisplayed != displayed)
 	{
 		boundariesDisplayed = displayed;
-		if (selected.begin() != selected.end() && isolateSelected)
+		if (!selected.empty() && isolateSelected)
 		{
-			vector < Constellation * >::const_iterator iter;
-			for (iter = selected.begin(); iter != selected.end(); ++iter)
+			for (auto* constellation : selected)
 			{
-				(*iter)->setFlagBoundaries(boundariesDisplayed);
+				constellation->setFlagBoundaries(boundariesDisplayed);
 			}
 		}
 		else
 		{
-			vector < Constellation * >::const_iterator iter;
-			for (iter = constellations.begin(); iter != constellations.end(); ++iter)
+			for (auto* constellation : constellations)
 			{
-				(*iter)->setFlagBoundaries(boundariesDisplayed);
+				constellation->setFlagBoundaries(boundariesDisplayed);
 			}
 		}
 		emit boundariesDisplayedChanged(displayed);
@@ -998,20 +978,18 @@ void ConstellationMgr::setFlagArt(const bool displayed)
 	if (artDisplayed != displayed)
 	{
 		artDisplayed = displayed;
-		if (selected.begin() != selected.end() && isolateSelected)
+		if (!selected.empty() && isolateSelected)
 		{
-			vector < Constellation * >::const_iterator iter;
-			for (iter = selected.begin(); iter != selected.end(); ++iter)
+			for (auto* constellation : selected)
 			{
-				(*iter)->setFlagArt(artDisplayed);
+				constellation->setFlagArt(artDisplayed);
 			}
 		}
 		else
 		{
-			vector < Constellation * >::const_iterator iter;
-			for (iter = constellations.begin(); iter != constellations.end(); ++iter)
+			for (auto* constellation : constellations)
 			{
-				(*iter)->setFlagArt(artDisplayed);
+				constellation->setFlagArt(artDisplayed);
 			}
 		}
 		emit artDisplayedChanged(displayed);
@@ -1028,17 +1006,15 @@ void ConstellationMgr::setFlagLabels(const bool displayed)
 	if (namesDisplayed != displayed)
 	{
 		namesDisplayed = displayed;
-		if (selected.begin() != selected.end() && isolateSelected)
+		if (!selected.empty() && isolateSelected)
 		{
-			vector < Constellation * >::const_iterator iter;
-			for (iter = selected.begin(); iter != selected.end(); ++iter)
-				(*iter)->setFlagLabels(namesDisplayed);
+			for (auto* constellation : selected)
+				constellation->setFlagLabels(namesDisplayed);
 		}
 		else
 		{
-			vector < Constellation * >::const_iterator iter;
-			for (iter = constellations.begin(); iter != constellations.end(); ++iter)
-				(*iter)->setFlagLabels(namesDisplayed);
+			for (auto* constellation : constellations)
+				constellation->setFlagLabels(namesDisplayed);
 		}
 		emit namesDisplayedChanged(displayed);
 	}
@@ -1058,13 +1034,12 @@ void ConstellationMgr::setFlagIsolateSelected(const bool isolate)
 		// when turning off isolated selection mode, clear exisiting isolated selections.
 		if (!isolateSelected)
 		{
-			vector < Constellation * >::const_iterator iter;
-			for (iter = constellations.begin(); iter != constellations.end(); ++iter)
+			for (auto* constellation : constellations)
 			{
-				(*iter)->setFlagLines(getFlagLines());
-				(*iter)->setFlagLabels(getFlagLabels());
-				(*iter)->setFlagArt(getFlagArt());
-				(*iter)->setFlagBoundaries(getFlagBoundaries());
+				constellation->setFlagLines(getFlagLines());
+				constellation->setFlagLabels(getFlagLabels());
+				constellation->setFlagArt(getFlagArt());
+				constellation->setFlagBoundaries(getFlagBoundaries());
 			}
 		}
 		emit isolateSelectedChanged(isolate);
@@ -1125,14 +1100,12 @@ void ConstellationMgr::setSelectedConst(Constellation * c)
 				c->setFlagArt(getFlagArt());
 				c->setFlagBoundaries(getFlagBoundaries());
 
-				vector < Constellation * >::const_iterator iter;
-				for (iter = constellations.begin(); iter != constellations.end(); ++iter)
+				for (auto* constellation : constellations)
 				{
 					bool match = false;
-					vector < Constellation * >::const_iterator s_iter;
-					for (s_iter = selected.begin(); s_iter != selected.end(); ++s_iter)
+					for (auto* selected_constellation : selected)
 					{
-						if( (*iter)==(*s_iter) )
+						if (constellation == selected_constellation)
 						{
 							match=true; // this is a selected constellation
 							break;
@@ -1142,22 +1115,21 @@ void ConstellationMgr::setSelectedConst(Constellation * c)
 					if(!match)
 					{
 						// Not selected constellation
-						(*iter)->setFlagLines(false);
-						(*iter)->setFlagLabels(false);
-						(*iter)->setFlagArt(false);
-						(*iter)->setFlagBoundaries(false);
+						constellation->setFlagLines(false);
+						constellation->setFlagLabels(false);
+						constellation->setFlagArt(false);
+						constellation->setFlagBoundaries(false);
 					}
 				}
 			}
 			else
 			{
-				vector < Constellation * >::const_iterator iter;
-				for (iter = constellations.begin(); iter != constellations.end(); ++iter)
+				for (auto* constellation : constellations)
 				{
-					(*iter)->setFlagLines(false);
-					(*iter)->setFlagLabels(false);
-					(*iter)->setFlagArt(false);
-					(*iter)->setFlagBoundaries(false);
+					constellation->setFlagLines(false);
+					constellation->setFlagLabels(false);
+					constellation->setFlagArt(false);
+					constellation->setFlagBoundaries(false);
 				}
 
 				// Propagate current settings to newly selected constellation
@@ -1177,13 +1149,12 @@ void ConstellationMgr::setSelectedConst(Constellation * c)
 		if (selected.empty()) return;
 
 		// Otherwise apply standard flags to all constellations
-		vector < Constellation * >::const_iterator iter;
-		for (iter = constellations.begin(); iter != constellations.end(); ++iter)
+		for (auto* constellation : constellations)
 		{
-			(*iter)->setFlagLines(getFlagLines());
-			(*iter)->setFlagLabels(getFlagLabels());
-			(*iter)->setFlagArt(getFlagArt());
-			(*iter)->setFlagBoundaries(getFlagBoundaries());
+			constellation->setFlagLines(getFlagLines());
+			constellation->setFlagLabels(getFlagLabels());
+			constellation->setFlagArt(getFlagArt());
+			constellation->setFlagBoundaries(getFlagBoundaries());
 		}
 
 		// And remove all selections
@@ -1197,8 +1168,7 @@ void ConstellationMgr::unsetSelectedConst(Constellation * c)
 	if (c != Q_NULLPTR)
 	{
 
-		vector < Constellation * >::iterator iter;
-		for (iter = selected.begin(); iter != selected.end();)
+		for (auto iter = selected.begin(); iter != selected.end();)
 		{
 			if( (*iter)->getEnglishName() == c->getEnglishName() )
 			{
@@ -1215,12 +1185,12 @@ void ConstellationMgr::unsetSelectedConst(Constellation * c)
 		{
 
 			// Otherwise apply standard flags to all constellations
-			for (iter = constellations.begin(); iter != constellations.end(); ++iter)
+			for (auto* constellation : constellations)
 			{
-				(*iter)->setFlagLines(getFlagLines());
-				(*iter)->setFlagLabels(getFlagLabels());
-				(*iter)->setFlagArt(getFlagArt());
-				(*iter)->setFlagBoundaries(getFlagBoundaries());
+				constellation->setFlagLines(getFlagLines());
+				constellation->setFlagLabels(getFlagLabels());
+				constellation->setFlagArt(getFlagArt());
+				constellation->setFlagBoundaries(getFlagBoundaries());
 			}
 
 			Constellation::singleSelected = false; // For boundaries
@@ -1246,10 +1216,9 @@ bool ConstellationMgr::loadBoundaries(const QString& boundaryFile)
 	unsigned int i, j;
 
 	// delete existing boundaries if any exist
-	vector<vector<Vec3d> *>::iterator iter;
-	for (iter = allBoundarySegments.begin(); iter != allBoundarySegments.end(); ++iter)
+	for (auto* segment : allBoundarySegments)
 	{
-		delete (*iter);
+		delete segment;
 	}
 	allBoundarySegments.clear();
 
@@ -1349,10 +1318,9 @@ bool ConstellationMgr::loadBoundaries(const QString& boundaryFile)
 void ConstellationMgr::drawBoundaries(StelPainter& sPainter) const
 {
 	sPainter.setBlending(false);
-	vector < Constellation * >::const_iterator iter;
-	for (iter = constellations.begin(); iter != constellations.end(); ++iter)
+	for (auto* constellation : constellations)
 	{
-		(*iter)->drawBoundaryOptim(sPainter);
+		constellation->drawBoundaryOptim(sPainter);
 	}
 }
 
@@ -1360,11 +1328,10 @@ StelObjectP ConstellationMgr::searchByNameI18n(const QString& nameI18n) const
 {
 	QString objw = nameI18n.toUpper();
 
-	vector <Constellation*>::const_iterator iter;
-	for (iter = constellations.begin(); iter != constellations.end(); ++iter)
+	for (auto* constellation : constellations)
 	{
-		QString objwcap = (*iter)->nameI18.toUpper();
-		if (objwcap==objw) return *iter;
+		QString objwcap = constellation->nameI18.toUpper();
+		if (objwcap == objw) return constellation;
 	}
 	return Q_NULLPTR;
 }
@@ -1372,24 +1339,22 @@ StelObjectP ConstellationMgr::searchByNameI18n(const QString& nameI18n) const
 StelObjectP ConstellationMgr::searchByName(const QString& name) const
 {
 	QString objw = name.toUpper();
-	vector <Constellation*>::const_iterator iter;
-	for (iter = constellations.begin(); iter != constellations.end(); ++iter)
+	for (auto* constellation : constellations)
 	{
-		QString objwcap = (*iter)->englishName.toUpper();
-		if (objwcap==objw) return *iter;
+		QString objwcap = constellation->englishName.toUpper();
+		if (objwcap == objw) return constellation;
 
-		objwcap = (*iter)->abbreviation.toUpper();
-		if (objwcap==objw) return *iter;
+		objwcap = constellation->abbreviation.toUpper();
+		if (objwcap == objw) return constellation;
 	}
 	return Q_NULLPTR;
 }
 
 StelObjectP ConstellationMgr::searchByID(const QString &id) const
 {
-	vector <Constellation*>::const_iterator iter;
-	for (iter = constellations.begin(); iter != constellations.end(); ++iter)
+	for (auto* constellation : constellations)
 	{
-		if ((*iter)->getID() == id) return *iter;
+		if (constellation->getID() == id) return constellation;
 	}
 	return Q_NULLPTR;
 }
@@ -1402,10 +1367,9 @@ QStringList ConstellationMgr::listMatchingObjects(const QString& objPrefix, int 
 		return result;
 	}
 
-	vector<Constellation*>::const_iterator iter;
-	for (iter = constellations.begin(); iter != constellations.end(); ++iter)
+	for (auto* constellation : constellations)
 	{
-		QString name = inEnglish ? (*iter)->getEnglishName() : (*iter)->getNameI18n();
+		QString name = inEnglish ? constellation->getEnglishName() : constellation->getNameI18n();
 		if (!matchObjectName(name, objPrefix, useStartOfWords))
 		{
 			continue;
@@ -1464,12 +1428,11 @@ Constellation* ConstellationMgr::isObjectIn(const StelObject *s) const
 {
 	StelCore *core = StelApp::getInstance().getCore();
 	QString IAUConst = core->getIAUConstellation(s->getEquinoxEquatorialPos(core));
-	vector < Constellation * >::const_iterator iter;
-	for (iter = constellations.begin(); iter != constellations.end(); ++iter)
+	for (auto* constellation : constellations)
 	{
 		// Check if the object is in the constellation
-		if ((*iter)->getShortName().toUpper()==IAUConst.toUpper())
-			return (*iter);
+		if (constellation->getShortName().toUpper() == IAUConst.toUpper())
+			return constellation;
 	}
 	return Q_NULLPTR;
 }

--- a/src/core/modules/LandscapeMgr.cpp
+++ b/src/core/modules/LandscapeMgr.cpp
@@ -305,7 +305,7 @@ void LandscapeMgr::update(double deltaTime)
 	// TBD: Reactivate and verify this code!? Source, reference?
 //	float groundLuminance = 0;
 //	const vector<Planet*>& allPlanets = ssystem->getAllPlanets();
-//	for (vector<Planet*>::const_iterator i=allPlanets.begin();i!=allPlanets.end();++i)
+//	for (auto i=allPlanets.begin();i!=allPlanets.end();++i)
 //	{
 //		Vec3d pos = (*i)->getAltAzPos(core);
 //		pos.normalize();

--- a/src/core/modules/Planet.cpp
+++ b/src/core/modules/Planet.cpp
@@ -1827,11 +1827,9 @@ QOpenGLShaderProgram* Planet::createShader(const QString& name, PlanetShaderVars
 	}
 
 	//process fixed attribute locations
-	QMap<QByteArray,int>::const_iterator it = fixedAttributeLocations.begin();
-	while(it!=fixedAttributeLocations.end())
+	for (auto it = fixedAttributeLocations.begin(); it != fixedAttributeLocations.end(); ++it)
 	{
 		program->bindAttributeLocation(it.key(),it.value());
-		++it;
 	}
 
 	if(!StelPainter::linkProg(program,name))

--- a/src/core/modules/StarMgr.cpp
+++ b/src/core/modules/StarMgr.cpp
@@ -180,7 +180,7 @@ QString StarMgr::getCommonName(int hip)
 	if (cmgr->getConstellationDisplayStyle() == ConstellationMgr::constellationsNative)
 		return getCommonEnglishName(hip);
 
-	QHash<int,QString>::const_iterator it(commonNamesMapI18n.find(hip));
+	auto it = commonNamesMapI18n.find(hip);
 	if (it!=commonNamesMapI18n.end())
 		return it.value();
 	return QString();
@@ -188,7 +188,7 @@ QString StarMgr::getCommonName(int hip)
 
 QString StarMgr::getAdditionalNames(int hip)
 {
-	QHash<int,QString>::const_iterator it(additionalNamesMapI18n.find(hip));
+	auto it = additionalNamesMapI18n.find(hip);
 	if (it!=additionalNamesMapI18n.end())
 		return it.value();
 	return QString();
@@ -196,7 +196,7 @@ QString StarMgr::getAdditionalNames(int hip)
 
 QString StarMgr::getAdditionalEnglishNames(int hip)
 {
-	QHash<int,QString>::const_iterator it(additionalNamesMap.find(hip));
+	auto it = additionalNamesMap.find(hip);
 	if (it!=additionalNamesMap.end())
 		return it.value();
 	return QString();
@@ -204,7 +204,7 @@ QString StarMgr::getAdditionalEnglishNames(int hip)
 
 QString StarMgr::getCommonEnglishName(int hip)
 {
-	QHash<int,QString>::const_iterator it(commonNamesMap.find(hip));
+	auto it = commonNamesMap.find(hip);
 	if (it!=commonNamesMap.end())
 		return it.value();
 	return QString();
@@ -213,7 +213,7 @@ QString StarMgr::getCommonEnglishName(int hip)
 
 QString StarMgr::getSciName(int hip)
 {
-	QHash<int,QString>::const_iterator it(sciNamesMapI18n.find(hip));
+	auto it = sciNamesMapI18n.find(hip);
 	if (it!=sciNamesMapI18n.end())
 		return it.value();
 	return QString();
@@ -221,7 +221,7 @@ QString StarMgr::getSciName(int hip)
 
 QString StarMgr::getSciAdditionalName(int hip)
 {
-	QHash<int,QString>::const_iterator it(sciAdditionalNamesMapI18n.find(hip));
+	auto it = sciAdditionalNamesMapI18n.find(hip);
 	if (it!=sciAdditionalNamesMapI18n.end())
 		return it.value();
 	return QString();
@@ -230,7 +230,7 @@ QString StarMgr::getSciAdditionalName(int hip)
 QString StarMgr::getCrossIdentificationDesignations(QString hip)
 {
 	QString designations;
-	QMap<QString, crossid>::const_iterator cr(crossIdMap.find(hip));
+	auto cr = crossIdMap.find(hip);
 	if (cr==crossIdMap.end() && hip.right(1).toUInt()==0)
 		cr = crossIdMap.find(hip.left(hip.size()-1));
 
@@ -262,7 +262,7 @@ QString StarMgr::getCrossIdentificationDesignations(QString hip)
 
 QString StarMgr::getWdsName(int hip)
 {
-	QHash<int,wds>::const_iterator it(wdsStarsMapI18n.find(hip));
+	auto it = wdsStarsMapI18n.find(hip);
 	if (it!=wdsStarsMapI18n.end())
 		return QString("WDS J%1").arg(it.value().designation);
 	return QString();
@@ -270,7 +270,7 @@ QString StarMgr::getWdsName(int hip)
 
 int StarMgr::getWdsLastObservation(int hip)
 {
-	QHash<int,wds>::const_iterator it(wdsStarsMapI18n.find(hip));
+	auto it = wdsStarsMapI18n.find(hip);
 	if (it!=wdsStarsMapI18n.end())
 		return it.value().observation;
 	return 0;
@@ -278,7 +278,7 @@ int StarMgr::getWdsLastObservation(int hip)
 
 int StarMgr::getWdsLastPositionAngle(int hip)
 {
-	QHash<int,wds>::const_iterator it(wdsStarsMapI18n.find(hip));
+	auto it = wdsStarsMapI18n.find(hip);
 	if (it!=wdsStarsMapI18n.end())
 		return it.value().positionAngle;
 	return 0;
@@ -286,7 +286,7 @@ int StarMgr::getWdsLastPositionAngle(int hip)
 
 float StarMgr::getWdsLastSeparation(int hip)
 {
-	QHash<int,wds>::const_iterator it(wdsStarsMapI18n.find(hip));
+	auto it = wdsStarsMapI18n.find(hip);
 	if (it!=wdsStarsMapI18n.end())
 		return it.value().separation;
 	return 0.f;
@@ -294,7 +294,7 @@ float StarMgr::getWdsLastSeparation(int hip)
 
 QString StarMgr::getGcvsName(int hip)
 {
-	QHash<int,varstar>::const_iterator it(varStarsMapI18n.find(hip));
+	auto it = varStarsMapI18n.find(hip);
 	if (it!=varStarsMapI18n.end())
 		return it.value().designation;
 	return QString();
@@ -302,7 +302,7 @@ QString StarMgr::getGcvsName(int hip)
 
 QString StarMgr::getGcvsVariabilityType(int hip)
 {
-	QHash<int,varstar>::const_iterator it(varStarsMapI18n.find(hip));
+	auto it = varStarsMapI18n.find(hip);
 	if (it!=varStarsMapI18n.end())
 		return it.value().vtype;
 	return QString();
@@ -310,7 +310,7 @@ QString StarMgr::getGcvsVariabilityType(int hip)
 
 float StarMgr::getGcvsMaxMagnitude(int hip)
 {
-	QHash<int,varstar>::const_iterator it(varStarsMapI18n.find(hip));
+	auto it = varStarsMapI18n.find(hip);
 	if (it!=varStarsMapI18n.end())
 		return it.value().maxmag;
 	return -99.f;
@@ -318,7 +318,7 @@ float StarMgr::getGcvsMaxMagnitude(int hip)
 
 int StarMgr::getGcvsMagnitudeFlag(int hip)
 {
-	QHash<int,varstar>::const_iterator it(varStarsMapI18n.find(hip));
+	auto it = varStarsMapI18n.find(hip);
 	if (it!=varStarsMapI18n.end())
 		return it.value().mflag;
 	return 0;
@@ -327,7 +327,7 @@ int StarMgr::getGcvsMagnitudeFlag(int hip)
 
 float StarMgr::getGcvsMinMagnitude(int hip, bool firstMinimumFlag)
 {
-	QHash<int,varstar>::const_iterator it(varStarsMapI18n.find(hip));
+	auto it = varStarsMapI18n.find(hip);
 	if (it!=varStarsMapI18n.end())
 	{
 		if (firstMinimumFlag)
@@ -344,7 +344,7 @@ float StarMgr::getGcvsMinMagnitude(int hip, bool firstMinimumFlag)
 
 QString StarMgr::getGcvsPhotometricSystem(int hip)
 {
-	QHash<int,varstar>::const_iterator it(varStarsMapI18n.find(hip));
+	auto it = varStarsMapI18n.find(hip);
 	if (it!=varStarsMapI18n.end())
 		return it.value().photosys;
 	return QString();
@@ -352,7 +352,7 @@ QString StarMgr::getGcvsPhotometricSystem(int hip)
 
 double StarMgr::getGcvsEpoch(int hip)
 {
-	QHash<int,varstar>::const_iterator it(varStarsMapI18n.find(hip));
+	auto it = varStarsMapI18n.find(hip);
 	if (it!=varStarsMapI18n.end())
 		return it.value().epoch;
 	return -99.f;
@@ -360,7 +360,7 @@ double StarMgr::getGcvsEpoch(int hip)
 
 double StarMgr::getGcvsPeriod(int hip)
 {
-	QHash<int,varstar>::const_iterator it(varStarsMapI18n.find(hip));
+	auto it = varStarsMapI18n.find(hip);
 	if (it!=varStarsMapI18n.end())
 		return it.value().period;
 	return -99.f;
@@ -368,7 +368,7 @@ double StarMgr::getGcvsPeriod(int hip)
 
 int StarMgr::getGcvsMM(int hip)
 {
-	QHash<int,varstar>::const_iterator it(varStarsMapI18n.find(hip));
+	auto it = varStarsMapI18n.find(hip);
 	if (it!=varStarsMapI18n.end())
 		return it.value().Mm;
 	return -99;
@@ -1320,7 +1320,7 @@ StelObjectP StarMgr::searchByNameI18n(const QString& nameI18n) const
 	QRegExp rx2("^\\s*(SAO)\\s*(\\d+)\\s*$", Qt::CaseInsensitive);
 	if (rx2.exactMatch(objw))
 	{
-		QMap<int, int>::const_iterator sao(saoStarsIndex.find(rx2.capturedTexts().at(2).toInt()));
+		auto sao = saoStarsIndex.find(rx2.capturedTexts().at(2).toInt());
 		if (sao!=saoStarsIndex.end())
 			return searchHP(sao.value());
 	}
@@ -1329,7 +1329,7 @@ StelObjectP StarMgr::searchByNameI18n(const QString& nameI18n) const
 	QRegExp rx3("^\\s*(HD)\\s*(\\d+)\\s*$", Qt::CaseInsensitive);
 	if (rx3.exactMatch(objw))
 	{
-		QMap<int, int>::const_iterator hd(hdStarsIndex.find(rx3.capturedTexts().at(2).toInt()));
+		auto hd = hdStarsIndex.find(rx3.capturedTexts().at(2).toInt());
 		if (hd!=hdStarsIndex.end())
 			return searchHP(hd.value());
 	}
@@ -1338,13 +1338,13 @@ StelObjectP StarMgr::searchByNameI18n(const QString& nameI18n) const
 	QRegExp rx4("^\\s*(HR)\\s*(\\d+)\\s*$", Qt::CaseInsensitive);
 	if (rx4.exactMatch(objw))
 	{
-		QMap<int, int>::const_iterator hr(hrStarsIndex.find(rx4.capturedTexts().at(2).toInt()));
+		auto hr = hrStarsIndex.find(rx4.capturedTexts().at(2).toInt());
 		if (hr!=hrStarsIndex.end())
 			return searchHP(hr.value());
 	}
 
 	// Search by I18n common name
-	QMap<QString,int>::const_iterator it(commonNamesIndexI18n.find(objw));
+	auto it = commonNamesIndexI18n.find(objw);
 	if (it!=commonNamesIndexI18n.end())
 	{
 		return searchHP(it.value());
@@ -1353,7 +1353,7 @@ StelObjectP StarMgr::searchByNameI18n(const QString& nameI18n) const
 	if (getFlagAdditionalNames())
 	{
 		// Search by I18n additional common names
-		QMap<QString,int>::const_iterator ita(additionalNamesIndexI18n.find(objw));
+		auto ita = additionalNamesIndexI18n.find(objw);
 		if (ita!=additionalNamesIndexI18n.end())
 		{
 			return searchHP(ita.value());
@@ -1361,7 +1361,7 @@ StelObjectP StarMgr::searchByNameI18n(const QString& nameI18n) const
 	}
 
 	// Search by sci name
-	QMap<QString,int>::const_iterator it2 = sciNamesIndexI18n.find(objw);
+	auto it2 = sciNamesIndexI18n.find(objw);
 	if (it2!=sciNamesIndexI18n.end())
 	{
 		return searchHP(it2.value());
@@ -1369,7 +1369,7 @@ StelObjectP StarMgr::searchByNameI18n(const QString& nameI18n) const
 
 
 	// Search by additional sci name
-	QMap<QString,int>::const_iterator it3 = sciAdditionalNamesIndexI18n.find(objw);
+	auto it3 = sciAdditionalNamesIndexI18n.find(objw);
 	if (it3!=sciAdditionalNamesIndexI18n.end())
 	{
 		return searchHP(it3.value());
@@ -1377,14 +1377,14 @@ StelObjectP StarMgr::searchByNameI18n(const QString& nameI18n) const
 
 
 	// Search by GCVS name
-	QMap<QString,int>::const_iterator it4 = varStarsIndexI18n.find(objw);
+	auto it4 = varStarsIndexI18n.find(objw);
 	if (it4!=varStarsIndexI18n.end())
 	{
 		return searchHP(it4.value());
 	}
 
 	// Search by WDS name
-	QMap<QString,int>::const_iterator wdsIt = wdsStarsIndexI18n.find(objw);
+	auto wdsIt = wdsStarsIndexI18n.find(objw);
 	if (wdsIt!=wdsStarsIndexI18n.end())
 	{
 		return searchHP(wdsIt.value());
@@ -1409,7 +1409,7 @@ StelObjectP StarMgr::searchByName(const QString& name) const
 	QRegExp rx2("^\\s*(SAO)\\s*(\\d+)\\s*$", Qt::CaseInsensitive);
 	if (rx2.exactMatch(objw))
 	{
-		QMap<int, int>::const_iterator sao(saoStarsIndex.find(rx2.capturedTexts().at(2).toInt()));
+		auto sao = saoStarsIndex.find(rx2.capturedTexts().at(2).toInt());
 		if (sao!=saoStarsIndex.end())
 			return searchHP(sao.value());
 	}
@@ -1418,7 +1418,7 @@ StelObjectP StarMgr::searchByName(const QString& name) const
 	QRegExp rx3("^\\s*(HD)\\s*(\\d+)\\s*$", Qt::CaseInsensitive);
 	if (rx3.exactMatch(objw))
 	{
-		QMap<int, int>::const_iterator hd(hdStarsIndex.find(rx3.capturedTexts().at(2).toInt()));
+		auto hd = hdStarsIndex.find(rx3.capturedTexts().at(2).toInt());
 		if (hd!=hdStarsIndex.end())
 			return searchHP(hd.value());
 	}
@@ -1427,13 +1427,13 @@ StelObjectP StarMgr::searchByName(const QString& name) const
 	QRegExp rx4("^\\s*(HR)\\s*(\\d+)\\s*$", Qt::CaseInsensitive);
 	if (rx4.exactMatch(objw))
 	{
-		QMap<int, int>::const_iterator hr(hrStarsIndex.find(rx4.capturedTexts().at(2).toInt()));
+		auto hr = hrStarsIndex.find(rx4.capturedTexts().at(2).toInt());
 		if (hr!=hrStarsIndex.end())
 			return searchHP(hr.value());
 	}
 
 	// Search by English common name
-	QMap<QString,int>::const_iterator it(commonNamesIndex.find(objw));
+	auto it = commonNamesIndex.find(objw);
 	if (it!=commonNamesIndex.end())
 	{
 		return searchHP(it.value());
@@ -1442,7 +1442,7 @@ StelObjectP StarMgr::searchByName(const QString& name) const
 	if (getFlagAdditionalNames())
 	{
 		// Search by English additional common names
-		QMap<QString,int>::const_iterator ita(additionalNamesIndex.find(objw));
+		auto ita = additionalNamesIndex.find(objw);
 		if (ita!=additionalNamesIndex.end())
 		{
 			return searchHP(ita.value());
@@ -1450,14 +1450,14 @@ StelObjectP StarMgr::searchByName(const QString& name) const
 	}
 
 	// Search by sci name
-	QMap<QString,int>::const_iterator it2 = sciNamesIndexI18n.find(objw);
+	auto it2 = sciNamesIndexI18n.find(objw);
 	if (it2!=sciNamesIndexI18n.end())
 	{
 		return searchHP(it2.value());
 	}
 
 	// Search by additional sci name
-	QMap<QString,int>::const_iterator it3 = sciAdditionalNamesIndexI18n.find(objw);
+	auto it3 = sciAdditionalNamesIndexI18n.find(objw);
 	if (it3!=sciAdditionalNamesIndexI18n.end())
 	{
 		return searchHP(it3.value());
@@ -1490,7 +1490,7 @@ QStringList StarMgr::listMatchingObjects(const QString& objPrefix, int maxNbItem
 	// Search for common names
 	if (useStartOfWords)
 	{
-		for (QMap<QString,int>::const_iterator it(cNamesIdx.lowerBound(objw)); it!=cNamesIdx.end(); ++it)
+		for (auto it = cNamesIdx.lowerBound(objw); it != cNamesIdx.end(); ++it)
 		{
 			if (it.key().startsWith(objw))
 			{
@@ -1502,7 +1502,7 @@ QStringList StarMgr::listMatchingObjects(const QString& objPrefix, int maxNbItem
 			else
 				break;
 		}
-		for (QMap<QString,int>::const_iterator ita(aNamesIdx.lowerBound(objw)); ita!=aNamesIdx.end(); ++ita)
+		for (auto ita = aNamesIdx.lowerBound(objw); ita != aNamesIdx.end(); ++ita)
 		{
 			if (ita.key().startsWith(objw))
 			{
@@ -1567,7 +1567,7 @@ QStringList StarMgr::listMatchingObjects(const QString& objPrefix, int maxNbItem
 	if (objw.at(0).unicode() >= 0x0391 && objw.at(0).unicode() <= 0x03A9)
 		bayerRegEx.setPattern(bayerPattern.insert(1,"\\d?"));
 
-	for (QMap<QString,int>::const_iterator it(sciNamesIndexI18n.lowerBound(objw)); it!=sciNamesIndexI18n.end(); ++it)
+	for (auto it = sciNamesIndexI18n.lowerBound(objw); it != sciNamesIndexI18n.end(); ++it)
 	{
 		if (it.key().indexOf(bayerRegEx)==0)
 		{
@@ -1580,7 +1580,7 @@ QStringList StarMgr::listMatchingObjects(const QString& objPrefix, int maxNbItem
 			break;
 	}
 
-	for (QMap<QString,int>::const_iterator it(sciAdditionalNamesIndexI18n.lowerBound(objw)); it!=sciAdditionalNamesIndexI18n.end(); ++it)
+	for (auto it = sciAdditionalNamesIndexI18n.lowerBound(objw); it != sciAdditionalNamesIndexI18n.end(); ++it)
 	{
 		if (it.key().indexOf(bayerRegEx)==0)
 		{
@@ -1594,7 +1594,7 @@ QStringList StarMgr::listMatchingObjects(const QString& objPrefix, int maxNbItem
 	}
 
 	// Search for sci names for var stars
-	for (QMap<QString,int>::const_iterator it(varStarsIndexI18n.lowerBound(objw)); it!=varStarsIndexI18n.end(); ++it)
+	for (auto it = varStarsIndexI18n.lowerBound(objw); it != varStarsIndexI18n.end(); ++it)
 	{
 		if (it.key().startsWith(objw))
 		{
@@ -1632,7 +1632,7 @@ QStringList StarMgr::listMatchingObjects(const QString& objPrefix, int maxNbItem
 	{
 		bool ok;
 		int saoNum = saoRx.capturedTexts().at(2).toInt(&ok);
-		QMap<int, int>::const_iterator sao(saoStarsIndex.find(saoNum));
+		auto sao = saoStarsIndex.find(saoNum);
 		if (sao!=saoStarsIndex.end())
 		{
 			StelObjectP s = searchHP(sao.value());
@@ -1651,7 +1651,7 @@ QStringList StarMgr::listMatchingObjects(const QString& objPrefix, int maxNbItem
 	{
 		bool ok;
 		int hdNum = hdRx.capturedTexts().at(2).toInt(&ok);
-		QMap<int, int>::const_iterator hd(hdStarsIndex.find(hdNum));
+		auto hd = hdStarsIndex.find(hdNum);
 		if (hd!=hdStarsIndex.end())
 		{
 			StelObjectP s = searchHP(hd.value());
@@ -1670,7 +1670,7 @@ QStringList StarMgr::listMatchingObjects(const QString& objPrefix, int maxNbItem
 	{
 		bool ok;
 		int hrNum = hrRx.capturedTexts().at(2).toInt(&ok);
-		QMap<int, int>::const_iterator hr(hrStarsIndex.find(hrNum));
+		auto hr = hrStarsIndex.find(hrNum);
 		if (hr!=hrStarsIndex.end())
 		{
 			StelObjectP s = searchHP(hr.value());
@@ -1688,7 +1688,7 @@ QStringList StarMgr::listMatchingObjects(const QString& objPrefix, int maxNbItem
 	wdsRx.setCaseSensitivity(Qt::CaseInsensitive);
 	if (wdsRx.exactMatch(objw))
 	{
-		for (QMap<QString,int>::const_iterator wds(wdsStarsIndexI18n.lowerBound(objw)); wds!=wdsStarsIndexI18n.end(); ++wds)
+		for (auto wds = wdsStarsIndexI18n.lowerBound(objw); wds != wdsStarsIndexI18n.end(); ++wds)
 		{
 			if (wds.key().startsWith(objw))
 			{

--- a/src/external/libindi/libs/indibase/baseclient.cpp
+++ b/src/external/libindi/libs/indibase/baseclient.cpp
@@ -570,9 +570,7 @@ int INDI::BaseClient::delPropertyCmd(XMLEle *root, char *errmsg)
 
 int INDI::BaseClient::deleteDevice(const char *devName, char *errmsg)
 {
-    std::vector<INDI::BaseDevice *>::iterator devicei;
-
-    for (devicei = cDevices.begin(); devicei != cDevices.end();)
+    for (auto devicei = cDevices.begin(); devicei != cDevices.end();)
     {
         if (!strcmp(devName, (*devicei)->getDeviceName()))
         {
@@ -591,9 +589,7 @@ int INDI::BaseClient::deleteDevice(const char *devName, char *errmsg)
 
 INDI::BaseDevice *INDI::BaseClient::findDev(const char *devName, char *errmsg)
 {
-    std::vector<INDI::BaseDevice *>::const_iterator devicei;
-
-    for (devicei = cDevices.begin(); devicei != cDevices.end(); devicei++)
+    for (auto devicei = cDevices.begin(); devicei != cDevices.end(); devicei++)
     {
         if (!strcmp(devName, (*devicei)->getDeviceName()))
             return (*devicei);

--- a/src/external/libindi/libs/indibase/basedevice.cpp
+++ b/src/external/libindi/libs/indibase/basedevice.cpp
@@ -126,12 +126,10 @@ IPState BaseDevice::getPropertyState(const char *name)
     ILightVectorProperty *lvp;
     IBLOBVectorProperty *bvp;
 
-    std::vector<INDI::Property *>::iterator orderi = pAll.begin();
-
-    for (; orderi != pAll.end(); ++orderi)
+    for (auto* prop : pAll)
     {
-        pType = (*orderi)->getType();
-        pPtr  = (*orderi)->getProperty();
+        pType = prop->getType();
+        pPtr  = prop->getProperty();
 
         switch (pType)
         {
@@ -190,12 +188,10 @@ IPerm BaseDevice::getPropertyPermission(const char *name)
     ISwitchVectorProperty *svp;
     IBLOBVectorProperty *bvp;
 
-    std::vector<INDI::Property *>::iterator orderi = pAll.begin();
-
-    for (; orderi != pAll.end(); ++orderi)
+    for (auto* prop : pAll)
     {
-        pType = (*orderi)->getType();
-        pPtr  = (*orderi)->getProperty();
+        pType = prop->getType();
+        pPtr  = prop->getProperty();
 
         switch (pType)
         {
@@ -241,19 +237,17 @@ void *BaseDevice::getRawProperty(const char *name, INDI_PROPERTY_TYPE type)
     void *pPtr = nullptr;
     bool pRegistered = false;
 
-    std::vector<INDI::Property *>::iterator orderi = pAll.begin();
-
     INumberVectorProperty *nvp = nullptr;
     ITextVectorProperty *tvp = nullptr;
     ISwitchVectorProperty *svp = nullptr;
     ILightVectorProperty *lvp = nullptr;
     IBLOBVectorProperty *bvp = nullptr;
 
-    for (; orderi != pAll.end(); ++orderi)
+    for (auto* prop : pAll)
     {
-        pType       = (*orderi)->getType();
-        pPtr        = (*orderi)->getProperty();
-        pRegistered = (*orderi)->getRegistered();
+        pType       = prop->getType();
+        pPtr        = prop->getProperty();
+        pRegistered = prop->getRegistered();
 
         if (type != INDI_UNKNOWN && pType != type)
             continue;
@@ -314,19 +308,17 @@ INDI::Property *BaseDevice::getProperty(const char *name, INDI_PROPERTY_TYPE typ
     void *pPtr;
     bool pRegistered = false;
 
-    std::vector<INDI::Property *>::iterator orderi;
-
     INumberVectorProperty *nvp;
     ITextVectorProperty *tvp;
     ISwitchVectorProperty *svp;
     ILightVectorProperty *lvp;
     IBLOBVectorProperty *bvp;
 
-    for (orderi = pAll.begin(); orderi != pAll.end(); ++orderi)
+    for (auto* prop : pAll)
     {
-        pType       = (*orderi)->getType();
-        pPtr        = (*orderi)->getProperty();
-        pRegistered = (*orderi)->getRegistered();
+        pType       = prop->getType();
+        pPtr        = prop->getProperty();
+        pRegistered = prop->getRegistered();
 
         if (type != INDI_UNKNOWN && pType != type)
             continue;
@@ -339,7 +331,7 @@ INDI::Property *BaseDevice::getProperty(const char *name, INDI_PROPERTY_TYPE typ
                     continue;
 
                 if (!strcmp(name, nvp->name) && pRegistered)
-                    return *orderi;
+                    return prop;
                 break;
             case INDI_TEXT:
                 tvp = static_cast<ITextVectorProperty *>(pPtr);
@@ -347,7 +339,7 @@ INDI::Property *BaseDevice::getProperty(const char *name, INDI_PROPERTY_TYPE typ
                     continue;
 
                 if (!strcmp(name, tvp->name) && pRegistered)
-                    return *orderi;
+                    return prop;
                 break;
             case INDI_SWITCH:
                 svp = static_cast<ISwitchVectorProperty *>(pPtr);
@@ -356,7 +348,7 @@ INDI::Property *BaseDevice::getProperty(const char *name, INDI_PROPERTY_TYPE typ
 
                 //IDLog("Switch %s and aux value is now %d\n", svp->name, regStatus );
                 if (!strcmp(name, svp->name) && pRegistered)
-                    return *orderi;
+                    return prop;
                 break;
             case INDI_LIGHT:
                 lvp = static_cast<ILightVectorProperty *>(pPtr);
@@ -364,7 +356,7 @@ INDI::Property *BaseDevice::getProperty(const char *name, INDI_PROPERTY_TYPE typ
                     continue;
 
                 if (!strcmp(name, lvp->name) && pRegistered)
-                    return *orderi;
+                    return prop;
                 break;
             case INDI_BLOB:
                 bvp = static_cast<IBLOBVectorProperty *>(pPtr);
@@ -372,7 +364,7 @@ INDI::Property *BaseDevice::getProperty(const char *name, INDI_PROPERTY_TYPE typ
                     continue;
 
                 if (!strcmp(name, bvp->name) && pRegistered)
-                    return *orderi;
+                    return prop;
                 break;
             case INDI_UNKNOWN:
                 break;
@@ -384,8 +376,6 @@ INDI::Property *BaseDevice::getProperty(const char *name, INDI_PROPERTY_TYPE typ
 
 int BaseDevice::removeProperty(const char *name, char *errmsg)
 {
-    std::vector<INDI::Property *>::iterator orderi;
-
     INDI_PROPERTY_TYPE pType;
     void *pPtr;
 
@@ -395,10 +385,11 @@ int BaseDevice::removeProperty(const char *name, char *errmsg)
     ILightVectorProperty *lvp;
     IBLOBVectorProperty *bvp;
 
-    for (orderi = pAll.begin(); orderi != pAll.end(); ++orderi)
+    for (auto orderi = pAll.begin(); orderi != pAll.end(); ++orderi)
     {
-        pType = (*orderi)->getType();
-        pPtr  = (*orderi)->getProperty();
+        auto* prop = *orderi;
+        pType = prop->getType();
+        pPtr  = prop->getProperty();
 
         switch (pType)
         {
@@ -406,10 +397,9 @@ int BaseDevice::removeProperty(const char *name, char *errmsg)
                 nvp = static_cast<INumberVectorProperty *>(pPtr);
                 if (!strcmp(name, nvp->name))
                 {
-                    (*orderi)->setRegistered(false);
-                    delete *orderi;
+                    prop->setRegistered(false);
+                    delete prop;
                     orderi = pAll.erase(orderi);
-
                     return 0;
                 }
                 break;
@@ -417,10 +407,9 @@ int BaseDevice::removeProperty(const char *name, char *errmsg)
                 tvp = static_cast<ITextVectorProperty *>(pPtr);
                 if (!strcmp(name, tvp->name))
                 {
-                    (*orderi)->setRegistered(false);
-                    delete *orderi;
+                    prop->setRegistered(false);
+                    delete prop;
                     orderi = pAll.erase(orderi);
-
                     return 0;
                 }
                 break;
@@ -428,8 +417,8 @@ int BaseDevice::removeProperty(const char *name, char *errmsg)
                 svp = static_cast<ISwitchVectorProperty *>(pPtr);
                 if (!strcmp(name, svp->name))
                 {
-                    (*orderi)->setRegistered(false);
-                    delete *orderi;
+                    prop->setRegistered(false);
+                    delete prop;
                     orderi = pAll.erase(orderi);
                     return 0;
                 }
@@ -438,8 +427,8 @@ int BaseDevice::removeProperty(const char *name, char *errmsg)
                 lvp = static_cast<ILightVectorProperty *>(pPtr);
                 if (!strcmp(name, lvp->name))
                 {
-                    (*orderi)->setRegistered(false);
-                    delete *orderi;
+                    prop->setRegistered(false);
+                    delete prop;
                     orderi = pAll.erase(orderi);
                     return 0;
                 }
@@ -448,8 +437,8 @@ int BaseDevice::removeProperty(const char *name, char *errmsg)
                 bvp = static_cast<IBLOBVectorProperty *>(pPtr);
                 if (!strcmp(name, bvp->name))
                 {
-                    (*orderi)->setRegistered(false);
-                    delete *orderi;
+                    prop->setRegistered(false);
+                    delete prop;
                     orderi = pAll.erase(orderi);
                     return 0;
                 }
@@ -1255,7 +1244,7 @@ void BaseDevice::addMessage(const std::string& msg)
     messageLog.push_back(msg);
 
     if (mediator)
-        mediator->newMessage(this, messageLog.size() - 1);
+        mediator->newMessage(this, static_cast<int>(messageLog.size() - 1));
 }
 
 std::string BaseDevice::messageQueue(int index) const

--- a/src/external/qcustomplot/qcustomplot.cpp
+++ b/src/external/qcustomplot/qcustomplot.cpp
@@ -11522,7 +11522,7 @@ QCPColorGradient QCPColorGradient::inverted() const
 {
   QCPColorGradient result(*this);
   result.clearColorStops();
-  for (QMap<double, QColor>::const_iterator it=mColorStops.constBegin(); it!=mColorStops.constEnd(); ++it)
+  for (auto it = mColorStops.constBegin(); it != mColorStops.constEnd(); ++it)
     result.setColorStopAt(1.0-it.key(), it.value());
   return result;
 }
@@ -11542,7 +11542,7 @@ void QCPColorGradient::updateColorBuffer()
     for (int i=0; i<mLevelCount; ++i)
     {
       double position = i*indexToPosFactor;
-      QMap<double, QColor>::const_iterator it = mColorStops.lowerBound(position);
+      auto it = mColorStops.lowerBound(position);
       if (it == mColorStops.constEnd()) // position is on or after last stop, use color of last stop
       {
         mColorBuffer[i] = (it-1).value().rgb();
@@ -11551,8 +11551,8 @@ void QCPColorGradient::updateColorBuffer()
         mColorBuffer[i] = it.value().rgb();
       } else // position is in between stops (or on an intermediate stop), interpolate color
       {
-        QMap<double, QColor>::const_iterator high = it;
-        QMap<double, QColor>::const_iterator low = it-1;
+        auto high = it;
+        auto low = it-1;
         double t = (position-low.key())/(high.key()-low.key()); // interpolation factor 0..1
         switch (mColorInterpolation)
         {
@@ -14919,7 +14919,7 @@ void QCPGraph::addData(const QVector<double> &keys, const QVector<double> &value
 */
 void QCPGraph::removeDataBefore(double key)
 {
-  QCPDataMap::iterator it = mData->begin();
+  auto it = mData->begin();
   while (it != mData->end() && it.key() < key)
     it = mData->erase(it);
 }
@@ -14931,7 +14931,7 @@ void QCPGraph::removeDataBefore(double key)
 void QCPGraph::removeDataAfter(double key)
 {
   if (mData->isEmpty()) return;
-  QCPDataMap::iterator it = mData->upperBound(key);
+  auto it = mData->upperBound(key);
   while (it != mData->end())
     it = mData->erase(it);
 }
@@ -14946,8 +14946,8 @@ void QCPGraph::removeDataAfter(double key)
 void QCPGraph::removeData(double fromKey, double toKey)
 {
   if (fromKey >= toKey || mData->isEmpty()) return;
-  QCPDataMap::iterator it = mData->upperBound(fromKey);
-  QCPDataMap::iterator itEnd = mData->upperBound(toKey);
+  auto it = mData->upperBound(fromKey);
+  auto itEnd = mData->upperBound(toKey);
   while (it != itEnd)
     it = mData->erase(it);
 }
@@ -15091,8 +15091,7 @@ void QCPGraph::draw(QCPPainter *painter)
   
   // check data validity if flag set:
 #ifdef QCUSTOMPLOT_CHECK_DATA
-  QCPDataMap::const_iterator it;
-  for (it = mData->constBegin(); it != mData->constEnd(); ++it)
+  for (auto it = mData->constBegin(); it != mData->constEnd(); ++it)
   {
     if (QCP::isInvalidData(it.value().key, it.value().value) ||
         QCP::isInvalidData(it.value().keyErrorPlus, it.value().keyErrorMinus) ||
@@ -15682,11 +15681,11 @@ void QCPGraph::getPreparedData(QVector<QCPData> *lineData, QVector<QCPData> *sca
   {
     if (lineData)
     {
-      QCPDataMap::const_iterator it = lower;
-      QCPDataMap::const_iterator upperEnd = upper+1;
+      auto it = lower;
+      auto upperEnd = upper+1;
       double minValue = it.value().value;
       double maxValue = it.value().value;
-      QCPDataMap::const_iterator currentIntervalFirstPoint = it;
+      auto currentIntervalFirstPoint = it;
       int reversedFactor = keyAxis->rangeReversed() != (keyAxis->orientation()==Qt::Vertical) ? -1 : 1; // is used to calculate keyEpsilon pixel into the correct direction
       int reversedRound = keyAxis->rangeReversed() != (keyAxis->orientation()==Qt::Vertical) ? 1 : 0; // is used to switch between floor (normal) and ceil (reversed) rounding of currentIntervalStartKey
       double currentIntervalStartKey = keyAxis->pixelToCoord((int)(keyAxis->coordToPixel(lower.key())+reversedRound));
@@ -15742,13 +15741,13 @@ void QCPGraph::getPreparedData(QVector<QCPData> *lineData, QVector<QCPData> *sca
     {
       double valueMaxRange = valueAxis->range().upper;
       double valueMinRange = valueAxis->range().lower;
-      QCPDataMap::const_iterator it = lower;
-      QCPDataMap::const_iterator upperEnd = upper+1;
+      auto it = lower;
+      auto upperEnd = upper+1;
       double minValue = it.value().value;
       double maxValue = it.value().value;
-      QCPDataMap::const_iterator minValueIt = it;
-      QCPDataMap::const_iterator maxValueIt = it;
-      QCPDataMap::const_iterator currentIntervalStart = it;
+      auto minValueIt = it;
+      auto maxValueIt = it;
+      auto currentIntervalStart = it;
       int reversedFactor = keyAxis->rangeReversed() ? -1 : 1; // is used to calculate keyEpsilon pixel into the correct direction
       int reversedRound = keyAxis->rangeReversed() ? 1 : 0; // is used to switch between floor (normal) and ceil (reversed) rounding of currentIntervalStartKey
       double currentIntervalStartKey = keyAxis->pixelToCoord((int)(keyAxis->coordToPixel(lower.key())+reversedRound));
@@ -15777,7 +15776,7 @@ void QCPGraph::getPreparedData(QVector<QCPData> *lineData, QVector<QCPData> *sca
             // determine value pixel span and add as many points in interval to maintain certain vertical data density (this is specific to scatter plot):
             double valuePixelSpan = qAbs(valueAxis->coordToPixel(minValue)-valueAxis->coordToPixel(maxValue));
             int dataModulo = qMax(1, qRound(intervalDataCount/(valuePixelSpan/4.0))); // approximately every 4 value pixels one data point on average
-            QCPDataMap::const_iterator intervalIt = currentIntervalStart;
+            auto intervalIt = currentIntervalStart;
             int c = 0;
             while (intervalIt != it)
             {
@@ -15804,7 +15803,7 @@ void QCPGraph::getPreparedData(QVector<QCPData> *lineData, QVector<QCPData> *sca
         // determine value pixel span and add as many points in interval to maintain certain vertical data density (this is specific to scatter plot):
         double valuePixelSpan = qAbs(valueAxis->coordToPixel(minValue)-valueAxis->coordToPixel(maxValue));
         int dataModulo = qMax(1, qRound(intervalDataCount/(valuePixelSpan/4.0))); // approximately every 4 value pixels one data point on average
-        QCPDataMap::const_iterator intervalIt = currentIntervalStart;
+        auto intervalIt = currentIntervalStart;
         int c = 0;
         while (intervalIt != it)
         {
@@ -15825,8 +15824,8 @@ void QCPGraph::getPreparedData(QVector<QCPData> *lineData, QVector<QCPData> *sca
       dataVector = scatterData;
     if (dataVector)
     {
-      QCPDataMap::const_iterator it = lower;
-      QCPDataMap::const_iterator upperEnd = upper+1;
+      auto it = lower;
+      auto upperEnd = upper+1;
       dataVector->reserve(dataCount+2); // +2 for possible fill end points
       while (it != upperEnd)
       {
@@ -15968,8 +15967,8 @@ void QCPGraph::getVisibleDataBounds(QCPDataMap::const_iterator &lower, QCPDataMa
   }
   
   // get visible data range as QMap iterators
-  QCPDataMap::const_iterator lbound = mData->lowerBound(mKeyAxis->range().lower);
-  QCPDataMap::const_iterator ubound = mData->upperBound(mKeyAxis->range().upper);
+  auto lbound = mData->lowerBound(mKeyAxis->range().lower);
+  auto ubound = mData->upperBound(mKeyAxis->range().upper);
   bool lowoutlier = lbound != mData->constBegin(); // indicates whether there exist points below axis range
   bool highoutlier = ubound != mData->constEnd(); // indicates whether there exist points above axis range
   
@@ -15991,7 +15990,7 @@ int QCPGraph::countDataInBounds(const QCPDataMap::const_iterator &lower, const Q
 {
   if (upper == mData->constEnd() && lower == mData->constEnd())
     return 0;
-  QCPDataMap::const_iterator it = lower;
+  auto it = lower;
   int count = 1;
   while (it != upper && count < maxCount)
   {
@@ -16513,8 +16512,7 @@ QCPRange QCPGraph::getKeyRange(bool &foundRange, SignDomain inSignDomain, bool i
   
   if (inSignDomain == sdBoth) // range may be anywhere
   {
-    QCPDataMap::const_iterator it = mData->constBegin();
-    while (it != mData->constEnd())
+    for (auto it = mData->constBegin(); it != mData->constEnd(); ++it)
     {
       if (!qIsNaN(it.value().value))
       {
@@ -16532,12 +16530,10 @@ QCPRange QCPGraph::getKeyRange(bool &foundRange, SignDomain inSignDomain, bool i
           haveUpper = true;
         }
       }
-      ++it;
     }
   } else if (inSignDomain == sdNegative) // range may only be in the negative sign domain
   {
-    QCPDataMap::const_iterator it = mData->constBegin();
-    while (it != mData->constEnd())
+    for (auto it = mData->constBegin(); it != mData->constEnd(); ++it)
     {
       if (!qIsNaN(it.value().value))
       {
@@ -16568,12 +16564,10 @@ QCPRange QCPGraph::getKeyRange(bool &foundRange, SignDomain inSignDomain, bool i
           }
         }
       }
-      ++it;
     }
   } else if (inSignDomain == sdPositive) // range may only be in the positive sign domain
   {
-    QCPDataMap::const_iterator it = mData->constBegin();
-    while (it != mData->constEnd())
+    for (auto it = mData->constBegin(); it != mData->constEnd(); ++it)
     {
       if (!qIsNaN(it.value().value))
       {
@@ -16604,7 +16598,6 @@ QCPRange QCPGraph::getKeyRange(bool &foundRange, SignDomain inSignDomain, bool i
           }
         }
       }
-      ++it;
     }
   }
   
@@ -16628,8 +16621,7 @@ QCPRange QCPGraph::getValueRange(bool &foundRange, SignDomain inSignDomain, bool
   
   if (inSignDomain == sdBoth) // range may be anywhere
   {
-    QCPDataMap::const_iterator it = mData->constBegin();
-    while (it != mData->constEnd())
+    for (auto it = mData->constBegin(); it != mData->constEnd(); ++it)
     {
       current = it.value().value;
       if (!qIsNaN(current))
@@ -16647,12 +16639,10 @@ QCPRange QCPGraph::getValueRange(bool &foundRange, SignDomain inSignDomain, bool
           haveUpper = true;
         }
       }
-      ++it;
     }
   } else if (inSignDomain == sdNegative) // range may only be in the negative sign domain
   {
-    QCPDataMap::const_iterator it = mData->constBegin();
-    while (it != mData->constEnd())
+    for (auto it = mData->constBegin(); it != mData->constEnd(); ++it)
     {
       current = it.value().value;
       if (!qIsNaN(current))
@@ -16683,12 +16673,10 @@ QCPRange QCPGraph::getValueRange(bool &foundRange, SignDomain inSignDomain, bool
           }
         }
       }
-      ++it;
     }
   } else if (inSignDomain == sdPositive) // range may only be in the positive sign domain
   {
-    QCPDataMap::const_iterator it = mData->constBegin();
-    while (it != mData->constEnd())
+    for (auto it = mData->constBegin(); it != mData->constEnd(); ++it)
     {
       current = it.value().value;
       if (!qIsNaN(current))
@@ -16719,7 +16707,6 @@ QCPRange QCPGraph::getValueRange(bool &foundRange, SignDomain inSignDomain, bool
           }
         }
       }
-      ++it;
     }
   }
   
@@ -16997,7 +16984,7 @@ void QCPCurve::addData(const QVector<double> &ts, const QVector<double> &keys, c
 */
 void QCPCurve::removeDataBefore(double t)
 {
-  QCPCurveDataMap::iterator it = mData->begin();
+  auto it = mData->begin();
   while (it != mData->end() && it.key() < t)
     it = mData->erase(it);
 }
@@ -17009,7 +16996,7 @@ void QCPCurve::removeDataBefore(double t)
 void QCPCurve::removeDataAfter(double t)
 {
   if (mData->isEmpty()) return;
-  QCPCurveDataMap::iterator it = mData->upperBound(t);
+  auto it = mData->upperBound(t);
   while (it != mData->end())
     it = mData->erase(it);
 }
@@ -17024,8 +17011,8 @@ void QCPCurve::removeDataAfter(double t)
 void QCPCurve::removeData(double fromt, double tot)
 {
   if (fromt >= tot || mData->isEmpty()) return;
-  QCPCurveDataMap::iterator it = mData->upperBound(fromt);
-  QCPCurveDataMap::iterator itEnd = mData->upperBound(tot);
+  auto it = mData->upperBound(fromt);
+  auto itEnd = mData->upperBound(tot);
   while (it != itEnd)
     it = mData->erase(it);
 }
@@ -17080,8 +17067,7 @@ void QCPCurve::draw(QCPPainter *painter)
   
   // check data validity if flag set:
 #ifdef QCUSTOMPLOT_CHECK_DATA
-  QCPCurveDataMap::const_iterator it;
-  for (it = mData->constBegin(); it != mData->constEnd(); ++it)
+  for (auto it = mData->constBegin(); it != mData->constEnd(); ++it)
   {
     if (QCP::isInvalidData(it.value().t) ||
         QCP::isInvalidData(it.value().key, it.value().value))
@@ -17233,8 +17219,8 @@ void QCPCurve::getCurveData(QVector<QPointF> *lineData) const
   double rectBottom = valueAxis->pixelToCoord(valueAxis->coordToPixel(valueAxis->range().lower)+strokeMargin*((valueAxis->orientation()==Qt::Horizontal)!=valueAxis->rangeReversed()?-1:1));
   double rectTop = valueAxis->pixelToCoord(valueAxis->coordToPixel(valueAxis->range().upper)-strokeMargin*((valueAxis->orientation()==Qt::Horizontal)!=valueAxis->rangeReversed()?-1:1));
   int currentRegion;
-  QCPCurveDataMap::const_iterator it = mData->constBegin();
-  QCPCurveDataMap::const_iterator prevIt = mData->constEnd()-1;
+  auto it = mData->constBegin();
+  auto prevIt = mData->constEnd()-1;
   int prevRegion = getRegion(prevIt.value().key, prevIt.value().value, rectLeft, rectTop, rectRight, rectBottom);
   QVector<QPointF> trailingPoints; // points that must be applied after all other points (are generated only when handling first point to get virtual segment between last and first point right)
   while (it != mData->constEnd())
@@ -17948,8 +17934,7 @@ QCPRange QCPCurve::getKeyRange(bool &foundRange, SignDomain inSignDomain) const
   
   double current;
   
-  QCPCurveDataMap::const_iterator it = mData->constBegin();
-  while (it != mData->constEnd())
+  for (auto it = mData->constBegin(); it != mData->constEnd(); ++it)
   {
     current = it.value().key;
     if (!qIsNaN(current) && !qIsNaN(it.value().value))
@@ -17968,7 +17953,6 @@ QCPRange QCPCurve::getKeyRange(bool &foundRange, SignDomain inSignDomain) const
         }
       }
     }
-    ++it;
   }
   
   foundRange = haveLower && haveUpper;
@@ -17984,8 +17968,7 @@ QCPRange QCPCurve::getValueRange(bool &foundRange, SignDomain inSignDomain) cons
   
   double current;
   
-  QCPCurveDataMap::const_iterator it = mData->constBegin();
-  while (it != mData->constEnd())
+  for (auto it = mData->constBegin(); it != mData->constEnd(); ++it)
   {
     current = it.value().value;
     if (!qIsNaN(current) && !qIsNaN(it.value().key))
@@ -18004,7 +17987,6 @@ QCPRange QCPCurve::getValueRange(bool &foundRange, SignDomain inSignDomain) cons
         }
       }
     }
-    ++it;
   }
   
   foundRange = haveLower && haveUpper;
@@ -18701,7 +18683,7 @@ void QCPBars::addData(const QVector<double> &keys, const QVector<double> &values
 */
 void QCPBars::removeDataBefore(double key)
 {
-  QCPBarDataMap::iterator it = mData->begin();
+  auto it = mData->begin();
   while (it != mData->end() && it.key() < key)
     it = mData->erase(it);
 }
@@ -18713,7 +18695,7 @@ void QCPBars::removeDataBefore(double key)
 void QCPBars::removeDataAfter(double key)
 {
   if (mData->isEmpty()) return;
-  QCPBarDataMap::iterator it = mData->upperBound(key);
+  auto it = mData->upperBound(key);
   while (it != mData->end())
     it = mData->erase(it);
 }
@@ -18728,8 +18710,8 @@ void QCPBars::removeDataAfter(double key)
 void QCPBars::removeData(double fromKey, double toKey)
 {
   if (fromKey >= toKey || mData->isEmpty()) return;
-  QCPBarDataMap::iterator it = mData->upperBound(fromKey);
-  QCPBarDataMap::iterator itEnd = mData->upperBound(toKey);
+  auto it = mData->upperBound(fromKey);
+  auto itEnd = mData->upperBound(toKey);
   while (it != itEnd)
     it = mData->erase(it);
 }
@@ -18782,9 +18764,9 @@ void QCPBars::draw(QCPPainter *painter)
   if (!mKeyAxis || !mValueAxis) { qDebug() << Q_FUNC_INFO << "invalid key or value axis"; return; }
   if (mData->isEmpty()) return;
   
-  QCPBarDataMap::const_iterator it, lower, upperEnd;
+  QCPBarDataMap::const_iterator lower, upperEnd;
   getVisibleDataBounds(lower, upperEnd);
-  for (it = lower; it != upperEnd; ++it)
+  for (auto it = lower; it != upperEnd; ++it)
   {
     // check data validity if flag set:
 #ifdef QCUSTOMPLOT_CHECK_DATA
@@ -18854,7 +18836,7 @@ void QCPBars::getVisibleDataBounds(QCPBarDataMap::const_iterator &lower, QCPBarD
   double upperPixelBound = mKeyAxis->coordToPixel(mKeyAxis->range().upper);
   bool isVisible = false;
   // walk left from lbound to find lower bar that actually is completely outside visible pixel range:
-  QCPBarDataMap::const_iterator it = lower;
+  auto it = lower;
   while (it != mData->constBegin())
   {
     --it;
@@ -18992,14 +18974,11 @@ double QCPBars::getStackedBaseValue(double key, bool positive) const
     double epsilon = qAbs(key)*1e-6; // should be safe even when changed to use float at some point
     if (key == 0)
       epsilon = 1e-6;
-    QCPBarDataMap::const_iterator it = mBarBelow->mData->lowerBound(key-epsilon);
-    QCPBarDataMap::const_iterator itEnd = mBarBelow->mData->upperBound(key+epsilon);
-    while (it != itEnd)
+    for (auto it = mBarBelow->mData->lowerBound(key-epsilon), itEnd = mBarBelow->mData->upperBound(key+epsilon); it != itEnd; ++it)
     {
       if ((positive && it.value().value > max) ||
           (!positive && it.value().value < max))
         max = it.value().value;
-      ++it;
     }
     // recurse down the bar-stack to find the total height:
     return max + mBarBelow->getStackedBaseValue(key, positive);
@@ -19052,8 +19031,7 @@ QCPRange QCPBars::getKeyRange(bool &foundRange, SignDomain inSignDomain) const
   bool haveUpper = false;
   
   double current;
-  QCPBarDataMap::const_iterator it = mData->constBegin();
-  while (it != mData->constEnd())
+  for (auto it = mData->constBegin(); it != mData->constEnd(); ++it)
   {
     current = it.value().key;
     if (inSignDomain == sdBoth || (inSignDomain == sdNegative && current < 0) || (inSignDomain == sdPositive && current > 0))
@@ -19069,7 +19047,6 @@ QCPRange QCPBars::getKeyRange(bool &foundRange, SignDomain inSignDomain) const
         haveUpper = true;
       }
     }
-    ++it;
   }
   // determine exact range of bars by including bar width and barsgroup offset:
   if (haveLower && mKeyAxis)
@@ -19104,8 +19081,7 @@ QCPRange QCPBars::getValueRange(bool &foundRange, SignDomain inSignDomain) const
   bool haveUpper = true; // set to true, because baseValue should always be visible in bar charts
   double current;
   
-  QCPBarDataMap::const_iterator it = mData->constBegin();
-  while (it != mData->constEnd())
+  for (auto it = mData->constBegin(); it != mData->constEnd(); ++it)
   {
     current = it.value().value + getStackedBaseValue(it.value().key, it.value().value >= 0);
     if (inSignDomain == sdBoth || (inSignDomain == sdNegative && current < 0) || (inSignDomain == sdPositive && current > 0))
@@ -19121,7 +19097,6 @@ QCPRange QCPBars::getValueRange(bool &foundRange, SignDomain inSignDomain) const
         haveUpper = true;
       }
     }
-    ++it;
   }
   
   foundRange = true; // return true because bar charts always have the 0-line visible
@@ -20865,7 +20840,7 @@ void QCPFinancial::addData(const QVector<double> &key, const QVector<double> &op
 */
 void QCPFinancial::removeDataBefore(double key)
 {
-  QCPFinancialDataMap::iterator it = mData->begin();
+  auto it = mData->begin();
   while (it != mData->end() && it.key() < key)
     it = mData->erase(it);
 }
@@ -20878,7 +20853,7 @@ void QCPFinancial::removeDataBefore(double key)
 void QCPFinancial::removeDataAfter(double key)
 {
   if (mData->isEmpty()) return;
-  QCPFinancialDataMap::iterator it = mData->upperBound(key);
+  auto it = mData->upperBound(key);
   while (it != mData->end())
     it = mData->erase(it);
 }
@@ -20893,8 +20868,8 @@ void QCPFinancial::removeDataAfter(double key)
 void QCPFinancial::removeData(double fromKey, double toKey)
 {
   if (fromKey >= toKey || mData->isEmpty()) return;
-  QCPFinancialDataMap::iterator it = mData->upperBound(fromKey);
-  QCPFinancialDataMap::iterator itEnd = mData->upperBound(toKey);
+  auto it = mData->upperBound(fromKey);
+  auto itEnd = mData->upperBound(toKey);
   while (it != itEnd)
     it = mData->erase(it);
 }
@@ -21087,8 +21062,7 @@ QCPRange QCPFinancial::getKeyRange(bool &foundRange, QCPAbstractPlottable::SignD
   bool haveUpper = false;
   
   double current;
-  QCPFinancialDataMap::const_iterator it = mData->constBegin();
-  while (it != mData->constEnd())
+  for (auto it = mData->constBegin(); it != mData->constEnd(); ++it)
   {
     current = it.value().key;
     if (inSignDomain == sdBoth || (inSignDomain == sdNegative && current < 0) || (inSignDomain == sdPositive && current > 0))
@@ -21104,7 +21078,6 @@ QCPRange QCPFinancial::getKeyRange(bool &foundRange, QCPAbstractPlottable::SignD
         haveUpper = true;
       }
     }
-    ++it;
   }
   // determine exact range by including width of bars/flags:
   if (haveLower && mKeyAxis)
@@ -21122,8 +21095,7 @@ QCPRange QCPFinancial::getValueRange(bool &foundRange, QCPAbstractPlottable::Sig
   bool haveLower = false;
   bool haveUpper = false;
   
-  QCPFinancialDataMap::const_iterator it = mData->constBegin();
-  while (it != mData->constEnd())
+  for (auto it = mData->constBegin(); it != mData->constEnd(); ++it)
   {
     // high:
     if (inSignDomain == sdBoth || (inSignDomain == sdNegative && it.value().high < 0) || (inSignDomain == sdPositive && it.value().high > 0))
@@ -21153,7 +21125,6 @@ QCPRange QCPFinancial::getValueRange(bool &foundRange, QCPAbstractPlottable::Sig
         haveUpper = true;
       }
     }
-    ++it;
   }
   
   foundRange = haveLower && haveUpper;
@@ -21176,7 +21147,7 @@ void QCPFinancial::drawOhlcPlot(QCPPainter *painter, const QCPFinancialDataMap::
   
   if (keyAxis->orientation() == Qt::Horizontal)
   {
-    for (QCPFinancialDataMap::const_iterator it = begin; it != end; ++it)
+    for (auto it = begin; it != end; ++it)
     {
       if (mSelected)
         linePen = mSelectedPen;
@@ -21198,7 +21169,7 @@ void QCPFinancial::drawOhlcPlot(QCPPainter *painter, const QCPFinancialDataMap::
     }
   } else
   {
-    for (QCPFinancialDataMap::const_iterator it = begin; it != end; ++it)
+    for (auto it = begin; it != end; ++it)
     {
       if (mSelected)
         linePen = mSelectedPen;
@@ -21238,7 +21209,7 @@ void QCPFinancial::drawCandlestickPlot(QCPPainter *painter, const QCPFinancialDa
   
   if (keyAxis->orientation() == Qt::Horizontal)
   {
-    for (QCPFinancialDataMap::const_iterator it = begin; it != end; ++it)
+    for (auto it = begin; it != end; ++it)
     {
       if (mSelected)
       {
@@ -21275,7 +21246,7 @@ void QCPFinancial::drawCandlestickPlot(QCPPainter *painter, const QCPFinancialDa
     }
   } else // keyAxis->orientation() == Qt::Vertical
   {
-    for (QCPFinancialDataMap::const_iterator it = begin; it != end; ++it)
+    for (auto it = begin; it != end; ++it)
     {
       if (mSelected)
       {
@@ -21325,10 +21296,9 @@ double QCPFinancial::ohlcSelectTest(const QPointF &pos, const QCPFinancialDataMa
   if (!keyAxis || !valueAxis) { qDebug() << Q_FUNC_INFO << "invalid key or value axis"; return -1; }
 
   double minDistSqr = std::numeric_limits<double>::max();
-  QCPFinancialDataMap::const_iterator it;
   if (keyAxis->orientation() == Qt::Horizontal)
   {
-    for (it = begin; it != end; ++it)
+    for (auto it = begin; it != end; ++it)
     {
       double keyPixel = keyAxis->coordToPixel(it.value().key);
       // calculate distance to backbone:
@@ -21338,7 +21308,7 @@ double QCPFinancial::ohlcSelectTest(const QPointF &pos, const QCPFinancialDataMa
     }
   } else // keyAxis->orientation() == Qt::Vertical
   {
-    for (it = begin; it != end; ++it)
+    for (auto it = begin; it != end; ++it)
     {
       double keyPixel = keyAxis->coordToPixel(it.value().key);
       // calculate distance to backbone:
@@ -21363,10 +21333,9 @@ double QCPFinancial::candlestickSelectTest(const QPointF &pos, const QCPFinancia
   if (!keyAxis || !valueAxis) { qDebug() << Q_FUNC_INFO << "invalid key or value axis"; return -1; }
 
   double minDistSqr = std::numeric_limits<double>::max();
-  QCPFinancialDataMap::const_iterator it;
   if (keyAxis->orientation() == Qt::Horizontal)
   {
-    for (it = begin; it != end; ++it)
+    for (auto it = begin; it != end; ++it)
     {
       double currentDistSqr;
       // determine whether pos is in open-close-box:
@@ -21390,7 +21359,7 @@ double QCPFinancial::candlestickSelectTest(const QPointF &pos, const QCPFinancia
     }
   } else // keyAxis->orientation() == Qt::Vertical
   {
-    for (it = begin; it != end; ++it)
+    for (auto it = begin; it != end; ++it)
     {
       double currentDistSqr;
       // determine whether pos is in open-close-box:
@@ -21443,8 +21412,8 @@ void QCPFinancial::getVisibleDataBounds(QCPFinancialDataMap::const_iterator &low
   }
   
   // get visible data range as QMap iterators
-  QCPFinancialDataMap::const_iterator lbound = mData->lowerBound(mKeyAxis->range().lower);
-  QCPFinancialDataMap::const_iterator ubound = mData->upperBound(mKeyAxis->range().upper);
+  auto lbound = mData->lowerBound(mKeyAxis->range().lower);
+  auto ubound = mData->upperBound(mKeyAxis->range().upper);
   bool lowoutlier = lbound != mData->constBegin(); // indicates whether there exist points below axis range
   bool highoutlier = ubound != mData->constEnd(); // indicates whether there exist points above axis range
   
@@ -23254,18 +23223,18 @@ void QCPItemTracer::updatePosition()
     {
       if (mGraph->data()->size() > 1)
       {
-        QCPDataMap::const_iterator first = mGraph->data()->constBegin();
-        QCPDataMap::const_iterator last = mGraph->data()->constEnd()-1;
+        auto first = mGraph->data()->constBegin();
+        auto last = mGraph->data()->constEnd()-1;
         if (mGraphKey < first.key())
           position->setCoords(first.key(), first.value().value);
         else if (mGraphKey > last.key())
           position->setCoords(last.key(), last.value().value);
         else
         {
-          QCPDataMap::const_iterator it = mGraph->data()->lowerBound(mGraphKey);
+          auto it = mGraph->data()->lowerBound(mGraphKey);
           if (it != first) // mGraphKey is somewhere between iterators
           {
-            QCPDataMap::const_iterator prevIt = it-1;
+            auto prevIt = it-1;
             if (mInterpolating)
             {
               // interpolate between iterators around mGraphKey:
@@ -23285,7 +23254,7 @@ void QCPItemTracer::updatePosition()
         }
       } else if (mGraph->data()->size() == 1)
       {
-        QCPDataMap::const_iterator it = mGraph->data()->constBegin();
+        auto it = mGraph->data()->constBegin();
         position->setCoords(it.key(), it.value().value);
       } else
         qDebug() << Q_FUNC_INFO << "graph has no data";

--- a/src/gui/LocationDialog.cpp
+++ b/src/gui/LocationDialog.cpp
@@ -414,13 +414,12 @@ void LocationDialog::populateTimeZonesList()
 	QComboBox* timeZones = ui->timeZoneNameComboBox;
 	// Return a list of all the known time zone names (from Qt)
 	QStringList tzNames;
-	QList<QByteArray> tzList = QTimeZone::availableTimeZoneIds(); // System dependent set of IANA timezone names.
-	QList<QByteArray>::iterator i;
-	for (i = tzList.begin(); i!= tzList.end(); ++i)
+	auto tzList = QTimeZone::availableTimeZoneIds(); // System dependent set of IANA timezone names.
+	for (const auto& tz : tzList)
 	{
-		tzNames.append(*i);
+		tzNames.append(tz);
 		// Activate this to get a list of known TZ names...
-		//qDebug() << "Qt/IANA TZ entry: " << *i;
+		//qDebug() << "Qt/IANA TZ entry: " << tz;
 	}
 
 	tzNames.sort();

--- a/src/gui/SearchDialog.cpp
+++ b/src/gui/SearchDialog.cpp
@@ -885,7 +885,7 @@ void SearchDialog::updateListTab()
 	ui->objectTypeComboBox->blockSignals(true);
 	ui->objectTypeComboBox->clear();	
 	QMap<QString, QString> modulesMap = objectMgr->objectModulesMap();
-	for (QMap<QString, QString>::const_iterator it = modulesMap.begin(); it != modulesMap.end(); ++it)
+	for (auto it = modulesMap.begin(); it != modulesMap.end(); ++it)
 	{
 		if (!objectMgr->listAllModuleObjects(it.key(), ui->searchInEnglishCheckBox->isChecked()).isEmpty())
 		{

--- a/src/gui/StelGuiItems.cpp
+++ b/src/gui/StelGuiItems.cpp
@@ -417,9 +417,9 @@ BottomStelBar::BottomStelBar(QGraphicsItem* parent,
 BottomStelBar::~BottomStelBar()
 {
 	// Remove currently hidden buttons which are not delete by a parent element
-	for (QMap<QString, ButtonGroup>::iterator iter=buttonGroups.begin();iter!=buttonGroups.end();++iter)
+	for (auto& group : buttonGroups)
 	{
-		for (auto* b : iter.value().elems)
+		for (auto* b : group.elems)
 		{
 			if (b->parentItem()==0)
 			{
@@ -464,7 +464,7 @@ StelButton* BottomStelBar::hideButton(const QString& actionName)
 {
 	QString gName;
 	StelButton* bToRemove = Q_NULLPTR;
-	for (QMap<QString, ButtonGroup>::iterator iter=buttonGroups.begin();iter!=buttonGroups.end();++iter)
+	for (auto iter = buttonGroups.begin(); iter != buttonGroups.end(); ++iter)
 	{
 		int i=0;
 		for (auto* b : iter.value().elems)
@@ -547,9 +547,8 @@ void BottomStelBar::updateButtonsGroups()
 {
 	double x = 0;
 	double y = datetime->boundingRect().height() + 3;
-	for (QMap<QString, ButtonGroup >::iterator iter=buttonGroups.begin();iter!=buttonGroups.end();++iter)
+	for (auto& group : buttonGroups)
 	{
-		ButtonGroup& group = iter.value();
 		QList<StelButton*>& buttons = group.elems;
 		if (buttons.empty())
 			continue;

--- a/src/scripting/StelMainScriptAPI.cpp
+++ b/src/scripting/StelMainScriptAPI.cpp
@@ -759,9 +759,8 @@ QString StelMainScriptAPI::mapToString(const QVariantMap& map) const
 	simpleTypeList.push_back(QVariant::UInt);
 	simpleTypeList.push_back(QVariant::Double);
 
-	QVariantMap::const_iterator i=map.constBegin();
-	while (i != map.constEnd()){
-
+	for (auto i = map.constBegin(); i != map.constEnd(); ++i)
+	{
 		if (i.value().type()==QVariant::String)
 		{
 			res.append(QString("[ \"%1\" = \"%2\" ]\n").arg(i.key()).arg(i.value().toString()));
@@ -774,8 +773,6 @@ QString StelMainScriptAPI::mapToString(const QVariantMap& map) const
 		{
 			res.append(QString("[ \"%1\" = \"<%2>:%3\" ]\n").arg(i.key()).arg(i.value().typeName()).arg(i.value().toString()));
 		}
-
-		++i;
 	}
 	res.append( QString("]\n"));
 	return res;


### PR DESCRIPTION
Continue to work on using C++11 features to simplify code.
1. Use auto instead of full type name of iterators,
2. More ranged-based for.