### PR TITLE
core/StelTexture: read image backwards, dont flip

### DIFF
--- a/src/core/StelTexture.cpp
+++ b/src/core/StelTexture.cpp
@@ -300,19 +300,10 @@ QByteArray StelTexture::convertToGLFormat(const QImage& image, GLint *format, GL
 	ret.reserve(width * height * bpp);
 	QImage tmp = image.convertToFormat(QImage::Format_ARGB32);
 
-	// flips bits over y
-	int ipl = tmp.bytesPerLine() / 4;
-	for (int y = 0; y < height / 2; ++y)
-	{
-		int *a = reinterpret_cast<int *>(tmp.scanLine(y));
-		int *b = reinterpret_cast<int *>(tmp.scanLine(height - y - 1));
-		for (int x = 0; x < ipl; ++x)
-			qSwap(a[x], b[x]);
-	}
-
 	// convert data
 	// we always use a tightly packed format, with 1-4 bpp
-	for (int i = 0; i < height; ++i)
+	// the image should be flipped over y, so read it backwards from the end
+	for (int i = height - 1; i >= 0; --i)
 	{
 		uint *p = reinterpret_cast<uint *>( tmp.scanLine(i));
 		for (int x = 0; x < width; ++x)


### PR DESCRIPTION
When loading images, instead of flipping the images upside down then converting then, just read them backwards.

### Description
I was profiling Stellarium and found that the image load flips the image upside down then loads it. Instead of flipping it, just read it backwards. There's no perceptible change in loading speed on my system since I suspect it's IO bound anyway, but the new code is simpler.

No dependency changes.

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### How Has This Been Tested?
I first removed the code to flip the image and ran stellarium to ensure it resulted in the images being upside down. I then switched the code to load backward and confirmed they were back to being right side up.

Ran all the automated tested as well (e.g. `make test`).

I don't think this change affects other areas of the code.

**Test Configuration**:
* Operating system: Arch Linux (up to date as of today) with wayland
* Graphics Card: Intel, Model (HD Graphics 530), i915

## Checklist:
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] (N/A) I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
     **I'm not sure what this should look like or where it should live. I'm happy to add a test, just let me know where it should live/what it should test.**
- [x] New and existing unit tests pass locally with my changes
- [x] (N/A) Any dependent changes have been merged and published in downstream modules
