### PR TITLE
missing horizon_line_color IS drawn - in black

### DIFF
--- a/landscapes/geneva/landscape.ini
+++ b/landscapes/geneva/landscape.ini
@@ -12,7 +12,7 @@ polygonal_angle_rotatez=0.00001
 
 ; Fill color for this landscape. It gets darkened at night
 ground_color = .15,.45,.45
-; Color for the line. It will not be drawn if this is not defined. This color will not be dimmed at night.
+; Color for the line. It will be drawn in black if this is not defined. This color will not be dimmed at night.
 horizon_line_color =  .25,.15,.15
 ; specify a minimum brightness value 0..1 to have the ground always visible.
 minimal_brightness = 0.15

--- a/landscapes/zero/landscape.ini
+++ b/landscapes/zero/landscape.ini
@@ -17,7 +17,7 @@ polygonal_angle_rotatez=0.00001
 ; ground_color = .35,.95,.25
 ; dark green
 ground_color = .15,.45,.05
-; Color for the line. It will not be drawn if this is not defined. This color will not be dimmed at night.
+; Color for the line. It will be drawn in black if this is not defined. This color will not be dimmed at night.
 ; horizon_line_color =  .85,.45,.15
 ; specify a minimum brightness value 0..1 to have the ground always visible if you also select the minimal landscape brightness setting in the GUI.
 minimal_brightness = 0.15


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
Two landscape files say that the horizon line will not be drawn:
https://github.com/Stellarium/stellarium/blob/4a6bd4f0660c33f909c73ed9c7a8a91a3e1c8096/landscapes/geneva/landscape.ini#L15-L16

however, this is the result when one comments out the parameter:
(polygon line thickness exaggerated to show the result)

![image](https://user-images.githubusercontent.com/3529789/92930056-d31a7700-f441-11ea-9ef6-8713c93867a8.png)

<!--- Please also include relevant motivation and context. -->
<!--- List any dependencies that are required for this change. -->

Fixes # (issue)

### Screenshots (if appropriate):

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
tested on Stellarium 0.20.2.18226 [master]
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system: KUbuntu 20.04
* Graphics Card: <Manufacturer (likely Intel, NVidia, AMD?), Model (HD, Geforce, Radeon..., with model number), driver version?>

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
