### PR TITLE
Enhance extra strings

### DIFF
--- a/plugins/Supernovae/src/Supernova.cpp
+++ b/plugins/Supernovae/src/Supernova.cpp
@@ -123,8 +123,10 @@ QString Supernova::getMagnitudeInfoString(const StelCore *core, const InfoString
 		if (getVMagnitude(core) <= maglimit)
 			res = StelObject::getMagnitudeInfoString(core, flags, alt_app, decimals);
 		else
+		{
 			res = QString("%1: <b>--</b><br />").arg(q_("Magnitude"));
-		res += getExtraInfoStrings(Magnitude).join(" ");
+			res += getExtraInfoStrings(Magnitude).join("");
+		}
 	}
 	return res;
 }

--- a/plugins/Supernovae/src/Supernova.cpp
+++ b/plugins/Supernovae/src/Supernova.cpp
@@ -124,6 +124,7 @@ QString Supernova::getMagnitudeInfoString(const StelCore *core, const InfoString
 			res = StelObject::getMagnitudeInfoString(core, flags, alt_app, decimals);
 		else
 			res = QString("%1: <b>--</b><br />").arg(q_("Magnitude"));
+		res += getExtraInfoStrings(Magnitude).join(" ");
 	}
 	return res;
 }

--- a/src/core/StelObject.cpp
+++ b/src/core/StelObject.cpp
@@ -251,7 +251,7 @@ QString StelObject::getMagnitudeInfoString(const StelCore *core, const InfoStrin
 			emag = QString(" (%1 <b>%2</b> %3 <b>%4</b> %5)").arg(q_("reduced to"), QString::number(getVMagnitudeWithExtinction(core), 'f', decimals), q_("by"), QString::number(airmass, 'f', 2), q_("Airmasses"));
 		}
 		QString str = QString("%1: <b>%2</b>%3<br />").arg(q_("Magnitude"), QString::number(getVMagnitude(core), 'f', decimals), emag);
-		str += getExtraInfoStrings(Magnitude).join(" ");
+		str += getExtraInfoStrings(Magnitude).join("");
 		return str;
 	}
 	else
@@ -262,28 +262,24 @@ QString StelObject::getMagnitudeInfoString(const StelCore *core, const InfoStrin
 QString StelObject::getCommonInfoString(const StelCore *core, const InfoStringGroup& flags) const
 {
 	StelApp& app = StelApp::getInstance();
-	bool withAtmosphere = core->getSkyDrawer()->getFlagHasAtmosphere();
-	bool withDecimalDegree = app.getFlagShowDecimalDegrees();
-	bool useSouthAzimuth = app.getFlagSouthAzimuthUsage();
-	bool withTables = app.getFlagUseFormattingOutput();
-	bool withDesignations = app.getFlagUseCCSDesignation();
+	const bool withAtmosphere = core->getSkyDrawer()->getFlagHasAtmosphere();
+	const bool withDecimalDegree = app.getFlagShowDecimalDegrees();
+	const bool useSouthAzimuth = app.getFlagSouthAzimuthUsage();
+	const bool withTables = app.getFlagUseFormattingOutput();
+	const bool withDesignations = app.getFlagUseCCSDesignation();
+	const QString cepoch = qc_("on date", "coordinates for current epoch");
+	const QString currentPlanet = core->getCurrentPlanet()->getEnglishName();
+	const QString apparent = " " + (withAtmosphere ? q_("(apparent)") : "");
+	QString res, firstCoordinate, secondCoordinate;
 	double az_app, alt_app;
 	StelUtils::rectToSphe(&az_app,&alt_app,getAltAzPosApparent(core));
 	Q_UNUSED(az_app)
-	QString cepoch = qc_("on date", "coordinates for current epoch");
-	QString res;
-	QString currentPlanet = core->getCurrentPlanet()->getEnglishName();
-	QString firstCoordinate, secondCoordinate, apparent = " ";
-	if (withAtmosphere)
-		apparent += q_("(apparent)");
 
 	if (withTables)
 		res += "<table style='margin:0em 0em 0em -0.125em;border-spacing:0px;border:0px;'>";
 
 	// TRANSLATORS: Right ascension/Declination
-	QString RADec = qc_("RA/Dec", "celestial coordinate system");
-	if (withDesignations)
-		RADec = QString("%1/%2").arg(QChar(0x03B1), QChar(0x03B4));
+	const QString RADec = withDesignations ? QString("%1/%2").arg(QChar(0x03B1), QChar(0x03B4)) : qc_("RA/Dec", "celestial coordinate system");
 
 	if (flags&RaDecJ2000)
 	{
@@ -304,6 +300,7 @@ QString StelObject::getCommonInfoString(const StelCore *core, const InfoStringGr
 			res += QString("<tr><td>%1 (J2000.0):</td><td style='text-align:right;'>%2/</td><td style='text-align:right;'>%3</td><td></td></tr>").arg(RADec, firstCoordinate, secondCoordinate);
 		else
 			res += QString("%1 (J2000.0): %2/%3").arg(RADec, firstCoordinate, secondCoordinate) + "<br>";
+		res += getExtraInfoStrings(RaDecJ2000).join("");
 	}
 
 	if (flags&RaDecOfDate)
@@ -325,6 +322,7 @@ QString StelObject::getCommonInfoString(const StelCore *core, const InfoStringGr
 			res += QString("<tr><td>%1 (%4):</td><td style='text-align:right;'>%2/</td><td style='text-align:right;'>%3</td><td></td></tr>").arg(RADec, firstCoordinate, secondCoordinate, cepoch);
 		else
 			res += QString("%1 (%4): %2/%3").arg(RADec, firstCoordinate, secondCoordinate, cepoch) + "<br>";
+		res += getExtraInfoStrings(RaDecOfDate).join("");
 	}
 
 	if (flags&HourAngle)
@@ -368,14 +366,13 @@ QString StelObject::getCommonInfoString(const StelCore *core, const InfoStringGr
 		}
 
 		// TRANSLATORS: Hour angle/Declination
-		QString HADec = qc_("HA/Dec", "celestial coordinate system");
-		if (withDesignations)
-			HADec = QString("h/%1").arg(QChar(0x03B4));
+		const QString HADec = withDesignations ? QString("h/%1").arg(QChar(0x03B4)) : qc_("HA/Dec", "celestial coordinate system");
 
 		if (withTables)
 			res += QString("<tr><td>%1:</td><td style='text-align:right;'>%2/</td><td style='text-align:right;'>%3</td><td>%4</td></tr>").arg(HADec, firstCoordinate, secondCoordinate, apparent);
 		else
 			res += QString("%1: %2/%3 %4").arg(HADec, firstCoordinate, secondCoordinate, apparent) + "<br>";
+		res += getExtraInfoStrings(HourAngle).join("");
 	}
 
 	if (flags&AltAzi)
@@ -423,6 +420,7 @@ QString StelObject::getCommonInfoString(const StelCore *core, const InfoStringGr
 			res += QString("<tr><td>%1:</td><td style='text-align:right;'>%2/</td><td style='text-align:right;'>%3</td><td>%4</td></tr>").arg(AzAlt, firstCoordinate, secondCoordinate, apparent);
 		else
 			res += QString("%1: %2/%3 %4").arg(AzAlt, firstCoordinate, secondCoordinate, apparent) + "<br>";
+		res += getExtraInfoStrings(AltAzi).join("");
 	}
 
 	if (flags&GalacticCoord)
@@ -446,6 +444,7 @@ QString StelObject::getCommonInfoString(const StelCore *core, const InfoStringGr
 			res += QString("<tr><td>%1:</td><td style='text-align:right;'>%2/</td><td style='text-align:right;'>%3</td><td></td></tr>").arg(GalLongLat, firstCoordinate, secondCoordinate);
 		else
 			res += QString("%1: %2/%3").arg(GalLongLat, firstCoordinate, secondCoordinate) + "<br>";
+		res += getExtraInfoStrings(GalacticCoord).join("");
 	}
 
 	if (flags&SupergalacticCoord)
@@ -470,6 +469,7 @@ QString StelObject::getCommonInfoString(const StelCore *core, const InfoStringGr
 			res += QString("<tr><td>%1:</td><td style='text-align:right;'>%2/</td><td style='text-align:right;'>%3</td><td></td></tr>").arg(SGalLongLat, firstCoordinate, secondCoordinate);
 		else
 			res += QString("%1: %2/%3").arg(SGalLongLat, firstCoordinate, secondCoordinate) + "<br>";
+		res += getExtraInfoStrings(SupergalacticCoord).join("");
 	}
 
 	// N.B. Ecliptical coordinates are particularly earth-bound.
@@ -505,6 +505,7 @@ QString StelObject::getCommonInfoString(const StelCore *core, const InfoStringGr
 			res += QString("<tr><td>%1 (J2000.0):</td><td style='text-align:right;'>%2/</td><td style='text-align:right;'>%3</td><td></td></tr>").arg(EqlLongLat, firstCoordinate, secondCoordinate);
 		else
 			res += QString("%1 (J2000.0): %2/%3").arg(EqlLongLat, firstCoordinate, secondCoordinate) + "<br>";
+		res += getExtraInfoStrings(EclipticCoordJ2000).join("");
 	}
 
 	if ((flags&EclipticCoordOfDate) && (QString("Earth Sun").contains(currentPlanet)))
@@ -537,6 +538,7 @@ QString StelObject::getCommonInfoString(const StelCore *core, const InfoStringGr
 			res += QString("<tr><td>%1 (%4):</td><td style='text-align:right;'>%2/</td><td style='text-align:right;'>%3</td><td></td></tr>").arg(EqlLongLat, firstCoordinate, secondCoordinate, cepoch) + "</table>";
 		else
 			res += QString("%1 (%4): %2/%3").arg(EqlLongLat, firstCoordinate, secondCoordinate, cepoch) + "<br>";
+		res += getExtraInfoStrings(EclipticCoordOfDate).join("");
 
 		// GZ Only for now: display epsilon_A, angle between Earth's Axis and ecl. of date.
 		if (withDecimalDegree)
@@ -554,12 +556,14 @@ QString StelObject::getCommonInfoString(const StelCore *core, const InfoStringGr
 			res += QString("%1 (%3): %2").arg(eqlObl, firstCoordinate, cepoch) + "<br>";
 	}
 
+	// Specialized plugins (e.g. Astro Navigation or ethno-astronomical specialties) may want to provide additional types of coordinates here.
+	if (flags&OtherCoord)
+	{
+		res += getExtraInfoStrings(OtherCoord).join("");
+	}
+
 	if (withTables)
 		 res += "</table>";
-	if (flags&EclipticCoordJ2000)
-		res += getExtraInfoStrings(flags&EclipticCoordJ2000).join(' ');
-	if (flags&EclipticCoordOfDate)
-		res += getExtraInfoStrings(flags&EclipticCoordOfDate).join(' ');
 
 	if ((flags&SiderealTime) && (currentPlanet==QStringLiteral("Earth")))
 	{
@@ -590,9 +594,9 @@ QString StelObject::getCommonInfoString(const StelCore *core, const InfoStringGr
 			else
 				res += QString("%1: %2").arg(STc, STd) + "<br>";
 		}
+		res += getExtraInfoStrings(flags&SiderealTime).join("");
 		if (withTables && !(flags&RTSTime && getType()!=QStringLiteral("Satellite")))
 			res += "</table>";
-		res += getExtraInfoStrings(flags&SiderealTime).join(' ');
 	}
 
 	if (flags&RTSTime && getType()!=QStringLiteral("Satellite") && !currentPlanet.contains("observer", Qt::CaseInsensitive))
@@ -682,14 +686,14 @@ QString StelObject::getCommonInfoString(const StelCore *core, const InfoStringGr
 
 			res += QString("%1: %2").arg(q_("Parallactic Angle")).arg(pa) + "<br />";
 		}
-		res += getExtraInfoStrings(Extra).join(' ');
+		res += getExtraInfoStrings(Extra).join("");
 	}
 
 	if (flags&IAUConstellation)
 	{
 		QString constel=core->getIAUConstellation(getEquinoxEquatorialPos(core));
 		res += QString("%1: %2").arg(q_("IAU Constellation"), constel) + "<br>";
-		res += getExtraInfoStrings(flags&IAUConstellation).join(' ');
+		res += getExtraInfoStrings(flags&IAUConstellation).join("");
 	}
 
 	return res;
@@ -699,8 +703,7 @@ QString StelObject::getCommonInfoString(const StelCore *core, const InfoStringGr
 void StelObject::postProcessInfoString(QString& str, const InfoStringGroup& flags) const
 {
 	str.append(getExtraInfoStrings(Script).join(' '));
-	str.append(QString("Object has %1 Script infostrings").arg(getExtraInfoStrings(Script).length())); // FIXME: Remove this line after developing!
-	str.append(getExtraInfoStrings(DebugAid).join(' '));
+	str.append(getExtraInfoStrings(DebugAid).join(' ')); // TBD: Remove for Release builds?
 
 	// hack for avoiding an empty line before table
 	str.replace(QRegExp("<br(\\s*/)?><table"), "<table");
@@ -889,7 +892,9 @@ void StelObject::setExtraInfoString(const InfoStringGroup& flags, const QString 
 }
 void StelObject::addToExtraInfoString(const StelObject::InfoStringGroup &flags, const QString &str)
 {
-	extraInfoStrings.insertMulti(flags, str);
+	// Avoid insertion of full duplicates!
+	if (!extraInfoStrings.contains(flags, str))
+		extraInfoStrings.insertMulti(flags, str);
 }
 
 QStringList StelObject::getExtraInfoStrings(const InfoStringGroup& flags) const
@@ -900,10 +905,11 @@ QStringList StelObject::getExtraInfoStrings(const InfoStringGroup& flags) const
 		  if (i.key() & flags)
 		  {
 			  QString val=i.value();
-			  // TODO: Maybe exclude DebugAid flags from Release builds.
+			  // TODO: Maybe exclude DebugAid flags from Release builds?
 			  if (flags&DebugAid)
 				  val.prepend("DEBUG: ");
-			  list.append(val);
+			  // For unclear reasons the sequence of entries can be preserved by *pre*pending in the returned list.
+			  list.prepend(val);
 		  }
 		  ++i;
 	  }
@@ -913,7 +919,6 @@ QStringList StelObject::getExtraInfoStrings(const InfoStringGroup& flags) const
 
 void StelObject::removeExtraInfoStrings(const InfoStringGroup& flags)
 {
-	QStringList list;
 	QMultiMap<InfoStringGroup, QString>::iterator i = extraInfoStrings.begin();
 	  while (i != extraInfoStrings.end()) {
 		  if (i.key() & flags)

--- a/src/core/StelObject.cpp
+++ b/src/core/StelObject.cpp
@@ -693,7 +693,7 @@ QString StelObject::getCommonInfoString(const StelCore *core, const InfoStringGr
 // Apply post processing on the info string
 void StelObject::postProcessInfoString(QString& str, const InfoStringGroup& flags) const
 {
-	str.append(extraInfoString);
+	str.append(getExtraInfoStrings(flags|DebugAid).join(' '));
 
 	// hack for avoiding an empty line before table
 	str.replace(QRegExp("<br(\\s*/)?><table"), "<table");
@@ -874,11 +874,32 @@ QVariantMap StelObject::getInfoMap(const StelCore *core) const
 	return map;
 }
 
-void StelObject::setExtraInfoString(const QString &str)
+void StelObject::setExtraInfoString(const InfoStringGroup flags, const QString &str)
 {
-	extraInfoString=str;
+	extraInfoStrings.remove(flags); // delete all entries with these flags
+	if (str.length()>0)
+		extraInfoStrings.insert(flags, str);
 }
-void StelObject::addToExtraInfoString(const QString &str)
+void StelObject::addToExtraInfoString(const InfoStringGroup flags, const QString &str)
 {
-	extraInfoString.append(str);
+	extraInfoStrings.insertMulti(flags, str);
+}
+
+QStringList StelObject::getExtraInfoStrings(const InfoStringGroup& flags) const
+{
+	QStringList list;
+	QMultiMap<InfoStringGroup, QString>::const_iterator i = extraInfoStrings.constBegin();
+	  while (i != extraInfoStrings.constEnd()) {
+		  if (i.key() & flags)
+		  {
+			  QString val=i.value();
+			  // TODO: Maybe exclude DebugAid flags from Release builds.
+			  if (flags&DebugAid)
+				  val.prepend("DEBUG: ");
+			  list.append(val);
+		  }
+		  ++i;
+	  }
+
+	return list;
 }

--- a/src/core/StelObject.hpp
+++ b/src/core/StelObject.hpp
@@ -68,6 +68,7 @@ public:
 		RTSTime			= 0x00080000, //!< Time of rise, transit and set of celestial object
 		NoFont			= 0x00100000,
 		PlainText			= 0x00200000, //!< Strip HTML tags from output
+		DebugAid                = 0x40000000  //!< Should be used in DEBUG builds only, place messages into extraInfoStrings.
 // TODO GZ
 //		RaDecJ2000Planetocentric  = 0x00020000, //!< The planetocentric equatorial position (J2000 ref) [Mostly to compare with almanacs]
 //		RaDecOfDatePlanetocentric = 0x00040000  //!< The planetocentric equatorial position (of date)
@@ -255,10 +256,13 @@ public:
 
 public slots:
 	//! Allow additions to the Info String. Can be used by plugins to show extra info for the selected object, or for debugging.
-	//! Hard-set this string to str
-	virtual void setExtraInfoString(const QString &str);
+	//! Hard-set this string group to a single str, or delete all messages when str==""
+	//! @note This should be used with caution.
+	virtual void setExtraInfoString(const InfoStringGroup flags, const QString &str);
 	//! Add str to the extra string. This should be preferrable over hard setting.
-	virtual void addToExtraInfoString(const QString &str);
+	virtual void addToExtraInfoString(const StelObject::InfoStringGroup flags, const QString &str);
+	//! Retrieve a QStringList of all extra info strings that match flags.
+	QStringList getExtraInfoStrings(const InfoStringGroup& flags) const;
 
 protected:
 	//! Format the positional info string containing J2000/of date/altaz/hour angle positions and constellation, sidereal time, etc. for the object
@@ -280,8 +284,9 @@ private:
 	Vec3f computeRTSTime(StelCore* core) const;
 
 	//! Location for additional object info that can be set for special purposes (at least for debugging, but maybe others), even via scripting.
-	//! TODO: Maybe convert this to a Map or Hash, and let modules/plugins set or reset strings with their IDs, to avoid conflicts.
-	QString extraInfoString;
+	//! TODO: Maybe enrich this Map with some Module ID, to avoid conflicts?
+	//! Make sure this string map gets cleared e.g. in update() methods.
+	QMultiMap<InfoStringGroup, QString> extraInfoStrings;
 
 	static int stelObjectPMetaTypeID;
 };

--- a/src/core/modules/Nebula.cpp
+++ b/src/core/modules/Nebula.cpp
@@ -151,7 +151,7 @@ QString Nebula::getMagnitudeInfoString(const StelCore *core, const InfoStringGro
 		res.append(QString("%1: <b>%2</b> (%3: B)<br />").arg(q_("Magnitude"), QString::number(bMag, 'f', decimals), q_("Photometric system")));
 	// TODO: Extinction for B magnitude? Or show B magnitude in addition to valid V magnitude?
 
-	res += getExtraInfoStrings(Magnitude).join(" ");
+	res += getExtraInfoStrings(Magnitude).join("");
 	return res;
 }
 
@@ -240,6 +240,19 @@ QString Nebula::getInfoString(const StelCore *core, const InfoStringGroup& flags
 	if ((flags&Name) || (flags&CatalogNumber))
 		oss << "</h2>";
 
+	if (flags&Name)
+	{
+		QStringList extraNames=getExtraInfoStrings(Name);
+		if (extraNames.length()>0)
+			oss << q_("Additional names: ") << extraNames.join(", ") << "<br/>";
+	}
+	if (flags&CatalogNumber)
+	{
+		QStringList extraCat=getExtraInfoStrings(CatalogNumber);
+		if (extraCat.length()>0)
+			oss << q_("Additional catalog numbers: ") << extraCat.join(", ") << "<br/>";
+	}
+
 	if (flags&ObjectType)
 	{
 		QString mt = getMorphologicalTypeString();
@@ -247,6 +260,7 @@ QString Nebula::getInfoString(const StelCore *core, const InfoStringGroup& flags
 			oss << QString("%1: <b>%2</b>").arg(q_("Type"), getTypeString()) << "<br>";
 		else
 			oss << QString("%1: <b>%2</b> (%3)").arg(q_("Type"), getTypeString(), mt) << "<br>";
+		oss << getExtraInfoStrings(ObjectType).join("");
 	}
 
 	oss << getMagnitudeInfoString(core, flags, alt_app, 2);
@@ -315,6 +329,8 @@ QString Nebula::getInfoString(const StelCore *core, const InfoStringGroup& flags
 				oss << QString("%1: %2%3").arg(q_("Orientation angle")).arg(orientationAngle).arg(QChar(0x00B0)) << "<br />";
 		}
 	}
+	if (flags&Size)
+		oss << getExtraInfoStrings(Size).join("");
 
 	if (flags&Distance)
 	{
@@ -386,6 +402,7 @@ QString Nebula::getInfoString(const StelCore *core, const InfoStringGroup& flags
 
 			oss << QString("%1: %2 %3 (%4 %5)").arg(q_("Distance"), dx, dupc, dy, duly) << "<br />";
 		}
+		oss << getExtraInfoStrings(Distance).join("");
 	}
 
 	if (flags&Extra)

--- a/src/core/modules/Nebula.cpp
+++ b/src/core/modules/Nebula.cpp
@@ -151,6 +151,7 @@ QString Nebula::getMagnitudeInfoString(const StelCore *core, const InfoStringGro
 		res.append(QString("%1: <b>%2</b> (%3: B)<br />").arg(q_("Magnitude"), QString::number(bMag, 'f', decimals), q_("Photometric system")));
 	// TODO: Extinction for B magnitude? Or show B magnitude in addition to valid V magnitude?
 
+	res += getExtraInfoStrings(Magnitude).join(" ");
 	return res;
 }
 

--- a/src/core/modules/Planet.cpp
+++ b/src/core/modules/Planet.cpp
@@ -427,6 +427,20 @@ QString Planet::getInfoString(const StelCore* core, const InfoStringGroup& flags
 		oss << "</h2>";
 	}
 
+	if (flags&Name)
+	{
+		QStringList extraNames=getExtraInfoStrings(Name);
+		if (extraNames.length()>0)
+			oss << q_("Additional names: ") << extraNames.join(", ") << "<br/>";
+	}
+
+	if (flags&CatalogNumber)
+	{
+		QStringList extraCat=getExtraInfoStrings(CatalogNumber);
+		if (extraCat.length()>0)
+			oss << q_("Additional catalog numbers: ") << extraCat.join(", ") << "<br/>";
+	}
+
 	if (flags&ObjectType && getPlanetType()!=isUNDEFINED)
 	{
 		oss << QString("%1: <b>%2</b>").arg(q_("Type"), q_(getPlanetTypeString())) << "<br />";
@@ -444,6 +458,8 @@ QString Planet::getInfoString(const StelCore* core, const InfoStringGroup& flags
 		if (moMag<50.f)
 			oss << QString("%1: %2").arg(q_("Mean Opposition Magnitude")).arg(moMag, 0, 'f', 2) << "<br />";
 	}
+	if (flags&AbsoluteMagnitude)
+		oss << getExtraInfoStrings(AbsoluteMagnitude).join("");
 
 	oss << getCommonInfoString(core, flags);
 
@@ -510,6 +526,7 @@ QString Planet::getInfoString(const StelCore* core, const InfoStringGroup& flags
 		oss << QString("%1: %2 %3 (%4 %5)").arg(q_("Distance"), distAU, au, distKM, km) << "<br />";
 		// TRANSLATORS: Distance measured in terms of the speed of light
 		oss << QString("%1: %2").arg(q_("Light time"), StelUtils::hoursToHmsStr(distanceKm/SPEED_OF_LIGHT/3600.) ) << "<br />";
+		oss << getExtraInfoStrings(Distance).join("");
 	}
 
 	if (flags&Velocity)
@@ -534,6 +551,7 @@ QString Planet::getInfoString(const StelCore* core, const InfoStringGroup& flags
 			double eqRotVel = 2.0*M_PI*(AU*getEquatorialRadius())/(getSiderealDay()*86400.0);
 			oss << QString("%1: %2 %3").arg(q_("Equatorial rotation velocity")).arg(qAbs(eqRotVel), 0, 'f', 3).arg(kms) << "<br />";
 		}
+		oss << getExtraInfoStrings(Velocity).join("");
 	}
 
 
@@ -591,6 +609,7 @@ QString Planet::getInfoString(const StelCore* core, const InfoStringGroup& flags
 		if (getPlanetType()==isPlanet)
 			diam = q_("Equatorial diameter");
 		oss << QString("%1: %2 %3").arg(diam, QString::number(AU * getEquatorialRadius() * 2.0, 'f', 1) , qc_("km", "distance")) << "<br />";
+		oss << getExtraInfoStrings(Size).join("");
 	}
 
 	const double siderealPeriod = getSiderealPeriod();

--- a/src/core/modules/StarWrapper.cpp
+++ b/src/core/modules/StarWrapper.cpp
@@ -172,13 +172,13 @@ QString StarWrapper1::getInfoString(const StelCore *core, const InfoStringGroup&
 	{
 		QStringList extraNames=getExtraInfoStrings(Name);
 		if (extraNames.length()>0)
-			oss << q_("Other names: ") << extraNames.join(", ");
+			oss << q_("Additional names: ") << extraNames.join(", ") << "<br/>";
 	}
 	if (flags&CatalogNumber)
 	{
 		QStringList extraCat=getExtraInfoStrings(CatalogNumber);
 		if (extraCat.length()>0)
-			oss << q_("Other catalog numbers: ") << extraCat.join(", ");
+			oss << q_("Additional catalog numbers: ") << extraCat.join(", ") << "<br/>";
 	}
 
 	bool ebsFlag = false;
@@ -219,7 +219,7 @@ QString StarWrapper1::getInfoString(const StelCore *core, const InfoStringGroup&
 		}
 		else
 			oss << QString("%1: <b>%2</b>").arg(q_("Type"), startype) << "<br />";
-		oss << getExtraInfoStrings(flags&ObjectType).join(' ');
+		oss << getExtraInfoStrings(flags&ObjectType).join("");
 	}
 
 	oss << getMagnitudeInfoString(core, flags, alt_app, 2);
@@ -227,7 +227,7 @@ QString StarWrapper1::getInfoString(const StelCore *core, const InfoStringGroup&
 	if ((flags&AbsoluteMagnitude) && s->getPlx ()&& !isNan(s->getPlx()) && !isInf(s->getPlx()))
 		oss << QString("%1: %2").arg(q_("Absolute Magnitude")).arg(getVMagnitude(core)+5.*(1.+std::log10(0.00001*s->getPlx())), 0, 'f', 2) << "<br />";
 	if (flags&AbsoluteMagnitude)
-		oss << getExtraInfoStrings(AbsoluteMagnitude).join(' ');
+		oss << getExtraInfoStrings(AbsoluteMagnitude).join("");
 
 	if (flags&Extra)
 	{
@@ -270,7 +270,7 @@ QString StarWrapper1::getInfoString(const StelCore *core, const InfoStringGroup&
 			else
 				oss << QString("%1: %2 %3").arg(q_("Distance"), QString::number(distance, 'f', 2), ly) << "<br />";
 		}
-		oss << getExtraInfoStrings(Distance).join(' ');
+		oss << getExtraInfoStrings(Distance).join("");
 	}
 
 	if (flags&Extra)
@@ -331,13 +331,10 @@ QString StarWrapper1::getInfoString(const StelCore *core, const InfoStringGroup&
 		if (pa<0)
 			pa += 360.f;
 
-		oss << QString("%1: %2%3 %4 %5%6").arg(q_("Proper motion (polar)"))
+		oss << QString("%1: %2%3 %4 %5%6").arg(q_("Proper motion"))
 		       .arg(QString::number(std::sqrt(dx*dx + dy*dy), 'f', 1)).arg(qc_("mas/yr", "milliarc second per year"))
-		       .arg(qc_("to", "into the direction of")).arg(QString::number(pa, 'f', 1)).arg(QChar(0x00B0)) << "<br />";
+		       .arg(qc_("towards", "into the direction of")).arg(QString::number(pa, 'f', 1)).arg(QChar(0x00B0)) << "<br />";
 		oss << QString("%1: %2 %3 (%4)").arg(q_("Proper motions by axes")).arg(QString::number(dx, 'f', 1)).arg(QString::number(dy, 'f', 1)).arg(qc_("mas/yr", "milliarc second per year")) << "<br />";
-		// FIXME: remove these if Polar line above looks better.
-		oss << QString("%1: %2%3").arg(q_("Position angle of the proper motion")).arg(QString::number(pa,'f', 1)).arg(QChar(0x00B0)) << "<br />";
-		oss << QString("%1: %2 (%3)").arg(q_("Angular speed of the proper motion")).arg(QString::number(std::sqrt(dx*dx + dy*dy), 'f', 1)).arg(qc_("mas/yr", "milliarc second per year")) << "<br />";
 	}
 
 	StelObject::postProcessInfoString(str, flags);

--- a/src/core/modules/StarWrapper.cpp
+++ b/src/core/modules/StarWrapper.cpp
@@ -168,6 +168,18 @@ QString StarWrapper1::getInfoString(const StelCore *core, const InfoStringGroup&
 		if ((flags&Name) || (flags&CatalogNumber))
 			oss << "</h2>";
 	}
+	if (flags&Name)
+	{
+		QStringList extraNames=getExtraInfoStrings(Name);
+		if (extraNames.length()>0)
+			oss << q_("Other names: ") << extraNames.join(", ");
+	}
+	if (flags&CatalogNumber)
+	{
+		QStringList extraCat=getExtraInfoStrings(CatalogNumber);
+		if (extraCat.length()>0)
+			oss << q_("Other catalog numbers: ") << extraCat.join(", ");
+	}
 
 	bool ebsFlag = false;
 	if (flags&ObjectType)
@@ -207,12 +219,15 @@ QString StarWrapper1::getInfoString(const StelCore *core, const InfoStringGroup&
 		}
 		else
 			oss << QString("%1: <b>%2</b>").arg(q_("Type"), startype) << "<br />";
+		oss << getExtraInfoStrings(flags&ObjectType).join(' ');
 	}
 
 	oss << getMagnitudeInfoString(core, flags, alt_app, 2);
 
 	if ((flags&AbsoluteMagnitude) && s->getPlx ()&& !isNan(s->getPlx()) && !isInf(s->getPlx()))
 		oss << QString("%1: %2").arg(q_("Absolute Magnitude")).arg(getVMagnitude(core)+5.*(1.+std::log10(0.00001*s->getPlx())), 0, 'f', 2) << "<br />";
+	if (flags&AbsoluteMagnitude)
+		oss << getExtraInfoStrings(AbsoluteMagnitude).join(' ');
 
 	if (flags&Extra)
 	{
@@ -241,24 +256,25 @@ QString StarWrapper1::getInfoString(const StelCore *core, const InfoStringGroup&
 
 	oss << getCommonInfoString(core, flags);
 
-	if ((flags&Distance) && s->getPlx() && !isNan(s->getPlx()) && !isInf(s->getPlx()))
+	if (flags&Distance)
 	{
-		//TRANSLATORS: Unit of measure for distance - Light Years
-		QString ly = qc_("ly", "distance");
-		double k = AU/(SPEED_OF_LIGHT*86400*365.25);
-		double d = ((0.00001/3600.)*(M_PI/180));
-		double distance = k/(s->getPlx()*d);
-		if (plxErr>0.f && (0.01f*s->getPlx())>plxErr) // No distance when error of parallax is bigger than parallax!
-			oss << QString("%1: %2%3%4 %5").arg(q_("Distance"), QString::number(distance, 'f', 2), QChar(0x00B1), QString::number(qAbs(k/((100*plxErr + s->getPlx())*d) - distance), 'f', 2), ly) << "<br />";
-		else
-			oss << QString("%1: %2 %3").arg(q_("Distance"), QString::number(distance, 'f', 2), ly) << "<br />";
+		if (s->getPlx() && !isNan(s->getPlx()) && !isInf(s->getPlx()))
+		{
+			//TRANSLATORS: Unit of measure for distance - Light Years
+			QString ly = qc_("ly", "distance");
+			double k = AU/(SPEED_OF_LIGHT*86400*365.25);
+			double d = ((0.00001/3600.)*(M_PI/180));
+			double distance = k/(s->getPlx()*d);
+			if (plxErr>0.f && (0.01f*s->getPlx())>plxErr) // No distance when error of parallax is bigger than parallax!
+				oss << QString("%1: %2%3%4 %5").arg(q_("Distance"), QString::number(distance, 'f', 2), QChar(0x00B1), QString::number(qAbs(k/((100*plxErr + s->getPlx())*d) - distance), 'f', 2), ly) << "<br />";
+			else
+				oss << QString("%1: %2 %3").arg(q_("Distance"), QString::number(distance, 'f', 2), ly) << "<br />";
+		}
+		oss << getExtraInfoStrings(Distance).join(' ');
 	}
 
 	if (flags&Extra)
 	{
-		if (s->getSpInt())
-			oss << QString("%1: %2").arg(q_("Spectral Type"), StarMgr::convertToSpectralType(s->getSpInt())) << "<br />";
-
 		if (s->getPlx())
 		{
 			QString plx = q_("Parallax");
@@ -268,6 +284,9 @@ QString StarWrapper1::getInfoString(const StelCore *core, const InfoStringGroup&
 				oss << QString("%1: %2 ").arg(plx, QString::number(0.01*s->getPlx(), 'f', 3));
 			oss  << qc_("mas", "parallax") << "<br />";
 		}
+
+		if (s->getSpInt())
+			oss << QString("%1: %2").arg(q_("Spectral Type"), StarMgr::convertToSpectralType(s->getSpInt())) << "<br />";
 
 		if (vPeriod>0)
 			oss << QString("%1: %2 %3").arg(q_("Period")).arg(vPeriod).arg(qc_("days", "duration")) << "<br />";
@@ -312,7 +331,11 @@ QString StarWrapper1::getInfoString(const StelCore *core, const InfoStringGroup&
 		if (pa<0)
 			pa += 360.f;
 
+		oss << QString("%1: %2%3 %4 %5%6").arg(q_("Proper motion (polar)"))
+		       .arg(QString::number(std::sqrt(dx*dx + dy*dy), 'f', 1)).arg(qc_("mas/yr", "milliarc second per year"))
+		       .arg(qc_("to", "into the direction of")).arg(QString::number(pa, 'f', 1)).arg(QChar(0x00B0)) << "<br />";
 		oss << QString("%1: %2 %3 (%4)").arg(q_("Proper motions by axes")).arg(QString::number(dx, 'f', 1)).arg(QString::number(dy, 'f', 1)).arg(qc_("mas/yr", "milliarc second per year")) << "<br />";
+		// FIXME: remove these if Polar line above looks better.
 		oss << QString("%1: %2%3").arg(q_("Position angle of the proper motion")).arg(QString::number(pa,'f', 1)).arg(QChar(0x00B0)) << "<br />";
 		oss << QString("%1: %2 (%3)").arg(q_("Angular speed of the proper motion")).arg(QString::number(std::sqrt(dx*dx + dy*dy), 'f', 1)).arg(qc_("mas/yr", "milliarc second per year")) << "<br />";
 	}

--- a/src/core/modules/StarWrapper.cpp
+++ b/src/core/modules/StarWrapper.cpp
@@ -331,7 +331,7 @@ QString StarWrapper1::getInfoString(const StelCore *core, const InfoStringGroup&
 		if (pa<0)
 			pa += 360.f;
 
-		oss << QString("%1: %2%3 %4 %5%6").arg(q_("Proper motion"))
+		oss << QString("%1: %2 %3 %4 %5%6").arg(q_("Proper motion"))
 		       .arg(QString::number(std::sqrt(dx*dx + dy*dy), 'f', 1)).arg(qc_("mas/yr", "milliarc second per year"))
 		       .arg(qc_("towards", "into the direction of")).arg(QString::number(pa, 'f', 1)).arg(QChar(0x00B0)) << "<br />";
 		oss << QString("%1: %2 %3 (%4)").arg(q_("Proper motions by axes")).arg(QString::number(dx, 'f', 1)).arg(QString::number(dy, 'f', 1)).arg(qc_("mas/yr", "milliarc second per year")) << "<br />";

--- a/src/gui/SkyGui.cpp
+++ b/src/gui/SkyGui.cpp
@@ -176,6 +176,7 @@ void InfoPanel::setTextFromObjects(const QList<StelObjectP>& selected)
 		// Must set lastRTS for currently selected object here...
 		StelCore *core=StelApp::getInstance().getCore();
 		QString s = selected[0]->getInfoString(core, infoTextFilters);
+		selected[0]->removeExtraInfoStrings(StelObject::AllInfo);
 		QFont font;
 		font.setPixelSize(StelApp::getInstance().getScreenFontSize());
 		setFont(font);

--- a/src/scripting/StelMainScriptAPI.cpp
+++ b/src/scripting/StelMainScriptAPI.cpp
@@ -911,10 +911,13 @@ void StelMainScriptAPI::addToSelectedObjectInfoString(const QString &str, bool r
 	}
 
 	StelObjectP obj = omgr->getSelectedObject()[0];
-	if (replace)
-		obj->setExtraInfoString(StelObject::Extra, str);
-	else
-		obj->addToExtraInfoString(StelObject::Extra, str);
+	if (obj)
+	{
+		if (replace)
+			obj->setExtraInfoString(StelObject::Script, str);
+		else
+			obj->addToExtraInfoString(StelObject::Script, str);
+	}
 }
 
 

--- a/src/scripting/StelMainScriptAPI.cpp
+++ b/src/scripting/StelMainScriptAPI.cpp
@@ -912,9 +912,9 @@ void StelMainScriptAPI::addToSelectedObjectInfoString(const QString &str, bool r
 
 	StelObjectP obj = omgr->getSelectedObject()[0];
 	if (replace)
-		obj->setExtraInfoString(str);
+		obj->setExtraInfoString(StelObject::Extra, str);
 	else
-		obj->addToExtraInfoString(str);
+		obj->addToExtraInfoString(StelObject::Extra, str);
 }
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Please include a summary of the change and which issue is fixed. -->
<!--- Please also include relevant motivation and context. -->
<!--- List any dependencies that are required for this change. -->

The last preliminary cherry-pick from gz_planetAxes.

The extraInfoStrings should allow plugins to add strings into the InfoString, e.g. 
customized coordinates for astro navigation, but all InfoString flag groups can be added to now. 

Strings from scripts are currently added to the end of all InfoStrings, followed by DebugAid strings. The latter can be of great help to display various intermediate values during development. 

TODO: We should probably have smaller virtual methods in StelObject & derived classes instead of StelObject::getCommonInfoString() for the various parts of the InfoString for better granularity. (This can happen also later when required by plugins which need these newly inserted strings.)

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] This change requires a documentation update

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

A module can insert new info strings e.g. in its draw() method. I am thinking especially of a more complete Astro Navigation plugin which may show new kinds of coordinates (SHA, GHA, ...), the Observability plugin, or some plugin that provides ethnoastronomical details I have not even yet considered. Also the Equation of Time could be modified to add its value only to the Sun's Infostring when selected (or also into the Infostring of whichever object is just shown). 

You can use a script 
```
core.addToSelectedObjectInfoString("some message from a script <br/>");
core.addToSelectedObjectInfoString("another message from script<br/>");
```
to add one or more strings,
`core.addToSelectedObjectInfoString("", true);`
to reset them. 

Currently it is not intended to remove the messages one-by-one, just all of them.
The extra information remains with the selected object and will be shown when that object is selected again. The exception are stars with their non-permanent StarWrapper. 

**Test Configuration**:
* Operating system: Windows 10
* Graphics Card: Geforce 960M (irrelevant)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (NOT YET to the SUG. Info should go to the scripting chapter.)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works. (-->tested only locally)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
