### PR TITLE
Make splash screen more informative

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -239,6 +239,8 @@ SET(stellarium_lib_SRCS
      core/modules/ZoneData.hpp
      StelMainView.hpp
      StelMainView.cpp
+     StelSplashScreen.hpp
+     StelSplashScreen.cpp
      StelLogger.hpp
      StelLogger.cpp
      CLIProcessor.hpp

--- a/src/StelSplashScreen.cpp
+++ b/src/StelSplashScreen.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2019 Ruslan Kabatsayev
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Suite 500, Boston, MA  02110-1335, USA.
+ */
+
+#include "StelSplashScreen.hpp"
+#include "StelFileMgr.hpp"
+#include "StelUtils.hpp"
+
+#include <QPainter>
+
+SplashScreen::SplashScreenWidget* SplashScreen::instance;
+
+static QPixmap makePixmap()
+{
+	QPixmap pixmap(StelFileMgr::findFile("data/splash.png"));
+	QPainter p(&pixmap);
+	p.setPen(Qt::white);
+	QFontMetrics metrics(p.font());
+	p.drawText(QPointF(metrics.averageCharWidth(), 1.3*metrics.height()), StelUtils::getApplicationVersion());
+	return pixmap;
+}
+
+void SplashScreen::present()
+{
+	static SplashScreenWidget splash(makePixmap());
+	instance=&splash;
+	splash.show();
+	splash.ensureFirstPaint();
+}
+
+void SplashScreen::showMessage(QString const& message)
+{
+	Q_ASSERT(instance);
+	instance->showMessage(message, Qt::AlignLeft|Qt::AlignBottom, Qt::white);
+}
+
+void SplashScreen::finish(QWidget* mainWindow)
+{
+	Q_ASSERT(instance);
+	instance->finish(mainWindow);
+}
+
+void SplashScreen::clearMessage()
+{
+	Q_ASSERT(instance);
+	instance->clearMessage();
+}

--- a/src/StelSplashScreen.hpp
+++ b/src/StelSplashScreen.hpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2019 Ruslan Kabatsayev
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Suite 500, Boston, MA  02110-1335, USA.
+ */
+
+#ifndef STELLARIUM_SPLASH_SCREEN_HPP
+#define STELLARIUM_SPLASH_SCREEN_HPP
+
+#include <QThread>
+#include <QApplication>
+#include <QSplashScreen>
+
+class SplashScreen
+{
+    class SplashScreenWidget : public QSplashScreen
+    {
+        bool painted=false;
+        void paintEvent(QPaintEvent* e) override
+        {
+            QSplashScreen::paintEvent(e);
+            painted=true;
+        }
+    public:
+        SplashScreenWidget(QPixmap const& pixmap)
+            : QSplashScreen(pixmap)
+        {}
+        void ensureFirstPaint() const
+        {
+            while(!painted)
+            {
+                QThread::msleep(1);
+                qApp->processEvents();
+            }
+        }
+    };
+
+    static SplashScreenWidget* instance;
+public:
+    static void present();
+    static void finish(QWidget* mainWindow);
+    static void showMessage(QString const& message);
+    static void clearMessage();
+};
+
+#endif

--- a/src/core/StelApp.cpp
+++ b/src/core/StelApp.cpp
@@ -21,6 +21,7 @@
 
 #include "StelCore.hpp"
 #include "StelMainView.hpp"
+#include "StelSplashScreen.hpp"
 #include "StelUtils.hpp"
 #include "StelTextureMgr.hpp"
 #include "StelObjectMgr.hpp"
@@ -417,13 +418,16 @@ void StelApp::init(QSettings* conf)
 	if (saveProjW!=-1 && saveProjH!=-1)
 		core->windowHasBeenResized(0, 0, saveProjW, saveProjH);
 
+	SplashScreen::showMessage(q_("Initializing textures..."));
 	// Initialize AFTER creation of openGL context
 	textureMgr = new StelTextureMgr();
 
+	SplashScreen::showMessage(q_("Initializing network access..."));
 	networkAccessManager = new QNetworkAccessManager(this);
 	#if QT_VERSION >= 0x050900
 	networkAccessManager->setRedirectPolicy(QNetworkRequest::NoLessSafeRedirectPolicy);
 	#endif
+	SplashScreen::showMessage(q_("Initializing network disk cache..."));
 	// Activate http cache if Qt version >= 4.5
 	QNetworkDiskCache* cache = new QNetworkDiskCache(networkAccessManager);
 	//make maximum cache size configurable (in MB)
@@ -435,6 +439,8 @@ void StelApp::init(QSettings* conf)
 	cache->setCacheDirectory(cachePath);
 	networkAccessManager->setCache(cache);	
 	connect(networkAccessManager, SIGNAL(finished(QNetworkReply*)), this, SLOT(reportFileDownloadFinished(QNetworkReply*)));
+
+    SplashScreen::clearMessage();
 
 	//create non-StelModule managers
 	propMgr = new StelPropertyMgr();
@@ -449,109 +455,133 @@ void StelApp::init(QSettings* conf)
 	propMgr->registerObject(mainWin);
 
 	// Stel Object Data Base manager
+	SplashScreen::showMessage(q_("Initializing Object Database..."));
 	stelObjectMgr = new StelObjectMgr();
 	stelObjectMgr->init();
 	getModuleMgr().registerModule(stelObjectMgr);	
 
+	SplashScreen::showMessage(q_("Initializing locales..."));
 	localeMgr->init();
 
 	// Hips surveys
+	SplashScreen::showMessage(q_("Initializing HiPS survey..."));
 	HipsMgr* hipsMgr = new HipsMgr();
 	hipsMgr->init();
 	getModuleMgr().registerModule(hipsMgr);
 
 	// Init the solar system first
+	SplashScreen::showMessage(q_("Initializing Solar System model..."));
 	SolarSystem* ssystem = new SolarSystem();
 	ssystem->init();
 	getModuleMgr().registerModule(ssystem);
 
 	// Init the nomenclature for Solar system bodies
+	SplashScreen::showMessage(q_("Initializing Solar System nomenclature..."));
 	NomenclatureMgr* nomenclature = new NomenclatureMgr();
 	nomenclature->init();
 	getModuleMgr().registerModule(nomenclature);
 
 	// Load hipparcos stars & names
+	SplashScreen::showMessage(q_("Initializing Hipparcos stars & names..."));
 	StarMgr* hip_stars = new StarMgr();
 	hip_stars->init();
 	getModuleMgr().registerModule(hip_stars);
 
+	SplashScreen::showMessage(q_("Initializing Stellarium Core..."));
 	core->init();
 
 	// Init nebulas
+	SplashScreen::showMessage(q_("Initializing deep-sky objects..."));
 	NebulaMgr* nebulas = new NebulaMgr();
 	nebulas->init();
 	getModuleMgr().registerModule(nebulas);
 
 	// Init milky way
+	SplashScreen::showMessage(q_("Initializing Milky Way..."));
 	MilkyWay* milky_way = new MilkyWay();
 	milky_way->init();
 	getModuleMgr().registerModule(milky_way);
 
 	// Init zodiacal light
+	SplashScreen::showMessage(q_("Initializing zodiacal light..."));
 	ZodiacalLight* zodiacal_light = new ZodiacalLight();
 	zodiacal_light->init();
 	getModuleMgr().registerModule(zodiacal_light);
 
 	// Init sky image manager
+	SplashScreen::showMessage(q_("Initializing sky image layer..."));
 	skyImageMgr = new StelSkyLayerMgr();
 	skyImageMgr->init();
 	getModuleMgr().registerModule(skyImageMgr);
 
 	// Toast surveys
+	SplashScreen::showMessage(q_("Initializing TOAST surveys..."));
 	ToastMgr* toasts = new ToastMgr();
 	toasts->init();
 	getModuleMgr().registerModule(toasts);
 
 	// Init audio manager
+	SplashScreen::showMessage(q_("Initializing audio..."));
 	audioMgr = new StelAudioMgr();
 
 	// Init video manager
+	SplashScreen::showMessage(q_("Initializing video..."));
 	videoMgr = new StelVideoMgr();
 	videoMgr->init();
 	getModuleMgr().registerModule(videoMgr);
 
 	// Constellations
+	SplashScreen::showMessage(q_("Initializing constellations..."));
 	ConstellationMgr* constellations = new ConstellationMgr(hip_stars);
 	constellations->init();
 	getModuleMgr().registerModule(constellations);
 
 	// Asterisms
+	SplashScreen::showMessage(q_("Initializing asterisms..."));
 	AsterismMgr* asterisms = new AsterismMgr(hip_stars);
 	asterisms->init();
 	getModuleMgr().registerModule(asterisms);
 
 	// Landscape, atmosphere & cardinal points section
+	SplashScreen::showMessage(q_("Initializing landscape..."));
 	LandscapeMgr* landscape = new LandscapeMgr();
 	landscape->init();
 	getModuleMgr().registerModule(landscape);
 
+	SplashScreen::showMessage(q_("Initializing grid lines..."));
 	GridLinesMgr* gridLines = new GridLinesMgr();
 	gridLines->init();
 	getModuleMgr().registerModule(gridLines);
 
 	// Sporadic Meteors
+	SplashScreen::showMessage(q_("Initializing sporadic meteors..."));
 	SporadicMeteorMgr* meteors = new SporadicMeteorMgr(10, 72);
 	meteors->init();
 	getModuleMgr().registerModule(meteors);
 
 	// User labels
+	SplashScreen::showMessage(q_("Initializing user labels..."));
 	LabelMgr* skyLabels = new LabelMgr();
 	skyLabels->init();
 	getModuleMgr().registerModule(skyLabels);
 
+	SplashScreen::showMessage(q_("Initializing sky cultures..."));
 	skyCultureMgr->init();
 
 	// User markers
+	SplashScreen::showMessage(q_("Initializing user markers..."));
 	MarkerMgr* skyMarkers = new MarkerMgr();
 	skyMarkers->init();
 	getModuleMgr().registerModule(skyMarkers);
 
 	// Init custom objects
+	SplashScreen::showMessage(q_("Initializing custom objects manager..."));
 	CustomObjectMgr* custObj = new CustomObjectMgr();
 	custObj->init();
 	getModuleMgr().registerModule(custObj);
 
 	// Init hightlights
+	SplashScreen::showMessage(q_("Initializing highlights..."));
 	HighlightMgr* hlMgr = new HighlightMgr();
 	hlMgr->init();
 	getModuleMgr().registerModule(hlMgr);
@@ -559,10 +589,12 @@ void StelApp::init(QSettings* conf)
 	//Create the script manager here, maybe some modules/plugins may want to connect to it
 	//It has to be initialized later after all modules have been loaded by calling initScriptMgr
 #ifndef DISABLE_SCRIPTING
+	SplashScreen::showMessage(q_("Initializing scripting..."));
 	scriptAPIProxy = new StelMainScriptAPIProxy(this);
 	scriptMgr = new StelScriptMgr(this);
 #endif
 
+	SplashScreen::showMessage(q_("Initializing color scheme..."));
 	// Initialisation of the color scheme
 	emit colorSchemeChanged("color");
 	setVisionModeNight(confSettings->value("viewing/flag_night", false).toBool());
@@ -571,7 +603,9 @@ void StelApp::init(QSettings* conf)
 	setViewportEffect(confSettings->value("video/viewport_effect", "none").toString());
 
 	// Proxy Initialisation
+	SplashScreen::showMessage(q_("Initializing network proxy..."));
 	setupNetworkProxy();
+    SplashScreen::clearMessage();
 	updateI18n();
 
 	// Init actions.
@@ -599,6 +633,7 @@ void StelApp::init(QSettings* conf)
 		}
 		else
 		{
+		SplashScreen::showMessage(q_("Initializing SPOUT sender..."));
 			// Create the SpoutSender object.
 			QString spoutName = qApp->property("spoutName").toString();
 			if(spoutName.isEmpty())
@@ -613,6 +648,7 @@ void StelApp::init(QSettings* conf)
 				spoutSender = Q_NULLPTR;
 				qApp->setProperty("spout", "");
 			}
+            SplashScreen::clearMessage();
 		}
 	}
 	else
@@ -633,6 +669,7 @@ void StelApp::initPlugIns()
 	{
 		if (i.loadAtStartup==false)
 			continue;
+		SplashScreen::showMessage(q_("Loading plugin \"%1\"").arg(i.info.displayedName));
 		StelModule* m = moduleMgr->loadPlugin(i.info.id);
 		if (m!=Q_NULLPTR)
 		{
@@ -642,6 +679,7 @@ void StelApp::initPlugIns()
 			m->init();
 		}
 	}
+    SplashScreen::clearMessage();
 }
 
 void StelApp::deinit()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "StelMainView.hpp"
+#include "StelSplashScreen.hpp"
 #include "StelTranslator.hpp"
 #include "StelLogger.hpp"
 #include "StelFileMgr.hpp"
@@ -45,7 +46,6 @@
 #include <QFontDatabase>
 #include <QGuiApplication>
 #include <QSettings>
-#include <QSplashScreen>
 #include <QString>
 #include <QStringList>
 #include <QTextStream>
@@ -128,28 +128,6 @@ void clearCache()
 	cacheMgr->clear(); // Removes all items from the cache.
 }
 
-class SplashScreen : public QSplashScreen
-{
-    bool painted=false;
-    void paintEvent(QPaintEvent* e) override
-    {
-        QSplashScreen::paintEvent(e);
-        painted=true;
-    }
-public:
-    SplashScreen(QPixmap const& pixmap)
-        : QSplashScreen(pixmap)
-    {}
-    void ensureFirstPaint() const
-    {
-        while(!painted)
-        {
-            QThread::usleep(1000);
-            qApp->processEvents();
-        }
-    }
-};
-
 // Main stellarium procedure
 int main(int argc, char **argv)
 {
@@ -209,11 +187,7 @@ int main(int argc, char **argv)
 	// Init the file manager
 	StelFileMgr::init();
 
-	QPixmap pixmap(StelFileMgr::findFile("data/splash.png"));
-	SplashScreen splash(pixmap);
-	splash.show();
-	splash.showMessage(StelUtils::getApplicationVersion() , Qt::AlignLeft, Qt::white);
-	splash.ensureFirstPaint();
+	SplashScreen::present();
 
 	// Log command line arguments.
 	QString argStr;
@@ -409,7 +383,7 @@ int main(int argc, char **argv)
 
 	StelMainView mainWin(confSettings);
 	mainWin.show();
-	splash.finish(&mainWin);
+	SplashScreen::finish(&mainWin);
 	app.exec();
 	mainWin.deinit();
 


### PR DESCRIPTION
Now the splash screen provides some clue as to what Stellarium is actually doing during its not so fast loading process. Changing messages let the users feel that the process has not hung, and is still in progress.

I've tried to preserve the version text in the top-left corner, only adding the status messages at the bottom-left side. Here's how it looks now (at one stage of initialization):

![new-splash](https://user-images.githubusercontent.com/6376882/61582733-3dce6c00-ab37-11e9-9640-333988a2196a.png)