### PR TITLE
Provide more screen space for some elements

### DIFF
--- a/src/gui/astroCalcDialog.ui
+++ b/src/gui/astroCalcDialog.ui
@@ -294,7 +294,7 @@
         <property name="currentIndex">
          <number>0</number>
         </property>
-        <widget class="QWidget" name="stackedWidgetPage1">
+        <widget class="QWidget" name="stackedWidget_Positions">
          <layout class="QGridLayout" name="gridLayout_2">
           <item row="3" column="0">
            <layout class="QHBoxLayout" name="horizontalLayout_15">
@@ -405,7 +405,7 @@
           </item>
          </layout>
         </widget>
-        <widget class="QWidget" name="stackedWidgetPage2">
+        <widget class="QWidget" name="stackedWidget_Ephems">
          <layout class="QGridLayout" name="gridLayout_3">
           <item row="7" column="0" colspan="2">
            <widget class="QTreeWidget" name="ephemerisTreeWidget">
@@ -828,7 +828,7 @@
           </item>
          </layout>
         </widget>
-        <widget class="QWidget" name="stackedWidgetPage3">
+        <widget class="QWidget" name="stackedWidget_Transits">
          <layout class="QGridLayout" name="gridLayout_16">
           <item row="4" column="0">
            <layout class="QHBoxLayout" name="horizontalLayout_30">
@@ -990,7 +990,7 @@
           </item>
          </layout>
         </widget>
-        <widget class="QWidget" name="stackedWidgetPage4">
+        <widget class="QWidget" name="stackedWidget_Phenomena">
          <layout class="QGridLayout" name="gridLayout_4">
           <item row="1" column="1">
            <layout class="QHBoxLayout" name="horizontalLayout_7">
@@ -1225,7 +1225,7 @@
           </item>
          </layout>
         </widget>
-        <widget class="QWidget" name="stackedWidgetPage5">
+        <widget class="QWidget" name="stackedWidget_Graphs">
          <layout class="QGridLayout" name="gridLayout_5">
           <item row="2" column="0">
            <widget class="QTabWidget" name="tabWidgetGraphs">
@@ -1825,7 +1825,7 @@
           </item>
          </layout>
         </widget>
-        <widget class="QWidget" name="stackedWidgetPage6">
+        <widget class="QWidget" name="stackedWidget_WUT">
          <layout class="QGridLayout" name="gridLayout">
           <item row="1" column="1">
            <layout class="QHBoxLayout" name="horizontalLayout_13">
@@ -1841,6 +1841,12 @@
             </item>
             <item>
              <widget class="QDoubleSpinBox" name="wutMagnitudeDoubleSpinBox">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="maximumSize">
                <size>
                 <width>70</width>
@@ -1975,6 +1981,12 @@
               <property name="enabled">
                <bool>true</bool>
               </property>
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="minimumSize">
                <size>
                 <width>120</width>
@@ -1994,6 +2006,12 @@
               <property name="enabled">
                <bool>true</bool>
               </property>
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="minimumSize">
                <size>
                 <width>120</width>
@@ -2012,7 +2030,7 @@
           </item>
          </layout>
         </widget>
-        <widget class="QWidget" name="stackedWidgetPage7">
+        <widget class="QWidget" name="stackedWidget_PC">
          <layout class="QGridLayout" name="gridLayout_8">
           <item row="0" column="0">
            <layout class="QGridLayout" name="gridLayoutPCalc">

--- a/src/gui/astroCalcDialog.ui
+++ b/src/gui/astroCalcDialog.ui
@@ -1138,6 +1138,12 @@
             </item>
             <item>
              <widget class="AngleSpinBox" name="allowedSeparationSpinBox">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="minimumSize">
                <size>
                 <width>120</width>

--- a/src/gui/astroCalcDialog.ui
+++ b/src/gui/astroCalcDialog.ui
@@ -1553,22 +1553,6 @@
               <property name="bottomMargin">
                <number>4</number>
               </property>
-              <item row="0" column="0" colspan="2">
-               <widget class="QLabel" name="graphsLabel">
-                <property name="font">
-                 <font>
-                  <weight>75</weight>
-                  <bold>true</bold>
-                 </font>
-                </property>
-                <property name="text">
-                 <string>Graphs since January 1st of the current year</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignCenter</set>
-                </property>
-               </widget>
-              </item>
               <item row="2" column="1">
                <layout class="QHBoxLayout" name="horizontalLayout_23">
                 <item>
@@ -1581,7 +1565,7 @@
                 <item>
                  <widget class="QComboBox" name="graphsSecondComboBox">
                   <property name="sizePolicy">
-                   <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                   <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
                     <horstretch>0</horstretch>
                     <verstretch>0</verstretch>
                    </sizepolicy>
@@ -1621,7 +1605,7 @@
                 <item>
                  <widget class="QComboBox" name="graphsFirstComboBox">
                   <property name="sizePolicy">
-                   <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                   <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
                     <horstretch>0</horstretch>
                     <verstretch>0</verstretch>
                    </sizepolicy>
@@ -1641,27 +1625,6 @@
               </item>
               <item row="3" column="0" colspan="2">
                <layout class="QHBoxLayout" name="horizontalLayout_28">
-                <item>
-                 <layout class="QHBoxLayout" name="horizontalLayout_24">
-                  <item>
-                   <widget class="QLabel" name="graphsCelestialBodyLabel">
-                    <property name="text">
-                     <string>Celestial body:</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="QComboBox" name="graphsCelestialBodyComboBox">
-                    <property name="editable">
-                     <bool>true</bool>
-                    </property>
-                    <property name="insertPolicy">
-                     <enum>QComboBox::NoInsert</enum>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </item>
                 <item>
                  <layout class="QHBoxLayout" name="horizontalLayout_29">
                   <item>
@@ -1722,6 +1685,45 @@
                   </property>
                   <property name="text">
                    <string>Draw graphs</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </item>
+              <item row="0" column="0" colspan="2">
+               <layout class="QHBoxLayout" name="horizontalLayout_24">
+                <item>
+                 <widget class="QLabel" name="graphsCelestialBodyLabel">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="font">
+                   <font>
+                    <weight>75</weight>
+                    <bold>true</bold>
+                   </font>
+                  </property>
+                  <property name="text">
+                   <string>Graphs since January 1st of the current year for celestial body:</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QComboBox" name="graphsCelestialBodyComboBox">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="editable">
+                   <bool>true</bool>
+                  </property>
+                  <property name="insertPolicy">
+                   <enum>QComboBox::NoInsert</enum>
                   </property>
                  </widget>
                 </item>

--- a/src/gui/viewDialog.ui
+++ b/src/gui/viewDialog.ui
@@ -4338,9 +4338,15 @@
                </item>
                <item>
                 <widget class="QDoubleSpinBox" name="constellationArtBrightnessSpinBox">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
                  <property name="maximumSize">
                   <size>
-                   <width>50</width>
+                   <width>75</width>
                    <height>16777215</height>
                   </size>
                  </property>


### PR DESCRIPTION
### Description
<!--- Please include a summary of the change and which issue is fixed. -->

Changed some input width policies so that more space is used if possible.

<!--- Please also include relevant motivation and context. -->

See https://github.com/Stellarium/stellarium/issues/1249#issuecomment-708598752

<!--- List any dependencies that are required for this change. -->

Fixes #1249, #1325

### Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/3529789/96049155-e624ca80-0e77-11eb-906c-6c37cced3903.png)



![image](https://user-images.githubusercontent.com/3529789/96048980-ad84f100-0e77-11eb-930d-48300d9349f2.png)


![image](https://user-images.githubusercontent.com/3529789/96048874-83333380-0e77-11eb-8240-156a24d7a944.png)

![image](https://user-images.githubusercontent.com/3529789/96048903-8f1ef580-0e77-11eb-91a9-1e2ad1289acb.png)


### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Ran on 1920x1080

Note that I did not test this on a small screen; I assume that Qt is intelligent enough to present sufficient (but likely reduced) space to low resolution screens.

<!--- Include details of your testing environment, and the tests you ran to -->

**1920x1080**

<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system: KUbuntu 0.20.04
* Graphics Card: <Manufacturer (likely Intel, NVidia, AMD?), Model (HD, Geforce, Radeon..., with model number), driver version?>

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
