### PR TITLE
Better looking faint stars

### DIFF
--- a/src/core/StelSkyDrawer.cpp
+++ b/src/core/StelSkyDrawer.cpp
@@ -348,16 +348,17 @@ bool StelSkyDrawer::computeRCMag(float mag, RCMag* rcMag) const
 	}
 
 	// if size of star is too small (blink) we put its size to 1.2 --> no more blink
+	// Atque 2020-02-14: Attempting to make the faint stars being drawn more realistically...
 	// And we compensate the difference of brighteness with cmag
-	if (rcMag->radius<1.2f)
+	if (rcMag->radius<2.0f)
 	{
-		rcMag->luminance= rcMag->radius * rcMag->radius * rcMag->radius / 1.728f;
-		if (rcMag->luminance < 0.05f)
+		rcMag->luminance= rcMag->radius * rcMag->radius * rcMag->radius / 1.5f;
+		if (rcMag->luminance < 0.01f)
 		{
 			rcMag->radius = rcMag->luminance = 0.f;
 			return false;
 		}
-		rcMag->radius = 1.2f;
+		rcMag->radius = 2.0f;
 	}
 	else
 	{


### PR DESCRIPTION
### Description
This is a small tweak to some values in StelSkyDrawer.cpp, to help draw faint stars a little more realistically. In reality, faint stars are not just smaller but also fainter. Stellarium seems to just draw them smaller.


### Screenshots:
![stellarium-065](https://user-images.githubusercontent.com/37028368/107872800-31de9380-6ead-11eb-8f66-88a1f7e58732.png)


### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### How Has This Been Tested?
Tested on a 1920 x 1080 screen and looks fine.

**Test Configuration**:
* Operating system: Irrelevant
* Graphics Card: (probably) Irrelevant

## Checklist:
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
