### PR TITLE
INDI: Followup fix for telescope syncing

### DIFF
--- a/plugins/TelescopeControl/src/INDI/INDIConnection.cpp
+++ b/plugins/TelescopeControl/src/INDI/INDIConnection.cpp
@@ -102,12 +102,13 @@ void INDIConnection::syncPosition(INDIConnection::Coordinates coords)
 		return;
 	}
 
+	ISwitch *track = IUFindSwitch(switchVector, "TRACK");
+	ISwitch *slew = IUFindSwitch(switchVector, "SLEW");
 	ISwitch *sync = IUFindSwitch(switchVector, "SYNC");
-	if (sync->s == ISS_OFF)
-	{
-		sync->s = ISS_ON;
-		sendNewSwitch(switchVector);
-	}
+	track->s = ISS_OFF;
+	slew->s = ISS_OFF;
+	sync->s = ISS_ON;
+	sendNewSwitch(switchVector);
 
 	INumberVectorProperty *property = Q_NULLPTR;
 	property = mTelescope->getNumber("EQUATORIAL_EOD_COORD");
@@ -122,11 +123,10 @@ void INDIConnection::syncPosition(INDIConnection::Coordinates coords)
 	sendNewNumber(property);
 
 	// And now unset SYNC switch member to revert to default state/behavior
-	if (sync->s == ISS_ON)
-	{
-		sync->s = ISS_OFF;
-		sendNewSwitch(switchVector);
-	}
+	track->s = ISS_ON;
+	slew->s = ISS_OFF;
+	sync->s = ISS_OFF;
+	sendNewSwitch(switchVector);
 }
 
 bool INDIConnection::isDeviceConnected() const


### PR DESCRIPTION
This is a followup for 40dc59f303b23ca1.

### Description

During testing with an actual telescope and viewing the traffic
exchanged between indiserver and stellarium, it was noticed that the
ON_COORD_SET switch would send the TRACK member as on and not the SYNC
member as on. To sidestep this, set all 3 members explicitly both before
sending EQUATORIAL_EOD_COORD and after sending it to restore state

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### How Has This Been Tested?
Tested with Skywatcher HEQ-5 Pro SynScan, in a stellarium flatpak build.

**Test Configuration**:
* Operating system: Debian buster, already running Stellarium using the flatpak build.
* Graphics Card: Intel Iris Graphics 5100. Whatever driver version currently ships with Debian Buster.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
