### PR TITLE
Fix crash on destruction of static QWidget

### DIFF
--- a/src/StelSplashScreen.cpp
+++ b/src/StelSplashScreen.cpp
@@ -36,10 +36,10 @@ static QPixmap makePixmap()
 
 void SplashScreen::present()
 {
-	static SplashScreenWidget splash(makePixmap());
-	instance=&splash;
-	splash.show();
-	splash.ensureFirstPaint();
+	Q_ASSERT(!instance);
+	instance=new SplashScreenWidget(makePixmap());
+	instance->show();
+	instance->ensureFirstPaint();
 }
 
 void SplashScreen::showMessage(QString const& message)
@@ -52,6 +52,8 @@ void SplashScreen::finish(QWidget* mainWindow)
 {
 	Q_ASSERT(instance);
 	instance->finish(mainWindow);
+	delete instance;
+	instance=nullptr;
 }
 
 void SplashScreen::clearMessage()


### PR DESCRIPTION
Static objects are destroyed after return from `main()`, when `QApplication` no longer exists. This isn't supported by Qt. This patch prevents destruction of `SplashScreenWidget` in such a circumstance, instead destroying it on SplashScreen::finish() call.