### PR TITLE
Make Travis fail if couldn't build at all

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -479,12 +479,12 @@ before_script:
 
 script:
   - if [[ "$TRAVIS_OS_NAME" == "linux" || "$TRAVIS_OS_NAME" == "osx" ]]; then
-      cmake -DENABLE_TESTING=1 -DCMAKE_BUILD_TYPE=Debug .. ;
-      make -j5 ;
+      cmake -DENABLE_TESTING=1 -DCMAKE_BUILD_TYPE=Debug .. &&
+      make -j5 &&
       ctest --output-on-failure ;
     fi
   - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
-      cmake -DENABLE_TESTING=0 -G "$MSVCNAME" .. ;
+      cmake -DENABLE_TESTING=0 -G "$MSVCNAME" .. &&
       cmake --build . --target ALL_BUILD --config RelWithDebInfo --parallel ;
     fi
   #- ctest --output-on-failure


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Please include a summary of the change and which issue is fixed. -->
<!--- Please also include relevant motivation and context. -->
<!--- List any dependencies that are required for this change. -->

CI should fail if build was not successful.

"CMake 3.14 or higher is required.  You are running version 3.12.4" is not a successful build, but it still shows as green.

Fixes # (issue)

### Screenshots (if appropriate):

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

By adding this commit on top of failing #1295 and verifying that travis now fails more loudly

**Test Configuration**:
* Operating system: <Name, version number>
* Graphics Card: <Manufacturer (likely Intel, NVidia, AMD?), Model (HD, Geforce, Radeon..., with model number), driver version?>

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
