### PR TITLE
Fix ZL being killed by LP even at low Bortle values (fix #1489)

### DIFF
--- a/src/core/modules/ZodiacalLight.cpp
+++ b/src/core/modules/ZodiacalLight.cpp
@@ -250,7 +250,7 @@ void ZodiacalLight::draw(StelCore* core)
 
 			float oneMag=0.0f;
 			extinction.forward(vertAltAz, &oneMag);
-			float extinctionFactor=std::pow(0.4f , oneMag) * (1.1f-bortleIntensity*0.1f);// Drop of one magnitude: factor 2.5 or 40%, and further reduced by light pollutton.
+			float extinctionFactor=std::pow(0.4f , oneMag) * (1.1f-bortleIntensity*0.1f);// Drop of one magnitude: factor 2.5 or 40%, and further reduced by light pollution.
 			Vec3f thisColor=Vec3f(c[0]*extinctionFactor, c[1]*extinctionFactor, c[2]*extinctionFactor);
 			vertexArray->colors.append(thisColor);
 		}

--- a/src/core/modules/ZodiacalLight.cpp
+++ b/src/core/modules/ZodiacalLight.cpp
@@ -250,7 +250,8 @@ void ZodiacalLight::draw(StelCore* core)
 
 			float oneMag=0.0f;
 			extinction.forward(vertAltAz, &oneMag);
-			float extinctionFactor=std::pow(0.4f , oneMag)/bortleIntensity; // drop of one magnitude: factor 2.5 or 40%, and further reduced by light pollution
+                        float extinctionFactor=std::pow(0.4f , oneMag); // drop of one magnitude: factor 2.5 or 40%, and further reduced by light pollution
+                        //Atque 2021-02-17: It seems the division by bortleIntensity caused the ZL to be completely killed by LP, which is unrealistic.
 			Vec3f thisColor=Vec3f(c[0]*extinctionFactor, c[1]*extinctionFactor, c[2]*extinctionFactor);
 			vertexArray->colors.append(thisColor);
 		}

--- a/src/core/modules/ZodiacalLight.cpp
+++ b/src/core/modules/ZodiacalLight.cpp
@@ -250,8 +250,7 @@ void ZodiacalLight::draw(StelCore* core)
 
 			float oneMag=0.0f;
 			extinction.forward(vertAltAz, &oneMag);
-			float extinctionFactor=std::pow(0.4f , oneMag) * (1.1f-bortleIntensity*0.1f);// Drop of one magnitude: factor 2.5 or 40%, and further reduced by light pollution.
-			//float extinctionFactor=std::pow(0.4f , oneMag)/bortleIntensity; // Atque 2021-02-22: This makes the ZL invisible with the slightest LP.
+			float extinctionFactor=std::pow(0.4f , oneMag) * (1.1f-bortleIntensity*0.1f);// Drop of one magnitude: factor 2.5 or 40%, and further reduced by light pollutton.
 			Vec3f thisColor=Vec3f(c[0]*extinctionFactor, c[1]*extinctionFactor, c[2]*extinctionFactor);
 			vertexArray->colors.append(thisColor);
 		}

--- a/src/core/modules/ZodiacalLight.cpp
+++ b/src/core/modules/ZodiacalLight.cpp
@@ -250,8 +250,8 @@ void ZodiacalLight::draw(StelCore* core)
 
 			float oneMag=0.0f;
 			extinction.forward(vertAltAz, &oneMag);
-                        float extinctionFactor=std::pow(0.4f , oneMag); // drop of one magnitude: factor 2.5 or 40%, and further reduced by light pollution
-                        //Atque 2021-02-17: It seems the division by bortleIntensity caused the ZL to be completely killed by LP, which is unrealistic.
+			float extinctionFactor=std::pow(0.4f , oneMag) * (1.1f-bortleIntensity*0.1f);// Drop of one magnitude: factor 2.5 or 40%, and further reduced by light pollution.
+			//float extinctionFactor=std::pow(0.4f , oneMag)/bortleIntensity; // Atque 2021-02-22: This makes the ZL invisible with the slightest LP.
 			Vec3f thisColor=Vec3f(c[0]*extinctionFactor, c[1]*extinctionFactor, c[2]*extinctionFactor);
 			vertexArray->colors.append(thisColor);
 		}


### PR DESCRIPTION
### Description
Currently, the light pollution almost completely hides the zodiacal light. This brings a better balance, so that users can use Bortle 2 and 3 skies, and still see some ZL without having to adjust it to crazy values (ZLi intensity = 5 or something).

Fixes #1489

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

**Test Configuration**:
Totally irrelevant.

**Please try it and see if you agree with my findings.**

## Checklist:
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
