### PR TITLE
Continuous Integration by Github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,14 +18,25 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2
 
-    - name: Make building directory
-      run: mkdir ./build && cd ./build
+    - name: Build & Test
+      uses: ashutoshvarma/action-cmake-build@master
+      with:
+        build-dir: ${{ runner.workspace }}/build
+        build-type: Debug
+        configure-options: -DENABLE_TESTING=On
+        run-test: true
+        ctest-options: --output-on-failure
+        install-build: false
+        parallel: 10
 
-    - name: Configure the project
-      run: cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_TESTING=On ${{ github.workspace }}
+#    - name: Preparation...
+#      run: mkdir ./build && cd ./build
 
-    - name: Build the project
-      run: make -j5
+#    - name: Configure the project
+#      run: cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_TESTING=On ${{ github.workspace }}
 
-    - name: Run unit tests
-      run: Xvfb :99 -ac -screen 0 1024x768x8 && sleep 3 && ctest --output-on-failure
+#    - name: Build the project
+#      run: make -j$(nproc + 1)
+
+#    - name: Run unit tests
+#      run: Xvfb :99 -ac -screen 0 1024x768x8 && sleep 3 && ctest --output-on-failure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,9 +42,11 @@ jobs:
     name: "macOS"
     runs-on: macos-latest
 
+    # @TODO Enable gpsd on macOS instance for CI testing
+    # @BODY At the moment after installing gpsd (brew install gpsd) library can be found by cmake, but not headers! Apparently we should add some magic for environment variables or something else on macOS Catalina to make headers available for cmake/make
     steps:
     - name: Install Dependencies
-      run: brew install qt gpsd
+      run: brew install qt
 
     - name: Checkout repository
       uses: actions/checkout@v2
@@ -53,8 +55,6 @@ jobs:
       shell: bash
       run: |
         export PATH="/usr/local/opt/qt/bin:$PATH"
-        export CPATH="/usr/local/include:/opt/local/include:$CPATH"
-        export LIBRARY_PATH="/usr/local/lib:/opt/local/lib:$LIBRARY_PATH"
         mkdir -p build
         cd build
         cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_TESTING=On ${{ github.workspace }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
 
     steps:
     - name: Install Dependencies
-      run: brew install -y qt gpsd cmake
+      run: brew install qt gpsd cmake
 
     - name: Set environment variables
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,6 @@ jobs:
       uses: GabrielBB/xvfb-action@v1
       with:
         working-directory: build
-#        run: make test
         run: ctest --output-on-failure
 
   ci-macos:
@@ -42,7 +41,7 @@ jobs:
 
     steps:
     - name: Install Dependencies
-      run: brew install qt gpsd
+      run: brew install qt #gpsd
 
     - name: Checkout repository
       uses: actions/checkout@v2
@@ -64,5 +63,4 @@ jobs:
       uses: GabrielBB/xvfb-action@v1
       with:
         working-directory: build
-#        run: make test
         run: ctest --output-on-failure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
 
     - name: Compile
       working-directory: build
-      run: make -j$(nproc + 1)
+      run: make -j5
 
     - name: Run unit tests
       working-directory: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,16 +18,40 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2
 
-#    - name: Build & Test
-#      uses: ashutoshvarma/action-cmake-build@master
-#      with:
-#        build-dir: ${{ runner.workspace }}/build
-#        build-type: Debug
-#        configure-options: -DENABLE_TESTING=On
-#        run-test: true
-#        ctest-options: --output-on-failure
-#        install-build: false
-#        parallel: 10
+    - name: Configure CMake
+      shell: bash
+      run: |
+        mkdir -p build
+        cd build
+        cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_TESTING=On ${{ github.workspace }}
+
+    - name: Compile
+      working-directory: build
+      run: make -j5
+
+    - name: Run unit tests
+      uses: GabrielBB/xvfb-action@v1
+      with:
+        working-directory: build
+#        run: make test
+        run: ctest --output-on-failure
+
+  ci-macos:
+    name: "macOS"
+    runs-on: macos-latest
+
+    steps:
+    - name: Install Dependencies
+      run: brew install -y qt gpsd cmake
+
+    - name: Set environment variables
+      shell: bash
+      run: |
+        export PATH="/usr/local/opt/qt/bin:$PATH"
+        export CPATH="/usr/local/include:$CPATH"
+
+    - name: Checkout repository
+      uses: actions/checkout@v2
 
     - name: Configure CMake
       shell: bash
@@ -44,5 +68,5 @@ jobs:
       uses: GabrielBB/xvfb-action@v1
       with:
         working-directory: build
-        run: make test
-#        ctest --output-on-failure;
+#        run: make test
+        run: ctest --output-on-failure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
       shell: bash
       run: |
         export PATH="/usr/local/opt/qt/bin:$PATH"
+        export CPATH="/usr/local/include:$CPATH"
         mkdir -p build
         cd build
         cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_TESTING=On ${{ github.workspace }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: "CI"
+
+on:
+  push:
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [master]
+
+jobs:
+  ci-linux:
+    name: "Linux"
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Install Dependencies
+      run: sudo apt-get install -y qtbase5-dev qtscript5-dev libqt5svg5-dev qttools5-dev-tools qttools5-dev libqt5opengl5-dev qtmultimedia5-dev libqt5multimedia5-plugins libqt5serialport5 libqt5serialport5-dev qtpositioning5-dev libgps-dev libqt5positioning5 libqt5positioning5-plugins zlib1g-dev libgl1-mesa-dev libdrm-dev xvfb cmake
+
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Make building dircetory
+      run: mkdir ${{ github.workspace }}/build && cd ${{ github.workspace }}/build
+
+    - name: Configure the project
+      run: cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_TESTING=On ..
+
+    - name: Build the project
+      run: make -j5
+
+    - name: Run unit tests
+      run: Xvfb :99 -ac -screen 0 1024x768x8 && sleep 3 && ctest --output-on-failure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,11 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2
 
-    - name: Make building dircetory
-      run: mkdir ${{ github.workspace }}/build && cd ${{ github.workspace }}/build
+    - name: Make building directory
+      run: mkdir ./build && cd ./build
 
     - name: Configure the project
-      run: cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_TESTING=On ..
+      run: cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_TESTING=On ${{ github.workspace }}
 
     - name: Build the project
       run: make -j5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,6 @@
+#
+# Implementation of Continuous Integration process for linux and macOS by Github actions
+#
 name: "CI"
 
 on:
@@ -41,7 +44,7 @@ jobs:
 
     steps:
     - name: Install Dependencies
-      run: brew install qt #gpsd
+      run: brew install qt gpsd
 
     - name: Checkout repository
       uses: actions/checkout@v2
@@ -50,7 +53,8 @@ jobs:
       shell: bash
       run: |
         export PATH="/usr/local/opt/qt/bin:$PATH"
-        export CPATH="/usr/local/include:$CPATH"
+        export CPATH="/usr/local/include:/opt/local/include:$CPATH"
+        export LIBRARY_PATH="/usr/local/lib:/opt/local/lib:$LIBRARY_PATH"
         mkdir -p build
         cd build
         cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_TESTING=On ${{ github.workspace }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
     - name: Install Dependencies
-      run: sudo apt-get install -y qtbase5-dev qtscript5-dev libqt5svg5-dev qttools5-dev-tools qttools5-dev libqt5opengl5-dev qtmultimedia5-dev libqt5multimedia5-plugins libqt5serialport5 libqt5serialport5-dev qtpositioning5-dev libgps-dev libqt5positioning5 libqt5positioning5-plugins zlib1g-dev libgl1-mesa-dev libdrm-dev xvfb cmake
+      run: sudo apt-get install -y qtbase5-dev qtscript5-dev libqt5svg5-dev qttools5-dev-tools qttools5-dev libqt5opengl5-dev qtmultimedia5-dev libqt5multimedia5-plugins libqt5serialport5 libqt5serialport5-dev qtpositioning5-dev libgps-dev libqt5positioning5 libqt5positioning5-plugins zlib1g-dev libgl1-mesa-dev libdrm-dev cmake
 
     - name: Checkout repository
       uses: actions/checkout@v2
@@ -41,10 +41,8 @@ jobs:
       run: make -j5
 
     - name: Run unit tests
-      working-directory: build
-      shell: bash
-      run: |
-        Xvfb :99 -ac -screen 0 1024x768x8
-        sleep 3
-        make test
+      uses: GabrielBB/xvfb-action@v1
+      with:
+        working-directory: build
+        run: make test
 #        ctest --output-on-failure;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,13 +42,7 @@ jobs:
 
     steps:
     - name: Install Dependencies
-      run: brew install qt gpsd cmake
-
-    - name: Set environment variables
-      shell: bash
-      run: |
-        export PATH="/usr/local/opt/qt/bin:$PATH"
-        export CPATH="/usr/local/include:$CPATH"
+      run: brew install qt gpsd
 
     - name: Checkout repository
       uses: actions/checkout@v2
@@ -56,6 +50,7 @@ jobs:
     - name: Configure CMake
       shell: bash
       run: |
+        export PATH="/usr/local/opt/qt/bin:$PATH"
         mkdir -p build
         cd build
         cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_TESTING=On ${{ github.workspace }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,25 +18,33 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2
 
-    - name: Build & Test
-      uses: ashutoshvarma/action-cmake-build@master
-      with:
-        build-dir: ${{ runner.workspace }}/build
-        build-type: Debug
-        configure-options: -DENABLE_TESTING=On
-        run-test: true
-        ctest-options: --output-on-failure
-        install-build: false
-        parallel: 10
+#    - name: Build & Test
+#      uses: ashutoshvarma/action-cmake-build@master
+#      with:
+#        build-dir: ${{ runner.workspace }}/build
+#        build-type: Debug
+#        configure-options: -DENABLE_TESTING=On
+#        run-test: true
+#        ctest-options: --output-on-failure
+#        install-build: false
+#        parallel: 10
 
-#    - name: Preparation...
-#      run: mkdir ./build && cd ./build
+    - name: Configure CMake
+      shell: bash
+      run: |
+        mkdir -p build
+        cd build
+        cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_TESTING=On ${{ github.workspace }}
 
-#    - name: Configure the project
-#      run: cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_TESTING=On ${{ github.workspace }}
+    - name: Compile
+      working-directory: build
+      run: make -j$(nproc + 1)
 
-#    - name: Build the project
-#      run: make -j$(nproc + 1)
-
-#    - name: Run unit tests
-#      run: Xvfb :99 -ac -screen 0 1024x768x8 && sleep 3 && ctest --output-on-failure
+    - name: Run unit tests
+      working-directory: build
+      shell: bash
+      run: |
+        Xvfb :99 -ac -screen 0 1024x768x8
+        sleep 3
+        make test
+#        ctest --output-on-failure;


### PR DESCRIPTION
I've added a simple implementation of Continuous Integration process for linux and macOS by Github actions, because probably we lost Travis-CI as a tool for Continuous Integration process. Of course in future we may add enhancements for this action (right now coveralls and transifex integrations are missing).