### PR TITLE
Fix caching of precession values not being used in precession code

### DIFF
--- a/src/core/planetsephems/precession.c
+++ b/src/core/planetsephems/precession.c
@@ -117,11 +117,12 @@ static const double p_epsVals[10][5]=
 
 // compute angles for the series we are in fact using.
 // jde: date JD_TT
-// 
+//
 void getPrecessionAnglesVondrak(const double jde, double *epsilon_A, double *chi_A, double *omega_A, double *psi_A)
 {
 	if (fabs(jde-c_lastJDE) > PRECESSION_EPOCH_THRESHOLD)
 	{
+		c_lastJDE=jde;
 		double T=(jde-2451545.0)* (1.0/36525.0); // Julian centuries from J2000.0
 		assert(fabs(T)<=2000); // MAKES SURE YOU NEVER OVERSTRETCH THIS!
 		double T2pi= T*(2.0*M_PI); // Julian centuries from J2000.0, premultiplied by 2Pi
@@ -184,6 +185,7 @@ void getPrecessionAnglesVondrakPQXYe(const double jde, double *vP_A, double *vQ_
 {
 	if (fabs(jde-c_lastJDE) > PRECESSION_EPOCH_THRESHOLD)
 	{
+		c_lastJDE=jde;
 		double T=(jde-2451545.0)* (1.0/36525.0);
 		assert(fabs(T)<=2000); // MAKES SURE YOU NEVER OVERSTRETCH THIS!
 		double T2pi= T*(2.0*M_PI); // Julian centuries from J2000.0, premultiplied by 2Pi
@@ -388,7 +390,7 @@ static double c_jdeLastNut=-1e-100;
 //! @note The model promises mas accuracy in the present era but gives no comment on long-time effects. Given that nutation was discovered in the early 18th century,
 //! it seems wise to set the returned values to zero before 1500 and after 2500. To avoid a jump, a linear fade-in/fade-out is applied within 100 days before 1500 and after 2500.
 void getNutationAngles(const double JDE, double *deltaPsi, double *deltaEpsilon)
-{	
+{
 // 1.1.1500
 #define NUT_BEGIN 2268932.5
 // 1.1.2500


### PR DESCRIPTION
Although precession values are stored and cached for later use, the caching code doesn't work because the JDE used for the calculation is never stored in `c_lastJDE` and hence the precession code is run more often than necessary.

Further optimisation is possible, but hasn't been implemented in this fix: When an object is selected on the main Stellarium view, the precession code is constantly executed, with input values alternating between JDE=2451545.0 (J2000) and (presumably) the JDE of the current date/time used for calculations. 

A first simple improvement could be to cache precession values for J2000, or optimise the calling code to either use the identity precession matrix for J2000 or cache the J2000 value for the obliquity of the ecliptic (this is a wild guess without having checked).

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system: macOS 10.14
* Graphics Card: Intel Iris

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
