### PR TITLE
Bigger window resize border

### DIFF
--- a/plugins/TextUserInterface/src/DummyDialog.cpp
+++ b/plugins/TextUserInterface/src/DummyDialog.cpp
@@ -102,7 +102,9 @@ void DummyDialog::setVisible(bool v)
 		proxy = new CustomProxy(Q_NULLPTR, Qt::Tool);
 		proxy->setWidget(dialog);
 		StelMainView::getInstance().scene()->addItem(proxy);
-		proxy->setWindowFrameMargins(2,0,2,2);
+		// Invisible frame around the window to make resizing easier
+		// (this also changes the bounding rectangle size)
+		proxy->setWindowFrameMargins(7,0,7,7);
 		proxy->setCacheMode(QGraphicsItem::DeviceCoordinateCache); 
 		proxy->setZValue(100);
 		StelMainView::getInstance().scene()->setActiveWindow(proxy);

--- a/src/gui/StelDialog.cpp
+++ b/src/gui/StelDialog.cpp
@@ -153,8 +153,9 @@ void StelDialog::setVisible(bool v)
 			if (newY <-0)
 				newY = 0;
 			proxy->setPos(newX, newY);
-			proxy->setWindowFrameMargins(2,0,2,2);
+			// Invisible frame around the window to make resizing easier
 			// (this also changes the bounding rectangle size)
+			proxy->setWindowFrameMargins(7,0,7,7);
 
 			// Retrieve stored panel sizes, scale panel up if it was stored larger than default.
 			QString confNameSize="DialogSizes/" + dialogName;


### PR DESCRIPTION
Makes the invisible border around windows a little bigger, so it is easier to resize. I could not find information on why it was only 2 pixels wide ([commit](https://github.com/Stellarium/stellarium/commit/246a423193295d518653a447d8bea9d55d1fe0b5)). Now the area is 7 pixels wide.

Fixes #937. 

### Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### How Has This Been Tested?
Tested only in Linux, but it should be the same in other platforms

**Test Configuration**:
- Operating system: Debian GNU/Linux
- Graphics Card: AMD Radeon R7 360. Driver: radeon

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
