### PR TITLE
Highlight

### DIFF
--- a/src/gui/ScriptConsole.cpp
+++ b/src/gui/ScriptConsole.cpp
@@ -268,10 +268,11 @@ void ScriptConsole::preprocessScript()
 	QString dest;
 	QString src = ui->scriptEdit->toPlainText();
 
+	int errLoc = 0;
 	if (sender() == ui->preprocessSSCButton)
 	{
 		qDebug() << "[ScriptConsole] Preprocessing with SSC proprocessor";
-		StelApp::getInstance().getScriptMgr().preprocessScript( scriptFileName, src, dest, ui->includeEdit->text());
+		StelApp::getInstance().getScriptMgr().preprocessScript( scriptFileName, src, dest, ui->includeEdit->text(), errLoc );
 	}
 	else
 		qWarning() << "[ScriptConsole] WARNING - unknown preprocessor type";
@@ -279,7 +280,10 @@ void ScriptConsole::preprocessScript()
 	ui->scriptEdit->setPlainText(dest);
 	scriptFileName = ""; // OK, it's a new file!
 	dirty = true;
-	ui->tabs->setCurrentIndex(0);
+	ui->tabs->setCurrentIndex( 0 );
+	QTextCursor tc = ui->scriptEdit->textCursor();
+	tc.setPosition( errLoc );
+	ui->scriptEdit->setTextCursor( tc );
 }
 
 void ScriptConsole::runScript()

--- a/src/gui/ScriptConsole.cpp
+++ b/src/gui/ScriptConsole.cpp
@@ -281,9 +281,11 @@ void ScriptConsole::preprocessScript()
 	scriptFileName = ""; // OK, it's a new file!
 	dirty = true;
 	ui->tabs->setCurrentIndex( 0 );
-	QTextCursor tc = ui->scriptEdit->textCursor();
-	tc.setPosition( errLoc );
-	ui->scriptEdit->setTextCursor( tc );
+	if( errLoc != -1 ){
+		QTextCursor tc = ui->scriptEdit->textCursor();
+		tc.setPosition( errLoc );
+		ui->scriptEdit->setTextCursor( tc );
+	}
 }
 
 void ScriptConsole::runScript()
@@ -294,11 +296,17 @@ void ScriptConsole::runScript()
 		ui->outputBrowser->clear();
 	
 	appendLogLine(QString("Starting script at %1").arg(QDateTime::currentDateTime().toString()));
-	if (!StelApp::getInstance().getScriptMgr().runScriptDirect(scriptFileName, ui->scriptEdit->toPlainText(), ui->includeEdit->text()))
+	int errLoc = 0;
+	if (!StelApp::getInstance().getScriptMgr().runScriptDirect(scriptFileName, ui->scriptEdit->toPlainText(), errLoc, ui->includeEdit->text()))
 	{
 		QString msg = QString("ERROR - cannot run script");
 		qWarning() << "[ScriptConsole] " + msg;
 		appendLogLine(msg);
+		if( errLoc != -1 ){
+			QTextCursor tc = ui->scriptEdit->textCursor();
+			tc.setPosition( errLoc );
+			ui->scriptEdit->setTextCursor( tc );
+		}
 		return;
 	}
 }
@@ -374,7 +382,8 @@ void ScriptConsole::quickRun(int idx)
 	if (!scriptText.isEmpty())
 	{
 		appendLogLine(QString("Running: %1").arg(scriptText));
-		StelApp::getInstance().getScriptMgr().runScriptDirect( "<>", scriptText);
+		int errLoc;
+		StelApp::getInstance().getScriptMgr().runScriptDirect( "<>", scriptText, errLoc );
 		ui->quickrunCombo->setCurrentIndex(0);
 	}
 }

--- a/src/scripting/StelScriptMgr.hpp
+++ b/src/scripting/StelScriptMgr.hpp
@@ -153,10 +153,11 @@ public slots:
 	//! @note This is a blocking call! The event queue is held up by calls of QCoreApplication::processEvents().
 	//! @param scriptId path name, if available, or something helpful
 	//! @param scriptCode The script to execute
+	//! @param errLoc offset of erroneous include line, or -1
 	//! @param includePath If a null string (the default), no pre-processing is done. If an empty string, the default
 	//! script directories are used (script/ in both user and install directory). Otherwise, the given directory is used.
 	//! @return false if the named script code could not be prepared or run, true otherwise
-	bool runScriptDirect(const QString scriptId, const QString& scriptCode, const QString &includePath = QString());
+	bool runScriptDirect(const QString scriptId, const QString& scriptCode, int &errLoc, const QString &includePath = QString());
 
 	//! Runs preprocessed script code which has been generated using runPreprocessedScript().
 	//! In general, you do not want to use this method, use runScript() or runScriptDirect() instead.

--- a/src/scripting/StelScriptMgr.hpp
+++ b/src/scripting/StelScriptMgr.hpp
@@ -69,7 +69,7 @@ public:
 	//! if the command line option --verbose has been given,
 	//! this dumps the preprocessed script with line numbers attached to log.
 	//! This helps to understand the line number given by the usual error message.
-	bool preprocessScript(const QString fileName, const QString& input, QString& output, const QString& scriptDir);
+	bool preprocessScript(const QString fileName, const QString& input, QString& output, const QString& scriptDir, int &errLoc);
 	bool preprocessFile(const QString fileName, QFile &input, QString& output, const QString& scriptDir);
 	
 	//! Add all the StelModules into the script engine
@@ -239,7 +239,7 @@ private:
 	QMap<QString, QString> mappify(const QStringList& args, bool lowerKey=false);
 	bool strToBool(const QString& str);
 	// The recursive preprocessing workhorse.
-        bool expand(const QString fileName, const QString &input, QString &output, const QString &scriptDir);
+	void expand(const QString fileName, const QString &input, QString &output, const QString &scriptDir, int &errLoc);
 
 	//! Generate one StelAction per script.
 	//! The name of the action is of the form: "actionScript/<script-path>"


### PR DESCRIPTION
Changes in the StelScriptMgr and ScriptConsole files are intended to improve diagnostics for failed includes.
Changes in the StelScriptSyntaxHighlighter fix the incorrect treatment of keywords followed by '(' and improve highlighting of regular expressions. (Check: hundreds of lines of JS code are highlit correctly.)
