### PR TITLE
Added penumbral and umbral magnitudes during lunar eclipse

### DIFF
--- a/src/core/modules/Planet.cpp
+++ b/src/core/modules/Planet.cpp
@@ -928,11 +928,15 @@ QString Planet::getInfoStringExtra(const StelCore *core, const InfoStringGroup& 
 			StelUtils::rectToSphe(&ra_equ, &dec_equ, getEquinoxEquatorialPos(core1));
 			StelUtils::rectToSphe(&raSun, &deSun, ssystem->getSun()->getEquinoxEquatorialPos(core1));
 
+			// R.A. of Earth's shadow
 			raShadow = (raSun / M_PI_180)+180.;
 			if (raShadow < 0.) raShadow += 360.;
+			// Dec. of Earth's shadow
 			deShadow = -(deSun / M_PI_180);
+			// R.A. of the Moon
 			raMoon = (ra_equ / M_PI_180);
 			if (raMoon < 0.) raMoon += 360.;
+			// Dec. of the Moon
 			deMoon = (dec_equ / M_PI_180);
 
 			raDiff = raMoon - raShadow;
@@ -940,7 +944,6 @@ QString Planet::getInfoStringExtra(const StelCore *core, const InfoStringGroup& 
 
 			if (raDiff < 3. || raDiff > 357.)
 			{
-
 				double sdistanceAu, mdistanceKm, mdistanceER, sHP, sSD, mHP, mSD;
 				sdistanceAu = ssystem->getSun()->getEquinoxEquatorialPos(core1).length();
 				mdistanceKm = getEquinoxEquatorialPos(core1).length() * AU;
@@ -958,22 +961,30 @@ QString Planet::getInfoStringExtra(const StelCore *core, const InfoStringGroup& 
 				mSD = 3600. * (asin(0.2725076 / mdistanceER) / M_PI_180);
 
 				// Bessellian elements
+				// ref: Explanatory supplement to the astronomical ephemeris
+				// and the American ephemeris and nautical almanac (1961)
 				double p1, f1, f2, x, y, L1, L2, m, pMag, uMag;
 
-				p1 = (1. + 1. / 85. - 1. / 594.) * mHP; // Danjon rule
-				f1 = p1 + sSD + sHP;
-				f2 = p1 - sSD + sHP;
+				p1 = (1. + 1. / 85. - 1. / 594.) * mHP;
+				// Danjon's method - used in French almanac and NASA web site.
+				// It's the enlargment of Earth's shadows due to Earth's atmosphere
+				// and correction for Earth's oblateness at latitude 45 deg.
+				// ref: Five Millennium Catalog of Lunar Eclipses: -1999 to +3000 (Fred Espenak, NASA)
+				// Note: Astronomical Almanac using different value which create a bit larger shadows.
+
+				f1 = p1 + sSD + sHP; // radius of umbra at the distance of the Moon
+				f2 = p1 - sSD + sHP; // radius of penumbra at the distance of the Moon
 
 				x = cos(deMoon * M_PI_180) * sin((raMoon - raShadow) * M_PI_180);
 				x = 3600. * (asin(x)) / M_PI_180;
 				y = cos(deShadow * M_PI_180) * sin(deMoon * M_PI_180);
 				y = y - sin(deShadow * M_PI_180) * cos(deMoon * M_PI_180) * cos((raMoon - raShadow) * M_PI_180);
 				y = 3600. * (asin(y)) / M_PI_180;
-				L1 = f1 + mSD;
-				L2 = f2 + mSD;
+				L1 = f1 + mSD; // distance between center of the Moon and shadow at beginning and end of penumbral eclipse
+				L2 = f2 + mSD; // distance between center of the Moon and shadow at beginning and end of partial eclipse
 				m = sqrt(x * x + y * y);
-				pMag = (L1 - m) / (2. * mSD);
-				uMag = (L2 - m) / (2. * mSD);
+				pMag = (L1 - m) / (2. * mSD); // penumbral magnitude
+				uMag = (L2 - m) / (2. * mSD); // umbral magnitude
 
 				core1->setUseTopocentricCoordinates(useTopocentric);
 				core1->update(0); // enforce update cache to avoid odd selection of Moon details!

--- a/src/core/modules/Planet.cpp
+++ b/src/core/modules/Planet.cpp
@@ -914,6 +914,80 @@ QString Planet::getInfoStringExtra(const StelCore *core, const InfoStringGroup& 
 				}
 			}
 		}
+
+		if (englishName == "Moon" && onEarth)
+		{
+			// Show magnitude of lunar eclipse
+			// Use geocentric coordinates
+			StelCore* core1 = StelApp::getInstance().getCore();
+			const bool useTopocentric = core1->getUseTopocentricCoordinates();
+			core1->setUseTopocentricCoordinates(false);
+			core1->update(0);
+
+			double ra_equ, dec_equ, raSun, deSun, raShadow, deShadow, raMoon, deMoon, raDiff;
+			StelUtils::rectToSphe(&ra_equ, &dec_equ, getEquinoxEquatorialPos(core1));
+			StelUtils::rectToSphe(&raSun, &deSun, ssystem->getSun()->getEquinoxEquatorialPos(core1));
+
+			raShadow = (raSun / M_PI_180)+180.;
+			if (raShadow < 0.) raShadow += 360.;
+			deShadow = -(deSun / M_PI_180);
+			raMoon = (ra_equ / M_PI_180);
+			if (raMoon < 0.) raMoon += 360.;
+			deMoon = (dec_equ / M_PI_180);
+
+			raDiff = raMoon - raShadow;
+			if (raDiff < 0.) raDiff += 360.;
+
+			if (raDiff < 3. || raDiff > 357.)
+			{
+
+				double sdistanceAu, mdistanceKm, mdistanceER, sHP, sSD, mHP, mSD;
+				sdistanceAu = ssystem->getSun()->getEquinoxEquatorialPos(core1).length();
+				mdistanceKm = getEquinoxEquatorialPos(core1).length() * AU;
+				// Moon's distance in Earth's radius
+				mdistanceER = mdistanceKm / 6378.14;
+
+				// Sun's horizontal parallax
+				sHP = 3600. * (asin(6378.14 / (AU * sdistanceAu))) / M_PI_180;
+				// Sun's semi-diameter
+				sSD = 959.64 / sdistanceAu;
+
+				// Moon's horizontal parallax
+				mHP = 3600. * asin(1. / mdistanceER) / M_PI_180;
+				// Moon's semi-diameter
+				mSD = 3600. * (asin(0.2725076 / mdistanceER) / M_PI_180);
+
+				// Bessellian elements
+				double p1, f1, f2, x, y, L1, L2, m, pMag, uMag;
+
+				p1 = (1. + 1. / 85. - 1. / 594.) * mHP; // Danjon rule
+				f1 = p1 + sSD + sHP;
+				f2 = p1 - sSD + sHP;
+
+				x = cos(deMoon * M_PI_180) * sin((raMoon - raShadow) * M_PI_180);
+				x = 3600. * (asin(x)) / M_PI_180;
+				y = cos(deShadow * M_PI_180) * sin(deMoon * M_PI_180);
+				y = y - sin(deShadow * M_PI_180) * cos(deMoon * M_PI_180) * cos((raMoon - raShadow) * M_PI_180);
+				y = 3600. * (asin(y)) / M_PI_180;
+				L1 = f1 + mSD;
+				L2 = f2 + mSD;
+				m = sqrt(x * x + y * y);
+				pMag = (L1 - m) / (2. * mSD);
+				uMag = (L2 - m) / (2. * mSD);
+
+				core1->setUseTopocentricCoordinates(useTopocentric);
+				core1->update(0); // enforce update cache to avoid odd selection of Moon details!
+
+				if (pMag > 1.e-6)
+				{
+					oss << QString("%1: %2").arg(q_("Penumbral eclipse magnitude")).arg(QString::number(pMag, 'f', 5)) << "<br />";
+					if (uMag > 1.e-6)
+					{
+						oss << QString("%1: %2").arg(q_("Umbral eclipse magnitude")).arg(QString::number(uMag, 'f', 5)) << "<br />";
+					}
+				}
+			}
+		}
 	}
 	return str;
 }


### PR DESCRIPTION
### Description
This added method for calculation of magnitudes of lunar eclipse. They can be used to accurately determine contact times and magnitudes of lunar eclipse (compared with NASA). The magnitudes will display when selecting the Moon during any lunar eclipses.

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### How Has This Been Tested?

**Test Configuration**:
* Operating system: Windows 10
* Graphics Card: NVidia, GeForce GTX 1070, 446.14>

## Checklist:
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
