### PR TITLE
Add .lgtm.yml file

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,0 +1,14 @@
+extraction:
+  cpp:
+    prepare:
+      packages:
+      - "libqt5serialport5-dev"
+      - "qtscript5-dev"
+      - "libqt5svg5-dev"
+      - "qttools5-dev-tools"
+      - "qttools5-dev"
+      - "libqt5opengl5-dev"
+      - "qtpositioning5-dev"
+      - "libgps-dev"
+      - "qtmultimedia5-dev"
+      - "libqt5multimedia5-plugins"


### PR DESCRIPTION
Hey @alex-w,

I'm part of the team behind LGTM.com

I see that you added (f5b7bd3) and removed (26e2bd9) a `.lgtm.yml` file for this repo, and also enabled and disabled the LGTM automated code review. I realised that we weren't analysing the C/C++ code for stellarium, and it looks like you were trying to get it working? A member of our C/C++ team looked into your project and managed to get it working with this `.lgtm.yml` file. And there are now [results for these languages on LGTM.com](https://lgtm.com/projects/g/Stellarium/stellarium/alerts/?mode=tree&lang=cpp).

If you would like to use LGTM for stellarium, I'd suggest checking this file in to your repo so that if you need to change it you know what's currently being used.

Let me know if you have any questions!