### PR TITLE
#897 Fix loading of TLEs that mangle the Norad Satellite ID number 

### DIFF
--- a/plugins/Satellites/src/CMakeLists.txt
+++ b/plugins/Satellites/src/CMakeLists.txt
@@ -50,6 +50,10 @@ QT5_WRAP_UI(SatellitesDialog_UIS_H ${SatellitesDialog_UIS})
 SET(Satellites_RES ../resources/Satellites.qrc)
 QT5_ADD_RESOURCES(Satellites_RES_CXX ${Satellites_RES})
 
+IF(ENABLE_TESTING)
+    ADD_SUBDIRECTORY(test)
+ENDIF(ENABLE_TESTING)
+
 ADD_LIBRARY(Satellites-static STATIC ${Satellites_SRCS} ${Satellites_RES_CXX} ${SatellitesDialog_UIS_H})
 TARGET_LINK_LIBRARIES(Satellites-static Qt5::Core Qt5::Network Qt5::Widgets)
 # The library target "Satellites-static" has a default OUTPUT_NAME of "Satellites-static", so change it.

--- a/plugins/Satellites/src/Satellites.cpp
+++ b/plugins/Satellites/src/Satellites.cpp
@@ -55,6 +55,7 @@
 #include <QVariant>
 #include <QDir>
 #include <QTemporaryFile>
+#include <QRegExp>
 
 StelModule* SatellitesStelPluginInterface::getStelModule() const
 {
@@ -1684,6 +1685,11 @@ void Satellites::parseTleFile(QFile& openFile,
 QString Satellites::getSatIdFromLine2(const QString& line)
 {
 	QString id = line.split(' ',  QString::SkipEmptyParts).at(1).trimmed();
+	if (!id.isEmpty())
+	{
+		// Strip any leading zeros as they should be unique ints as strings.
+		id.remove(QRegExp("^[0]*"));
+	}
 	return id;
 }
 

--- a/plugins/Satellites/src/Satellites.cpp
+++ b/plugins/Satellites/src/Satellites.cpp
@@ -1653,9 +1653,11 @@ void Satellites::parseTleFile(QFile& openFile,
 				lastData.second = line;
 				// The Satellite Catalog Number is the second number
 				// on the second line.
-				QString id = line.split(' ').at(1).trimmed();
-				if (id.isEmpty())
+				QString id = getSatIdFromLine2(line);
+				if (id.isEmpty()) {
+					qDebug() << "[Satellites] failed to extract SatId from \"" << line << "\"";
 					continue;
+				}
 				lastData.id = id;
 				
 				// This is the second line and there will be no more,
@@ -1677,6 +1679,12 @@ void Satellites::parseTleFile(QFile& openFile,
 				qDebug() << "[Satellites] unprocessed line " << lineNumber <<  " in file " << QDir::toNativeSeparators(openFile.fileName());
 		}
 	}
+}
+
+QString Satellites::getSatIdFromLine2(const QString& line)
+{
+	QString id = line.split(' ',  QString::SkipEmptyParts).at(1).trimmed();
+	return id;
 }
 
 void Satellites::parseQSMagFile(QString qsMagFile)

--- a/plugins/Satellites/src/Satellites.hpp
+++ b/plugins/Satellites/src/Satellites.hpp
@@ -361,6 +361,10 @@ public:
 	                         TleDataHash& tleList,
 				 bool addFlagValue = false);
 
+	//! Insert a three line TLE into the hash array.
+	//! @param[in] line The second line from the TLE
+	static QString Satellites::getSatIdFromLine2(const QString& line);
+
 	//! Reads qs.mag file and its parsing for getting id and standard magnitude
 	//! for satellites.
 	//! @note We are having permissions for use this file from Mike McCants.

--- a/plugins/Satellites/src/test/CMakeLists.txt
+++ b/plugins/Satellites/src/test/CMakeLists.txt
@@ -1,0 +1,10 @@
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+set(CMAKE_AUTOMOC ON)
+
+FIND_PACKAGE(Qt5Test)
+
+ADD_EXECUTABLE(testSatellites testSatellites.cpp testSatellites.hpp)
+TARGET_LINK_LIBRARIES(testSatellites Qt5::Test Satellites-static stelMain)
+ADD_TEST(testSatellites testSatellites)
+SET_TARGET_PROPERTIES(testSatellites PROPERTIES FOLDER "plugins/Satellites/test")
+

--- a/plugins/Satellites/src/test/testSatellites.cpp
+++ b/plugins/Satellites/src/test/testSatellites.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Andy Kirkham <ToDo>
+ * Copyright (C) 2019 Andy Kirkham
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -21,18 +21,29 @@
 
 QTEST_GUILESS_MAIN(TestSatellites)
 
-void TestSatellites::testIssue408_CelestrackFormattedLine2()
+void TestSatellites::testIssue897CelestrackFormattedLine2()
 {
-    QString Line  = "2 07530 101.7770 337.7317 0012122 318.4445 104.4962 12.53641440 65623";
+    QString Line = "2 07530 101.7770 337.7317 0012122 318.4445 104.4962 12.53641440 65623";
     QString dut = Satellites::getSatIdFromLine2(Line);
     QVERIFY(!dut.isEmpty());
-    QVERIFY("07530" == dut);
+    QVERIFY("7530" == dut);
 }
 
-void TestSatellites::testIssue408_SpaceTrackFormattedLine2()
+void TestSatellites::testIssue897SpaceTrackFormattedLine2()
 {
     QString Line = "2  7530 101.7765 338.2965 0012116 317.3609 153.9519 12.53641545 65932";
     QString dut = Satellites::getSatIdFromLine2(Line);
     QVERIFY(!dut.isEmpty());
     QVERIFY("7530" == dut);
 }
+
+void TestSatellites::testIssue897NoSatDuplication()
+{
+    QString LineA = "2 07530 101.7770 337.7317 0012122 318.4445 104.4962 12.53641440 65623";
+    QString LineB = "2  7530 101.7765 338.2965 0012116 317.3609 153.9519 12.53641545 65932";
+    QString dutA = Satellites::getSatIdFromLine2(LineA);
+    QString dutB = Satellites::getSatIdFromLine2(LineB);
+    QVERIFY(dutA == dutB);
+}
+
+

--- a/plugins/Satellites/src/test/testSatellites.cpp
+++ b/plugins/Satellites/src/test/testSatellites.cpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2019 Andy Kirkham <ToDo>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Suite 500, Boston, MA  02110-1335, USA.
+ */
+
+#include <QString>
+#include "testSatellites.hpp"
+
+QTEST_GUILESS_MAIN(TestSatellites)
+
+void TestSatellites::testIssue408_CelestrackFormattedLine2()
+{
+    QString Line  = "2 07530 101.7770 337.7317 0012122 318.4445 104.4962 12.53641440 65623";
+    QString dut = Satellites::getSatIdFromLine2(Line);
+    QVERIFY(!dut.isEmpty());
+    QVERIFY("07530" == dut);
+}
+
+void TestSatellites::testIssue408_SpaceTrackFormattedLine2()
+{
+    QString Line = "2  7530 101.7765 338.2965 0012116 317.3609 153.9519 12.53641545 65932";
+    QString dut = Satellites::getSatIdFromLine2(Line);
+    QVERIFY(!dut.isEmpty());
+    QVERIFY("7530" == dut);
+}

--- a/plugins/Satellites/src/test/testSatellites.hpp
+++ b/plugins/Satellites/src/test/testSatellites.hpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2019 Andy Kirkham <>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Suite 500, Boston, MA  02110-1335, USA.
+ */
+
+#ifndef TESTSATELLITES_HPP
+#define TESTSATELLITES_HPP
+
+#include <QtTest>
+
+#include "Satellites.hpp"
+
+class TestSatellites : public QObject
+{
+Q_OBJECT
+private slots:
+    void testIssue408_CelestrackFormattedLine2();
+    void testIssue408_SpaceTrackFormattedLine2();
+};
+
+#endif // TESTSATELLITES_HPP

--- a/plugins/Satellites/src/test/testSatellites.hpp
+++ b/plugins/Satellites/src/test/testSatellites.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Andy Kirkham <>
+ * Copyright (C) 2019 Andy Kirkham
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -27,8 +27,9 @@ class TestSatellites : public QObject
 {
 Q_OBJECT
 private slots:
-    void testIssue408_CelestrackFormattedLine2();
-    void testIssue408_SpaceTrackFormattedLine2();
+    void testIssue897CelestrackFormattedLine2();
+    void testIssue897SpaceTrackFormattedLine2();
+    void testIssue897NoSatDuplication();
 };
 
 #endif // TESTSATELLITES_HPP


### PR DESCRIPTION
Relates to #897 

Celestrak's TLE distribution "mangles" the official TLEs published by Space Track.

### Description
The splitting of the substrings did not ignore double spaces.

Fixes # (issue)

See patch

### Screenshots (if appropriate):
N/A

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### How Has This Been Tested?
Unit Tests added to highlight the bug before fix and verify after fix.
I also ran Stellarium and tested the updater using my Space Track account and against Celestrak's TLE distribution.

**Test Configuration**:
* Operating system: Windows 10 (or any will do).
* Graphics Card: n/a for this test

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ n/a] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
- [ x] I have added tests that prove my fix is effective or that my feature works
- [ n/a] N/A as I added the first tests for this plugin. New and existing unit tests pass locally with my changes
- [n/a ] Any dependent changes have been merged and published in downstream modules
