### PR TITLE
Add Full Sensor Grid to Ocular plugin

### DIFF
--- a/plugins/Oculars/src/Oculars.cpp
+++ b/plugins/Oculars/src/Oculars.cpp
@@ -181,6 +181,7 @@ Oculars::Oculars()
 	, equatorialMountEnabledMain(false)
 	, reticleRotation(0.)
 	, flagShowCcdCropOverlay(false)
+	, flagShowCcdCropOverlayPixelGrid(false)
 	, ccdCropOverlayHSize(DEFAULT_CCD_CROP_OVERLAY_SIZE)
 	, ccdCropOverlayVSize(DEFAULT_CCD_CROP_OVERLAY_SIZE)
 	, flagShowContour(false)
@@ -613,6 +614,7 @@ void Oculars::init()
 		relativeStarScaleCCD=settings->value("stars_scale_relative_ccd", 1.0).toDouble();
 		absoluteStarScaleCCD=settings->value("stars_scale_absolute_ccd", 1.0).toDouble();
 		setFlagShowCcdCropOverlay(settings->value("show_ccd_crop_overlay", false).toBool());
+		setFlagShowCcdCropOverlayPixelGrid(settings-> value("ccd_crop_overlay_pixel_grid",false).toBool());
 		setCcdCropOverlayHSize(settings->value("ccd_crop_overlay_hsize", DEFAULT_CCD_CROP_OVERLAY_SIZE).toInt());
 		setCcdCropOverlayVSize(settings->value("ccd_crop_overlay_vsize", DEFAULT_CCD_CROP_OVERLAY_SIZE).toInt());
 		setFlagShowContour(settings->value("show_ocular_contour", false).toBool());
@@ -1529,9 +1531,16 @@ void Oculars::paintCCDBounds()
 			const float width = params.viewportXywh[aspectIndex] * static_cast<float>(ccdXRatio * params.devicePixelsPerPixel);
 			const float height = params.viewportXywh[aspectIndex] * static_cast<float>(ccdYRatio * params.devicePixelsPerPixel);
 
+			// Get Crop size taking into account the binning rounded to the lower limit and limiting it to sensor size
+			const float actualCropOverlayX = (std::min(ccd->resolutionX(), ccdCropOverlayHSize) / ccd->binningX()) * ccd->binningX();
+			const float actualCropOverlayY = (std::min(ccd->resolutionY(), ccdCropOverlayVSize)  / ccd->binningY()) * ccd->binningY();
 			// Calculate the size of the CCD crop overlay
-			const float overlayWidth = width * ccdCropOverlayHSize / ccd->resolutionX();
-			const float overlayHeight = height * ccdCropOverlayVSize / ccd->resolutionY();
+			const float overlayWidth = width * actualCropOverlayX / ccd->resolutionX();
+			const float overlayHeight = height * actualCropOverlayY / ccd->resolutionY();
+
+			//calculate the size of a pixel in the image
+			float pixelProjectedWidth = width /ccd->resolutionX() * ccd->binningX();
+			float pixelProjectedHeight = height /ccd->resolutionY()* ccd->binningY();
 
 			double polarAngle = 0;
 			// if the telescope is Equatorial derotate the field
@@ -1596,8 +1605,23 @@ void Oculars::paintCCDBounds()
 					a = transform.map(QPoint(static_cast<int>(overlayWidth*0.5f), static_cast<int>(overlayHeight*0.5f)));
 					b = transform.map(QPoint(static_cast<int>(overlayWidth*0.5f), static_cast<int>(-overlayHeight*0.5f)));
 					painter.drawLine2d(a.x(), a.y(), b.x(), b.y());
+					
+					//Tool to show full CCD grid overlay
+					if(flagShowCcdCropOverlayPixelGrid) {
+						//vertical lines
+						for (int l =1 ; l< actualCropOverlayX/ccd->binningX(); l++ ){
+							a = transform.map(QPoint(static_cast<int>(overlayWidth*0.5f- l*pixelProjectedWidth), static_cast<int>(-overlayHeight*0.5f)));
+							b = transform.map(QPoint(static_cast<int>(overlayWidth*0.5f- l*pixelProjectedWidth), static_cast<int>(overlayHeight*0.5f)));
+							painter.drawLine2d(a.x(), a.y(), b.x(), b.y());
+						}
+						//horizontal lines
+						for (int l =1 ; l< actualCropOverlayY/ccd->binningY(); l++ ){
+							a = transform.map(QPoint(static_cast<int>(-overlayWidth*0.5f), static_cast<int>(overlayHeight*0.5f - l*pixelProjectedHeight)));
+							b = transform.map(QPoint(static_cast<int>(overlayWidth*0.5f), static_cast<int>(overlayHeight*0.5f - l*pixelProjectedHeight)));
+							painter.drawLine2d(a.x(), a.y(), b.x(), b.y());
+						}
+					}
 				}
-
 				if(ccd->hasOAG())
 				{
 					const double InnerOAGRatio = ccd->getInnerOAGRadius(telescope, lens) / screenFOV;
@@ -1693,8 +1717,8 @@ void Oculars::paintCCDBounds()
 					{
 						// show the CCD crop overlay text
 						QString resolutionOverlayText = QString("%1%3 %4 %2%3")
-								.arg(QString::number(ccdCropOverlayHSize, 'd', 0))
-								.arg(QString::number(ccdCropOverlayVSize, 'd', 0))
+								.arg(QString::number(actualCropOverlayX, 'd', 0))
+								.arg(QString::number(actualCropOverlayY, 'd', 0))
 								.arg(qc_("px", "pixel"))
 								.arg(QChar(0x00D7));
 						a = transform.map(QPoint(qRound(overlayWidth*0.5f - painter.getFontMetrics().width(resolutionOverlayText)*params.devicePixelsPerPixel), qRound(-overlayHeight*0.5f - fontSize*scaleFactor)));
@@ -2610,6 +2634,20 @@ bool Oculars::getFlagShowCcdCropOverlay(void) const
 {
 	return flagShowCcdCropOverlay;
 }
+
+void Oculars::setFlagShowCcdCropOverlayPixelGrid(const bool b)
+{
+	flagShowCcdCropOverlayPixelGrid = b;
+	settings->setValue("ccd_crop_overlay_pixel_grid", b);
+	settings->sync();
+	emit flagShowCcdCropOverlayPixelGridChanged(b);
+}
+
+bool Oculars::getFlagShowCcdCropOverlayPixelGrid(void) const
+{
+	return flagShowCcdCropOverlayPixelGrid;
+}
+
 
 void Oculars::setFlagShowFocuserOverlay(const bool b)
 {

--- a/plugins/Oculars/src/Oculars.cpp
+++ b/plugins/Oculars/src/Oculars.cpp
@@ -1607,15 +1607,18 @@ void Oculars::paintCCDBounds()
 					painter.drawLine2d(a.x(), a.y(), b.x(), b.y());
 					
 					//Tool to show full CCD grid overlay
-					if(flagShowCcdCropOverlayPixelGrid) {
+					if(flagShowCcdCropOverlayPixelGrid)
+					{
 						//vertical lines
-						for (int l =1 ; l< actualCropOverlayX/ccd->binningX(); l++ ){
+						for (int l =1 ; l< actualCropOverlayX/ccd->binningX(); l++ )
+						{
 							a = transform.map(QPoint(static_cast<int>(overlayWidth*0.5f- l*pixelProjectedWidth), static_cast<int>(-overlayHeight*0.5f)));
 							b = transform.map(QPoint(static_cast<int>(overlayWidth*0.5f- l*pixelProjectedWidth), static_cast<int>(overlayHeight*0.5f)));
 							painter.drawLine2d(a.x(), a.y(), b.x(), b.y());
 						}
 						//horizontal lines
-						for (int l =1 ; l< actualCropOverlayY/ccd->binningY(); l++ ){
+						for (int l =1 ; l< actualCropOverlayY/ccd->binningY(); l++ )
+						{
 							a = transform.map(QPoint(static_cast<int>(-overlayWidth*0.5f), static_cast<int>(overlayHeight*0.5f - l*pixelProjectedHeight)));
 							b = transform.map(QPoint(static_cast<int>(overlayWidth*0.5f), static_cast<int>(overlayHeight*0.5f - l*pixelProjectedHeight)));
 							painter.drawLine2d(a.x(), a.y(), b.x(), b.y());

--- a/plugins/Oculars/src/Oculars.hpp
+++ b/plugins/Oculars/src/Oculars.hpp
@@ -114,6 +114,7 @@ class Oculars : public StelModule
 	Q_PROPERTY(Vec3f lineColor             READ getLineColor               WRITE setLineColor               NOTIFY textColorChanged)
 
 	Q_PROPERTY(bool flagShowCcdCropOverlay READ getFlagShowCcdCropOverlay  WRITE setFlagShowCcdCropOverlay  NOTIFY flagShowCcdCropOverlayChanged)
+	Q_PROPERTY(bool flagShowCcdCropOverlayPixelGrid READ getFlagShowCcdCropOverlayPixelGrid WRITE setFlagShowCcdCropOverlayPixelGrid NOTIFY flagShowCcdCropOverlayPixelGridChanged)
 	//Q_PROPERTY(int ccdCropOverlaySize      READ getCcdCropOverlaySize      WRITE setCcdCropOverlaySize      NOTIFY ccdCropOverlaySizeChanged)
 	Q_PROPERTY(int ccdCropOverlayHSize      READ getCcdCropOverlayHSize      WRITE setCcdCropOverlayHSize      NOTIFY ccdCropOverlayHSizeChanged)
 	Q_PROPERTY(int ccdCropOverlayVSize      READ getCcdCropOverlayVSize      WRITE setCcdCropOverlayVSize      NOTIFY ccdCropOverlayVSizeChanged)
@@ -275,6 +276,9 @@ public slots:
 	void setFlagShowCcdCropOverlay(const bool b);
 	bool getFlagShowCcdCropOverlay(void) const;
 
+	void setFlagShowCcdCropOverlayPixelGrid(const bool b);
+	bool getFlagShowCcdCropOverlayPixelGrid(void) const;
+
 	void setFlagShowContour(const bool b);
 	bool getFlagShowContour(void) const;
 
@@ -331,6 +335,7 @@ signals:
 	void flagShowCcdCropOverlayChanged(bool value);	
 	void ccdCropOverlayHSizeChanged(int value);
 	void ccdCropOverlayVSizeChanged(int value);
+	void flagShowCcdCropOverlayPixelGridChanged(bool value);
 	void flagShowContourChanged(bool value);
 	void flagShowCardinalsChanged(bool value);
 	void flagAlignCrosshairChanged(bool value);
@@ -506,6 +511,7 @@ private:
 	bool equatorialMountEnabledMain;  //!< Keep track of mount used in main program.
 	double reticleRotation;
 	bool flagShowCcdCropOverlay;  // !< Flag used to track if the ccd crop overlay should be shown.
+	bool flagShowCcdCropOverlayPixelGrid;  // !< Flag used to track if the ccd full grid overlay should be shown.
 	int ccdCropOverlayHSize;  //!< Holds the ccd crop overlay size
 	int ccdCropOverlayVSize;  //!< Holds the ccd crop overlay size
 	bool flagShowContour;

--- a/plugins/Oculars/src/gui/OcularDialog.cpp
+++ b/plugins/Oculars/src/gui/OcularDialog.cpp
@@ -309,6 +309,7 @@ void OcularDialog::createDialogContent()
 	connectBoolProperty(ui->checkBoxToolbarButton,		"Oculars.flagShowOcularsButton");
 	connectDoubleProperty(ui->arrowButtonScaleDoubleSpinBox,	"Oculars.arrowButtonScale");
 	connectBoolProperty(ui->checkBoxShowCcdCropOverlay,	"Oculars.flagShowCcdCropOverlay");
+	connectBoolProperty(ui->checkBoxShowCcdCropOverlayPixelGrid,	"Oculars.flagShowCcdCropOverlayPixelGrid");
 	connectIntProperty(ui->guiCcdCropOverlayHSizeSpinBox,	"Oculars.ccdCropOverlayHSize");
 	connectIntProperty(ui->guiCcdCropOverlayVSizeSpinBox,	"Oculars.ccdCropOverlayVSize");
 	connectBoolProperty(ui->contourCheckBox,		"Oculars.flagShowContour");

--- a/plugins/Oculars/src/gui/ocularDialog.ui
+++ b/plugins/Oculars/src/gui/ocularDialog.ui
@@ -669,6 +669,29 @@
                  </property>
                 </spacer>
                </item>
+               <item>
+                <widget class="QCheckBox" name="checkBoxShowCcdCropOverlayPixelGrid">
+                 <property name="toolTip">
+                   <string>Enable Full Grid of sensor binned pixels.</string>
+                 </property>
+                 <property name="text">
+                   <string>Show pixel grid</string>
+                 </property>
+                </widget>
+               </item>
+                <item>
+                <spacer name="horizontalSpacer_4">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
               </layout>
              </item>
              <item row="1" column="0">
@@ -681,7 +704,7 @@
              <item row="6" column="0">
               <layout class="QHBoxLayout" name="horizontalLayout_14">
                <item>
-                <spacer name="horizontalSpacer_4">
+                <spacer name="horizontalSpacer_5">
                  <property name="orientation">
                   <enum>Qt::Horizontal</enum>
                  </property>
@@ -725,7 +748,7 @@
                 </widget>
                </item>
                <item>
-                <spacer name="horizontalSpacer_5">
+                <spacer name="horizontalSpacer_6">
                  <property name="orientation">
                   <enum>Qt::Horizontal</enum>
                  </property>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
Inside Crop overlay add a new checkbox to have the full sensor grid so we can see pixel width on the image and have a fair estimate of detail. I fund my self playing with crop sizes on image to estimate what detail level i would expect from my setup. Now you can see immediately the projected pixel size, check how many pixel is the object
in the process i made a change to the crop to add an upper limit of the sensor size 
Also i have to round the crop size to be multiple of binned pixel

I have changed naming of crop size as it was using Hsize/VSize whereas sensor/binning/fov do use X/Y so i opted for X/Y naming in my variable and i can add a commit to rename all ccdCropOverlayHSize,... to ccdCropOverlayX,... (or use HSize and VSize in my variable name, what ever you prefer)

PS: i'm not used to c++/Qt and i m willing to do the commit correctly (if you find idea worthy) do not hesitate to tell me what to fix/improve

### Screenshots (if appropriate):
(new option is show pixel grid)
![image](https://user-images.githubusercontent.com/26446500/89597641-f2c6ea00-d85a-11ea-8116-85ebe70ce47c.png)
with higer resolution sensor zooming in
![image](https://user-images.githubusercontent.com/26446500/89597575-d3c85800-d85a-11ea-95a6-45a3657bfef7.png)

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] This change requires a documentation update

### How Has This Been Tested?
unit test ok
manual test on y laptop

**Test Configuration**:
* Operating system: <Linux Mint 19.2>
* Graphics Card: <Intel, kernel 5.3> 1920x1080

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
