### PR TITLE
Remove QSignalMapper

### DIFF
--- a/plugins/TelescopeControl/src/TelescopeControl.cpp
+++ b/plugins/TelescopeControl/src/TelescopeControl.cpp
@@ -189,7 +189,6 @@ void TelescopeControl::init()
 			shortcut = QString("Ctrl+Shift+Alt+%1").arg(i);
 			text = q_("Abort last slew command of telescope #%1").arg(i);
 			addAction(name, section, text, this, [=](){abortTelescopeSlew(i);}, shortcut);
-
 		}
 		connect(&StelApp::getInstance(), SIGNAL(languageChanged()), this, SLOT(translateActionDescriptions()));
 

--- a/plugins/TelescopeControl/src/TelescopeControl.cpp
+++ b/plugins/TelescopeControl/src/TelescopeControl.cpp
@@ -57,7 +57,6 @@
 #include <QString>
 #include <QStringList>
 #include <QDir>
-#include <QSignalMapper>
 
 #include <QDebug>
 
@@ -160,11 +159,6 @@ void TelescopeControl::init()
 		reticleTexture = StelApp::getInstance().getTextureManager().createTexture(":/telescopeControl/telescope_reticle.png");
 		selectionTexture = StelApp::getInstance().getTextureManager().createTexture(StelFileMgr::getInstallationDir()+"/textures/pointeur2.png");
 
-		QSignalMapper* slewObj = new QSignalMapper(this);
-		QSignalMapper* syncObj = new QSignalMapper(this);
-		QSignalMapper* slewDir = new QSignalMapper(this);
-		QSignalMapper* abortSlew = new QSignalMapper(this);
-
 		//Create telescope key bindings
 		/* StelAction-s with these key bindings existed in Stellarium prior to
 			revision 6311. Any future backports should account for that. */
@@ -176,36 +170,28 @@ void TelescopeControl::init()
 			QString shortcut = QString("Ctrl+%1").arg(i);
 			QString text;
 			text = q_("Move telescope #%1 to selected object").arg(i);
-			StelAction* actionSlewObj = addAction(name, section, text, slewObj, "map()", shortcut);
-			slewObj->setMapping(actionSlewObj, i);
+			addAction(name, section, text, this, [=](){slewTelescopeToSelectedObject(i);}, shortcut);
 
 			// "Slew to the center of the screen" commands
 			name = moveToCenterActionId.arg(i);
 			shortcut = QString("Alt+%1").arg(i);
 			text = q_("Move telescope #%1 to the point currently in the center of the screen").arg(i);
-			StelAction* actionSlewDir = addAction(name, section, text, slewDir, "map()", shortcut);
-			slewDir->setMapping(actionSlewDir, i);
+			addAction(name, section, text, this, [=](){slewTelescopeToViewDirection(i);}, shortcut);
 
 			// "Sync to object" commands
 			name = syncActionId.arg(i);
 			shortcut = QString("Ctrl+Shift+%1").arg(i);
 			text = q_("Sync telescope #%1 position to selected object").arg(i);
-			StelAction* actionSyncObj = addAction(name, section, text, syncObj, "map()", shortcut);
-			syncObj->setMapping(actionSyncObj, i);
+			addAction(name, section, text, this, [=](){syncTelescopeWithSelectedObject(i);}, shortcut);
 
 			// "Abort Slew" commands
 			name = abortSlewActionId.arg(i);
 			shortcut = QString("Ctrl+Shift+Alt+%1").arg(i);
 			text = q_("Abort last slew command of telescope #%1").arg(i);
-			StelAction* actionAbortSlew = addAction(name, section, text, abortSlew, "map()", shortcut);
-			abortSlew->setMapping(actionAbortSlew, i);
+			addAction(name, section, text, this, [=](){abortTelescopeSlew(i);}, shortcut);
+
 		}
-		connect(slewObj, SIGNAL(mapped(int)), this, SLOT(slewTelescopeToSelectedObject(int)));
-		connect(syncObj, SIGNAL(mapped(int)), this, SLOT(syncTelescopeWithSelectedObject(int)));
-		connect(slewDir, SIGNAL(mapped(int)), this, SLOT(slewTelescopeToViewDirection(int)));
-		connect(abortSlew, SIGNAL(mapped(int)), this, SLOT(abortTelescopeSlew(int)));
-		connect(&StelApp::getInstance(), SIGNAL(languageChanged()),
-				this, SLOT(translateActionDescriptions()));
+		connect(&StelApp::getInstance(), SIGNAL(languageChanged()), this, SLOT(translateActionDescriptions()));
 
 		//Create and initialize dialog windows
 		telescopeDialog = new TelescopeDialog();

--- a/src/core/StelActionMgr.cpp
+++ b/src/core/StelActionMgr.cpp
@@ -179,18 +179,6 @@ void StelAction::connectToObject(QObject* obj, const char* slot)
 	emit changed();
 }
 
-template<typename Functor>
-void StelAction::connectToObject(QObject* obj, Functor functor)
-{
-	//let Qt handle invoking the functor when the StelAction is triggered
-	int signalIndex = metaObject()->indexOfSignal("triggered()");
-	connect(this,metaObject()->method(signalIndex),obj,functor, Qt::AutoConnection);
-	//connect(this,SIGNAL(triggered()),obj,functor, Qt::AutoConnection);
-
-	emit changed();
-}
-
-
 void StelAction::propertyChanged(bool value)
 {
 	emit toggled(value);
@@ -224,18 +212,16 @@ StelAction* StelActionMgr::addAction(const QString& id, const QString& groupId, 
 	return action;
 }
 
-//template<typename Functor>
-//typename std::enable_if<!std::is_same<const char*, Functor>::value, StelAction *>::type
-//StelActionMgr::addAction(const QString& id, const QString& groupId, const QString& text,
-//			 QObject *object, Functor functor,
-//			 const QString& shortcut, const QString& altShortcut,
-//			 bool global)
-//{
-//	StelAction* action = new StelAction(id, groupId, text, shortcut, altShortcut, global);
-//	connect(action,SIGNAL(toggled(bool)),this,SLOT(onStelActionToggled(bool)));
-//	action->connectToObject(object, std::move(functor));
-//	return action;
-//}
+
+StelAction* StelActionMgr::addAction(const QString& id, const QString& groupId, const QString& text,
+				      QObject* context, std::function<void()> lambda,
+				      const QString& shortcut, const QString& altShortcut,
+				      bool global)
+{
+	StelAction* action = new StelAction(id, groupId, text, shortcut, altShortcut, global);
+	connect(action, &StelAction::triggered, context, lambda);
+	return action;
+}
 
 StelAction* StelActionMgr::findAction(const QString& id)
 {

--- a/src/core/StelActionMgr.hpp
+++ b/src/core/StelActionMgr.hpp
@@ -111,20 +111,6 @@ private:
 	//! case the action is made not checkable, or have the signature `func(bool)` and in that case the action
 	//! is made checkable.  When linked to a property the action is always made checkable.
 	void connectToObject(QObject* target, const char* slot);
-	//! Connect the action to a Lambda function
-	//! @param obj a "context object". functor will not be called if object does not exist (e.g. has been deleted).
-	//! @param functor A void Lambda function.  This can trigger actions, but the action is never checkable.
-	//!
-	template<typename Functor>
-	void connectToObject(QObject* obj, Functor functor);
-//	{
-//		//let Qt handle invoking the functor when the StelAction is triggered
-////		int signalIndex = metaObject()->indexOfSignal("triggered()");
-////		connect(this,metaObject()->method(signalIndex),obj,functor);
-//		connect(this,SIGNAL(triggered()),obj,functor, Qt::AutoConnection);
-//
-//		emit changed();
-//	}
 
 	QString group;
 	QString text;
@@ -172,32 +158,23 @@ public:
 	//! @param altShortcut Alternative shortcut
 	//! @param global determines QAction shortcut context (not necessary anymore?)
 	StelAction* addAction(const QString& id, const QString& groupId, const QString& text,
-						  QObject* target, const char* slot,
-						  const QString& shortcut="", const QString& altShortcut="",
-						  bool global=false);
+			      QObject* target, const char* slot,
+			      const QString& shortcut="", const QString& altShortcut="",
+			      bool global=false);
 
 	//! Create and add a new StelAction, connected to an object slot.
 	//! @param id Global identifier.
 	//! @param groupId Group identifier.
 	//! @param text Short human-readable description in English.
-	//! @param object a reference object. When this is deleted, the Lambda functor will not be called.
-	//! @param functor a void function (Lambda). This can call slots and other functions.
+	//! @param context a reference object. When this is deleted, the Lambda function will not be called.
+	//! @param lambda a void function (Lambda). This can call slots and other functions.
 	//! @param shortcut Default shortcut/key combination for this action
 	//! @param altShortcut Alternative shortcut
 	//! @param global determines QAction shortcut context (not necessary anymore?)
-	// N.B. This template declaration formed after Qt5.13's qmenu.h
-	template<typename Functor>
-	inline typename std::enable_if<!std::is_same<const char*, Functor>::value, StelAction *>::type
-	addAction(const QString& id, const QString& groupId, const QString& text,
-					     QObject *object, Functor functor,
-					     const QString& shortcut, const QString& altShortcut="",
-					     bool global=false)
-{
-	StelAction* action = new StelAction(id, groupId, text, shortcut, altShortcut, global);
-	connect(action,SIGNAL(toggled(bool)),this,SLOT(onStelActionToggled(bool)));
-	action->connectToObject(object, std::move(functor));
-	return action;
-}
+	StelAction* addAction(const QString& id, const QString& groupId, const QString& text,
+			      QObject* context,  std::function<void()> lambda,
+			      const QString& shortcut="", const QString& altShortcut="",
+			      bool global=false);
 
 	StelAction* findAction(const QString& id);
 	StelAction* findActionFromShortcut(const QString& shortcut);

--- a/src/core/StelActionMgr.hpp
+++ b/src/core/StelActionMgr.hpp
@@ -111,6 +111,20 @@ private:
 	//! case the action is made not checkable, or have the signature `func(bool)` and in that case the action
 	//! is made checkable.  When linked to a property the action is always made checkable.
 	void connectToObject(QObject* target, const char* slot);
+	//! Connect the action to a Lambda function
+	//! @param obj a "context object". functor will not be called if object does not exist (e.g. has been deleted).
+	//! @param functor A void Lambda function.  This can trigger actions, but the action is never checkable.
+	//!
+	template<typename Functor>
+	void connectToObject(QObject* obj, Functor functor);
+//	{
+//		//let Qt handle invoking the functor when the StelAction is triggered
+////		int signalIndex = metaObject()->indexOfSignal("triggered()");
+////		connect(this,metaObject()->method(signalIndex),obj,functor);
+//		connect(this,SIGNAL(triggered()),obj,functor, Qt::AutoConnection);
+//
+//		emit changed();
+//	}
 
 	QString group;
 	QString text;
@@ -161,6 +175,30 @@ public:
 						  QObject* target, const char* slot,
 						  const QString& shortcut="", const QString& altShortcut="",
 						  bool global=false);
+
+	//! Create and add a new StelAction, connected to an object slot.
+	//! @param id Global identifier.
+	//! @param groupId Group identifier.
+	//! @param text Short human-readable description in English.
+	//! @param object a reference object. When this is deleted, the Lambda functor will not be called.
+	//! @param functor a void function (Lambda). This can call slots and other functions.
+	//! @param shortcut Default shortcut/key combination for this action
+	//! @param altShortcut Alternative shortcut
+	//! @param global determines QAction shortcut context (not necessary anymore?)
+	// N.B. This template declaration formed after Qt5.13's qmenu.h
+	template<typename Functor>
+	inline typename std::enable_if<!std::is_same<const char*, Functor>::value, StelAction *>::type
+	addAction(const QString& id, const QString& groupId, const QString& text,
+					     QObject *object, Functor functor,
+					     const QString& shortcut, const QString& altShortcut="",
+					     bool global=false)
+{
+	StelAction* action = new StelAction(id, groupId, text, shortcut, altShortcut, global);
+	connect(action,SIGNAL(toggled(bool)),this,SLOT(onStelActionToggled(bool)));
+	action->connectToObject(object, std::move(functor));
+	return action;
+}
+
 	StelAction* findAction(const QString& id);
 	StelAction* findActionFromShortcut(const QString& shortcut);
 	bool pushKey(int key, bool global=false);

--- a/src/core/StelModule.cpp
+++ b/src/core/StelModule.cpp
@@ -44,11 +44,10 @@ class StelAction* StelModule::addAction(const QString& id, const QString& groupI
 	return mgr->addAction(id, groupId, text, target, slot, shortcut, altShortcut);
 }
 
-template<typename Functor>
  StelAction* StelModule::addAction(const QString& id, const QString& groupId, const QString& text,
-					QObject* contextObject, Functor functor,
+					QObject* contextObject, std::function<void()> lambda,
 					const QString& shortcut, const QString& altShortcut)
 {
 	StelActionMgr* mgr = StelApp::getInstance().getStelActionManager();
-	return mgr->addAction(id, groupId, text, contextObject, std::function<Functor>(functor), shortcut, altShortcut);
+	return mgr->addAction(id, groupId, text, contextObject, lambda, shortcut, altShortcut);
 }

--- a/src/core/StelModule.cpp
+++ b/src/core/StelModule.cpp
@@ -43,3 +43,12 @@ class StelAction* StelModule::addAction(const QString& id, const QString& groupI
 	StelActionMgr* mgr = StelApp::getInstance().getStelActionManager();
 	return mgr->addAction(id, groupId, text, target, slot, shortcut, altShortcut);
 }
+
+template<typename Functor>
+ StelAction* StelModule::addAction(const QString& id, const QString& groupId, const QString& text,
+					QObject* contextObject, Functor functor,
+					const QString& shortcut, const QString& altShortcut)
+{
+	StelActionMgr* mgr = StelApp::getInstance().getStelActionManager();
+	return mgr->addAction(id, groupId, text, contextObject, std::function<Functor>(functor), shortcut, altShortcut);
+}

--- a/src/core/StelModule.hpp
+++ b/src/core/StelModule.hpp
@@ -178,14 +178,13 @@ protected:
 	//! @param id unique identifier. Should be called actionMy_Action. (i.e., start with "action" and then "Capitalize_Underscore" style.)
 	//! @param groupId string to be used in the Help menu. The action will be listed in this group.
 	//! @param text short translatable description what the action does.
-	//! @param contextObject The functor will only be called if this object exists. Use "this" in most cases.
-	//! @param functor a C++11 Lambda function.
+	//! @param contextObject The lambda will only be called if this object exists. Use "this" in most cases.
+	//! @param lambda a C++11 Lambda function.
 	//! @param shortcut default shortcut. Can be reconfigured.
 	//! @param altShortcut default alternative shortcut. Can be reconfigured.
-	template<typename Functor>
 	StelAction* addAction(const QString& id, const QString& groupId, const QString& text,
-						QObject* contextObject, Functor functor,
-						const QString& shortcut, const QString& altShortcut);
+						QObject* contextObject, std::function<void()> lambda,
+						const QString& shortcut="", const QString& altShortcut="");
 
 };
 

--- a/src/core/StelModule.hpp
+++ b/src/core/StelModule.hpp
@@ -22,6 +22,7 @@
 
 #include <QString>
 #include <QObject>
+#include <functional>
 
 // Predeclaration
 class StelCore;
@@ -172,6 +173,20 @@ protected:
 	                            const QString& shortcut="", const QString& altShortcut="") {
 		return addAction(id, groupId, text, this, slot, shortcut, altShortcut);
 	}
+
+	//! convenience methods to add an action (call to Lambda functor) to the StelActionMgr object.
+	//! @param id unique identifier. Should be called actionMy_Action. (i.e., start with "action" and then "Capitalize_Underscore" style.)
+	//! @param groupId string to be used in the Help menu. The action will be listed in this group.
+	//! @param text short translatable description what the action does.
+	//! @param contextObject The functor will only be called if this object exists. Use "this" in most cases.
+	//! @param functor a C++11 Lambda function.
+	//! @param shortcut default shortcut. Can be reconfigured.
+	//! @param altShortcut default alternative shortcut. Can be reconfigured.
+	template<typename Functor>
+	StelAction* addAction(const QString& id, const QString& groupId, const QString& text,
+						QObject* contextObject, Functor functor,
+						const QString& shortcut, const QString& altShortcut);
+
 };
 
 Q_DECLARE_METATYPE(StelModule::StelModuleSelectAction)

--- a/src/core/StelModule.hpp
+++ b/src/core/StelModule.hpp
@@ -185,7 +185,6 @@ protected:
 	StelAction* addAction(const QString& id, const QString& groupId, const QString& text,
 						QObject* contextObject, std::function<void()> lambda,
 						const QString& shortcut="", const QString& altShortcut="");
-
 };
 
 Q_DECLARE_METATYPE(StelModule::StelModuleSelectAction)

--- a/src/scripting/StelScriptMgr.cpp
+++ b/src/scripting/StelScriptMgr.cpp
@@ -70,7 +70,7 @@ defined in https://www.w3.org/TR/SVG11/types.htm.
 
 QScriptValue vec3fToString(QScriptContext* context, QScriptEngine *engine)
 {
-	std::ignore = engine;
+	Q_UNUSED(engine)
 	QScriptValue that = context->thisObject();
 	QScriptValue rVal = that.property( "r", QScriptValue::ResolveLocal );
 	QScriptValue gVal = that.property( "g", QScriptValue::ResolveLocal );
@@ -81,7 +81,7 @@ QScriptValue vec3fToString(QScriptContext* context, QScriptEngine *engine)
 
 QScriptValue vec3fToHex(QScriptContext* context, QScriptEngine *engine)
 {
-	std::ignore = engine;
+	Q_UNUSED(engine)
 	QScriptValue that = context->thisObject();
 	QScriptValue rVal = that.property( "r", QScriptValue::ResolveLocal );
 	QScriptValue gVal = that.property( "g", QScriptValue::ResolveLocal );
@@ -187,7 +187,7 @@ by StelUtils::getDecAngle.
 
 QScriptValue vec3dToString(QScriptContext* context, QScriptEngine *engine)
 {
-	std::ignore = engine;
+	Q_UNUSED(engine)
 	QScriptValue that = context->thisObject();
 	QScriptValue xVal = that.property( "r", QScriptValue::ResolveLocal );
 	QScriptValue yVal = that.property( "g", QScriptValue::ResolveLocal );
@@ -198,40 +198,40 @@ QScriptValue vec3dToString(QScriptContext* context, QScriptEngine *engine)
 
 QScriptValue getX(QScriptContext* context, QScriptEngine *engine)
 {
-	std::ignore = engine;
+	Q_UNUSED(engine)
 	QScriptValue that = context->thisObject();
 	return that.property( "r", QScriptValue::ResolveLocal );
 }
 QScriptValue getY(QScriptContext* context, QScriptEngine *engine)
 {
-	std::ignore = engine;
+	Q_UNUSED(engine)
 	QScriptValue that = context->thisObject();
 	return that.property( "g", QScriptValue::ResolveLocal );
 }
 QScriptValue getZ(QScriptContext* context, QScriptEngine *engine)
 {
-	std::ignore = engine;
+	Q_UNUSED(engine)
 	QScriptValue that = context->thisObject();
 	return that.property( "b", QScriptValue::ResolveLocal );
 }
 
 QScriptValue setX(QScriptContext* context, QScriptEngine *engine)
 {
-	std::ignore = engine;
+	Q_UNUSED(engine)
 	QScriptValue that = context->thisObject();
 	that.setProperty("r", context->argument(0).toNumber());
 	return QScriptValue();
 }
 QScriptValue setY(QScriptContext* context, QScriptEngine *engine)
 {
-	std::ignore = engine;
+	Q_UNUSED(engine)
 	QScriptValue that = context->thisObject();
 	that.setProperty("g", context->argument(0).toNumber());
 	return QScriptValue();
 }
 QScriptValue setZ(QScriptContext* context, QScriptEngine *engine)
 {
-	std::ignore = engine;
+	Q_UNUSED(engine)
 	QScriptValue that = context->thisObject();
 	that.setProperty("b", context->argument(0).toNumber());
 	return QScriptValue();
@@ -368,10 +368,12 @@ void StelScriptMgr::initActions()
 	{
 		QString shortcut = getShortcut(script);
 		QString actionId = "actionScript/" + script;
-		StelAction* action = actionMgr->addAction(
-					actionId, N_("Scripts"), q_(getName(script).trimmed()), mapper, "map()", shortcut);
+		StelAction* action = actionMgr->addAction(actionId, N_("Scripts"), q_(getName(script).trimmed()), mapper, "map()", shortcut);
 		mapper->setMapping(action, script);
+		// TODO: If all goes well, this should be enough. Currently, we have an unresolved symbol
+		//actionMgr->addAction(actionId, N_("Scripts"), q_(getName(script).trimmed()), this,[=](){this->runScript(script);}, shortcut);
 	}
+	// TODO: Remove this.
 	connect(mapper, SIGNAL(mapped(QString)), this, SLOT(runScript(QString)));
 }
 
@@ -917,9 +919,8 @@ QString StelScriptMgr::lookup( int outputPos )
 
 StelScriptEngineAgent::StelScriptEngineAgent(QScriptEngine *engine) 
 	: QScriptEngineAgent(engine)
-{
-	isPaused = false;
-}
+	, isPaused(false)
+	{}
 
 void StelScriptEngineAgent::positionChange(qint64 scriptId, int lineNumber, int columnNumber)
 {

--- a/src/scripting/StelScriptMgr.cpp
+++ b/src/scripting/StelScriptMgr.cpp
@@ -324,7 +324,6 @@ void StelScriptMgr::defVecClasses(QScriptEngine *engine)
 	engine->globalObject().setProperty("Vec3d", ctorVec3d);
 }
 
-
 StelScriptMgr::StelScriptMgr(QObject *parent): QObject(parent)
 {
 	waitEventLoop = new QEventLoop();
@@ -363,20 +362,14 @@ StelScriptMgr::StelScriptMgr(QObject *parent): QObject(parent)
 void StelScriptMgr::initActions()
 {
 	StelActionMgr* actionMgr = StelApp::getInstance().getStelActionManager();
-	QSignalMapper* mapper = new QSignalMapper(this);
 	for (const auto& script : getScriptList())
 	{
 		QString shortcut = getShortcut(script);
 		QString actionId = "actionScript/" + script;
-		StelAction* action = actionMgr->addAction(actionId, N_("Scripts"), q_(getName(script).trimmed()), mapper, "map()", shortcut);
-		mapper->setMapping(action, script);
-		// TODO: If all goes well, this should be enough. Currently, we have an unresolved symbol
-		//actionMgr->addAction(actionId, N_("Scripts"), q_(getName(script).trimmed()), this,[=](){this->runScript(script);}, shortcut);
+		actionMgr->addAction(actionId, N_("Scripts"), q_(getName(script).trimmed()),
+				     this, [this, script] { runScript(script); }, shortcut);
 	}
-	// TODO: Remove this.
-	connect(mapper, SIGNAL(mapped(QString)), this, SLOT(runScript(QString)));
 }
-
 
 StelScriptMgr::~StelScriptMgr()
 {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Thanks to Guillaume to find the right syntax. This branch should now compile on all CI platforms. 

### Description
<!--- Please include a summary of the change and which issue is fixed. -->
<!--- Please also include relevant motivation and context. -->
<!--- List any dependencies that are required for this change. -->

In preparation for the upcoming Qt6 we must get rid of several obsolete classes. One is QSignalMapper, used for signal/slot connections with several senders and trivial arguments. These can be avoided by using Lambda functions. I could cleanup the Oculars plugin in https://github.com/Stellarium/stellarium/commit/eb7b297d4821cfa98356a81850883d07b39c1cc7, but further changes are more difficult.

Currently there are only 5 files affected:
- StelActionMgr.{h|cpp}
- StelModule.{h|cpp}
- StelScriptMgr.cpp

As soon as I try to use the new variant of addAction() in StelScriptMgr.cpp, I trigger link errors. Any solution to this?
The branch should be used to first solve this, and then remove the last QSignalMappers in the TelescopeControl plugin.

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system: Windows 10, Qt 5.13, MSVC2017. 

This must compile on all CI platforms, obviously. 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
