### PR TITLE
guide: remove duplicate line

### DIFF
--- a/guide/ch_astronomical_phenomena.tex
+++ b/guide/ch_astronomical_phenomena.tex
@@ -421,7 +421,6 @@ temperature gives a diagram called a Hertzsprung-Russell diagram
 (after the two astronomers \name[Ejnar]{Hertzsprung} (1873--1967) and 
 \name[Henry Norris]{Russell} (1877--1957) who devised it). A slight variation of this is shown
 in figure~\ref{fig:colourmag} (which is technically a colour/magnitude
-in figure~\ref{fig:colourmag} (which is technically a colour/magnitude
 plot).
 
 \begin{figure}[tp]


### PR DESCRIPTION
The user guide, chapter 18.2.4, Astronomical Phenomena, Stars,
Spectral Type & Luminosity Class, contained the following line twice:

```
in figure~\ref{fig:colourmag} (which is technically a colour/magnitude
```

This commit removes the duplicate copy.
