### PR TITLE
Minor changes to CMakeLists.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,8 @@ IF(NOT (CMAKE_VERSION VERSION_LESS 3.1.0))
 ELSE()
      # Add std=c++11 to gcc flags
      SET(STEL_GCC_CXX_FLAGS "-std=c++11 ${STEL_GCC_CXX_FLAGS}")
+     # Add std=c11 to gcc flags
+     SET(STEL_GCC_C_FLAGS "-std=c11 ${STEL_GCC_C_FLAGS}")
 ENDIF()
 
 IF(WIN32)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -527,8 +527,6 @@ IF(ENABLE_TESTING)
     SET(tests_testDates_SRCS
         tests/testDates.hpp
         tests/testDates.cpp
-        core/StelUtils.hpp
-        core/StelUtils.cpp
     )
     ADD_EXECUTABLE(testDates ${tests_testDates_SRCS})
     TARGET_LINK_LIBRARIES(testDates ${TESTS_LIBRARIES})


### PR DESCRIPTION
1. Add -std=c11 for consistency, because SET(CMAKE_C_STANDARD 11) is defined on CMake 3.1+,
2. Remove StelUtils.* from testDates, because it has been linked to stelMain.