### PR TITLE
Update BUILDING.md

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -103,6 +103,27 @@ export LD_LIBRARY_PATH=$QTDIR/lib:$LD_LIBRARY_PATH
 $ brew install cmake git gettext
 $ brew link gettext --force
 ```
+
+#### OSX 11 and above
+If 
+```
+$ brew link gettext --force
+```
+
+failed due to :
+```
+Linking /usr/local/Cellar/gettext/0.21...
+Error: Could not symlink include/autosprintf.h
+/usr/local/include is not writable.
+```
+Try the following:
+
+```
+$ sudo mkdir /usr/local/include
+$ sudo chown -R $(whoami) $(brew --prefix)/*
+
+```
+
 - Install latest Qt:
 ```
 $ brew install qt


### PR DESCRIPTION
* On OSX 11.0.1 
Running : 
`brew link gettext --force
`
Results in:
```
Linking /usr/local/Cellar/gettext/0.21...
Error: Could not symlink include/autosprintf.h
/usr/local/include is not writable.
```

Which is due to change of how file system works in newer versions.

The fix is to first create the directory:
`sudo mkdir /usr/local/include`

and then obtain the permission using:
`sudo chown -R $(whoami) $(brew --prefix)/*
`
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Please include a summary of the change and which issue is fixed. -->
<!--- Please also include relevant motivation and context. -->
<!--- List any dependencies that are required for this change. -->

Fixes # (issue)

### Screenshots (if appropriate):

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### How Has This Been Tested?
Tested on OSX 11.0.1 on a fresh clone and build process of Stellarium.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
