### PR TITLE
Make the subcardinal labels smaller

### DIFF
--- a/src/core/modules/LandscapeMgr.cpp
+++ b/src/core/modules/LandscapeMgr.cpp
@@ -88,7 +88,7 @@ Cardinals::Cardinals(float _radius)
 	// Default font size is 24
 	fontC.setPixelSize(conf->value("viewing/cardinal_font_size", screenFontSize+11).toInt());
 	// Default font size is 18
-	fontSC.setPixelSize(conf->value("viewing/subcardinal_font_size", screenFontSize+6).toInt());
+        fontSC.setPixelSize(conf->value("viewing/subcardinal_font_size", screenFontSize+5).toInt());
 	// Draw the sub-subcardinal points even smaller.
 	fontSSC.setPixelSize(conf->value("viewing/subsubcardinal_font_size", screenFontSize+2).toInt());
 	propMgr = StelApp::getInstance().getStelPropertyManager();


### PR DESCRIPTION
### Description
This minor tweak makes the subcardinal (NE, NW etc) labels a bit smaller, which make them stand out more compared to cardinal (N, S) and sub-subcardinal (NNE, NNW) labels. Only one value has changed, from 6 to 5. I believe 5 was the value before my last PR, so really, we're only returning to old values here.

### Screenshot
![stellarium-075](https://user-images.githubusercontent.com/37028368/109390749-b00e5180-7913-11eb-8c63-11000b7c28ae.png)


### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update


## Checklist:
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
