### PR TITLE
Fix build with cmake -DBUILD_SHARED_LIBS=ON

### DIFF
--- a/plugins/TelescopeControl/src/INDI/CMakeLists.txt
+++ b/plugins/TelescopeControl/src/INDI/CMakeLists.txt
@@ -10,7 +10,7 @@ SET(TelescopeControl_INDI_UIS
 
 QT5_WRAP_UI(TelescopeControl_INDI_UIS_H ${TelescopeControl_INDI_UIS})
 
-add_library(TelescopeControl_INDI
+add_library(TelescopeControl_INDI STATIC
     INDIConnection.hpp
     INDIConnection.cpp
     TelescopeClientINDI.hpp

--- a/plugins/TelescopeControl/src/Lx200/CMakeLists.txt
+++ b/plugins/TelescopeControl/src/Lx200/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 
-add_library(TelescopeControl_Lx200
+add_library(TelescopeControl_Lx200 STATIC
     Lx200Command.hpp
     Lx200Command.cpp
     Lx200Connection.hpp

--- a/plugins/TelescopeControl/src/NexStar/CMakeLists.txt
+++ b/plugins/TelescopeControl/src/NexStar/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 
-add_library(TelescopeControl_NexStar
+add_library(TelescopeControl_NexStar STATIC
     NexStarCommand.hpp
     NexStarCommand.cpp
     NexStarConnection.hpp

--- a/plugins/TelescopeControl/src/Rts2/CMakeLists.txt
+++ b/plugins/TelescopeControl/src/Rts2/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 
-add_library(TelescopeControl_Rts2
+add_library(TelescopeControl_Rts2 STATIC
     TelescopeClientJsonRts2.hpp
     TelescopeClientJsonRts2.cpp
     )

--- a/plugins/TelescopeControl/src/common/CMakeLists.txt
+++ b/plugins/TelescopeControl/src/common/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 
-add_library(TelescopeControl_common
+add_library(TelescopeControl_common STATIC
     LogFile.hpp
     LogFile.cpp
     Socket.hpp

--- a/plugins/TelescopeControl/src/gui/CMakeLists.txt
+++ b/plugins/TelescopeControl/src/gui/CMakeLists.txt
@@ -10,7 +10,7 @@ SET(TelescopeControl_GUI_UIS
 
 QT5_WRAP_UI(TelescopeControl_GUI_UIS_H ${TelescopeControl_GUI_UIS})
 
-add_library(TelescopeControl_gui
+add_library(TelescopeControl_gui STATIC
     SlewDialog.hpp
     SlewDialog.cpp
     TelescopeDialog.hpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -469,7 +469,7 @@ IF(GENERATE_STELMAINLIB)
      #stelMain should be after the plug-ins, otherwise the build crashes
      TARGET_LINK_LIBRARIES(stellarium stelMain ${winMMLib})
 ELSE()
-     ADD_LIBRARY(stelMain ${stellarium_lib_SRCS} ${stellarium_RES_CXX})
+     ADD_LIBRARY(stelMain STATIC ${stellarium_lib_SRCS} ${stellarium_RES_CXX})
      TARGET_LINK_LIBRARIES(stelMain ${STELMAIN_DEPS})
      ADD_EXECUTABLE(stellarium WIN32 ${stellarium_exe_SRCS})
      TARGET_LINK_LIBRARIES(stellarium ${winMMLib} ${STELMAIN_DEPS} stelMain)

--- a/src/external/CMakeLists.txt
+++ b/src/external/CMakeLists.txt
@@ -190,7 +190,7 @@ IF(USE_PLUGIN_TELESCOPECONTROL)
     include_directories(libindi)
     include_directories(libindi/libs)
     include_directories(libindi/libs/indibase)
-    add_library(indiclient
+    add_library(indiclient STATIC
         libindi/libs/lilxml.c
         libindi/base64.c
         libindi/libs/indibase/basedevice.h


### PR DESCRIPTION
Ref https://github.com/gentoo/gentoo/pull/11770

<!--- Provide a general summary of your changes in the Title above -->

### Description

`BUILD_SHARED_LIBS=ON` causes `add_library()` to default to `SHARED` instead of `STATIC`. Having some of libraries shared causes the following error:

`/usr/lib/gcc/x86_64-pc-linux-gnu/8.3.0/../../../../x86_64-pc-linux-gnu/bin/ld: ../libTelescopeControl_INDI.so: undefined reference to StelObject::getInfoMap(StelCore const*) const'`

### Screenshots (if appropriate):

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### How Has This Been Tested?
by building, by running the test, and by running stellarium after successful build
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system: <Name, version number> Gentoo Linux
* Graphics Card: <Manufacturer (likely Intel, NVidia, AMD?), Model (HD, Geforce, Radeon..., with model number), driver version?> NVidia GeForce GTX 275 with x11-drivers/xf86-video-nouveau-1.0.15-r1:0

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
