### PR TITLE
Added satellite color & description handling

### DIFF
--- a/plugins/Satellites/src/gui/SatellitesDialog.hpp
+++ b/plugins/Satellites/src/gui/SatellitesDialog.hpp
@@ -117,6 +117,13 @@ private slots:
 
 	void searchSatellitesClear();
 
+	// change selection's color
+	void askSatColor();
+
+	// change description text
+	void descriptionTextChanged();
+
+
 private:
 	//! @todo find out if this is really necessary... --BM
 	void enableSatelliteDataForm(bool enabled);
@@ -158,6 +165,9 @@ private:
 
 	QString delimiter, acEndl;
 	QStringList iridiumFlaresHeader;
+
+	// colorpickerbutton's color
+	QColor buttonColor;
 };
 
 // Reimplements the QTreeWidgetItem class to fix the sorting bug

--- a/plugins/Satellites/src/gui/satellitesDialog.ui
+++ b/plugins/Satellites/src/gui/satellitesDialog.ui
@@ -135,7 +135,7 @@
       </sizepolicy>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <property name="documentMode">
       <bool>false</bool>
@@ -715,6 +715,9 @@
          </item>
          <item>
           <layout class="QGridLayout" name="flagsCheckBoxesLayout">
+           <property name="verticalSpacing">
+            <number>6</number>
+           </property>
            <item row="0" column="0">
             <widget class="QCheckBox" name="displayedCheckbox">
              <property name="toolTip">
@@ -751,6 +754,37 @@
              </property>
             </widget>
            </item>
+           <item row="1" column="1" alignment="Qt::AlignLeft">
+            <widget class="QPushButton" name="satColorPickerButton">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>1</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>20</width>
+               <height>20</height>
+              </size>
+             </property>
+             <property name="toolTip">
+              <string>Change color for selected satellite(s)</string>
+             </property>
+             <property name="layoutDirection">
+              <enum>Qt::LeftToRight</enum>
+             </property>
+             <property name="text">
+              <string/>
+             </property>
+            </widget>
+           </item>
           </layout>
          </item>
          <item>
@@ -768,7 +802,20 @@
            <item>
             <widget class="QTextEdit" name="descriptionTextEdit">
              <property name="readOnly">
-              <bool>true</bool>
+              <bool>false</bool>
+             </property>
+             <property name="html">
+              <string notr="true">&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             </property>
+             <property name="acceptRichText">
+              <bool>false</bool>
+             </property>
+             <property name="placeholderText">
+              <string notr="true"/>
              </property>
             </widget>
            </item>


### PR DESCRIPTION
Changing of satellite(s) color (for now both hintColor & orbitColor at once) is now possible from within Satellite Config Dialog.
Description can be modified there as well.

It might not be the prettiest solution but it works well (for me anyway).