### PR TITLE
[style fix] QColorDialog

### DIFF
--- a/src/gui/StelDialog.cpp
+++ b/src/gui/StelDialog.cpp
@@ -345,8 +345,8 @@ void StelDialog::askColor()
 		return;
 	}
 	Vec3d vColor = StelApp::getInstance().getStelPropertyManager()->getProperty(propName)->getValue().value<Vec3f>().toVec3d();
-	QColor color = vColor.toQColor();
-	QColor c = QColorDialog::getColor(color, Q_NULLPTR, q_(static_cast<QToolButton*>(QObject::sender())->toolTip()));
+    QColor color = vColor.toQColor();
+    QColor c = QColorDialog::getColor(color, &StelMainView::getInstance() , q_(static_cast<QToolButton*>(QObject::sender())->toolTip()));
 	if (c.isValid())
 	{
 		vColor = Vec3d(c.redF(), c.greenF(), c.blueF());


### PR DESCRIPTION
fix style of QColorDialog.
Although style fixed, QColorDialog cannot be embed into MainView like other. Any way?

![image](https://user-images.githubusercontent.com/32613953/101583876-61899f00-3a17-11eb-9126-380ca4d38cd8.png)
