### PR TITLE
Small tweak to draw planet halos

### DIFF
--- a/src/core/StelSkyDrawer.cpp
+++ b/src/core/StelSkyDrawer.cpp
@@ -536,7 +536,7 @@ void StelSkyDrawer::postDrawSky3dModel(StelPainter* painter, const Vec3f& v, flo
 	// so that the radius of the halo is small enough to be not visible (so that we see the disk)
 
 	// TODO: Change drawing halo to more realistic view of stars and planets
-	float tStart = 6.f; // Was 3.f: planet's halo is too dim. Trying with 6.f to see if it's better.
+	float tStart = 5.f; // Was 3.f: planet's halo is too dim. This value needs to be lower than tStop, otherwise the halo disappears abruptly when zooming in.
 	float tStop = 6.f;
 	bool truncated=false;
 

--- a/src/core/StelSkyDrawer.cpp
+++ b/src/core/StelSkyDrawer.cpp
@@ -536,7 +536,7 @@ void StelSkyDrawer::postDrawSky3dModel(StelPainter* painter, const Vec3f& v, flo
 	// so that the radius of the halo is small enough to be not visible (so that we see the disk)
 
 	// TODO: Change drawing halo to more realistic view of stars and planets
-	float tStart = 3.f; // Was 2.f: planet's halo is too dim
+	float tStart = 6.f; // Was 3.f: planet's halo is too dim. Trying with 6.f to see if it's better.
 	float tStop = 6.f;
 	bool truncated=false;
 


### PR DESCRIPTION
This fix provides a better balance to planet halos, both relative to each other, and relative to bright stars. It may not be perfect, but looks a lot better and gives the "annoyingly" bright shine of Venus. Also looks good when zooming in on the moon, and the moon's halo is not oversized.

(sort of) Fixes #367 

### Screenshots:
![STELLCOMPARE](https://user-images.githubusercontent.com/37028368/65977109-9abc9b80-e471-11e9-8971-6a87e48b0637.png)


### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### How Has This Been Tested?
Especially used Venus/Jupiter when testing, as they used to be identical in size.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
