### PR TITLE
Add support for CORS preflight request to the Remote Control plugin

### DIFF
--- a/plugins/RemoteControl/src/RequestHandler.cpp
+++ b/plugins/RemoteControl/src/RequestHandler.cpp
@@ -137,6 +137,11 @@ void RequestHandler::service(HttpRequest &request, HttpResponse &response)
 #define SERVER_HEADER "Stellarium RemoteControl " REMOTECONTROL_PLUGIN_VERSION
 	response.setHeader("Server",SERVER_HEADER);
 
+	if(QString::compare(request.getMethod(),"OPTIONS",Qt::CaseInsensitive)==0) {
+		handleCorsPreflightRequest(request,response);
+		return;
+	}
+
 	//try to support keep-alive connections
 	if(QString::compare(request.getHeader("Connection"),"keep-alive",Qt::CaseInsensitive)==0)
 		response.setHeader("Connection","keep-alive");
@@ -286,4 +291,13 @@ void RequestHandler::refreshTemplates()
 	{
 		qWarning()<<"[RemoteControl] "<<transFileList.fileName()<<" could not be opened, can not automatically translate files with StelTranslator!";
 	}
+}
+
+void RequestHandler::handleCorsPreflightRequest(HttpRequest &request, HttpResponse &response) {
+	response.setStatus(204,"No Content");
+	response.setHeader("Access-Control-Allow-Origin",corsOrigin.toUtf8());
+	response.setHeader("Access-Control-Allow-Methods","GET, POST");
+	response.setHeader("Access-Control-Allow-Headers",request.getHeader("Access-Control-Request-Headers"));
+	response.setHeader("Access-Control-Max-Age","0");
+	response.setHeader("Vary","Origin");
 }

--- a/plugins/RemoteControl/src/RequestHandler.cpp
+++ b/plugins/RemoteControl/src/RequestHandler.cpp
@@ -148,6 +148,13 @@ void RequestHandler::service(HttpRequest &request, HttpResponse &response)
 	else
 		response.setHeader("Connection","close");
 
+	if(enableCors)
+	{
+		response.setHeader("Access-Control-Allow-Origin",corsOrigin.toUtf8());
+		response.setHeader("Access-Control-Allow-Methods","GET, PUT, POST, HEAD, OPTIONS");
+		response.setHeader("Vary","Origin");
+	}
+
 	if(usePassword)
 	{
 		//Check if the browser provided correct password, else reject request
@@ -158,13 +165,6 @@ void RequestHandler::service(HttpRequest &request, HttpResponse &response)
 			response.write("HTTP 401 Not Authorized",true);
 			return;
 		}
-	}
-
-	if(enableCors)
-	{
-		response.setHeader("Access-Control-Allow-Origin",corsOrigin.toUtf8());
-		response.setHeader("Access-Control-Allow-Methods","GET, PUT, POST, HEAD, OPTIONS");
-		response.setHeader("Vary","Origin");
 	}
 
 	//QByteArray rawPath = request.getRawPath();

--- a/plugins/RemoteControl/src/RequestHandler.hpp
+++ b/plugins/RemoteControl/src/RequestHandler.hpp
@@ -99,6 +99,8 @@ private:
 	QMutex templateMutex;
 
 	static const QByteArray AUTH_REALM;
+
+	void handleCorsPreflightRequest(HttpRequest &request, HttpResponse &response);
 };
 
 #endif


### PR DESCRIPTION
When a CORS request with basic auth password is sent to the Remote Control plugin, the browser generates what's known as a [preflight request](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#Preflighted_requests). In this pull request I'm adding support for this kind of requests, otherwise we can't use basic authentication with CORS requests.

This can be considered either a bug or a new feature if we consider CORS support was incomplete before ;-)


### Description
<!--- Please include a summary of the change and which issue is fixed. -->
<!--- Please also include relevant motivation and context. -->
<!--- List any dependencies that are required for this change. -->

Fixes # (issue)

### Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### How Has This Been Tested?
I've tested sending a CORS request with basic authentication and the browser console showed it failed because of CORS limitations. After I compiled this new code, the preflight request went through just fine and I could connect to Stellarium using the configured password in the Remote Control plugin.

**Test Configuration**:
Operating system: macOS Catalina 10.15.2, Google Chrome 79.0.3945.117 (Official Build) (64-bit)
* Graphics Card: N/A

## Checklist:
- [X] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation - **I don't think this needs to be documented**
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
