### PR TITLE
Bugfix: A script isn't terminated properly via the stop script button

### DIFF
--- a/src/scripting/StelMainScriptAPI.cpp
+++ b/src/scripting/StelMainScriptAPI.cpp
@@ -43,6 +43,7 @@
 #include "StelModuleMgr.hpp"
 #include "StelMovementMgr.hpp"
 #include "StelPropertyMgr.hpp"
+#include "StelScriptMgr.hpp"
 
 #include "StelObject.hpp"
 #include "StelObjectMgr.hpp"
@@ -845,9 +846,13 @@ double StelMainScriptAPI::jdFromDateString(const QString& dt, const QString& spe
 
 void StelMainScriptAPI::wait(double t)
 {
-	QEventLoop loop;
-	QTimer::singleShot(qRound(1000*t), &loop, SLOT(quit()));
-	loop.exec();
+	StelScriptMgr* scriptMgr = &StelApp::getInstance().getScriptMgr();
+	QEventLoop* loop = scriptMgr->getWaitEventLoop();
+	QTimer::singleShot(qRound(1000*t), loop, SLOT(quit()));
+	if( loop->exec() != 0 )
+	{
+		emit(requestExit()); // causes a call of stopScript
+	}
 }
 
 void StelMainScriptAPI::waitFor(const QString& dt, const QString& spec)
@@ -865,9 +870,13 @@ void StelMainScriptAPI::waitFor(const QString& dt, const QString& spec)
 		qDebug() << "waitFor() called, but negative interval (time exceeded before starting timer). Not waiting!";
 		return;
 	}
-	QEventLoop loop;
-	QTimer::singleShot(interval, &loop, SLOT(quit()));
-	loop.exec();
+	StelScriptMgr* scriptMgr = &StelApp::getInstance().getScriptMgr();
+	QEventLoop* loop = scriptMgr->getWaitEventLoop();
+	QTimer::singleShot(interval, loop, SLOT(quit()));
+	if( loop->exec() != 0 )
+	{
+		emit(requestExit()); // causes a call of stopScript
+	}
 }
 
 

--- a/src/scripting/StelMainScriptAPI.hpp
+++ b/src/scripting/StelMainScriptAPI.hpp
@@ -810,7 +810,7 @@ public slots:
 	// re-implemented for 0.15.1 to avoid a busy-loop.
 	//! Pauses the script for \e t seconds
 	//! @param t the number of seconds to wait
-	static void wait(double t);
+	void wait(double t);
 
 	//! Waits until a specified simulation date/time. This function
 	//! will take into account the rate (and direction) in which simulation
@@ -820,7 +820,7 @@ public slots:
 	//! prevent infinite wait time.
 	//! @param dt the date string to use, format like "2012-06-06T4:44:00" or "-1428-03-04T22:23:45"
 	//! @param spec "local" or "utc"
-	static void waitFor(const QString& dt, const QString& spec="utc");
+	void waitFor(const QString& dt, const QString& spec="utc");
 
 	//! Retrieve value of environment variable @param name.
 	//! On desktop Windows and Qt before 5.10, this call may result in data loss if the original

--- a/src/scripting/StelScriptMgr.hpp
+++ b/src/scripting/StelScriptMgr.hpp
@@ -23,8 +23,8 @@
 #include <QObject>
 #include <QStringList>
 #include <QFile>
-#include <QTime>
 #include <QTimer>
+#include <QEventLoop>
 #include <QMap>
 #include <QPair>
 #include <QSet>
@@ -80,6 +80,9 @@ public:
 
     //! Permit access to StelScriptMainAPI's methods
 	const QMetaObject * getMetaOfStelMainScriptAPI(){ return mainAPI->metaObject(); }
+
+    //! Accessor to QEventLoop
+    QEventLoop* getWaitEventLoop(){ return waitEventLoop; }
 
 public slots:
 	//! Returns a HTML description of the specified script.
@@ -258,6 +261,9 @@ private:
 	//! The thread in which scripts are run
 	StelMainScriptAPI *mainAPI;
 
+	//! The QEventLoop for wait and waitFor
+    QEventLoop* waitEventLoop;
+	
 	QString scriptFileName;
 	
 	//Script engine agent


### PR DESCRIPTION
if the script is waiting for the end of a core.wait or core.waitFor command,
inhibiting another execution until timeout expiry.

<!--- Provide a general summary of your changes in the Title above -->
Declare the QEventLoop running the timer as a member of StelScriptMgr so that stopScript may distinguish a waiting script from a running one.

### Description
<!--- Please include a summary of the change and which issue is fixed. -->
<!--- Please also include relevant motivation and context. -->
<!--- List any dependencies that are required for this change. -->

Fixes # (issue)

### Screenshots (if appropriate):

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Checked "stop script" button effect during and not during wait/waitFor states.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
