### PR TITLE
a few suggestions for calendar formats

### DIFF
--- a/guide/plg_calendars.tex
+++ b/guide/plg_calendars.tex
@@ -14,24 +14,24 @@
 \subsection{Introduction}
 \label{sec:plugin:Calendars:Introduction}
 
-The calendar dates in the main program behave like most other astronomical software titles:
+The calendar dates in the main program behave like most other astronomical software utilities:
 
 \begin{itemize}
 \item Dates are given in the Gregorian calendar for all dates
   beginning with October 15, 1582.
 \item All earlier dates are given in the Julian Calendar in its
   finalized form by Augustus. Historically, only dates beginning with
-  March 1st, 4 A.D. coincide with historically recorded dates: the
+  March 1st, 4 AD coincide with historically recorded dates: the
   Roman priesthood messed up the 4-year count introduced by Julius
   Caesar and counted leap years every third year. Augustus decreed to
-  omit leap days from 12 B.C. to 4~A.D to move the seasons to where
+  omit leap days from 12 BC to 4 AD to move the seasons to where
   Julius Caesar had placed them.
 \item Given the errors in the Julian calendar, simulation in early
   prehistory will provide non-intuitive calendar dates for the
   seasons' beginnings.
 \item Astronomical counting of years includes a year zero and negative
-  years. Historical calendars don't have a year zero. 1~A.D. is
-  preceded by 1~B.C. Therefore a negative year in Stellarium may look
+  years. Historical calendars don't have a year zero. 1 AD is
+  preceded by 1 BC Therefore a negative year in Stellarium may look
   uncommon to historians who may think Stellarium is one year off.
 \end{itemize}
 
@@ -43,13 +43,12 @@ presentation of calendars from the pre-computer era is still the
 monumental work by \citet{Ginzel:ChronologieI, Ginzel:ChronologieII,
   Ginzel:ChronologieIII}.  The next challenge was then to describe
 the systematic of these and make them available for computer programs.
-\citet{Reingold-Dershowitz:2018} have presented a modern masterpiece
-of this kind and are our preferred source of algorithms. This plugin
-\newFeature{v0.20.4} will evolve over the next time to bring a good
-sample.
+\citet{Reingold-Dershowitz:2018} presents a modern masterpiece
+of this kind and is our preferred source of algorithms. This plugin
+\newFeature{v0.20.4} will evolve over time to bring a good sample of these algorithms.
 
 In the configuration panel you can select which calendars you want to
-display in the lower right corner of the sceen, and can also directly
+display in the lower right corner of the screen, and also allows to directly
 interact with some of them.
 
 
@@ -58,7 +57,7 @@ The calendars displayed in this plugin come with their own logic:
 \subsection{Lunisolar European calendars}
 \begin{description}
 \item[Julian] This implementation utilizes historical year counting,
-  i.e., has no year zero. Years are marked A.D. or B.C., respectively.
+  i.e., has no year zero. Years are marked AD or BC, respectively.
 \item[Gregorian] This implementation acts like Stellarium with respect
   to year counting and counts negative and positive years, with a year
   zero between them. It shows dates in a \emph{Proleptic Gregorian}
@@ -66,21 +65,21 @@ The calendars displayed in this plugin come with their own logic:
   keep the seasons's beginnings closer to the commonly known dates, at
   least for many more centuries in the past than the Julian calendar
   commonly used by historians.
-\item[ISO Week] The International Standards Organisation describes
+\item[ISO week] The International Standards Organisation describes
   weeks in the Gregorian calendar from Monday (Day 1) to Sunday (Day
   7). Week 1 of each year contains the first Thursday of the
   year. Years may have a week 53, where the last days already belong
-  to the next Gregorian year.
+  to the next Gregorian year. See also WP\footnote{\url{https://en.wikipedia.org/wiki/ISO_week_date}}
 \item[Roman calendar] This presents the Roman way of writing calendar
-  dates in the Julian calendar and provides dates \emph{ab urbe condita} (A.U.C.).
+  dates in the Julian calendar and provides dates \emph{ab urbe condita} (AUC).
 \item[Olympic calendar] Another way to write the years in the Julian
   calendar uses the Greek Olympiads, a 4-year cycle starting in 776
-  B.C.E. The Olympic games of antiquity were held in year 1 of each cycle.
+  BC. The Olympic games of antiquity were held in year 1 of each cycle.
 \end{description}
 
 \subsection{Near Eastern calendars}
 Several calendars with 12 months of 30 days plus 5 ``epagomenae''
-days, with different calendar eras.
+days\footnote{\url{https://en.wikipedia.org/wiki/Intercalary_month_(Egypt)}}, with different calendar eras.
 \begin{description}
 \item[Egyptian]
 \item[Armenian]
@@ -99,19 +98,19 @@ days, with different calendar eras.
   so that the third number from the right (\emph{tun}) increases about
   once per year. The higher places are called \emph{katun} and
   \emph{baktun}. In December of 2012 some people were afraid that the
-  switchover from \emph{baktun} 12 to 13 (something which accurs about
-  every 400 years) would cause armageddon, just as other people prefer
+  switchover from \emph{baktun} 12 to 13 (something which occurs about
+  every 400 years) would cause Armageddon, just as other people prefer
   to be afraid of turns of centuries or millennia of the Christian
   year count.
-\item[Maya Haab] is a calendar of 18 ``months'' of 20 days each
-  (counted 1 to 20), plus 5 days (Uayeb) at the end, providing
+\item[Maya Haab\'] is a calendar of 18 ``months'' of 20 days each
+  (counted 1 to 20), plus 5 days (Uayeb or Wayeb\') at the end, providing
   ``years'' of 365 days.
-\item[Maya Tzolkin] is described as ritual calendar consisting of two
+\item[Maya Tzolkin] is described as a ritual calendar consisting of two
   cycles with 13 day numbers (1 to 13) and 20 names. Each day both
   counters are advanced. Date names repeat after 260 days. Usually
   both calendars were used to define a unique date which repeats only
   after a \emph{calendar round} of 52 years.
-\item[Aztec Xihuitl] is similar to the Maya Haab, consisting of 18
+\item[Aztec Xihuitl] is similar to the Maya Haab\', consisting of 18
   ``months'' of 20 days, plus 5 \emph{nemontemi} (worthless
   days). Days are counted from 1 to 20. The Aztecs may have used
   intercalation, but details have been lost. The correlation in use
@@ -125,18 +124,18 @@ days, with different calendar eras.
 The plugin is in an early phase of development. More calendars will be added in later versions. 
 
 
-\subsection{Configuration Options}
+\subsection{Configuration options}
 \label{sec:plugin:Calendars:configuration}
 
 The configuration dialog allows the selection of the calendars which are
-of interest to you, and also provides direct interaction with the calendars.
+of interest to you, and also provides direct interaction with some calendars.
 The Mayan and Aztec calendars allow moving to the previous or next date of that respective name. 
 
 \subsection*{Section \big[Calendars\big] in config.ini file}
 
 Apart from changing settings using the plugin configuration dialog,
 you can also edit the \file{config.ini} file to change
-settings for the Calendars plugin -- just make it carefully!
+settings for the Calendars plugin -- just make it carefully! In later iterations these settings can be made available via the configuration panel.
 
 \begin{longtable}{l|l|l}\toprule
 \emph{ID}                      &\emph{Type} & \emph{Default}  \\\midrule

--- a/plugins/Calendars/src/Calendar.hpp
+++ b/plugins/Calendars/src/Calendar.hpp
@@ -80,10 +80,10 @@ public:
 	//! get a formatted complete string for a date. The default implementation just concatenates all strings from getDateStrings() with a space in between.
 	virtual QString getFormattedDateString() const;
 
-	constexpr static const double J2000=2451545.0;
-	constexpr static const double jdEpoch=-1721424.5;
-	constexpr static const double mjdEpoch=678576.0;
-	constexpr static const int bogus=-1000000; // special value to indicate invalid result in some calendars.
+	constexpr static const double   J2000           = 2451545.0;
+	constexpr static const double   jdEpoch         = -1721424.5;
+	constexpr static const double   mjdEpoch        = 678576.0;
+	constexpr static const int      bogus           = -1000000; // special value to indicate invalid result in some calendars.
 
 	//! Interfacing function from Reingold/Dershowitz: Calendrical Calculations
 	//! Returns a "moment" in RD that represents JD.

--- a/plugins/Calendars/src/Calendar.hpp
+++ b/plugins/Calendars/src/Calendar.hpp
@@ -27,7 +27,7 @@
 //! Abstract superclass for all calendars.
 //! Stellarium uses Julian Day numbers internally, and the conventional approach of using the Gregorian calendar for dates after 1582-10-15.
 //! For dates before that, the Julian calendar is used, in the form finalized by Augustus and running unchanged since 8AD.
-//! Astronomical year counting implies having a year 0, while some calendars adhere to historical counting like 1 B.C., 1 A.D.
+//! Astronomical year counting implies having a year 0, while some calendars adhere to historical counting like 1 BC, 1 AD
 //! Some European countries, especially the Protestant countries, delayed the calendar switch well into the 18th century.
 //! Other cultures have various other calendar schemes.
 //! All calendars have a numerical vector of time elements and may have individual string lists for names of elements like "week days" and "months".

--- a/plugins/Calendars/src/Calendars.cpp
+++ b/plugins/Calendars/src/Calendars.cpp
@@ -76,7 +76,7 @@ StelPluginInfo CalendarsStelPluginInterface::getPluginInfo() const
 *************************************************************************/
 Calendars::Calendars():
 	toolbarButton(Q_NULLPTR),
-	enabled(true),
+
 	flagShowJulian(true),
 	flagShowGregorian(true),
 	flagShowISO(true),
@@ -86,12 +86,14 @@ Calendars::Calendars():
 	flagShowEgyptian(true),
 	flagShowArmenian(true),
 	flagShowZoroastrian(true),
-	flagShowChinese(true),
+	flagShowChinese(true), // ?
 	flagShowMayaLongCount(true),
 	flagShowMayaHaab(true),
 	flagShowMayaTzolkin(true),
 	flagShowAztecXihuitl(true),
-	flagShowAztecTonalpohualli(true)
+	flagShowAztecTonalpohualli(true),
+
+	enabled(true)
 {
 	setObjectName("Calendars");
 	font.setPixelSize(15);
@@ -238,6 +240,7 @@ void Calendars::draw(StelCore* core)
 	oss << "<table>";
 	// Select the drawable calendars from GUI or settings.
 	if (calendars.count()==0) return;
+
 	if (flagShowJulian)        oss << QString("<tr><td>%1</td><td>%2</td></tr>").arg(qc_("Julian",          "calendar")).arg(getCal("Julian")->getFormattedDateString());
 	if (flagShowGregorian)     oss << QString("<tr><td>%1</td><td>%2</td></tr>").arg(qc_("Gregorian",       "calendar")).arg(getCal("Gregorian")->getFormattedDateString());
 	if (flagShowISO)           oss << QString("<tr><td>%1</td><td>%2</td></tr>").arg(qc_("ISO week",        "calendar")).arg(getCal("ISO")->getFormattedDateString());
@@ -252,7 +255,9 @@ void Calendars::draw(StelCore* core)
 	if (flagShowMayaTzolkin)   oss << QString("<tr><td>%1</td><td>%2</td></tr>").arg(qc_("Maya Tzolkin",    "calendar")).arg(getCal("MayaTzolkin")->getFormattedDateString());
 	if (flagShowAztecXihuitl)  oss << QString("<tr><td>%1</td><td>%2</td></tr>").arg(qc_("Aztec Xihuitl",   "calendar")).arg(getCal("AztecXihuitl")->getFormattedDateString());
 	if (flagShowAztecTonalpohualli) oss << QString("<tr><td>%1</td><td>%2</td></tr>").arg(qc_("Aztec Tonalpohualli", "calendar")).arg(getCal("AztecTonalpohualli")->getFormattedDateString());
+
 	oss << "</table>";
+
 	Vec3f color(1);
 	if (StelApp::getInstance().getFlagOverwriteInfoColor())
 	{

--- a/plugins/Calendars/src/GregorianCalendar.cpp
+++ b/plugins/Calendars/src/GregorianCalendar.cpp
@@ -70,6 +70,7 @@ QString GregorianCalendar::getFormattedDateString() const
 {
 	QStringList str=getDateStrings();
 	// TODO: Maybe use QDate with user's localisation here? Weekday has to be taken from our results, though.
+	// see also https://en.wikipedia.org/wiki/Calendar_date#Advantages_for_ordering_in_sequence
 	return QString("%1-%2-%3 (%4, %3 %5 %1)")
 			.arg(str.at(0)) // year
 			.arg(str.at(1)) // month, numerical
@@ -77,8 +78,7 @@ QString GregorianCalendar::getFormattedDateString() const
 
 			.arg(str.at(3)) // weekday
 			.arg(monthNames.value(parts.at(1))) // month, name
-			; // put this on a separate line for flexible editing
-	// see also https://en.wikipedia.org/wiki/Calendar_date#Advantages_for_ordering_in_sequence
+			;
 }
 
 // returns true for leap years

--- a/plugins/Calendars/src/GregorianCalendar.cpp
+++ b/plugins/Calendars/src/GregorianCalendar.cpp
@@ -70,12 +70,15 @@ QString GregorianCalendar::getFormattedDateString() const
 {
 	QStringList str=getDateStrings();
 	// TODO: Maybe use QDate with user's localisation here? Weekday has to be taken from our results, though.
-	return QString("%1, %2 - %3 (%4) - %5")
-			.arg(str.at(3)) // weekday
-			.arg(str.at(2)) // day
+	return QString("%1-%2-%3 (%4, %3 %5 %1)")
+			.arg(str.at(0)) // year
 			.arg(str.at(1)) // month, numerical
+			.arg(str.at(2)) // day
+
+			.arg(str.at(3)) // weekday
 			.arg(monthNames.value(parts.at(1))) // month, name
-			.arg(str.at(0));// year
+			; // put this on a separate line for flexible editing
+	// see also https://en.wikipedia.org/wiki/Calendar_date#Advantages_for_ordering_in_sequence
 }
 
 // returns true for leap years

--- a/plugins/Calendars/src/ISOCalendar.cpp
+++ b/plugins/Calendars/src/ISOCalendar.cpp
@@ -67,7 +67,7 @@ QStringList ISOCalendar::getDateStrings() const
 	list << weekday(JD); // name of day
 
 	// https://en.wikipedia.org/wiki/ISO_week_date
-	list << QString::number(dayOfWeekFromFixed(JD) + 1); // day of week (1-7), 1= monday // XXX hackish, to check/test!
+	list << QString::number(dayOfWeekFromFixed(JD) + 1); // day of week, numerical (1-7), 1= monday // XXX hackish, to check/test!
 
 	return list;
 }
@@ -81,7 +81,7 @@ QString ISOCalendar::getFormattedDateString() const
 			//.arg(q_("Week")) // NOTE: ISO does not need translations?
 			.arg(str.at(1),2,'0') // week, numerical
 			.arg(str.at(4)) // day of week
-			.arg(str.at(3)) // weekday
+			.arg(str.at(3)) // weekday, numerical
 			;
 }
 

--- a/plugins/Calendars/src/ISOCalendar.cpp
+++ b/plugins/Calendars/src/ISOCalendar.cpp
@@ -56,29 +56,31 @@ void ISOCalendar::setDate(QVector<int> parts)
 	emit jdChanged(JD);
 }
 
-//// get a stringlist of calendar date elements sorted from the largest to the smallest.
-//// The order depends on the actual calendar
-//QStringList ISOCalendar::getDateStrings()
-//{
-//	// If we don't change this, just delete this inherited version
-//	QStringList list;
-//	list << QString::number(parts.at(0));
-//	list << QString::number(parts.at(1));
-//	list << QString::number(parts.at(2));
-//	list << weekday(JD);
-//
-//	return list;
-//}
+// get a stringlist of calendar date elements sorted from the largest to the smallest.
+// The order depends on the actual calendar
+QStringList ISOCalendar::getDateStrings() const
+{
+	QStringList list;
+	list << QString::number(parts.at(0)); // year
+	list << QString::number(parts.at(1)); // month
+	list << QString::number(parts.at(2)); // day
+	list << weekday(JD); // name of day
+
+	// https://en.wikipedia.org/wiki/ISO_week_date
+	list << QString::number(dayOfWeekFromFixed(JD) + 1); // day of week (1-7), 1= monday // XXX hackish, to check/test!
+
+	return list;
+}
 
 //! get a formatted complete string for a date
 QString ISOCalendar::getFormattedDateString() const
 {
 	QStringList str=getDateStrings();
-	return QString("%1-W%2 (%4)")
+	return QString("%1-W%2-%3 (%4)")
 			.arg(str.at(0)) // year
-			//.arg(q_("Week"))
-			.arg(str.at(1)) // week, numerical
-
+			//.arg(q_("Week")) // NOTE: ISO does not need translations?
+			.arg(str.at(1),2,'0') // week, numerical
+			.arg(str.at(4)) // day of week
 			.arg(str.at(3)) // weekday
 			;
 }
@@ -95,8 +97,8 @@ int ISOCalendar::fixedFromISO(QVector<int> iso)
 QVector<int> ISOCalendar::isoFromFixed(int rd)
 {
 	int approx = gregorianYearFromFixed(rd-3);
-	int year   = rd>=fixedFromISO({approx+1, 1, 1}) ? approx+1 : approx;
-	int week   = StelUtils::intFloorDiv(rd-fixedFromISO({year, 1, 1}), 7)+1;
+	int year   = rd >= fixedFromISO({approx+1, 1, 1}) ? approx+1 : approx;
+	int week   = StelUtils::intFloorDiv(rd-fixedFromISO({year, 1, 1}), 7) + 1;
 	int day    = StelUtils::amod(rd, 7);
 	return {year, week, day};
 }

--- a/plugins/Calendars/src/ISOCalendar.cpp
+++ b/plugins/Calendars/src/ISOCalendar.cpp
@@ -74,11 +74,13 @@ void ISOCalendar::setDate(QVector<int> parts)
 QString ISOCalendar::getFormattedDateString() const
 {
 	QStringList str=getDateStrings();
-	return QString("%1, %2 %3, %4")
-			.arg(str.at(3)) // weekday
-			.arg(q_("Week"))
+	return QString("%1-W%2 (%4)")
+			.arg(str.at(0)) // year
+			//.arg(q_("Week"))
 			.arg(str.at(1)) // week, numerical
-			.arg(str.at(0));// year
+
+			.arg(str.at(3)) // weekday
+			;
 }
 
 int ISOCalendar::fixedFromISO(QVector<int> iso)

--- a/plugins/Calendars/src/ISOCalendar.hpp
+++ b/plugins/Calendars/src/ISOCalendar.hpp
@@ -41,7 +41,7 @@ public:
 
 //	//! get a stringlist of calendar date elements sorted from the largest to the smallest.
 //	//! The order depends on the actual calendar
-//	virtual QStringList getDateStrings() Q_DECL_OVERRIDE;
+	virtual QStringList getDateStrings() const Q_DECL_OVERRIDE;
 
 	//! get a formatted complete string for a date
 	virtual QString getFormattedDateString() const Q_DECL_OVERRIDE;

--- a/plugins/Calendars/src/JulianCalendar.cpp
+++ b/plugins/Calendars/src/JulianCalendar.cpp
@@ -73,7 +73,10 @@ void JulianCalendar::setJD(double JD)
 QStringList JulianCalendar::getDateStrings() const
 {
 	QStringList list;
-	list << QString("%1 %2").arg(abs(parts.at(0))).arg(parts.at(0)>0 ? q_("A.D.") : q_("B.C."));
+	list << QString("%1 %2")
+		.arg(abs(parts.at(0)))
+		.arg(parts.at(0)>0 ? q_("AD") : q_("BC"))
+		; // AD/BC: see also https://en.wikipedia.org/wiki/Anno_Domini
 	list << QString::number(parts.at(1));
 	list << QString::number(parts.at(2));
 	list << weekday(JD);
@@ -86,12 +89,13 @@ QString JulianCalendar::getFormattedDateString() const
 {
 	QStringList str=getDateStrings();
 	// TODO: Maybe use QDate with user's localisation here? Weekday has to be taken from our results, though.
-	return QString("%1, %2 - %3 (%4) - %5")
+	return QString("%1, %2 %5 %4 (%4-%3-%2)")
 			.arg(str.at(3)) // weekday
 			.arg(str.at(2)) // day
 			.arg(str.at(1)) // month, numerical
+			.arg(str.at(0)) // year + BC/AD
 			.arg(monthNames.value(parts.at(1))) // month, name
-			.arg(str.at(0));// year
+			;
 }
 
 // set date from a vector of calendar date elements sorted from the largest to the smallest.

--- a/plugins/Calendars/src/JulianCalendar.cpp
+++ b/plugins/Calendars/src/JulianCalendar.cpp
@@ -73,10 +73,11 @@ void JulianCalendar::setJD(double JD)
 QStringList JulianCalendar::getDateStrings() const
 {
 	QStringList list;
+	// AD/BC rather than A.D./B.C.: see also https://en.wikipedia.org/wiki/Anno_Domini
 	list << QString("%1 %2")
 		.arg(abs(parts.at(0)))
 		.arg(parts.at(0)>0 ? q_("AD") : q_("BC"))
-		; // AD/BC: see also https://en.wikipedia.org/wiki/Anno_Domini
+		; 
 	list << QString::number(parts.at(1));
 	list << QString::number(parts.at(2));
 	list << weekday(JD);

--- a/plugins/Calendars/src/JulianCalendar.hpp
+++ b/plugins/Calendars/src/JulianCalendar.hpp
@@ -25,7 +25,7 @@
 //! For dates before that, the Julian calendar is used, in the form finalized by Augustus and running unchanged since 8AD.
 //! Some European countries, especially the Protestant countries, delayed the calendar switch well into the 18th century.
 //! @note The implementation does not correctly represent the Roman Julian calendar valid from introduction by Julius Caesar to the reform by Augustus.
-//! @note this implementation adheres to Calendrical Calculation's style of omitting a year zero. Negative years represent years B.C.E.
+//! @note this implementation adheres to Calendrical Calculation's style of omitting a year zero. Negative years represent years BC.
 //!       This is very much in contrast to Stellarium's usual behaviour, and also different from a year zero in CC's implementation of the Gregorian calendar.
 
 class JulianCalendar : public Calendar

--- a/plugins/Calendars/src/OlympicCalendar.cpp
+++ b/plugins/Calendars/src/OlympicCalendar.cpp
@@ -58,7 +58,7 @@ QStringList OlympicCalendar::getDateStrings() const
 QString OlympicCalendar::getFormattedDateString() const
 {
 	QStringList str=getDateStrings();
-	return QString(q_("Day %1, month %2 in the year %3 of the %4th Olympiad"))
+	return QString(q_("Day %1, month %2, year %3 of the %4th Olympiad"))
 			.arg(str.at(3)) // day
 			.arg(str.at(2)) // month, numerical
 			.arg(str.at(1)) // year

--- a/plugins/Calendars/src/RomanCalendar.cpp
+++ b/plugins/Calendars/src/RomanCalendar.cpp
@@ -98,7 +98,7 @@ QString RomanCalendar::getFormattedDateString() const
 			.arg(str.at(3))
 			.arg(str.at(2))
 			.arg(str.at(0))
-			.arg(qc_("A.U.C.", "ab urbe condita"));// year AUC
+			.arg(qc_("AUC", "ab urbe condita"));// year AUC
 }
 
 // set date from a vector of calendar date elements sorted from the largest to the smallest.

--- a/plugins/Calendars/src/gui/calendarsDialog.ui
+++ b/plugins/Calendars/src/gui/calendarsDialog.ui
@@ -441,7 +441,7 @@
          <item row="1" column="1">
           <widget class="QSpinBox" name="julianYearSpinBox">
            <property name="toolTip">
-            <string>Negative years here mark years B.C.</string>
+            <string>Negative years here mark years BC</string>
            </property>
            <property name="minimum">
             <number>-100000</number>


### PR DESCRIPTION
Suggestions for improvements

![image](https://user-images.githubusercontent.com/3529789/102724522-62240e80-4310-11eb-8a15-831b665ca993.png)

- follow ISO format more closely
- try to use less confusing formats, pending better proposals and maye use of locale (see https://en.wikipedia.org/wiki/Calendar_date#Advantages_for_ordering_in_sequence)

(Julian: I suspect that AD/BC needs to be separated fro the year number; also, avoid dots in the abreviation).