### PR TITLE
Added JPL DE430 for unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
     - name: Download JPL DE430 ephemeris
       uses: carlosperate/download-file-action@v1.0.3
       with:
-        file-url: 'http://dss.stellarium.org/de/de430/linux_p1550p2650.430'
+        file-url: 'https://github.com/Stellarium/stellarium-data/releases/download/qt-5.6/linux_p1550p2650.430'
         file-name: 'linux_p1550p2650.430'
         location: '../../../.stellarium/ephem'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Update installed packages
-      run: sudo apt update && sudo apt upgrade -y
-
     - name: Install dependencies
-      run: sudo apt install -y qtbase5-dev qtscript5-dev libqt5svg5-dev qttools5-dev-tools qttools5-dev libqt5opengl5-dev qtmultimedia5-dev libqt5multimedia5-plugins libqt5serialport5 libqt5serialport5-dev qtpositioning5-dev libgps-dev libqt5positioning5 libqt5positioning5-plugins zlib1g-dev libgl1-mesa-dev libdrm-dev cmake
+      run: |
+        sudo apt update
+        sudo apt upgrade -y
+        sudo apt install -y qtbase5-dev qtscript5-dev libqt5svg5-dev qttools5-dev-tools qttools5-dev libqt5opengl5-dev qtmultimedia5-dev libqt5multimedia5-plugins libqt5serialport5 libqt5serialport5-dev qtpositioning5-dev libgps-dev libqt5positioning5 libqt5positioning5-plugins zlib1g-dev libgl1-mesa-dev libdrm-dev cmake
 
     - name: Checkout repository
       uses: actions/checkout@v2
@@ -80,11 +80,11 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
-    - name: Update installed packages
-      run: sudo apt update && sudo apt upgrade -y
-
     - name: Install dependencies
-      run: sudo apt install -y qtbase5-dev qtscript5-dev libqt5svg5-dev qttools5-dev-tools qttools5-dev libqt5opengl5-dev qtmultimedia5-dev libqt5multimedia5-plugins libqt5serialport5 libqt5serialport5-dev qtpositioning5-dev libgps-dev libqt5positioning5 libqt5positioning5-plugins zlib1g-dev libgl1-mesa-dev libdrm-dev cmake lcov
+      run: |
+        sudo apt update
+        sudo apt upgrade -y
+        sudo apt install -y qtbase5-dev qtscript5-dev libqt5svg5-dev qttools5-dev-tools qttools5-dev libqt5opengl5-dev qtmultimedia5-dev libqt5multimedia5-plugins libqt5serialport5 libqt5serialport5-dev qtpositioning5-dev libgps-dev libqt5positioning5 libqt5positioning5-plugins zlib1g-dev libgl1-mesa-dev libdrm-dev cmake lcov
 
     - name: Checkout repository
       uses: actions/checkout@v2
@@ -92,6 +92,7 @@ jobs:
     - name: Configure CMake
       shell: bash
       run: |
+        mkdir -p ../.stellarium/ephem
         mkdir -p build
         cd build
         cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_TESTING=On ${{ github.workspace }}
@@ -100,12 +101,12 @@ jobs:
       working-directory: build
       run: make -j3
 
-#    - name: Downloads JPL DE430 ephemeris
-#      uses: carlosperate/download-file-action@v1.0.3
-#      with:
-#        file-url: 'http://dss.stellarium.org/de/de430/linux_p1550p2650.430'
-#        file-name: 'linux_p1550p2650.430'
-#        location: '~/.stellarium/ephem'
+    - name: Download JPL DE430 ephemeris
+      uses: carlosperate/download-file-action@v1.0.3
+      with:
+        file-url: 'http://dss.stellarium.org/de/de430/linux_p1550p2650.430'
+        file-name: 'linux_p1550p2650.430'
+        location: '../.stellarium/ephem'
 
     - name: Make coverage
       uses: GabrielBB/xvfb-action@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Configure CMake
       shell: bash
       run: |
-        mkdir -p ../.stellarium/ephem
+        mkdir -p ../../../.stellarium/ephem
         mkdir -p build
         cd build
         cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_TESTING=On ${{ github.workspace }}
@@ -106,7 +106,7 @@ jobs:
       with:
         file-url: 'http://dss.stellarium.org/de/de430/linux_p1550p2650.430'
         file-name: 'linux_p1550p2650.430'
-        location: '../.stellarium/ephem'
+        location: '../../../.stellarium/ephem'
 
     - name: Make coverage
       uses: GabrielBB/xvfb-action@v1


### PR DESCRIPTION
I've added new one step for CI/Coveralls action (downloading JPL DE430 ephemeris) to allow use unit tests for JPL DE430 ephemeris in additional to VSOP87 ephemeris. This step add extra 10 seconds to all time of running action (for example updating installed packages add extra 5 minutes).