### PR TITLE
Textures: fix load errors

### DIFF
--- a/guide/ch_landscapes_gz.tex
+++ b/guide/ch_landscapes_gz.tex
@@ -1547,6 +1547,30 @@ already be saturated.
 
 The possibilities seem limited only by your time and skills!
 
+\section{Packing}
+\label{sec:landscapes:Packing}
+
+For easy distribution, you should place all required files and some
+file usually named \file{README.txt} which may contain some
+background or extended license information into one directory and
+create a \file{ZIP} archive. Then you can install it directly in
+the running program (see section \ref{sec:gui:view:landscape}).
+
+
+\section{Troubleshooting}
+\label{sec:landscapes:Troubleshooting}
+
+If something does not work as described and Stellarium does not show
+your landscape as expected but maybe just a bright magenta-colored
+box, don't panic.  Double and triple-check the entries in
+\file{landscape.ini}. \newFeature{v0.20.2} Make sure the texture is in
+PNG format and the file name is correct. Check the logfile for error
+messages. If the image is too large, it will be re-scaled on loading,
+but it is more efficient to keep images as small as required. Only few
+systems can use textures larger than $16384\times16384$~Pixels. If you
+need high resolution, use the \texttt{old\_style} type (see section
+\ref{sec:landscapes:oldStyle}).
+
 \section{Other recommended software}
 \label{sec:landscapes:otherSoftware}
 

--- a/plugins/AngleMeasure/src/AngleMeasure.cpp
+++ b/plugins/AngleMeasure/src/AngleMeasure.cpp
@@ -151,7 +151,7 @@ void AngleMeasure::init()
 			toolbarButton = new StelButton(Q_NULLPTR,
 						       QPixmap(":/angleMeasure/bt_anglemeasure_on.png"),
 						       QPixmap(":/angleMeasure/bt_anglemeasure_off.png"),
-						       QPixmap(":/graphicGui/glow32x32.png"),
+						       QPixmap(":/graphicGui/miscGlow32x32.png"),
 						       "actionShow_Angle_Measure");
 			gui->getButtonBar()->addButton(toolbarButton, "065-pluginsGroup");
 		}

--- a/plugins/ArchaeoLines/src/ArchaeoLines.cpp
+++ b/plugins/ArchaeoLines/src/ArchaeoLines.cpp
@@ -266,7 +266,7 @@ void ArchaeoLines::init()
 			toolbarButton = new StelButton(Q_NULLPTR,
 						       QPixmap(":/archaeoLines/bt_archaeolines_on.png"),
 						       QPixmap(":/archaeoLines/bt_archaeolines_off.png"),
-						       QPixmap(":/graphicGui/glow32x32.png"),
+						       QPixmap(":/graphicGui/miscGlow32x32.png"),
 						       "actionShow_ArchaeoLines");
 			gui->getButtonBar()->addButton(toolbarButton, "065-pluginsGroup");
 		}

--- a/plugins/CompassMarks/src/CompassMarks.cpp
+++ b/plugins/CompassMarks/src/CompassMarks.cpp
@@ -100,7 +100,7 @@ void CompassMarks::init()
 			toolbarButton = new StelButton(Q_NULLPTR,
 						       QPixmap(":/compassMarks/bt_compass_on.png"),
 						       QPixmap(":/compassMarks/bt_compass_off.png"),
-						       QPixmap(":/graphicGui/glow32x32.png"),
+						       QPixmap(":/graphicGui/miscGlow32x32.png"),
 						       "actionShow_Compass_Marks");
 			gui->getButtonBar()->addButton(toolbarButton, "065-pluginsGroup");			
 		}

--- a/plugins/EquationOfTime/src/EquationOfTime.cpp
+++ b/plugins/EquationOfTime/src/EquationOfTime.cpp
@@ -231,7 +231,7 @@ void EquationOfTime::setFlagShowEOTButton(bool b)
 			toolbarButton = new StelButton(Q_NULLPTR,
 						       QPixmap(":/EquationOfTime/bt_EquationOfTime_On.png"),
 						       QPixmap(":/EquationOfTime/bt_EquationOfTime_Off.png"),
-						       QPixmap(":/graphicGui/glow32x32.png"),
+						       QPixmap(":/graphicGui/miscGlow32x32.png"),
 						       "actionShow_EquationOfTime");
 		}
 		gui->getButtonBar()->addButton(toolbarButton, "065-pluginsGroup");

--- a/plugins/Exoplanets/src/Exoplanets.cpp
+++ b/plugins/Exoplanets/src/Exoplanets.cpp
@@ -783,7 +783,7 @@ void Exoplanets::setFlagShowExoplanetsButton(bool b)
 				toolbarButton = new StelButton(Q_NULLPTR,
 							       QPixmap(":/Exoplanets/btExoplanets-on.png"),
 							       QPixmap(":/Exoplanets/btExoplanets-off.png"),
-							       QPixmap(":/graphicGui/glow32x32.png"),
+							       QPixmap(":/graphicGui/miscGlow32x32.png"),
 							       "actionShow_Exoplanets");
 			}
 			gui->getButtonBar()->addButton(toolbarButton, "065-pluginsGroup");

--- a/plugins/MeteorShowers/src/MeteorShowersMgr.cpp
+++ b/plugins/MeteorShowers/src/MeteorShowersMgr.cpp
@@ -485,7 +485,7 @@ void MeteorShowersMgr::setShowEnableButton(const bool& show)
 			StelButton* enablePlugin = new StelButton(Q_NULLPTR,
 								  QPixmap(":/MeteorShowers/btMS-on.png"),
 								  QPixmap(":/MeteorShowers/btMS-off.png"),
-								  QPixmap(":/graphicGui/glow32x32.png"),
+								  QPixmap(":/graphicGui/miscGlow32x32.png"),
 								  "actionShow_MeteorShowers");
 			gui->getButtonBar()->addButton(enablePlugin, "065-pluginsGroup");
 		}
@@ -518,7 +518,7 @@ void MeteorShowersMgr::setShowSearchButton(const bool& show)
 			StelButton* searchMS = new StelButton(Q_NULLPTR,
 							      QPixmap(":/MeteorShowers/btMS-search-on.png"),
 							      QPixmap(":/MeteorShowers/btMS-search-off.png"),
-							      QPixmap(":/graphicGui/glow32x32.png"),
+							      QPixmap(":/graphicGui/miscGlow32x32.png"),
 							      "actionShow_MeteorShowers_search_dialog");
 			gui->getButtonBar()->addButton(searchMS, "065-pluginsGroup");
 		}

--- a/plugins/NavStars/src/NavStars.cpp
+++ b/plugins/NavStars/src/NavStars.cpp
@@ -135,7 +135,7 @@ void NavStars::init()
 			toolbarButton = new StelButton(Q_NULLPTR,
 						       QPixmap(":/NavStars/btNavStars-on.png"),
 						       QPixmap(":/NavStars/btNavStars-off.png"),
-						       QPixmap(":/graphicGui/glow32x32.png"),
+						       QPixmap(":/graphicGui/miscGlow32x32.png"),
 						       "actionShow_NavStars");
 		}
 		gui->getButtonBar()->addButton(toolbarButton, "065-pluginsGroup");

--- a/plugins/Observability/src/Observability.cpp
+++ b/plugins/Observability/src/Observability.cpp
@@ -222,7 +222,7 @@ void Observability::init()
 		button = new StelButton(Q_NULLPTR,
 					QPixmap(":/observability/bt_observab_on.png"),
 					QPixmap(":/observability/bt_observab_off.png"),
-					QPixmap(":/graphicGui/glow32x32.png"),
+					QPixmap(":/graphicGui/miscGlow32x32.png"),
 					actionShow);
 		gui->getButtonBar()->addButton(button, "065-pluginsGroup");
 	}

--- a/plugins/Oculars/src/Oculars.cpp
+++ b/plugins/Oculars/src/Oculars.cpp
@@ -576,7 +576,7 @@ void Oculars::init()
 		}
 		selectedLensIndex=settings->value("lens_index", -1).toInt(); // Lens is not selected by default!
 
-		pxmapGlow = new QPixmap(":/graphicGui/glow32x32.png");
+		pxmapGlow = new QPixmap(":/graphicGui/miscGlow32x32.png");
 		pxmapOnIcon = new QPixmap(":/ocular/bt_ocular_on.png");
 		pxmapOffIcon = new QPixmap(":/ocular/bt_ocular_off.png");
 
@@ -772,11 +772,17 @@ void Oculars::retranslateGui()
 void Oculars::updateOcularReticle(void)
 {
 	reticleRotation = 0.0;
-	StelTextureMgr& manager = StelApp::getInstance().getTextureManager();
-	//Load OpenGL textures
-	StelTexture::StelTextureParams params;
-	params.generateMipmaps = true;
-	reticleTexture = manager.createTexture(oculars[selectedOcularIndex]->reticlePath(), params);
+	QString reticleTexturePath=oculars[selectedOcularIndex]->reticlePath();
+	if (reticleTexturePath.length()==0)
+		reticleTexture=StelTextureSP();
+	else
+	{
+		StelTextureMgr& manager = StelApp::getInstance().getTextureManager();
+		//Load OpenGL textures
+		StelTexture::StelTextureParams params;
+		params.generateMipmaps = true;
+		reticleTexture = manager.createTexture(reticleTexturePath, params);
+	}
 }
 
 /* ****************************************************************************************************************** */

--- a/plugins/PointerCoordinates/src/PointerCoordinates.cpp
+++ b/plugins/PointerCoordinates/src/PointerCoordinates.cpp
@@ -392,7 +392,7 @@ void PointerCoordinates::setFlagShowCoordinatesButton(bool b)
 				toolbarButton = new StelButton(Q_NULLPTR,
 							       QPixmap(":/PointerCoordinates/bt_PointerCoordinates_On.png"),
 							       QPixmap(":/PointerCoordinates/bt_PointerCoordinates_Off.png"),
-							       QPixmap(":/graphicGui/glow32x32.png"),
+							       QPixmap(":/graphicGui/miscGlow32x32.png"),
 							       "actionShow_MousePointer_Coordinates");
 			}
 			gui->getButtonBar()->addButton(toolbarButton, "065-pluginsGroup");

--- a/plugins/Pulsars/src/Pulsars.cpp
+++ b/plugins/Pulsars/src/Pulsars.cpp
@@ -169,7 +169,7 @@ void Pulsars::init()
 		addAction("actionShow_Pulsars", N_("Pulsars"), N_("Show pulsars"), "pulsarsVisible", "Ctrl+Alt+P");
 		addAction("actionShow_Pulsars_ConfigDialog", N_("Pulsars"), N_("Pulsars configuration window"), configDialog, "visible", ""); // Allow assign shortkey
 
-		GlowIcon = new QPixmap(":/graphicGui/glow32x32.png");
+		GlowIcon = new QPixmap(":/graphicGui/miscGlow32x32.png");
 		OnIcon = new QPixmap(":/Pulsars/btPulsars-on.png");
 		OffIcon = new QPixmap(":/Pulsars/btPulsars-off.png");
 

--- a/plugins/Quasars/src/Quasars.cpp
+++ b/plugins/Quasars/src/Quasars.cpp
@@ -171,7 +171,7 @@ void Quasars::init()
 		addAction("actionShow_Quasars", N_("Quasars"), N_("Show quasars"), "quasarsVisible", "Ctrl+Alt+Q");
 		addAction("actionShow_Quasars_ConfigDialog", N_("Quasars"), N_("Quasars configuration window"), configDialog, "visible", ""); // Allow assign shortkey
 
-		GlowIcon = new QPixmap(":/graphicGui/glow32x32.png");
+		GlowIcon = new QPixmap(":/graphicGui/miscGlow32x32.png");
 		OnIcon = new QPixmap(":/Quasars/btQuasars-on.png");
 		OffIcon = new QPixmap(":/Quasars/btQuasars-off.png");
 

--- a/plugins/RemoteControl/src/RemoteControl.cpp
+++ b/plugins/RemoteControl/src/RemoteControl.cpp
@@ -162,7 +162,7 @@ void RemoteControl::init()
 			toolbarButton = new StelButton(Q_NULLPTR,
 						       QPixmap(":/RemoteControl/resources/bt_remote_on.png"),
 						       QPixmap(":/RemoteControl/resources/bt_remote_off.png"),
-						       QPixmap(":/graphicGui/glow32x32.png"),
+						       QPixmap(":/graphicGui/miscGlow32x32.png"),
 						       "actionShow_Remote_Control");
 			gui->getButtonBar()->addButton(toolbarButton, "065-pluginsGroup");
 		}

--- a/plugins/Satellites/src/Satellites.cpp
+++ b/plugins/Satellites/src/Satellites.cpp
@@ -156,7 +156,7 @@ void Satellites::init()
 			toolbarButton = new StelButton(Q_NULLPTR,
 						       QPixmap(":/satellites/bt_satellites_on.png"),
 						       QPixmap(":/satellites/bt_satellites_off.png"),
-						       QPixmap(":/graphicGui/glow32x32.png"),
+						       QPixmap(":/graphicGui/miscGlow32x32.png"),
 						       "actionShow_Satellite_Hints");
 			gui->getButtonBar()->addButton(toolbarButton, "065-pluginsGroup");
 		}

--- a/plugins/Scenery3d/src/Scenery3d.cpp
+++ b/plugins/Scenery3d/src/Scenery3d.cpp
@@ -350,17 +350,17 @@ void Scenery3d::createToolbarButtons() const
 			StelButton* toolbarEnableButton =	new StelButton(Q_NULLPTR,
 									       QPixmap(":/Scenery3d/bt_scenery3d_on.png"),
 									       QPixmap(":/Scenery3d/bt_scenery3d_off.png"),
-									       QPixmap(":/graphicGui/glow32x32.png"),
+									       QPixmap(":/graphicGui/miscGlow32x32.png"),
 									       "actionShow_Scenery3d");
 			StelButton* toolbarSettingsButton =	new StelButton(Q_NULLPTR,
 									       QPixmap(":/Scenery3d/bt_scenery3d_settings_on.png"),
 									       QPixmap(":/Scenery3d/bt_scenery3d_settings_off.png"),
-									       QPixmap(":/graphicGui/glow32x32.png"),
+									       QPixmap(":/graphicGui/miscGlow32x32.png"),
 									       "actionShow_Scenery3d_dialog");
 			StelButton* toolbarStoredViewButton =	new StelButton(Q_NULLPTR,
 									       QPixmap(":/Scenery3d/bt_scenery3d_eyepoint_on.png"),
 									       QPixmap(":/Scenery3d/bt_scenery3d_eyepoint_off.png"),
-									       QPixmap(":/graphicGui/glow32x32.png"),
+									       QPixmap(":/graphicGui/miscGlow32x32.png"),
 									       "actionShow_Scenery3d_storedViewDialog");
 
 			gui->getButtonBar()->addButton(toolbarEnableButton, "065-pluginsGroup");

--- a/plugins/TelescopeControl/src/TelescopeControl.cpp
+++ b/plugins/TelescopeControl/src/TelescopeControl.cpp
@@ -220,7 +220,7 @@ void TelescopeControl::init()
 			toolbarButton =	new StelButton(Q_NULLPTR,
 						       QPixmap(":/telescopeControl/button_Slew_Dialog_on.png"),
 						       QPixmap(":/telescopeControl/button_Slew_Dialog_off.png"),
-						       QPixmap(":/graphicGui/glow32x32.png"),
+						       QPixmap(":/graphicGui/miscGlow32x32.png"),
 						       "actionShow_Slew_Window");
 			gui->getButtonBar()->addButton(toolbarButton, "065-pluginsGroup");
 		}

--- a/src/core/StelTextureMgr.hpp
+++ b/src/core/StelTextureMgr.hpp
@@ -41,6 +41,9 @@ public:
 	//! @param filename the texture file name, can be absolute path if starts with '/' otherwise
 	//!    the file will be looked for in Stellarium's standard textures directories.
 	//! @param params the texture creation parameters.
+	//! @note If filename is invalid, this creates a fuchsia-colored (magenta) replacement texture to signify "great error".
+	//!       Create an empty StelTextureSP yourself if you have no valid filename.
+	//! @note If image is larger than maximum allowed texture size, it will be automatically rescaled to fit and a warning printed to the logfile.
 	StelTextureSP createTexture(const QString& filename, const StelTexture::StelTextureParams& params=StelTexture::StelTextureParams());
 
 	//! Create a texture from a QImage.
@@ -82,6 +85,7 @@ private:
 	QMutex mutex;
 	TexCache textureCache;
 	IdMap idMap;
+	GLint maxTexSize; // Useful to avoid loading too large textures
 };
 
 

--- a/src/core/modules/Landscape.cpp
+++ b/src/core/modules/Landscape.cpp
@@ -261,6 +261,8 @@ const QString Landscape::getTexturePath(const QString& basename, const QString& 
 	QString path = StelFileMgr::findFile("landscapes/" + landscapeId + "/" + basename);
 	if (path.isEmpty())
 		path = StelFileMgr::findFile("textures/" + basename);
+	if (path.isEmpty())
+		qWarning() << "Warning: Landscape" << landscapeId << ": File" << basename << "does not exist.";
 	return path;
 }
 
@@ -760,6 +762,7 @@ void LandscapeOldStyle::drawGround(StelCore* core, StelPainter& sPainter) const
 float LandscapeOldStyle::getOpacity(Vec3d azalt) const
 {
 	if(!validLandscape) return (azalt[2]>0.0 ? 0.0f : 1.0f);
+	if (sidesImages[0]->isNull()) return 0.0f; // can happen if image is misconfigured and failed to load.
 
 	if (angleRotateZOffset!=0.0f)
 		azalt.transfo4d(Mat4d::zrotation(static_cast<double>(angleRotateZOffset)));
@@ -1055,6 +1058,7 @@ void LandscapeFisheye::draw(StelCore* core, bool onlyPolygon)
 float LandscapeFisheye::getOpacity(Vec3d azalt) const
 {
 	if(!validLandscape) return (azalt[2]>0.0 ? 0.0f : 1.0f);
+	if (mapImage->isNull()) return 0.0f; // can happen if image is misconfigured and failed to load.
 
 	if (angleRotateZOffset!=0.0f)
 		azalt.transfo4d(Mat4d::zrotation(static_cast<double>(angleRotateZOffset)));
@@ -1276,6 +1280,7 @@ void LandscapeSpherical::draw(StelCore* core, bool onlyPolygon)
 float LandscapeSpherical::getOpacity(Vec3d azalt) const
 {
 	if(!validLandscape) return (azalt[2]>0.0 ? 0.0f : 1.0f);
+	if (mapImage->isNull()) return 0.0f; // can happen if image is misconfigured and failed to load.
 
 	if (angleRotateZOffset!=0.0f)
 		azalt.transfo4d(Mat4d::zrotation(static_cast<double>(angleRotateZOffset)));

--- a/src/core/modules/Landscape.cpp
+++ b/src/core/modules/Landscape.cpp
@@ -762,7 +762,6 @@ void LandscapeOldStyle::drawGround(StelCore* core, StelPainter& sPainter) const
 float LandscapeOldStyle::getOpacity(Vec3d azalt) const
 {
 	if(!validLandscape) return (azalt[2]>0.0 ? 0.0f : 1.0f);
-	if (sidesImages[0]->isNull()) return 0.0f; // can happen if image is misconfigured and failed to load.
 
 	if (angleRotateZOffset!=0.0f)
 		azalt.transfo4d(Mat4d::zrotation(static_cast<double>(angleRotateZOffset)));
@@ -801,6 +800,7 @@ float LandscapeOldStyle::getOpacity(Vec3d azalt) const
 	int currentSide = static_cast<int>(floor(fmodf(az_panel, nbSide)));
 	Q_ASSERT(currentSide>=0);
 	Q_ASSERT(currentSide<static_cast<int>(nbSideTexs));
+	if (sidesImages[currentSide]->isNull()) return 0.0f; // can happen if image is misconfigured and failed to load.
 	int x= static_cast<int>(sides[currentSide].texCoords[0] + x_in_panel*(sides[currentSide].texCoords[2]-sides[currentSide].texCoords[0]))
 			* sidesImages[currentSide]->width(); // pixel X from left.
 

--- a/src/core/modules/Landscape.hpp
+++ b/src/core/modules/Landscape.hpp
@@ -208,7 +208,7 @@ protected:
 	//! search for a texture in landscape directory, else global textures directory
 	//! @param basename The name of a texture file, e.g. "fog.png"
 	//! @param landscapeId The landscape ID (directory name) to which the texture belongs
-	//! @exception misc possibility of throwing "file not found" exceptions
+	//! @note returns an empty string if file not found.
 	static const QString getTexturePath(const QString& basename, const QString& landscapeId);
 	double radius;
 	QString name;          //! Read from landscape.ini:[landscape]name


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Please include a summary of the change and which issue is fixed. -->
<!--- Please also include relevant motivation and context. -->
<!--- List any dependencies that are required for this change. -->

More often that you would believe we have people who fail to build their own landscapes. 
Sometimes they fail to write the right texture name, sometimes their image size exceeds their GPU's max texture size. So far this has lead to a crash.

This branch fixes two issues:
+ when file not found, complain with an entry in the logfile, and replace with a glaringly bright "fuchsia" (magenta) texture. 
+ when texture exceeds the system's capabilities, scale down on loading, and leave a message in the logfile.

In addition, it also restores the glow texture for plugin buttons
 
Note that skyculture art is loaded with different methods and does not allow rescaling on the fly, so this has not been touched.

Fixes # (issue) (several complaints on various forums. No issue listed.)

### Screenshots (if appropriate):

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system: Windows 10, 1909
* Graphics Card: NVidia GeForce M960 (but irrelevant)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings (EXCEPT WHERE INTENDED!)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
