### PR TITLE
Introduce a GimbalOrbit for the "Observer" planets

### DIFF
--- a/plugins/Exoplanets/src/gui/ExoplanetsDialog.cpp
+++ b/plugins/Exoplanets/src/gui/ExoplanetsDialog.cpp
@@ -763,7 +763,7 @@ void ExoplanetsDialog::populateDiagramsList()
 	axisX->clear();
 	axisY->clear();
 
-	const QList<axisPair> axis = {
+	static const QList<axisPair> axis = {
 	{ q_("Orbital Eccentricity"),          0},
 	{ q_("Orbit Semi-Major Axis, AU"),     1},
 	{ q_("Planetary Mass, Mjup"),          2},

--- a/plugins/RemoteControl/src/gui/remoteControlDialog.ui
+++ b/plugins/RemoteControl/src/gui/remoteControlDialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>666</width>
-    <height>525</height>
+    <width>530</width>
+    <height>358</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -251,9 +251,9 @@
         <widget class="QLineEdit" name="corsOriginEdit"/>
        </item>
        <item row="12" column="0" colspan="2">
-        <widget class="QLabel" name="corsLabel">
+        <widget class="QLabel" name="label">
          <property name="text">
-          <string>Cross-Origin Resource Sharing lets the specified website access and control your Stellarium.&lt;br/&gt;Specify &quot;*&quot; to let any website take control - do this at your own risk.</string>
+          <string>Cross-Origin Resource Sharing lets the specified website access and control your Stellarium.&lt;br/&gt;Specify "*" to let any website take control - do this at your own risk.</string>
          </property>
         </widget>
        </item>

--- a/src/core/StelMovementMgr.cpp
+++ b/src/core/StelMovementMgr.cpp
@@ -420,7 +420,7 @@ void StelMovementMgr::handleKeys(QKeyEvent* event)
 			case Qt::Key_multiply:
 				if (gimbal && event->modifiers().testFlag(Qt::KeypadModifier))
 				{
-					qDebug() << "Num-*";
+					//qDebug() << "Num-*";
 					gimbal->addToDistance(gimbal->getDistance()*0.05);
 				} else
 					zoomIn(true);
@@ -428,7 +428,7 @@ void StelMovementMgr::handleKeys(QKeyEvent* event)
 			case Qt::Key_division:
 				if (gimbal && event->modifiers().testFlag(Qt::KeypadModifier))
 				{
-					qDebug() << "Num-/";
+					//qDebug() << "Num-/";
 					gimbal->addToDistance(-gimbal->getDistance()*0.05);
 				}
 				else
@@ -437,28 +437,28 @@ void StelMovementMgr::handleKeys(QKeyEvent* event)
 			case Qt::Key_Plus:
 				if (gimbal && event->modifiers().testFlag(Qt::AltModifier))
 				{
-					qDebug() << "Alt-Plus";
+					//qDebug() << "Alt-Plus";
 					gimbal->addToDistance(gimbal->getDistance()*0.05);
 				}
 				break;
 			case Qt::Key_Minus:
 				if (gimbal && event->modifiers().testFlag(Qt::AltModifier))
 				{
-					qDebug() << "Alt-Minus";
+					//qDebug() << "Alt-Minus";
 					gimbal->addToDistance(-gimbal->getDistance()*0.05);
 				}
 				break;
 			case Qt::Key_5:
 				if (gimbal && event->modifiers().testFlag(Qt::AltModifier))
 				{
-					qDebug() << "5";
+					//qDebug() << "5";
 					gimbal->addToDistance(gimbal->getDistance()*0.05);
 				}
 				break;
 			case Qt::Key_6:
 				if (gimbal && event->modifiers().testFlag(Qt::AltModifier))
 				{
-					qDebug() << "6";
+					//qDebug() << "6";
 					gimbal->addToDistance(-gimbal->getDistance()*0.05);
 				}
 				break;

--- a/src/core/StelMovementMgr.cpp
+++ b/src/core/StelMovementMgr.cpp
@@ -33,6 +33,8 @@
 #include "StelPainter.hpp"
 #include "StelProjector.hpp"
 #include "LabelMgr.hpp"
+#include "Planet.hpp"
+#include "Orbit.hpp"
 
 #include <cmath>
 #include <QString>
@@ -353,33 +355,114 @@ double StelMovementMgr::getCallOrder(StelModuleActionName actionName) const
 
 void StelMovementMgr::handleKeys(QKeyEvent* event)
 {
+	GimbalOrbit *gimbal=Q_NULLPTR;
+#ifdef USE_GIMBAL_ORBIT
+	StelCore *core=StelApp::getInstance().getCore();
+	Planet* obsPlanet= core->getCurrentPlanet().get();
+	if (obsPlanet->getPlanetType()==Planet::isObserver)
+	{
+		gimbal=static_cast<GimbalOrbit*>(obsPlanet->getOrbit());
+	}
+#endif
         if (event->type() == QEvent::KeyPress)
 	{
+		// qDebug() << "Modifiers:" << event->modifiers();
+		// FIXME: Alt modifier seems problematic. The keys to modify distance in an observer gimbal seem to
+		// collide with operating system hotkeys. Using Alt5/Alt6 is experimental just to have "some" working solution.
 		// Direction and zoom deplacements
 		switch (event->key())
 		{
 			case Qt::Key_Left:
-				turnLeft(true); break;
+				if (gimbal && event->modifiers().testFlag(Qt::AltModifier)){
+					gimbal->addToLongitude(-5.);
+				} else {
+					turnLeft(true);
+				}
+				break;
 			case Qt::Key_Right:
-				turnRight(true); break;
+				if (gimbal && event->modifiers().testFlag(Qt::AltModifier)){
+					gimbal->addToLongitude(5.);
+				} else
+				turnRight(true);
+				break;
 			case Qt::Key_Up:
-				if (event->modifiers().testFlag(Qt::ControlModifier)){
+				if (gimbal && event->modifiers().testFlag(Qt::AltModifier)){
+					gimbal->addToLatitude(5.);
+				}
+				else if (event->modifiers().testFlag(Qt::ControlModifier)){
 					zoomIn(true);
 				} else {
 					turnUp(true);
 				}
 				break;
 			case Qt::Key_Down:
-				if (event->modifiers().testFlag(Qt::ControlModifier)) {
+				if (gimbal && event->modifiers().testFlag(Qt::AltModifier)){
+					gimbal->addToLatitude(-5.);
+				}
+				else if (event->modifiers().testFlag(Qt::ControlModifier)) {
 					zoomOut(true);
 				} else {
 					turnDown(true);
 				}
 				break;
 			case Qt::Key_PageUp:
-				zoomIn(true); break;
+				if (gimbal && event->modifiers().testFlag(Qt::AltModifier))
+					gimbal->addToDistance(gimbal->getDistance()*0.05);
+				else
+					zoomIn(true);
+				break;
 			case Qt::Key_PageDown:
-				zoomOut(true); break;
+				if (gimbal && event->modifiers().testFlag(Qt::AltModifier))
+					gimbal->addToDistance(-gimbal->getDistance()*0.05);
+				else
+					zoomOut(true);
+				break;
+			case Qt::Key_multiply:
+				if (gimbal && event->modifiers().testFlag(Qt::KeypadModifier))
+				{
+					qDebug() << "Num-*";
+					gimbal->addToDistance(gimbal->getDistance()*0.05);
+				} else
+					zoomIn(true);
+				break;
+			case Qt::Key_division:
+				if (gimbal && event->modifiers().testFlag(Qt::KeypadModifier))
+				{
+					qDebug() << "Num-/";
+					gimbal->addToDistance(-gimbal->getDistance()*0.05);
+				}
+				else
+					zoomOut(true);
+				break;
+			case Qt::Key_Plus:
+				if (gimbal && event->modifiers().testFlag(Qt::AltModifier))
+				{
+					qDebug() << "Alt-Plus";
+					gimbal->addToDistance(gimbal->getDistance()*0.05);
+				}
+				break;
+			case Qt::Key_Minus:
+				if (gimbal && event->modifiers().testFlag(Qt::AltModifier))
+				{
+					qDebug() << "Alt-Minus";
+					gimbal->addToDistance(-gimbal->getDistance()*0.05);
+				}
+				break;
+			case Qt::Key_5:
+				if (gimbal && event->modifiers().testFlag(Qt::AltModifier))
+				{
+					qDebug() << "5";
+					gimbal->addToDistance(gimbal->getDistance()*0.05);
+				}
+				break;
+			case Qt::Key_6:
+				if (gimbal && event->modifiers().testFlag(Qt::AltModifier))
+				{
+					qDebug() << "6";
+					gimbal->addToDistance(-gimbal->getDistance()*0.05);
+				}
+				break;
+
 			case Qt::Key_Shift:
 				moveSlow(true); break;
 			default:

--- a/src/core/StelMovementMgr.cpp
+++ b/src/core/StelMovementMgr.cpp
@@ -358,7 +358,7 @@ void StelMovementMgr::handleKeys(QKeyEvent* event)
 	GimbalOrbit *gimbal=Q_NULLPTR;
 #ifdef USE_GIMBAL_ORBIT
 	StelCore *core=StelApp::getInstance().getCore();
-	Planet* obsPlanet= core->getCurrentPlanet().get();
+	Planet* obsPlanet= core->getCurrentPlanet().data();
 	if (obsPlanet->getPlanetType()==Planet::isObserver)
 	{
 		gimbal=static_cast<GimbalOrbit*>(obsPlanet->getOrbit());

--- a/src/core/StelUtils.hpp
+++ b/src/core/StelUtils.hpp
@@ -788,7 +788,7 @@ namespace StelUtils
 		return (T(0) < val) - (val < T(0));
 	}
 	
-	//! Compute cosines and sines around a circle which is split in "slices" parts.
+	//! Compute cosines and sines around a circle which is split in "segments" parts.
 	//! Values are stored in the global static array cos_sin_theta.
 	//! Used for the sin/cos values along a latitude circle, equator, etc. for a spherical mesh.
 	//! @param slices number of partitions (elsewhere called "segments") for the circle

--- a/src/core/modules/Comet.cpp
+++ b/src/core/modules/Comet.cpp
@@ -190,8 +190,8 @@ QString Comet::getInfoString(const StelCore *core, const InfoStringGroup &flags)
 	QString distAU, distKM;
 	if (flags&Distance)
 	{
-		const double hdistanceAu = getHeliocentricEclipticPos().length();
-		const double hdistanceKm = AU * hdistanceAu;
+		double hdistanceAu = getHeliocentricEclipticPos().length();
+		double hdistanceKm = AU * hdistanceAu;
 		// TRANSLATORS: Unit of measure for distance - astronomical unit
 		QString au = qc_("AU", "distance, astronomical unit");
 		bool useKM = true;
@@ -208,8 +208,8 @@ QString Comet::getInfoString(const StelCore *core, const InfoStringGroup &flags)
 		}
 		oss << QString("%1: %2 %3 (%4 %5)").arg(q_("Distance from Sun"), distAU, au, distKM, useKM ? km : Mkm) << "<br />";
 
-		const double distanceAu = getJ2000EquatorialPos(core).length();
-		const double distanceKm = AU * distanceAu;
+		double distanceAu = getJ2000EquatorialPos(core).length();
+		double distanceKm = AU * distanceAu;
 		if (distanceAu < 0.1)
 		{
 			distAU = QString::number(distanceAu, 'f', 6);
@@ -230,8 +230,8 @@ QString Comet::getInfoString(const StelCore *core, const InfoStringGroup &flags)
 		// TRANSLATORS: Unit of measure for speed - kilometers per second
 		QString kms = qc_("km/s", "speed");
 
-		const Vec3d orbitalVel=getEclipticVelocity();
-		const double orbVel=orbitalVel.length();
+		Vec3d orbitalVel=getEclipticVelocity();
+		double orbVel=orbitalVel.length();
 		if (orbVel>0.)
 		{ // AU/d * km/AU /24
 			oss << QString("%1: %2 %3").arg(q_("Orbital velocity")).arg(orbVel* AU/86400., 0, 'f', 3).arg(kms) << "<br />";
@@ -241,14 +241,14 @@ QString Comet::getInfoString(const StelCore *core, const InfoStringGroup &flags)
 	if (flags&Extra)
 	{
 		// If semi-major axis not zero then calculate and display orbital period for comet in days
-		const double siderealPeriod = getSiderealPeriod();
+		double siderealPeriod = getSiderealPeriod();
 		if (siderealPeriod>0.0)
 		{
 			// Sidereal (orbital) period for comets in Julian years (symbol: a)
 			oss << QString("%1: %2 a").arg(q_("Sidereal period"), QString::number(siderealPeriod/365.25, 'f', 3)) << "<br />";
 		}
 
-		const double siderealPeriodCurrentPlanet = core->getCurrentPlanet()->getSiderealPeriod();
+		double siderealPeriodCurrentPlanet = core->getCurrentPlanet()->getSiderealPeriod();
 		if (siderealPeriodCurrentPlanet > 0.0 && siderealPeriod > 0.0 && core->getCurrentPlanet()->getPlanetType()==Planet::isPlanet && getPlanetType()!=Planet::isArtificial && getPlanetType()!=Planet::isStar && getPlanetType()!=Planet::isMoon)
 		{
 			double sp = qAbs(1/(1/siderealPeriodCurrentPlanet - 1/siderealPeriod));
@@ -276,7 +276,7 @@ QString Comet::getInfoString(const StelCore *core, const InfoStringGroup &flags)
 	}
 
 
-	if ((flags&Size) && (tailFactors[0]>0.0))
+	if ((flags&Size) && (tailFactors[0]>0.0f))
 	{
 		// GZ: Add estimates for coma diameter and tail length.
 		QString comaEst = q_("Coma diameter (estimate)");

--- a/src/core/modules/Comet.hpp
+++ b/src/core/modules/Comet.hpp
@@ -60,7 +60,7 @@ public:
 	      float dustTailBrightnessFact=1.5f
 	);
 
-	virtual ~Comet() Q_DECL_OVERRIDE;
+	virtual ~Comet();
 
 	//Inherited from StelObject via Planet
 	//! Get a string with data about the Comet.

--- a/src/core/modules/Comet.hpp
+++ b/src/core/modules/Comet.hpp
@@ -75,22 +75,22 @@ public:
 	//! \param core the StelCore object
 	//! \param flags a set of InfoStringGroup items to include in the return value.
 	//! \return a QString containing an HMTL encoded description of the Comet.
-	virtual QString getInfoString(const StelCore *core, const InfoStringGroup &flags) const;
+	virtual QString getInfoString(const StelCore *core, const InfoStringGroup &flags) const Q_DECL_OVERRIDE;
 	//! In addition to Planet::getInfoMap(), Comets provides estimates for
 	//! - tail-length-km
 	//! - coma-diameter-km
 	//! using the formula from Guide found by the GSoC2012 initiative at http://www.projectpluto.com/update7b.htm#comet_tail_formula
-	virtual QVariantMap getInfoMap(const StelCore *core) const;
+	virtual QVariantMap getInfoMap(const StelCore *core) const Q_DECL_OVERRIDE;
 	//The Comet class inherits the "Planet" type because the SolarSystem class
 	//was not designed to handle different types of objects.
 	//virtual QString getType() const {return "Comet";}
 	//! \todo Find better sources for the g,k system
-	virtual float getVMagnitude(const StelCore* core) const;
+	virtual float getVMagnitude(const StelCore* core) const Q_DECL_OVERRIDE;
 	//! sets the nameI18 property with the appropriate translation.
 	//! Function overriden to handle the problem with name conflicts.
-	virtual void translateName(const StelTranslator& trans);
-	virtual QString getEnglishName(void) const {return englishName;}
-	virtual QString getNameI18n(void) const {return nameI18;}
+	virtual void translateName(const StelTranslator& trans) Q_DECL_OVERRIDE;
+	virtual QString getEnglishName(void) const Q_DECL_OVERRIDE {return englishName;}
+	virtual QString getNameI18n(void) const Q_DECL_OVERRIDE {return nameI18;}
 	QString getCommonEnglishName(void) const {return englishName;}
 	QString getCommonNameI18n(void) const {return nameI18;}
 
@@ -105,13 +105,13 @@ public:
 	void setSemiMajorAxis(const double value);
 
 	//! get sidereal period for comet, days, or returns 0 if not possible (paraboloid, hyperboloid orbit)
-	virtual double getSiderealPeriod() const;
+	virtual double getSiderealPeriod() const Q_DECL_OVERRIDE;
 
 	//! re-implementation of Planet's draw()
-	virtual void draw(StelCore* core, float maxMagLabels, const QFont& planetNameFont);
+	virtual void draw(StelCore* core, float maxMagLabels, const QFont& planetNameFont) Q_DECL_OVERRIDE;
 
 	// re-implementation of Planet's update() to prepare tails (extinction etc). @param deltaTime: ms (since last call)
-	virtual void update(int deltaTime);
+	virtual void update(int deltaTime) Q_DECL_OVERRIDE;
 
 private:
 	//! @returns estimates for (Coma diameter [AU], gas tail length [AU]).

--- a/src/core/modules/MinorPlanet.cpp
+++ b/src/core/modules/MinorPlanet.cpp
@@ -275,7 +275,7 @@ QString MinorPlanet::getInfoString(const StelCore *core, const InfoStringGroup &
 			if (!fuzzyEquals(helioVel, orbVel))
 				oss << QString("%1: %2 %3").arg(q_("Heliocentric velocity")).arg(helioVel* AU/86400., 0, 'f', 3).arg(kms) << "<br />";
 		}
-		if (qAbs(re.period)>0.f)
+		if (qAbs(re.period)>0.)
 		{
 			double eqRotVel = 2.0*M_PI*(AU*getEquatorialRadius())/(getSiderealDay()*86400.0);
 			oss << QString("%1: %2 %3").arg(q_("Equatorial rotation velocity")).arg(qAbs(eqRotVel), 0, 'f', 3).arg(kms) << "<br />";
@@ -376,7 +376,7 @@ QString MinorPlanet::getInfoString(const StelCore *core, const InfoStringGroup &
 
 double MinorPlanet::getSiderealPeriod() const
 {
-	return KeplerOrbit::calculateSiderealPeriod(orbitPtr->getSemimajorAxis());
+	return KeplerOrbit::calculateSiderealPeriod(static_cast<KeplerOrbit*>(orbitPtr)->getSemimajorAxis());
 }
 
 float MinorPlanet::getVMagnitude(const StelCore* core) const

--- a/src/core/modules/MinorPlanet.cpp
+++ b/src/core/modules/MinorPlanet.cpp
@@ -131,6 +131,10 @@ void MinorPlanet::setAbsoluteMagnitudeAndSlope(const float magnitude, const floa
 		qDebug() << "MinorPlanet::setAbsoluteMagnitudeAndSlope(): Invalid slope parameter value (must be between 0 and 1)";
 		return;
 	}
+
+	//TODO: More checks?
+	//TODO: Make it set-once like the number?
+
 	absoluteMagnitude = magnitude;
 	slopeParameter = slope;
 }
@@ -138,11 +142,7 @@ void MinorPlanet::setAbsoluteMagnitudeAndSlope(const float magnitude, const floa
 void MinorPlanet::setProvisionalDesignation(QString designation)
 {
 	//TODO: This feature has to be implemented better, anyway.
-	if (designation.length()>0)
-	{
-		provisionalDesignationHtml = renderProvisionalDesignationinHtml(designation);
-		nameIsProvisionalDesignation = false;
-	}
+	provisionalDesignationHtml = renderProvisionalDesignationinHtml(designation);
 }
 
 QString MinorPlanet::getEnglishName() const

--- a/src/core/modules/MinorPlanet.hpp
+++ b/src/core/modules/MinorPlanet.hpp
@@ -119,7 +119,7 @@ public:
 	void setColorIndexBV(float bv=99.f);
 
 	//! get sidereal period for minor planet
-	double getSiderealPeriod() const;
+	virtual double getSiderealPeriod() const Q_DECL_OVERRIDE;
 
 private:
 	int minorPlanetNumber;

--- a/src/core/modules/Orbit.hpp
+++ b/src/core/modules/Orbit.hpp
@@ -1,10 +1,9 @@
 // orbit.h
 //
-// Copyright (C) 2001, Chris Laurel <claurel@shatters.net>
-//
-// CometOrbit: Copyright (C) 2007,2008 Johannes Gajdosik
-//             Amendments (c) 2013 Georg Zotti
-//             Recombined to KeplerOrbit (c) 2019 Georg Zotti
+// Initial structure of orbit computation; EllipticalOrbit: Copyright (C) 2001, Chris Laurel <claurel@shatters.net>
+// CometOrbit: Copyright (c) 2007,2008 Johannes Gajdosik
+//             Amendments (c) 2013 Georg Zotti (GZ).
+// Combination to KeplerOrbit, GimbalOrbit (c) 2020 Georg Zotti
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -14,7 +13,10 @@
 #ifndef ORBIT_HPP
 #define ORBIT_HPP
 
+#define USE_GIMBAL_ORBIT 1
+
 #include "VecMath.hpp"
+#include "StelUtils.hpp"
 
 //! @internal
 //! Orbit computations used for comets, minor planets and "simple" moons
@@ -23,54 +25,27 @@ class Orbit
 public:
     Orbit(void) {}
     virtual ~Orbit(void) {}
+    //! Return a position (XYZ in AU).
+    //! @param JDE Julian Ephemeris Date
+    //! @param v double array of at least 3 elements. The first three should be filled by the X/Y/Z data.
+    virtual void positionAtTimevInVSOP87Coordinates(double JDE, double* v){Q_UNUSED(JDE) Q_UNUSED(v)}
+    //! return speed value [AU/d]. (zero in the base class)
+    virtual Vec3d getVelocity() const { return Vec3d(0.); }
+    //! write speed value [AU/d] into first 3 elements of vel. (zero in the base class)
+    virtual void getVelocity(double *vel) const { vel[0]=0.; vel[1]=0.; vel[2]=0.;}
+    //! return semimajor axis. (zero in the base class)
+    virtual double getSemimajorAxis() const { return 0.; }
+    //! return orbit eccentricity. (zero in the base class)
+    virtual double getEccentricity() const { return 0; }
+    //! For planet moons which have orbits given in relation to their parent planet's equator.
+    //! This is called by the constructor, and must be updated for parent planets when their axis changes over time.
+    void setParentOrientation(const double parentRotObliquity, const double parentRotAscendingNode, const double parentRotJ2000Longitude);
 private:
     Orbit(const Orbit&);
     const Orbit &operator=(const Orbit&);
+protected:
+    double rotateToVsop87[9]; //! Rotation matrix.
 };
-
-/*
-class EllipticalOrbit : public Orbit
-{
-public:
-	EllipticalOrbit(double pericenterDistance,
-			double eccentricity,
-			double inclination,
-			double ascendingNode,
-			double argOfPeriapsis,
-			double meanAnomalyAtEpoch,
-			double period,
-			double epoch,			// = 2451545.0,
-			double parentRotObliquity,	// = 0.0,
-			double parentRotAscendingnode,	// = 0.0
-			double parentRotJ2000Longitude	// = 0.0
-			);
-
-	// Compute position for a specified Julian date and return coordinates
-	// given in "dynamical equinox and ecliptic J2000"
-	// which is the reference frame for VSOP87
-	// In order to rotate to VSOP87
-	// parentRotObliquity and parentRotAscendingnode must be supplied.
-	void positionAtTimevInVSOP87Coordinates(const double JDE, double* v) const;
-
-	// Original one
-	Vec3d positionAtTime(const double JDE) const;
-	double getPeriod() const{return period;}
-private:
-	//! returns eccentric anomaly E for Mean anomaly M
-	double eccentricAnomaly(const double M) const;
-	Vec3d positionAtE(const double E) const;
-
-	double pericenterDistance;
-	double eccentricity;
-	double inclination;
-	double ascendingNode;
-	double argOfPeriapsis;
-	double meanAnomalyAtEpoch;
-	double period;
-	double epoch;
-	double rotateToVsop87[9];
-};
-*/
 
 // This class was called CometOrbit, but was now recombined with the former EllipticalOrbit class. They did almost the same.
 class KeplerOrbit : public Orbit {
@@ -83,38 +58,67 @@ public:
 		   double timeAtPerihelion,
 		   double orbitGoodDays,
 		   double meanMotion,			// GZ: for parabolics, this is W/dt in Heafner's lettering
-		   double parentRotObliquity,		// Comets only have parent==sun, no need for these? Oh yes, VSOP/J2000 eq frames!
+		   double parentRotObliquity,		// Comets/Minor Planets only have parent==sun, no need for these? Oh yes, VSOP/J2000 eq frames!
 		   double parentRotAscendingnode,
 		   double parentRotJ2000Longitude
 		   );
-	//! Compute the orbit for a specified Julian day and return a "stellarium compliant" function
-	void positionAtTimevInVSOP87Coordinates(double JDE, double* v);
+	//! Compute the object position for a specified Julian day.
+	//! @param JDE Julian Ephemeris Day
+	//! @param v double vector of at least 3 elements. The first three will receive X/Y/Z values in AU.
+	virtual void positionAtTimevInVSOP87Coordinates(double JDE, double* v) Q_DECL_OVERRIDE;
 	//! updating comet tails is a bit expensive. try not to overdo it.
 	bool getUpdateTails() const { return updateTails; }
 	void setUpdateTails(const bool update){ updateTails=update; }
 	//! return speed value [AU/d] last computed by positionAtTimevInVSOP87Coordinates(JDE, v)
-	Vec3d getVelocity() const { return rdot; }
-	void getVelocity(double *vel) const { vel[0]=rdot[0]; vel[1]=rdot[1]; vel[2]=rdot[2];}
-	//! Returns semimajor axis [AU] for elliptic orbit, 0 for a parabolic orbit, and a negative value for hyperbolic orbit.
-	double getSemimajorAxis() const { return (e==1. ? 0. : q / (1.-e)); }
-	double getEccentricity() const { return e; }
+	virtual Vec3d getVelocity() const Q_DECL_OVERRIDE { return rdot; }
+	virtual void getVelocity(double *vel) const Q_DECL_OVERRIDE { vel[0]=rdot[0]; vel[1]=rdot[1]; vel[2]=rdot[2];}
+	//! Returns semimajor axis [AU] for elliptic orbit, 0 for a parabolic orbit, and a negative value [AU] for hyperbolic orbit.
+	virtual double getSemimajorAxis() const Q_DECL_OVERRIDE { return (e==1. ? 0. : q / (1.-e)); }
+	virtual double getEccentricity() const Q_DECL_OVERRIDE { return e; }
 	bool objectDateValid(const double JDE) const { return ((orbitGood<=0) || (fabs(t0-JDE)<orbitGood)); }
-	//! Calculate sidereal period in days from semi-major axis. If sMA<0 (hyperbolic orbit), return max double.
+	//! Calculate sidereal period in days from semi-major axis. If SMA<0 (hyperbolic orbit), return max double.
 	//! NOTE: The result is for a solar-centered orbit only!
 	static double calculateSiderealPeriod(const double semiMajorAxis);
 
 private:
-	const double q;  //! perihel distance
+	const double q;  //! pericenter distance [AU]
 	const double e;  //! eccentricity
-	const double i;  //! inclination
-	const double Om; //! longitude of ascending node
-	const double w;  //! argument of perihel
+	const double i;  //! inclination [radians]
+	const double Om; //! longitude of ascending node [radians]
+	const double w;  //! argument of perihel [radians]
 	const double t0; //! time of perihel, JDE
-	const double n;  //! mean motion (for parabolic orbits: W/dt in Heafner's presentation)
-	Vec3d rdot;      //! GZ: velocity vector. Caches velocity from last position computation, [AU/d]
-	double rotateToVsop87[9]; //! Rotation matrix
-	bool updateTails; //! flag to signal that tails must be recomputed.
-	const double orbitGood; //! orb. elements are only valid for this time from perihel [days]. Don't draw the object outside. Values <=0 mean "always good" (objects on elliptic orbit)
+	const double n;  //! mean motion (for parabolic orbits: W/dt in Heafner's presentation) [radians/day]
+	Vec3d rdot;      //! velocity vector. Caches velocity from last position computation, [AU/d]
+	bool updateTails; //! flag to signal that comet tails must be recomputed.
+	const double orbitGood; //! orb. elements are only valid for this time from perihel [days]. Don't draw the object outside. Values <=0 mean "always good" (objects on undisturbed elliptic orbit)
 };
 
+//! A pseudo-orbit for "observers" linked to a planet's sphere. It allows setting distance and longitude/latitude in the VSOP87 frame.
+//! This class ic currently in an experimental state. rotateToVsop87 may need to be set up correctly, and view frame currently cannot be controlled properly.
+class GimbalOrbit : public Orbit {
+public:
+	GimbalOrbit(double distance,
+		   double longitude,
+		   double latitude
+		   );
+	//! Compute position for a (unused) Julian day.
+	virtual void positionAtTimevInVSOP87Coordinates(double JDE, double* v) Q_DECL_OVERRIDE;
+	//! Returns (pseudo) semimajor axis [AU] of a circular orbit.
+	double getSemimajorAxis() const Q_DECL_OVERRIDE { return distance; }
+
+	double getLongitude() const { return longitude*M_180_PI;}
+	double getLatitude()  const { return latitude*M_180_PI;}
+	double getDistance()  const { return distance;}
+	void setLongitude(const double lng){ longitude=lng*M_PI_180;}
+	void setLatitude(const double lat) { latitude=lat*M_PI_180;}
+	void setDistance(const double dist){ distance=dist;}
+	void addToLongitude(const double dlong){ longitude+=dlong*M_PI_180; }
+	void addToLatitude(const double dlat)  { latitude=qBound(-M_PI_2, latitude+dlat*M_PI_180, M_PI_2);}
+	void addToDistance(const double ddist) { distance=qBound(0.01, distance+ddist, 50.);}
+
+private:
+	double distance;   //! distance to parent planet center, AU
+	double longitude;  //! longitude [radians]
+	double latitude;   //! latitude [radians]
+};
 #endif // ORBIT_HPP

--- a/src/core/modules/Planet.cpp
+++ b/src/core/modules/Planet.cpp
@@ -180,7 +180,7 @@ Planet::Planet(const QString& englishName,
 	       const QString& anormalMapName,
 	       const QString& aobjModelName,
 	       posFuncType coordFunc,
-	       KeplerOrbit* anOrbitPtr,
+	       Orbit* anOrbitPtr,
 	       OsculatingFunctType *osculatingFunc,
 	       bool acloseOrbit,
 	       bool hidden,
@@ -1250,7 +1250,7 @@ float Planet::getMeanOppositionMagnitude() const
 	{
 		Q_ASSERT(orbitPtr);
 		if (orbitPtr)
-			semimajorAxis=orbitPtr->getSemimajorAxis();
+			semimajorAxis=static_cast<KeplerOrbit*>(orbitPtr)->getSemimajorAxis();
 		else
 			qDebug() << "WARNING: No orbitPtr for " << englishName;
 	}
@@ -3211,6 +3211,12 @@ void Planet::drawOrbit(const StelCore* core)
 		return;
 	if (!static_cast<bool>(re.siderealPeriod))
 		return;
+
+	if (orbitPtr && pType>=isArtificial)
+	{
+		if (!static_cast<KeplerOrbit*>(orbitPtr)->objectDateValid(lastJDE))
+			return;
+	}
 
 	// Update the orbit positions to the current planet date.
 	computeOrbit();

--- a/src/core/modules/Planet.cpp
+++ b/src/core/modules/Planet.cpp
@@ -518,14 +518,14 @@ QString Planet::getInfoString(const StelCore* core, const InfoStringGroup& flags
 		QString kms = qc_("km/s", "speed");
 
 		Vec3d orbitalVel=getEclipticVelocity();
-		const double orbVel=orbitalVel.length();
+		double orbVel=orbitalVel.length();
 		if (orbVel>0.)
 		{ // AU/d * km/AU /24
-			const double orbVelKms=orbVel* AU/86400.;
+			double orbVelKms=orbVel* AU/86400.;
 //			if (englishName=="Moon")
 //				orbVelKms=orbVel;
 			oss << QString("%1: %2 %3").arg(q_("Orbital velocity")).arg(orbVelKms, 0, 'f', 3).arg(kms) << "<br />";
-			const double helioVel=getHeliocentricEclipticVelocity().length();
+			double helioVel=getHeliocentricEclipticVelocity().length();
 			if (!fuzzyEquals(helioVel, orbVel))
 				oss << QString("%1: %2 %3").arg(q_("Heliocentric velocity")).arg(helioVel* AU/86400., 0, 'f', 3).arg(kms) << "<br />";
 		}
@@ -537,7 +537,7 @@ QString Planet::getInfoString(const StelCore* core, const InfoStringGroup& flags
 	}
 
 
-	const double angularSize = 2.*getAngularSize(core)*M_PI_180;
+	double angularSize = 2.*getAngularSize(core)*M_PI/180.;
 	if (flags&Size && angularSize>=4.8e-8)
 	{
 		QString s1, s2, sizeStr = "";
@@ -593,8 +593,8 @@ QString Planet::getInfoString(const StelCore* core, const InfoStringGroup& flags
 		oss << QString("%1: %2 %3").arg(diam, QString::number(AU * getEquatorialRadius() * 2.0, 'f', 1) , qc_("km", "distance")) << "<br />";
 	}
 
-	const double siderealPeriod = getSiderealPeriod();
-	const double siderealDay = getSiderealDay();
+	double siderealPeriod = getSiderealPeriod();
+	double siderealDay = getSiderealDay();
 	if (flags&Extra)
 	{
 		static SolarSystem *ssystem=GETSTELMODULE(SolarSystem);
@@ -626,7 +626,7 @@ QString Planet::getInfoString(const StelCore* core, const InfoStringGroup& flags
 			}
 		}
 
-		const double siderealPeriodCurrentPlanet = currentPlanet->getSiderealPeriod();
+		double siderealPeriodCurrentPlanet = currentPlanet->getSiderealPeriod();
 		QString celestialObject = getEnglishName();
 		if (celestialObject!="Sun")
 			celestialObject = getParent()->getEnglishName();

--- a/src/core/modules/Planet.hpp
+++ b/src/core/modules/Planet.hpp
@@ -42,6 +42,7 @@ typedef void (OsculatingFunctType)(double jde0,double jde,double xyz[3], double 
 #define J2000 2451545.0
 #define ORBIT_SEGMENTS 360
 
+class Orbit;
 class KeplerOrbit;
 class StelFont;
 class StelPainter;
@@ -150,7 +151,7 @@ public:
 	       const QString& normalMapName,
 	       const QString& objModelName,
 	       posFuncType _coordFunc,
-	       KeplerOrbit *anOrbitPtr,
+	       Orbit *anOrbitPtr,
 	       OsculatingFunctType *osculatingFunc,
 	       bool closeOrbit,
 	       bool hidden,
@@ -248,6 +249,7 @@ public:
 	const QString& getTextMapName() const {return texMapName;}
 	const QString getPlanetTypeString() const {return pTypeMap.value(pType);}
 	PlanetType getPlanetType() const {return pType;}
+	Orbit* getOrbit() const {return orbitPtr;}
 
 	void setNativeName(QString planet) { nativeName = planet; }
 
@@ -565,7 +567,9 @@ protected:
 	double lastJDE;                  // caches JDE of last positional computation
 	// The callback for the calculation of the equatorial rect heliocentric position at time JDE.
 	posFuncType coordFunc;
-	KeplerOrbit* orbitPtr;           // Usable for positional computations of Minor Planets, Comets and Moons. For the major planets, it is Q_NULLPTR.
+	Orbit* orbitPtr;		// Usually a KeplerOrbit for positional computations of Minor Planets, Comets and Moons.
+					// For an "observer", it is GizmoOrbit.
+					// For the major planets, it is Q_NULLPTR.
 
 	OsculatingFunctType *const osculatingFunc;
 	QSharedPointer<Planet> parent;           // Planet parent i.e. sun for earth

--- a/src/core/modules/SolarSystem.cpp
+++ b/src/core/modules/SolarSystem.cpp
@@ -682,7 +682,6 @@ bool SolarSystem::loadPlanets(const QString& filePath)
 
 			orbitPtr = orb;
 			posfunc = &gimbalOrbitPosFunc;
-
 		}
 		else
 #endif
@@ -957,7 +956,7 @@ bool SolarSystem::loadPlanets(const QString& filePath)
 		}
 		else // type==star|planet|moon|dwarf planet|observer|artificial
 		{
-			qDebug() << type;
+			//qDebug() << type;
 			Q_ASSERT(type=="star" || type=="planet" || type=="moon" || type=="artificial" || type=="observer" || type=="dwarf planet"); // TBD: remove Pluto...
 			// Set possible default name of the normal map for avoiding yin-yang shaped moon
 			// phase when normal map key not exists. Example: moon_normals.png

--- a/src/core/modules/SolarSystem.cpp
+++ b/src/core/modules/SolarSystem.cpp
@@ -529,9 +529,9 @@ void SolarSystem::loadPlanets()
 			shadowPlanetCount++;
 }
 
-unsigned char SolarSystem::BvToColorIndex(double bV)
+unsigned char SolarSystem::BvToColorIndex(float bV)
 {
-	const double dBV = qBound(-500., static_cast<double>(bV)*1000.0, 3499.);
+	double dBV = qBound(-500., static_cast<double>(bV)*1000.0, 3499.);
 	return static_cast<unsigned char>(floor(0.5+127.0*((500.0+dBV)/4000.0)));
 }
 
@@ -972,13 +972,13 @@ bool SolarSystem::loadPlanets(const QString& filePath)
 					       pd.value(secname+"/albedo", 0.25f).toFloat(),
 					       pd.value(secname+"/roughness",0.9f).toFloat(),
 					       pd.value(secname+"/tex_map", "nomap.png").toString(),
-					       pd.value(secname+"/normals_map", englishName.toLower().append("_normals.png")).toString(),
+					       pd.value(secname+"/normals_map", normalMapName).toString(),
 					       pd.value(secname+"/model").toString(),
 					       posfunc,
 					       static_cast<KeplerOrbit*>(orbitPtr), // This remains Q_NULLPTR for the major planets, or has a KeplerOrbit for planet moons.
 					       osculatingFunc,
 					       closeOrbit,
-					       pd.value(secname+"/hidden", false).toBool(),
+					       hidden,
 					       pd.value(secname+"/atmosphere", false).toBool(),
 					       pd.value(secname+"/halo", true).toBool(),          // GZ new default. Avoids clutter in ssystem.ini.
 					       type));
@@ -1010,7 +1010,7 @@ bool SolarSystem::loadPlanets(const QString& filePath)
 		const double J2000NPoleRA = pd.value(secname+"/rot_pole_ra", 0.).toDouble()*M_PI/180.;
 		const double J2000NPoleDE = pd.value(secname+"/rot_pole_de", 0.).toDouble()*M_PI/180.;
 
-		if((J2000NPoleRA!=0.) || (J2000NPoleDE!=0.))
+		if(J2000NPoleRA || J2000NPoleDE)
 		{
 			Vec3d J2000NPole;
 			StelUtils::spheToRect(J2000NPoleRA,J2000NPoleDE,J2000NPole);

--- a/src/core/modules/SolarSystem.cpp
+++ b/src/core/modules/SolarSystem.cpp
@@ -446,6 +446,12 @@ void keplerOrbitPosFunc(double jd,double xyz[3], double xyzdot[3], void* orbitPt
 	static_cast<KeplerOrbit*>(orbitPtr)->getVelocity(xyzdot);
 }
 
+void gimbalOrbitPosFunc(double jd,double xyz[3], double xyzdot[3], void* orbitPtr)
+{
+	static_cast<GimbalOrbit*>(orbitPtr)->positionAtTimevInVSOP87Coordinates(jd, xyz);
+	static_cast<GimbalOrbit*>(orbitPtr)->getVelocity(xyzdot);
+}
+
 // Init and load the solar system data (2 files)
 void SolarSystem::loadPlanets()
 {
@@ -658,11 +664,28 @@ bool SolarSystem::loadPlanets(const QString& filePath)
 		const QString coordFuncName = pd.value(secname+"/coord_func", "kepler_orbit").toString(); // 0.20: Add a new default for all non *_special.
 		// qDebug() << "englishName:" << englishName << ", parent:" << strParent <<  ", coord_func:" << coordFuncName;
 		posFuncType posfunc=Q_NULLPTR;
-		KeplerOrbit* orbitPtr=Q_NULLPTR;
+		Orbit* orbitPtr=Q_NULLPTR;
 		OsculatingFunctType *osculatingFunc = Q_NULLPTR;
 		bool closeOrbit = true;
 		double semi_major_axis=0; // used again below.
+		const QString type = pd.value(secname+"/type").toString();
 
+
+#ifdef USE_GIMBAL_ORBIT
+		// undefine the flag in Orbit.h to disable and use the old, static observer solution (on an infintely slow KeplerOrbit)
+		// Note that for now we ignore any orbit-related config values from the ini file.
+		if (type=="observer")
+		{
+			// Create a pseudo orbit that allows interaction with keyboard
+			GimbalOrbit *orb = new GimbalOrbit(1, 0., 90.);    // [1 AU over north pole]
+			orbits.push_back(orb);
+
+			orbitPtr = orb;
+			posfunc = &gimbalOrbitPosFunc;
+
+		}
+		else
+#endif
 		if ((coordFuncName=="ell_orbit") || (coordFuncName=="comet_orbit") || (coordFuncName=="kepler_orbit")) // ell_orbit used for planet moons. TODO: rename to kepler_orbit for all!
 		{
 			// ell_orbit was used for planet moons, comet_orbit for minor bodies. The only difference is that pericenter distance for moons is given in km, not AU.
@@ -762,6 +785,7 @@ bool SolarSystem::loadPlanets(const QString& filePath)
 			const double inclination = pd.value(secname+"/orbit_Inclination", 0.0).toDouble()*(M_PI/180.0);
 
 			// Create a Keplerian orbit. This has been called CometOrbit before 0.20.
+			//qDebug() << "Creating KeplerOrbit for" << parent->englishName << "---" << englishName;
 			KeplerOrbit *orb = new KeplerOrbit(pericenterDistance,     // [AU]
 								   eccentricity,           // 0..>1, but practically only 0..1
 								   inclination,            // [radians]
@@ -832,17 +856,16 @@ bool SolarSystem::loadPlanets(const QString& filePath)
 		}
 
 		// Create the Solar System body and add it to the list
-		QString type = pd.value(secname+"/type").toString();
-
 		//TODO: Refactor the subclass selection to reduce duplicate code mess here,
 		// by at least using this base class pointer and using setXXX functions instead of mega-constructors
 		// that have to pass most of it on to the Planet class
-		PlanetP p;
+		PlanetP newP;
 
 		// New class objects, named "plutino", "cubewano", "dwarf planet", "SDO", "OCO", has properties
 		// similar to asteroids and we should calculate their positions like for asteroids. Dwarf planets
 		// have one exception: Pluto - we should use special function for calculation of orbit of Pluto.
-		if ((type == "asteroid" || type == "dwarf planet" || type == "cubewano" || type == "plutino" || type == "scattered disc object" || type == "Oort cloud object" || type == "interstellar object") && !englishName.contains("Pluto"))
+		// FIXME: Try Pluto as MinorPlanet! It has its own pos_func and just no KeplerOrbit. So what? (Just fix getSiderealPeriod())
+		if ((type == "asteroid" || type == "dwarf planet" || type == "cubewano" || type=="sednoid" || type == "plutino" || type == "scattered disc object" || type == "Oort cloud object" || type == "interstellar object") && !englishName.contains("Pluto"))
 		{
 			minorBodies << englishName;
 
@@ -856,7 +879,7 @@ bool SolarSystem::loadPlanets(const QString& filePath)
 			const bool hidden = pd.value(secname+"/hidden", false).toBool();
 			const QString normalMapName = ( hidden ? "" : englishName.toLower().append("_normals.png")); // no normal maps for invisible objects!
 
-			p = PlanetP(new MinorPlanet(englishName,
+			newP = PlanetP(new MinorPlanet(englishName,
 						    pd.value(secname+"/radius", 1.0).toDouble()/AU,
 						    pd.value(secname+"/oblateness", 0.0).toDouble(),
 						    color, // halo color
@@ -866,13 +889,12 @@ bool SolarSystem::loadPlanets(const QString& filePath)
 						    pd.value(secname+"/normals_map", normalMapName).toString(),
 						    pd.value(secname+"/model").toString(),
 						    posfunc,
-						    orbitPtr, // the CometOrbit object created previously
+						    static_cast<KeplerOrbit*>(orbitPtr), // the KeplerOrbit object created previously
 						    osculatingFunc, // should be Q_NULLPTR
 						    closeOrbit,
 						    hidden,
 						    type));
-
-			QSharedPointer<MinorPlanet> mp =  p.dynamicCast<MinorPlanet>();
+			QSharedPointer<MinorPlanet> mp =  newP.dynamicCast<MinorPlanet>();
 
 			//Number, Provisional designation
 			mp->setMinorPlanetNumber(pd.value(secname+"/minor_planet_number", 0).toInt());
@@ -890,24 +912,24 @@ bool SolarSystem::loadPlanets(const QString& filePath)
 			mp->setColorIndexBV(bV);
 			mp->setSpectralType(pd.value(secname+"/spec_t", "").toString(), pd.value(secname+"/spec_b", "").toString());
 
-			systemMinorBodies.push_back(p);
+			systemMinorBodies.push_back(newP);
 		}
 		else if (type == "comet")
 		{
 			minorBodies << englishName;
-			p = PlanetP(new Comet(englishName,
+			newP = PlanetP(new Comet(englishName,
 					      pd.value(secname+"/radius", 1.0).toDouble()/AU,
 					      pd.value(secname+"/oblateness", 0.0).toDouble(),
 					      StelUtils::strToVec3f(pd.value(secname+"/color", "1.0,1.0,1.0").toString()), // halo color
-					      pd.value(secname+"/albedo", 0.25f).toFloat(),
+					      pd.value(secname+"/albedo", 0.075f).toFloat(), // assume very dark surface
 					      pd.value(secname+"/roughness",0.9f).toFloat(),
 					      pd.value(secname+"/outgas_intensity",0.1f).toFloat(),
 					      pd.value(secname+"/outgas_falloff", 0.1f).toFloat(),
 					      pd.value(secname+"/tex_map", "nomap.png").toString(),
 					      pd.value(secname+"/model").toString(),
 					      posfunc,
-					      orbitPtr,
-					      osculatingFunc,
+					      static_cast<KeplerOrbit*>(orbitPtr), // the KeplerOrbit object
+					      osculatingFunc, // ALWAYS NULL for comets.
 					      closeOrbit,
 					      pd.value(secname+"/hidden", false).toBool(),
 					      type,
@@ -915,12 +937,11 @@ bool SolarSystem::loadPlanets(const QString& filePath)
 					      pd.value(secname+"/dust_lengthfactor", 0.4f).toFloat(),
 					      pd.value(secname+"/dust_brightnessfactor", 1.5f).toFloat()
 					      ));
-
-			QSharedPointer<Comet> mp =  p.dynamicCast<Comet>();
+			QSharedPointer<Comet> mp = newP.dynamicCast<Comet>();
 
 			//g,k magnitude system
 			const float magnitude = pd.value(secname+"/absolute_magnitude", -99).toFloat();
-			const float slope = qBound(0.0f, pd.value(secname+"/slope_parameter", 4.0f).toFloat(), 20.0f);
+			const float slope = qBound(-1.0f, pd.value(secname+"/slope_parameter", 4.0f).toFloat(), 20.0f);
 			if (magnitude > -99)
 			{
 					mp->setAbsoluteMagnitudeAndSlope(magnitude, slope);
@@ -932,10 +953,12 @@ bool SolarSystem::loadPlanets(const QString& filePath)
 			{
 				mp->setSemiMajorAxis(pericenterDistance / (1.0-eccentricity));
 			}
-			systemMinorBodies.push_back(p);
+			systemMinorBodies.push_back(newP);
 		}
-		else
+		else // type==star|planet|moon|dwarf planet|observer|artificial
 		{
+			qDebug() << type;
+			Q_ASSERT(type=="star" || type=="planet" || type=="moon" || type=="artificial" || type=="observer" || type=="dwarf planet"); // TBD: remove Pluto...
 			// Set possible default name of the normal map for avoiding yin-yang shaped moon
 			// phase when normal map key not exists. Example: moon_normals.png
 			// Details: https://bugs.launchpad.net/stellarium/+bug/1335609
@@ -943,7 +966,7 @@ bool SolarSystem::loadPlanets(const QString& filePath)
 			bool hidden = pd.value(secname+"/hidden", false).toBool();
 			if (!hidden) // no normal maps for invisible objects!
 				normalMapName = englishName.toLower().append("_normals.png");
-			p = PlanetP(new Planet(englishName,
+			newP = PlanetP(new Planet(englishName,
 					       pd.value(secname+"/radius", 1.0).toDouble()/AU,
 					       pd.value(secname+"/oblateness", 0.0).toDouble(),
 					       StelUtils::strToVec3f(pd.value(secname+"/color", "1.0,1.0,1.0").toString()), // halo color
@@ -953,31 +976,31 @@ bool SolarSystem::loadPlanets(const QString& filePath)
 					       pd.value(secname+"/normals_map", normalMapName).toString(),
 					       pd.value(secname+"/model").toString(),
 					       posfunc,
-					       orbitPtr, // This remains Q_NULLPTR for the major planets, or has a KeplerOrbit for planet moons.
+					       static_cast<KeplerOrbit*>(orbitPtr), // This remains Q_NULLPTR for the major planets, or has a KeplerOrbit for planet moons.
 					       osculatingFunc,
 					       closeOrbit,
 					       hidden,
 					       pd.value(secname+"/atmosphere", false).toBool(),
 					       pd.value(secname+"/halo", true).toBool(),          // GZ new default. Avoids clutter in ssystem.ini.
 					       type));
-			p->absoluteMagnitude = pd.value(secname+"/absolute_magnitude", -99.).toFloat();
+			newP->absoluteMagnitude = pd.value(secname+"/absolute_magnitude", -99.f).toFloat();
 
 			// Moon designation (planet index + IAU moon number)
 			QString moonDesignation = pd.value(secname+"/iau_moon_number", "").toString();
 			if (!moonDesignation.isEmpty())
 			{
-				p->setIAUMoonNumber(moonDesignation);
+				newP->setIAUMoonNumber(moonDesignation);
 			}
 		}
 
 		if (!parent.isNull())
 		{
-			parent->satellites.append(p);
-			p->parent = parent;
+			parent->satellites.append(newP);
+			newP->parent = parent;
 		}
-		if (secname=="earth") earth = p;
-		if (secname=="sun") sun = p;
-		if (secname=="moon") moon = p;
+		if (secname=="earth") earth = newP;
+		if (secname=="sun") sun = newP;
+		if (secname=="moon") moon = newP;
 
 		float rotObliquity = pd.value(secname+"/rot_obliquity",0.).toFloat()*(M_PI_180f);
 		float rotAscNode = pd.value(secname+"/rot_equator_ascending_node",0.).toFloat()*(M_PI_180f);
@@ -1006,7 +1029,7 @@ bool SolarSystem::loadPlanets(const QString& filePath)
 		}
 
 		// rot_periode given in hours, or orbit_Period given in days, orbit_visualization_period in days. The latter should have a meaningful default.
-		p->setRotationElements(
+		newP->setRotationElements(
 			pd.value(secname+"/rot_periode", pd.value(secname+"/orbit_Period", 1.).toDouble()*24.).toFloat()/24.f,
 			pd.value(secname+"/rot_rotation_offset",0.).toFloat(),
 			pd.value(secname+"/rot_epoch", J2000).toDouble(),
@@ -1015,15 +1038,14 @@ bool SolarSystem::loadPlanets(const QString& filePath)
 			pd.value(secname+"/rot_precession_rate",0.).toFloat()*M_PIf/(180*36525),
 			pd.value(secname+"/orbit_visualization_period", fabs(pd.value(secname+"/orbit_Period", 1.).toDouble())).toDouble()); // this is given in days...
 
-
-		if (pd.value(secname+"/rings", 0).toBool()) {
+		if (pd.value(secname+"/rings", false).toBool()) {
 			const float rMin = pd.value(secname+"/ring_inner_size").toFloat()/AUf;
 			const float rMax = pd.value(secname+"/ring_outer_size").toFloat()/AUf;
 			Ring *r = new Ring(rMin,rMax,pd.value(secname+"/tex_ring").toString());
-			p->setRings(r);
+			newP->setRings(r);
 		}
 
-		systemPlanets.push_back(p);
+		systemPlanets.push_back(newP);
 		readOk++;
 	}
 
@@ -1032,6 +1054,7 @@ bool SolarSystem::loadPlanets(const QString& filePath)
 		qWarning() << "No Solar System objects loaded from" << QDir::toNativeSeparators(filePath);
 		return false;
 	}
+	else qDebug() << "SolarSystem has " << systemPlanets.count() << "entries.";
 
 	// special case: load earth shadow texture
 	if (!Planet::texEarthShadow)

--- a/src/core/modules/SolarSystem.hpp
+++ b/src/core/modules/SolarSystem.hpp
@@ -1120,7 +1120,7 @@ private:
 
 	//! Calculate a color of Solar system bodies
 	//! @param bV value of B-V color index
-	static unsigned char BvToColorIndex(double bV);
+	unsigned char BvToColorIndex(float bV);
 
 	//! Used to count how many planets actually need shadow information
 	int shadowPlanetCount;

--- a/src/scripting/StelMainScriptAPI.cpp
+++ b/src/scripting/StelMainScriptAPI.cpp
@@ -921,18 +921,13 @@ void StelMainScriptAPI::addToSelectedObjectInfoString(const QString &str, bool r
 
 void StelMainScriptAPI::clear(const QString& state)
 {
-	int stateInt = 0;
-	if (state.toLower() == "natural")
-		stateInt = 1;
-	else if (state.toLower() == "starchart")
-		stateInt = 2;
-	else if (state.toLower() == "deepspace")
-		stateInt = 3;
-	else if (state.toLower() == "galactic")
-		stateInt = 4;
-	else if (state.toLower() == "supergalactic")
-		stateInt = 5;
-
+	static const QMap<QString, int>stateMap={
+		{ "natural",   1},
+		{ "starchart", 2},
+		{ "deepspace", 3},
+		{ "galactic",  4},
+		{ "supergalactic", 5 }};
+	const int stateInt = stateMap.value(state.toLower(), 0);
 	if (stateInt == 0)
 	{
 		qWarning() << "WARNING clear(" << state << ") - state not known";
@@ -952,7 +947,7 @@ void StelMainScriptAPI::clear(const QString& state)
 		ZodiacalLight* zl = GETSTELMODULE(ZodiacalLight);
 		StelPropertyMgr* propMgr = StelApp::getInstance().getStelPropertyManager();
 
-		// Hide artificial satellites through StelProperties to avoid crash if plugin was did't loaded
+		// Hide artificial satellites through StelProperties to avoid crash if plugin was not loaded
 		propMgr->setStelPropertyValue("Satellites.hintsVisible",   false);
 		propMgr->setStelPropertyValue("Satellites.labelsVisible",  false);
 		propMgr->setStelPropertyValue("Satellites.flagOrbitLines", false);


### PR DESCRIPTION
Another cherry-pick from the Planet Axes branch.

This allows arbitrary viewpoints by keyboard actions.

The current "observer" planets are admittedly rather lame: we must place them high above the ecliptic plane to lose perspective effects. Then light time interferes with e.g. observation of eclipses or shadow phenomena on Jupiter. And we can never observe a planet sideways. 

### Description
<!--- Please include a summary of the change and which issue is fixed. -->
<!--- Please also include relevant motivation and context. -->
<!--- List any dependencies that are required for this change. -->

This new GimbalOrbit allows setting location manually. On loading "observer" planets they receive this specialized "Orbit" subclass. When observing from such an object, keyboard interaction (Alt-Cursor) allows changing orientation and distance from the parent planet. 

The state of implementation is "not perfect yet", but interesting enough for further development, and could be easily disabled in the master branch if required and merged now.

- Problem 1: Currently the view orientation cannot be properly controlled. We would need an EclipticalJ2000 view frame for meaningful screen orientation, or maybe just a fixed observer "latitude" on our "point planet"? 
- Problem 2: hotkey collision with OS hotkeys in StelMovementMgr. I cannot find an appropriate key combination to change distance from parent. Alt-5/6 are preliminary keys of course.

It can be disabled by disabling a define in Orbit.h

### Screenshot:

![gimbalObserver](https://user-images.githubusercontent.com/18099873/73081885-b3413d80-3ec8-11ea-80ef-b7ce3dbaf00d.png)

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [X] This change requires a documentation update

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Just set any "observer" as location planet. Moving to another planet with Ctrl-G works. I have so far not found any critical operational or graphical issue. 

What needs to be done is some way to keep the view aligned with the J2000 ecliptic frame. 

I think even if we don't activate the functionality it can be merged now, feature disabled in Orbit.h, and continued on a later date. 

**Test Configuration**:
* Operating system: Windows 10
* Graphics Card: NVidia Geforce M960 (likely irrelevant)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation. (This will be required after finishing all related works and activating it for release.)
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
