### PR TITLE
Add a config option to use multisampling for rendering "Planet"s

### DIFF
--- a/guide/app_config_ini.tex
+++ b/guide/app_config_ini.tex
@@ -793,7 +793,8 @@ screen\_x        & int    & Horizontal position of the top-left corner in window
 screen\_y        & int    & Vertical   position of the top-left corner in windowed mode. Value in pixels, e.g. \emph{0}\\%\midrule
 viewport\_effect & string & This is used when the spheric mirror display mode is activated. Values include \emph{none} and \emph{sphericMirrorDistorter}.\\%\midrule
 minimum\_fps     & int    & Sets the minimum number of frames per second to display at (hardware performance permitting)\\%\midrule
-maximum\_fps     & int    & Sets the maximum number of frames per second to display at. This is useful to reduce power consumption in laptops.\\\bottomrule
+maximum\_fps     & int    & Sets the maximum number of frames per second to display at. This is useful to reduce power consumption in laptops.\\%\midrule
+multisampling    & int    & Sets the number of samples to use for multisampling antialiasing. 0 disables antialiasing, higher values increase smoothness and degrade performance. Too high a value may result in excessive blurriness of the GUI.\\\bottomrule
 \end{tabularx}
 
 \subsection{\big[viewing\big]}

--- a/src/StelMainView.cpp
+++ b/src/StelMainView.cpp
@@ -744,6 +744,8 @@ QSurfaceFormat StelMainView::getDesiredGLFormat() const
 	fmt.setDepthBufferSize(24);
 	//Stencil buffer seems necessary for GUI boxes
 	fmt.setStencilBufferSize(8);
+	if(const auto multisamplingLevel = configuration->value("video/multisampling", 0).toUInt())
+        fmt.setSamples(multisamplingLevel);
 
 #ifdef OPENGL_DEBUG_LOGGING
 	//try to enable GL debugging using GL_KHR_debug
@@ -1553,6 +1555,8 @@ void StelMainView::doScreenshot(void)
 	QOpenGLFramebufferObjectFormat fbFormat;
 	fbFormat.setAttachment(QOpenGLFramebufferObject::CombinedDepthStencil);
 	fbFormat.setInternalTextureFormat(isGLES ? GL_RGBA : GL_RGB); // try to avoid transparent background!
+	if(const auto multisamplingLevel = configuration->value("video/multisampling", 0).toUInt())
+        fbFormat.setSamples(multisamplingLevel);
 	QOpenGLFramebufferObject * fbObj = new QOpenGLFramebufferObject(imgWidth * pixelRatio, imgHeight * pixelRatio, fbFormat);
 	fbObj->bind();
 	// Now the painter has to be convinced to paint to the potentially larger image frame.

--- a/src/core/modules/Planet.cpp
+++ b/src/core/modules/Planet.cpp
@@ -254,6 +254,7 @@ Planet::Planet(const QString& englishName,
 	  hidden(hidden),
 	  atmosphere(hasAtmosphere),
 	  halo(hasHalo),
+      multisamplingEnabled_(StelApp::getInstance().getSettings()->value("video/multisampling", 0).toUInt() != 0),
 	  gl(Q_NULLPTR),
 	  iauMoonNumber(""),
 	  positionsCache(ORBIT_SEGMENTS * 2)
@@ -2620,6 +2621,11 @@ void Planet::draw3dModel(StelCore* core, StelProjector::ModelViewTranformP trans
 		transfo2->combine(Mat4d::zrotation(M_PI_180*static_cast<double>(axisRotation + 90.f)));
 		StelPainter sPainter(core->getProjection(transfo2));
 		gl = sPainter.glFuncs();
+
+        if(multisamplingEnabled_)
+            gl->glEnable(GL_MULTISAMPLE);
+        else
+            gl->glDisable(GL_MULTISAMPLE);
 		
 		// Set the main source of light to be the sun
 		Vec3d sunPos(0.);
@@ -2688,6 +2694,8 @@ void Planet::draw3dModel(StelCore* core, StelProjector::ModelViewTranformP trans
 
 
 		core->setClippingPlanes(n,f);  // Restore old clipping planes
+        if(multisamplingEnabled_)
+            gl->glDisable(GL_MULTISAMPLE);
 	}
 
 	bool allowDrawHalo = true;

--- a/src/core/modules/Planet.hpp
+++ b/src/core/modules/Planet.hpp
@@ -610,6 +610,8 @@ protected:
 	bool halo;                       // Does the planet have a halo?
 	PlanetType pType;                // Type of body
 
+    bool multisamplingEnabled_;
+
 	static ApparentMagnitudeAlgorithm vMagAlgorithm;
 
 	QOpenGLFunctions* gl;


### PR DESCRIPTION
## Description

This adds a new option, `video/multisampling`, that lets one enable multisampling antialiasing for rendering planet-like objects (`class Planet`) and specify number of samples to use.

Currently there's no GUI for this. Moreover, if one were to add a GUI control, this control should tell the user to restart Stellarium for changes to take effect, because the OpenGL format is applied at the creation of `StelGLWidget`. Implementation of it without requiring a restart would likely need quite a bit of work.

## Why would one want MSAA in Stellarium?

Just look at the following animation [no-msaa.mp4.gz](https://github.com/Stellarium/stellarium/files/5612648/no-msaa.mp4.gz). Note the borders of the Moon (the same would be with the Sun etc.): not only are they jagged, but the motion of the object makes these jaggies even more prominent and ugly. And here's what it'll look like after the patch: [with-msaa.mp4.gz](https://github.com/Stellarium/stellarium/files/5612650/with-msaa.mp4.gz).

## Some warnings for users
Be careful when choosing the value for the option. On my system with GeForce GTX 750 Ti Linux `nvidia` driver 390.116, if I set the setting to something ≤8, everything is OK. But if I try a higher value, NVidia driver appears to enable FXAA instead of (or in addition to) MSAA, which ruins sharpness of the GUI widgets and text. And that's even if the value is less than `GL_MAX_SAMPLES` (which is 32 on my system).