### PR TITLE
Add Cross-origin (CORS) support to Remote Control plugin

### DIFF
--- a/guide/plg_interfaces.tex
+++ b/guide/plg_interfaces.tex
@@ -406,6 +406,15 @@ usage are taken! If you are in a home network using NAT (network access
 translation), this should be enough for basic security except if port 
 forwarding or a DMZ is configured.}
 
+The Web API also supports Cross-Origin Resource Sharing (CORS). By enabling CORS,
+compatible websites and web apps can be used to control your Stellarium server.
+
+Enable CORS by checking the "Enable CORS for the following URL" option in the
+configuration dialog. Then, enter the URL of the website you'd like to use to control
+Stellarium - e.g. \url{https://telescopius.com}. Specify "*" to let any website
+take control. Do this at your own risk.
+
+
 \subsection{Remote Control Web Interface}
 \label{sec:plugins:RemoteControl:webinterface}
 

--- a/guide/plg_interfaces.tex
+++ b/guide/plg_interfaces.tex
@@ -409,7 +409,7 @@ forwarding or a DMZ is configured.}
 The Web API also supports Cross-Origin Resource Sharing (CORS). By enabling CORS,
 compatible websites and web apps can be used to control your Stellarium server.
 
-Enable CORS by checking the "Enable CORS for the following URL" option in the
+Enable CORS by checking the "Enable CORS for the following origin" option in the
 configuration dialog. Then, enter the URL of the website you'd like to use to control
 Stellarium - e.g. \url{https://telescopius.com}. Specify "*" to let any website
 take control. Do this at your own risk.

--- a/plugins/RemoteControl/src/RemoteControl.cpp
+++ b/plugins/RemoteControl/src/RemoteControl.cpp
@@ -72,6 +72,8 @@ RemoteControl::RemoteControl()
 	, autoStart(false)
 	, usePassword(false)
 	, password("")
+	, enableCors(false)
+	, corsHosts("")
 	, port(8090)
 	, minThreads(1)
 	, maxThreads(30)
@@ -230,6 +232,24 @@ void RemoteControl::setPassword(const QString &password)
 	}
 }
 
+void RemoteControl::setFlagEnableCors(bool b)
+{
+	if(b!=enableCors)
+	{
+		enableCors = b;
+		emit flagEnableCorsChanged(b);
+	}
+}
+
+void RemoteControl::setCorsHosts(const QString &corsHosts)
+{
+	if(corsHosts != this->corsHosts)
+	{
+		this->corsHosts = corsHosts;
+		emit corsHostsChanged(corsHosts);
+	}
+}
+
 void RemoteControl::setPort(const int port)
 {
 	if(port!=this->port)
@@ -246,6 +266,8 @@ void RemoteControl::startServer()
 	//set request handler password settings
 	requestHandler->setPassword(password);
 	requestHandler->setUsePassword(usePassword);
+	requestHandler->setEnableCors(enableCors);
+	requestHandler->setCorsHosts(corsHosts);
 	HttpListenerSettings settings;
 	settings.port = port;
 	settings.minThreads = minThreads;
@@ -279,6 +301,8 @@ void RemoteControl::loadSettings()
 	setFlagAutoStart(conf->value("autostart", false).toBool()); // disable autostart for security reason
 	setFlagUsePassword(conf->value("use_password", false).toBool());
 	setPassword(conf->value("password", "").toString());
+	setFlagEnableCors(conf->value("enable_cors", false).toBool());
+	setCorsHosts(conf->value("cors_hosts", "").toString());
 	setPort(conf->value("port", 8090).toInt());
 	minThreads = conf->value("min_threads", 1).toInt();
 	maxThreads = conf->value("max_threads", 30).toInt();
@@ -291,6 +315,8 @@ void RemoteControl::saveSettings()
 	conf->setValue("autostart", autoStart);
 	conf->setValue("use_password", usePassword);
 	conf->setValue("password", password);
+	conf->setValue("enable_cors", enableCors);
+	conf->setValue("cors_hosts", corsHosts);
 	conf->setValue("port", port);
 	conf->setValue("min_threads", minThreads);
 	conf->setValue("max_threads", maxThreads);

--- a/plugins/RemoteControl/src/RemoteControl.cpp
+++ b/plugins/RemoteControl/src/RemoteControl.cpp
@@ -73,7 +73,7 @@ RemoteControl::RemoteControl()
 	, usePassword(false)
 	, password("")
 	, enableCors(false)
-	, corsHosts("")
+	, corsOrigin("")
 	, port(8090)
 	, minThreads(1)
 	, maxThreads(30)
@@ -241,12 +241,12 @@ void RemoteControl::setFlagEnableCors(bool b)
 	}
 }
 
-void RemoteControl::setCorsHosts(const QString &corsHosts)
+void RemoteControl::setCorsOrigin(const QString &corsOrigin)
 {
-	if(corsHosts != this->corsHosts)
+	if(corsOrigin != this->corsOrigin)
 	{
-		this->corsHosts = corsHosts;
-		emit corsHostsChanged(corsHosts);
+		this->corsOrigin = corsOrigin;
+		emit corsOriginChanged(corsOrigin);
 	}
 }
 
@@ -267,7 +267,7 @@ void RemoteControl::startServer()
 	requestHandler->setPassword(password);
 	requestHandler->setUsePassword(usePassword);
 	requestHandler->setEnableCors(enableCors);
-	requestHandler->setCorsHosts(corsHosts);
+	requestHandler->setCorsOrigin(corsOrigin);
 	HttpListenerSettings settings;
 	settings.port = port;
 	settings.minThreads = minThreads;
@@ -302,7 +302,7 @@ void RemoteControl::loadSettings()
 	setFlagUsePassword(conf->value("use_password", false).toBool());
 	setPassword(conf->value("password", "").toString());
 	setFlagEnableCors(conf->value("enable_cors", false).toBool());
-	setCorsHosts(conf->value("cors_hosts", "").toString());
+	setCorsOrigin(conf->value("cors_origin", "").toString());
 	setPort(conf->value("port", 8090).toInt());
 	minThreads = conf->value("min_threads", 1).toInt();
 	maxThreads = conf->value("max_threads", 30).toInt();
@@ -316,7 +316,7 @@ void RemoteControl::saveSettings()
 	conf->setValue("use_password", usePassword);
 	conf->setValue("password", password);
 	conf->setValue("enable_cors", enableCors);
-	conf->setValue("cors_hosts", corsHosts);
+	conf->setValue("cors_origin", corsOrigin);
 	conf->setValue("port", port);
 	conf->setValue("min_threads", minThreads);
 	conf->setValue("max_threads", maxThreads);

--- a/plugins/RemoteControl/src/RemoteControl.hpp
+++ b/plugins/RemoteControl/src/RemoteControl.hpp
@@ -16,7 +16,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Suite 500, Boston, MA  02110-1335, USA.
  */
- 
+
 #ifndef REMOTECONTROL_HPP
 #define REMOTECONTROL_HPP
 
@@ -59,10 +59,14 @@ class RemoteControl : public StelModule
 		   READ getFlagUsePassword
 		   WRITE setFlagUsePassword
 		   NOTIFY flagUsePasswordChanged)
+	Q_PROPERTY(bool enableCors
+		   READ getFlagEnableCors
+		   WRITE setFlagEnableCors
+		   NOTIFY flagEnableCorsChanged)
 public:
 	RemoteControl();
 	virtual ~RemoteControl();
-	
+
 	///////////////////////////////////////////////////////////////////////////
 	// Methods defined in the StelModule class
 	virtual void init();
@@ -79,8 +83,10 @@ public:
 	bool getFlagEnabled() const {return enabled;}
 	bool getFlagAutoStart() const { return autoStart; }
 	bool getFlagUsePassword() const { return usePassword; }
+	bool getFlagEnableCors() const { return enableCors; }
 
 	QString getPassword() const { return password; }
+	QString getCorsHosts() const { return corsHosts; }
 	int getPort() const {return port; }
 
 public slots:
@@ -96,6 +102,14 @@ public slots:
 	//! The password is required by RequestHandler for all HTTP requests.
 	//! Basic HTTP auth is used, without a user name.
 	void setPassword(const QString& password);
+
+	//! If true, Access-Control-Allow-Origin header will be appended to responses.
+	void setFlagEnableCors(bool b);
+
+	//! Sets the CORS hosts that are optionally enabled with setFlagEnableCors().
+	void setCorsHosts(const QString& corsHosts);
+
+
 	//! Sets the port where the server listens. Must be done before startServer() is called,
 	//! or restart the server to use the new setting.
 	void setPort(const int port);
@@ -129,9 +143,11 @@ signals:
 	void flagEnabledChanged(bool val);
 	void flagAutoStartChanged(bool val);
 	void flagUsePasswordChanged(bool val);
+	void flagEnableCorsChanged(bool val);
 
 	void portChanged(int val);
 	void passwordChanged(const QString& val);
+	void corsHostsChanged(const QString& val);
 
 
 private:
@@ -144,6 +160,8 @@ private:
 	bool autoStart;
 	bool usePassword;
 	QString password;
+	bool enableCors;
+	QString corsHosts;
 
 	int port;
 	int minThreads;

--- a/plugins/RemoteControl/src/RemoteControl.hpp
+++ b/plugins/RemoteControl/src/RemoteControl.hpp
@@ -86,7 +86,7 @@ public:
 	bool getFlagEnableCors() const { return enableCors; }
 
 	QString getPassword() const { return password; }
-	QString getCorsHosts() const { return corsHosts; }
+	QString getCorsOrigin() const { return corsOrigin; }
 	int getPort() const {return port; }
 
 public slots:
@@ -106,8 +106,8 @@ public slots:
 	//! If true, Access-Control-Allow-Origin header will be appended to responses.
 	void setFlagEnableCors(bool b);
 
-	//! Sets the CORS hosts that are optionally enabled with setFlagEnableCors().
-	void setCorsHosts(const QString& corsHosts);
+	//! Sets the CORS origin that is optionally enabled with setFlagEnableCors().
+	void setCorsOrigin(const QString& corsOrigin);
 
 
 	//! Sets the port where the server listens. Must be done before startServer() is called,
@@ -147,7 +147,7 @@ signals:
 
 	void portChanged(int val);
 	void passwordChanged(const QString& val);
-	void corsHostsChanged(const QString& val);
+	void corsOriginChanged(const QString& val);
 
 
 private:
@@ -161,7 +161,7 @@ private:
 	bool usePassword;
 	QString password;
 	bool enableCors;
-	QString corsHosts;
+	QString corsOrigin;
 
 	int port;
 	int minThreads;

--- a/plugins/RemoteControl/src/RequestHandler.cpp
+++ b/plugins/RemoteControl/src/RequestHandler.cpp
@@ -157,7 +157,7 @@ void RequestHandler::service(HttpRequest &request, HttpResponse &response)
 
 	if(enableCors)
 	{
-		response.setHeader("Access-Control-Allow-Origin",corsHosts.toUtf8());
+		response.setHeader("Access-Control-Allow-Origin",corsOrigin.toUtf8());
 		response.setHeader("Access-Control-Allow-Methods","GET, PUT, POST, HEAD, OPTIONS");
 		response.setHeader("Vary","Origin");
 	}
@@ -228,9 +228,9 @@ void RequestHandler::setEnableCors(bool v)
 	enableCors = v;
 }
 
-void RequestHandler::setCorsHosts(const QString &hosts)
+void RequestHandler::setCorsOrigin(const QString &origin)
 {
-	corsHosts = hosts;
+	corsOrigin = origin;
 }
 
 

--- a/plugins/RemoteControl/src/RequestHandler.cpp
+++ b/plugins/RemoteControl/src/RequestHandler.cpp
@@ -85,7 +85,7 @@ private:
 	StelTranslator* rcTranslator;
 };
 
-RequestHandler::RequestHandler(const StaticFileControllerSettings& settings, QObject* parent) : HttpRequestHandler(parent), usePassword(false), templateMutex(QMutex::Recursive)
+RequestHandler::RequestHandler(const StaticFileControllerSettings& settings, QObject* parent) : HttpRequestHandler(parent), usePassword(false), enableCors(false), templateMutex(QMutex::Recursive)
 {
 	apiController = new APIController(QByteArray("/api/").size(),this);
 
@@ -155,6 +155,13 @@ void RequestHandler::service(HttpRequest &request, HttpResponse &response)
 		}
 	}
 
+	if(enableCors)
+	{
+		response.setHeader("Access-Control-Allow-Origin",corsHosts.toUtf8());
+		response.setHeader("Access-Control-Allow-Methods","GET, PUT, POST, HEAD, OPTIONS");
+		response.setHeader("Vary","Origin");
+	}
+
 	//QByteArray rawPath = request.getRawPath();
 	QByteArray path = request.getPath();
 	//qDebug()<<"Request path:"<<rawPath<<" decoded:"<<path;
@@ -215,6 +222,17 @@ void RequestHandler::setPassword(const QString &pw)
 	arr.prepend(':');
 	passwordReply = "Basic " + arr.toBase64();
 }
+
+void RequestHandler::setEnableCors(bool v)
+{
+	enableCors = v;
+}
+
+void RequestHandler::setCorsHosts(const QString &hosts)
+{
+	corsHosts = hosts;
+}
+
 
 void RequestHandler::refreshTemplates()
 {

--- a/plugins/RemoteControl/src/RequestHandler.hpp
+++ b/plugins/RemoteControl/src/RequestHandler.hpp
@@ -75,7 +75,7 @@ public slots:
 	bool getEnableCors() const { return enableCors; }
 	//! Set the host for which CORS is enabled. Specify "*" to let any website take control.
 	//! @warning Make sure to only call this only when the server is offline because they are not synchronized
-	void setCorsHosts(const QString& hosts);
+	void setCorsOrigin(const QString& origin);
 
 
 
@@ -92,7 +92,7 @@ private:
 	bool usePassword;
 	QString password;
 	bool enableCors;
-	QString corsHosts;
+	QString corsOrigin;
 	QByteArray passwordReply;
 	APIController* apiController;
 	StaticFileController* staticFiles;

--- a/plugins/RemoteControl/src/RequestHandler.hpp
+++ b/plugins/RemoteControl/src/RequestHandler.hpp
@@ -69,6 +69,18 @@ public slots:
 	//! @warning Make sure to only call this only when the server is offline because they are not synchronized
 	void setPassword(const QString& pw);
 
+	//! Sets wether CORS is enabled.
+	//! @warning Make sure to only call this only when the server is offline because they are not synchronized
+	void setEnableCors(bool v);
+	//! Returns if CORS is enabled
+	//! @warning Make sure to only call this only when the server is offline because they are not synchronized
+	bool getEnableCors() { return enableCors; }
+	//! @warning Make sure to only call this only when the server is offline because they are not synchronized
+	void setCorsHosts(const QString& hosts);
+
+
+
+
 private slots:
 	void refreshTemplates();
 
@@ -80,6 +92,8 @@ private:
 
 	bool usePassword;
 	QString password;
+	bool enableCors;
+	QString corsHosts;
 	QByteArray passwordReply;
 	APIController* apiController;
 	StaticFileController* staticFiles;

--- a/plugins/RemoteControl/src/RequestHandler.hpp
+++ b/plugins/RemoteControl/src/RequestHandler.hpp
@@ -73,6 +73,7 @@ public slots:
 	void setEnableCors(bool v);
 	//! Returns if CORS is enabled
 	bool getEnableCors() { return enableCors; }
+	//! Set the host for which CORS is enabled. Specify "*" to let any website take control.
 	//! @warning Make sure to only call this only when the server is offline because they are not synchronized
 	void setCorsHosts(const QString& hosts);
 

--- a/plugins/RemoteControl/src/RequestHandler.hpp
+++ b/plugins/RemoteControl/src/RequestHandler.hpp
@@ -72,7 +72,7 @@ public slots:
 	//! @warning Make sure to only call this only when the server is offline because they are not synchronized
 	void setEnableCors(bool v);
 	//! Returns if CORS is enabled
-	bool getEnableCors() { return enableCors; }
+	bool getEnableCors() const { return enableCors; }
 	//! Set the host for which CORS is enabled. Specify "*" to let any website take control.
 	//! @warning Make sure to only call this only when the server is offline because they are not synchronized
 	void setCorsHosts(const QString& hosts);

--- a/plugins/RemoteControl/src/RequestHandler.hpp
+++ b/plugins/RemoteControl/src/RequestHandler.hpp
@@ -64,7 +64,6 @@ public slots:
 	//! @warning Make sure to only call this only when the server is offline because they are not synchronized
 	void setUsePassword(bool v);
 	//! Returns if a password is required to access the remote control
-	//! @warning Make sure to only call this only when the server is offline because they are not synchronized
 	bool getUsePassword() { return usePassword; }
 	//! @warning Make sure to only call this only when the server is offline because they are not synchronized
 	void setPassword(const QString& pw);
@@ -73,7 +72,6 @@ public slots:
 	//! @warning Make sure to only call this only when the server is offline because they are not synchronized
 	void setEnableCors(bool v);
 	//! Returns if CORS is enabled
-	//! @warning Make sure to only call this only when the server is offline because they are not synchronized
 	bool getEnableCors() { return enableCors; }
 	//! @warning Make sure to only call this only when the server is offline because they are not synchronized
 	void setCorsHosts(const QString& hosts);

--- a/plugins/RemoteControl/src/gui/RemoteControlDialog.cpp
+++ b/plugins/RemoteControl/src/gui/RemoteControlDialog.cpp
@@ -95,17 +95,17 @@ void RemoteControlDialog::createDialogContent()
 	connect(ui->enableCorsCheckbox, SIGNAL(toggled(bool)), rc, SLOT(setFlagEnableCors(bool)));
 	connect(rc, SIGNAL(flagEnableCorsChanged(bool)), ui->enableCorsCheckbox, SLOT(setChecked(bool)));
 
-	ui->corsHostsEdit->setEnabled(rc->getFlagEnableCors());
-	ui->corsHostsEdit->setText(rc->getCorsHosts());
+	ui->corsOriginEdit->setEnabled(rc->getFlagEnableCors());
+	ui->corsOriginEdit->setText(rc->getCorsOrigin());
 
-	connect(rc,SIGNAL(flagEnableCorsChanged(bool)),ui->corsHostsEdit,SLOT(setEnabled(bool)));
-	connect(ui->corsHostsEdit, SIGNAL(textChanged(QString)), rc, SLOT(setCorsHosts(QString)));
+	connect(rc,SIGNAL(flagEnableCorsChanged(bool)),ui->corsOriginEdit,SLOT(setEnabled(bool)));
+	connect(ui->corsOriginEdit, SIGNAL(textChanged(QString)), rc, SLOT(setCorsOrigin(QString)));
 
 	ui->restartPanel->setVisible(false);
 	connect(rc, SIGNAL(flagUsePasswordChanged(bool)), this, SLOT(requiresRestart()));
 	connect(rc, SIGNAL(passwordChanged(QString)), this, SLOT(requiresRestart()));
 	connect(rc, SIGNAL(flagEnableCorsChanged(bool)), this, SLOT(requiresRestart()));
-	connect(rc, SIGNAL(corsHostsChanged(QString)), this, SLOT(requiresRestart()));
+	connect(rc, SIGNAL(corsOriginChanged(QString)), this, SLOT(requiresRestart()));
 	connect(rc, SIGNAL(portChanged(int)), this, SLOT(requiresRestart()));
 
 	connect(ui->resetButton, SIGNAL(clicked(bool)),this,SLOT(restart()));

--- a/plugins/RemoteControl/src/gui/RemoteControlDialog.cpp
+++ b/plugins/RemoteControl/src/gui/RemoteControlDialog.cpp
@@ -91,9 +91,21 @@ void RemoteControlDialog::createDialogContent()
 	ui->portNumberSpinBox->setValue(rc->getPort());
 	connect(ui->portNumberSpinBox, SIGNAL(valueChanged(int)), rc, SLOT(setPort(int)));
 
+	ui->enableCorsCheckbox->setChecked(rc->getFlagEnableCors());
+	connect(ui->enableCorsCheckbox, SIGNAL(toggled(bool)), rc, SLOT(setFlagEnableCors(bool)));
+	connect(rc, SIGNAL(flagEnableCorsChanged(bool)), ui->enableCorsCheckbox, SLOT(setChecked(bool)));
+
+	ui->corsHostsEdit->setEnabled(rc->getFlagEnableCors());
+	ui->corsHostsEdit->setText(rc->getCorsHosts());
+
+	connect(rc,SIGNAL(flagEnableCorsChanged(bool)),ui->corsHostsEdit,SLOT(setEnabled(bool)));
+	connect(ui->corsHostsEdit, SIGNAL(textChanged(QString)), rc, SLOT(setCorsHosts(QString)));
+
 	ui->restartPanel->setVisible(false);
 	connect(rc, SIGNAL(flagUsePasswordChanged(bool)), this, SLOT(requiresRestart()));
 	connect(rc, SIGNAL(passwordChanged(QString)), this, SLOT(requiresRestart()));
+	connect(rc, SIGNAL(flagEnableCorsChanged(bool)), this, SLOT(requiresRestart()));
+	connect(rc, SIGNAL(corsHostsChanged(QString)), this, SLOT(requiresRestart()));
 	connect(rc, SIGNAL(portChanged(int)), this, SLOT(requiresRestart()));
 
 	connect(ui->resetButton, SIGNAL(clicked(bool)),this,SLOT(restart()));

--- a/plugins/RemoteControl/src/gui/remoteControlDialog.ui
+++ b/plugins/RemoteControl/src/gui/remoteControlDialog.ui
@@ -155,7 +155,7 @@
          </property>
         </widget>
        </item>
-       <item row="14" column="0">
+       <item row="15" column="0">
         <spacer name="verticalSpacer_3">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
@@ -168,7 +168,7 @@
          </property>
         </spacer>
        </item>
-       <item row="15" column="0" colspan="2">
+       <item row="16" column="0" colspan="2">
         <layout class="QHBoxLayout" name="horizontalLayout_7">
          <item>
           <widget class="QPushButton" name="restoreDefaultsButton">
@@ -243,7 +243,7 @@
        <item row="11" column="0">
         <widget class="QCheckBox" name="enableCorsCheckbox">
          <property name="text">
-          <string>Enable CORS from these hosts</string>
+          <string>Enable CORS for the following URL</string>
          </property>
         </widget>
        </item>
@@ -251,6 +251,13 @@
         <widget class="QLineEdit" name="corsHostsEdit"/>
        </item>
        <item row="12" column="0" colspan="2">
+        <widget class="QLabel" name="label">
+         <property name="text">
+          <string>Cross-Origin Resource Sharing lets the specified website access and control your Stellarium.&lt;br/&gt;Specify "*" to let any website take control - do this at your own risk.</string>
+         </property>
+        </widget>
+       </item>
+       <item row="13" column="0" colspan="2">
         <widget class="QWidget" name="restartPanel" native="true">
          <layout class="QVBoxLayout" name="verticalLayout">
           <item>

--- a/plugins/RemoteControl/src/gui/remoteControlDialog.ui
+++ b/plugins/RemoteControl/src/gui/remoteControlDialog.ui
@@ -243,12 +243,12 @@
        <item row="11" column="0">
         <widget class="QCheckBox" name="enableCorsCheckbox">
          <property name="text">
-          <string>Enable CORS for the following URL</string>
+          <string>Enable CORS for the following origin</string>
          </property>
         </widget>
        </item>
        <item row="11" column="1">
-        <widget class="QLineEdit" name="corsHostsEdit"/>
+        <widget class="QLineEdit" name="corsOriginEdit"/>
        </item>
        <item row="12" column="0" colspan="2">
         <widget class="QLabel" name="label">

--- a/plugins/RemoteControl/src/gui/remoteControlDialog.ui
+++ b/plugins/RemoteControl/src/gui/remoteControlDialog.ui
@@ -240,6 +240,16 @@
          </property>
         </widget>
        </item>
+       <item row="11" column="0">
+        <widget class="QCheckBox" name="enableCorsCheckbox">
+         <property name="text">
+          <string>Enable CORS from these hosts</string>
+         </property>
+        </widget>
+       </item>
+       <item row="11" column="1">
+        <widget class="QLineEdit" name="corsHostsEdit"/>
+       </item>
        <item row="12" column="0" colspan="2">
         <widget class="QWidget" name="restartPanel" native="true">
          <layout class="QVBoxLayout" name="verticalLayout">


### PR DESCRIPTION
...so it can be called from web applications in browsers.


### Description
This change will let web applications to call Stellarium using the Remote Control plugin. This was not possible before because of Cross-origin Resource Sharing (CORS) limitations: browsers don't allow websites to make cross-origin requests unless the server returns certain headers. This branch lets the user enable CORS support and enter the web application that will be calling it so no other websites hijack this connection.

No dependencies.

Fixes #941


### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] This change requires a documentation update

### How Has This Been Tested?
After opening Stellarium, enable the Remote Control plugin, and configure it. Check the checkbox "Enable CORS for the following origin" and enter the URL of the website that will be accessing Stellarium through the Remote Control plugin - e.g. https://telescopius.com

When the plugin is restarted, such website will be able to send requests to the Remote Control plugin. Conversely, if the checkbox is unchecked, access to Stellarium will be denied by the browser.


**Test Configuration**:
* Operating system: macOS Catalina 10.15.2, Google Chrome 79.0.3945.117 (Official Build) (64-bit)
* Graphics Card: N/A

## Checklist:
- [X] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation - **it seems there's no documentation about the remote control configuration popup where to add an explanation of this new field. In any case, it should be self-explanatory.**
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes - **it seems the Remote Control plugin doesn't have any unit tests**
- [X] Any dependent changes have been merged and published in downstream modules
