### PR TITLE
angle measure plugin: user option for measurement to follow the cursor

### DIFF
--- a/guide/plg_interfaces.tex
+++ b/guide/plg_interfaces.tex
@@ -42,8 +42,8 @@ angular distance between two points on the sky.
   \key{\ctrl+A}. A message will appear at the bottom of the screen to
   tell you that the tool is active.
 \item Drag a line from the first point to the second point using the
-  left mouse button
-\item To clear the measurement, click the right mouse button
+  left mouse button.
+\item To measure to a different endpoint, click the right mouse button.
 \item To deactivate the angle measure tool, press the tool-bar button
   again, or press \key{\ctrl+A} on the keyboard.
 \end{enumerate}
@@ -52,6 +52,7 @@ angular distance between two points on the sky.
 distances given on the rotating sphere, or in horizontal
 (alt-azimuthal) coordinates. You can also link one point to the
 resting horizon, the other to the sky and observe how angles change.
+You can choose where to display the measurement.
 
 \newpage
 \section{Equation of Time Plugin}

--- a/plugins/AngleMeasure/src/AngleMeasure.cpp
+++ b/plugins/AngleMeasure/src/AngleMeasure.cpp
@@ -68,6 +68,7 @@ AngleMeasure::AngleMeasure()
 	, withDecimalDegree(false)
 	, dragging(false)
 	, angleEquatorial(0.)
+	, flagFollowCursor(false)
 	, flagUseDmsFormat(false)
 	, flagShowEquatorial(false)
 	, flagShowHorizontal(false)
@@ -84,6 +85,7 @@ AngleMeasure::AngleMeasure()
 	perp1EndPoint.set(0.,0.,0.);
 	perp2StartPoint.set(0.,0.,0.);
 	perp2EndPoint.set(0.,0.,0.);
+
 	startPointHor.set(0.,0.,0.);
 	endPointHor.set(0.,0.,0.);
 	perp1StartPointHor.set(0.,0.,0.);
@@ -163,6 +165,7 @@ void AngleMeasure::init()
 	}
 }
 
+// handle time updates
 void AngleMeasure::update(double deltaTime)
 {
 	messageFader.update(static_cast<int>(deltaTime*1000));
@@ -193,11 +196,11 @@ void AngleMeasure::drawOne(StelCore *core, const StelCore::FrameType frameType, 
 
 	if (lineVisible.getInterstate() > 0.000001f)
 	{
-		Vec3d xy;
+		Vec3d xy; // plot position of data text block
 		QString displayedText;
 		if (frameType==StelCore::FrameEquinoxEqu)
 		{
-			if (prj->project(perp1EndPoint,xy))
+			if (prj->project(flagFollowCursor ? perp2StartPoint : perp1EndPoint ,xy))
 			{
 				painter.setColor(txtColor, lineVisible.getInterstate());
 				if (flagShowEquatorialPA)
@@ -209,7 +212,7 @@ void AngleMeasure::drawOne(StelCore *core, const StelCore::FrameType frameType, 
 		}
 		else
 		{
-			if (prj->project(perp1EndPointHor,xy))
+			if (prj->project(flagFollowCursor ? perp2StartPointHor : perp1EndPointHor, xy))
 			{
 				painter.setColor(txtColor, lineVisible.getInterstate());
 				if (flagShowHorizontalPA)
@@ -245,6 +248,7 @@ void AngleMeasure::drawOne(StelCore *core, const StelCore::FrameType frameType, 
 	}
 	if (messageFader.getInterstate() > 0.000001f)
 	{
+		// text block (bottom left)
 		painter.setColor(txtColor[0], txtColor[1], txtColor[2], messageFader.getInterstate());
 		int x = 83;
 		int y = 120;
@@ -481,6 +485,7 @@ void AngleMeasure::showHorizontalPA(bool b)
 	conf->setValue("AngleMeasure/show_position_angle_horizontal", flagShowHorizontalPA);
 	emit flagShowHorizontalPAChanged(b);
 }
+
 void AngleMeasure::showEquatorial(bool b)
 {
 	flagShowEquatorial = b;
@@ -488,6 +493,7 @@ void AngleMeasure::showEquatorial(bool b)
 	conf->setValue("AngleMeasure/show_equatorial", flagShowEquatorial);
 	emit flagShowEquatorialChanged(b);
 }
+
 void AngleMeasure::showHorizontal(bool b)
 {
 	flagShowHorizontal = b;
@@ -495,6 +501,7 @@ void AngleMeasure::showHorizontal(bool b)
 	conf->setValue("AngleMeasure/show_horizontal", flagShowHorizontal);
 	emit flagShowHorizontalChanged(b);
 }
+
 void AngleMeasure::showHorizontalStartSkylinked(bool b)
 {
 	flagShowHorizontalStartSkylinked = b;
@@ -502,6 +509,7 @@ void AngleMeasure::showHorizontalStartSkylinked(bool b)
 	conf->setValue("AngleMeasure/link_horizontal_start_to_sky", flagShowHorizontalStartSkylinked);
 	emit flagShowHorizontalStartSkylinkedChanged(b);
 }
+
 void AngleMeasure::showHorizontalEndSkylinked(bool b)
 {
 	flagShowHorizontalEndSkylinked = b;
@@ -509,6 +517,15 @@ void AngleMeasure::showHorizontalEndSkylinked(bool b)
 	conf->setValue("AngleMeasure/link_horizontal_end_to_sky", flagShowHorizontalEndSkylinked);
 	emit flagShowHorizontalEndSkylinkedChanged(b);
 }
+
+void AngleMeasure::followCursor(bool b)
+{
+	flagFollowCursor=b;
+	// persistent
+	conf->setValue("AngleMeasure/follow_cursor", flagFollowCursor);
+	emit flagFollowCursorChanged(b);
+}
+
 void AngleMeasure::useDmsFormat(bool b)
 {
 	flagUseDmsFormat=b;
@@ -526,6 +543,7 @@ void AngleMeasure::setEquatorialTextColor(Vec3f color)
 		emit equatorialTextColorChanged(color);
 	}
 }
+
 void AngleMeasure::setEquatorialLineColor(Vec3f color)
 {
 	if (equatorialLineColor != color)
@@ -535,6 +553,7 @@ void AngleMeasure::setEquatorialLineColor(Vec3f color)
 		emit equatorialLineColorChanged(color);
 	}
 }
+
 void AngleMeasure::setHorizontalTextColor(Vec3f color)
 {
 	if (horizontalTextColor != color)
@@ -544,6 +563,7 @@ void AngleMeasure::setHorizontalTextColor(Vec3f color)
 		emit horizontalTextColorChanged(color);
 	}
 }
+
 void AngleMeasure::setHorizontalLineColor(Vec3f color)
 {
 	if (horizontalLineColor != color)
@@ -590,6 +610,7 @@ void AngleMeasure::restoreDefaultSettings()
 
 void AngleMeasure::loadSettings()
 {
+	followCursor(conf->value("AngleMeasure/follow_cursor", false).toBool());
 	useDmsFormat(conf->value("AngleMeasure/angle_format_dms", false).toBool());
 	equatorialTextColor = Vec3f(conf->value("AngleMeasure/text_color", "0,0.5,1").toString());
 	equatorialLineColor = Vec3f(conf->value("AngleMeasure/line_color", "0,0.5,1").toString());
@@ -602,3 +623,4 @@ void AngleMeasure::loadSettings()
 	showHorizontalStartSkylinked(conf->value("AngleMeasure/link_horizontal_start_to_sky", false).toBool());
 	showHorizontalEndSkylinked(conf->value("AngleMeasure/link_horizontal_end_to_sky", false).toBool());
 }
+

--- a/plugins/AngleMeasure/src/AngleMeasure.cpp
+++ b/plugins/AngleMeasure/src/AngleMeasure.cpp
@@ -623,4 +623,3 @@ void AngleMeasure::loadSettings()
 	showHorizontalStartSkylinked(conf->value("AngleMeasure/link_horizontal_start_to_sky", false).toBool());
 	showHorizontalEndSkylinked(conf->value("AngleMeasure/link_horizontal_end_to_sky", false).toBool());
 }
-

--- a/plugins/AngleMeasure/src/AngleMeasure.hpp
+++ b/plugins/AngleMeasure/src/AngleMeasure.hpp
@@ -179,7 +179,7 @@ private:
 	Vec3d perp2StartPoint;
 	Vec3d perp2EndPoint;
 	double angleEquatorial;
-	bool flagFollowCursor;
+	bool flagFollowCursor;	//!< measurement data block follows cursor rather than start of measurement line
 	bool flagUseDmsFormat;
 	bool flagShowEquatorial;
 	bool flagShowHorizontal;

--- a/plugins/AngleMeasure/src/AngleMeasure.hpp
+++ b/plugins/AngleMeasure/src/AngleMeasure.hpp
@@ -72,6 +72,7 @@ class AngleMeasure : public StelModule
 {
 	Q_OBJECT
 	Q_PROPERTY(bool enabled                          READ isEnabled                  WRITE enableAngleMeasure           NOTIFY flagAngleMeasureChanged)
+	Q_PROPERTY(bool flagFollowCursor                 READ isFollowCursor             WRITE followCursor                 NOTIFY flagFollowCursorChanged )
 	Q_PROPERTY(bool dmsFormat                        READ isDmsFormat                WRITE useDmsFormat                 NOTIFY dmsFormatChanged )
 	Q_PROPERTY(bool flagShowEquatorial               READ isEquatorial               WRITE showEquatorial               NOTIFY flagShowEquatorialChanged )
 	Q_PROPERTY(bool flagShowHorizontal               READ isHorizontal               WRITE showHorizontal               NOTIFY flagShowHorizontalChanged )
@@ -113,6 +114,7 @@ public:
 
 signals:
 	void flagAngleMeasureChanged(bool b);
+	void flagFollowCursorChanged(bool b);
 	void dmsFormatChanged(bool b);
 	void flagShowEquatorialChanged(bool b);
 	void flagShowHorizontalChanged(bool b);
@@ -127,6 +129,7 @@ signals:
 
 public slots:
 	bool isEnabled() const    { return flagShowAngleMeasure; }
+	bool isFollowCursor() const  { return flagFollowCursor; }
 	bool isDmsFormat() const  { return flagUseDmsFormat; }
 	bool isEquatorial() const { return flagShowEquatorial; }
 	bool isHorizontal() const { return flagShowHorizontal; }
@@ -140,6 +143,7 @@ public slots:
 	Vec3f getHorizontalLineColor() const { return horizontalLineColor; }
 
 	void enableAngleMeasure(bool b);
+	void followCursor(bool b);
 	void useDmsFormat(bool b);      //!< Use d/m/s instead of degree/minute/second symbols.
 	void showEquatorialPA(bool b);
 	void showHorizontalPA(bool b);
@@ -175,6 +179,7 @@ private:
 	Vec3d perp2StartPoint;
 	Vec3d perp2EndPoint;
 	double angleEquatorial;
+	bool flagFollowCursor;
 	bool flagUseDmsFormat;
 	bool flagShowEquatorial;
 	bool flagShowHorizontal;
@@ -202,6 +207,9 @@ private:
 	//! @arg angle in radians
 	QString formatAngleString(double angle) const;
 	QString calculatePositionAngle(const Vec3d p1, const Vec3d p2) const;
+
+	//! draw for one set of coordinate system
+	//! @arg FrameType specifies the coordinate system
 	void drawOne(StelCore *core, const StelCore::FrameType frameType, const StelCore::RefractionMode refractionMode, const Vec3f txtColor, const Vec3f lineColor);
 
 	QSettings* conf;

--- a/plugins/AngleMeasure/src/gui/AngleMeasureDialog.cpp
+++ b/plugins/AngleMeasure/src/gui/AngleMeasureDialog.cpp
@@ -60,17 +60,19 @@ void AngleMeasureDialog::createDialogContent()
 	connect(ui->closeStelWindow, SIGNAL(clicked()), this, SLOT(close()));
 	connect(ui->TitleBar, SIGNAL(movedTo(QPoint)), this, SLOT(handleMovedTo(QPoint)));
 
-	connectBoolProperty(ui->useDmsFormatCheckBox, "AngleMeasure.dmsFormat");
-	connectBoolProperty(ui->showPositionAngleCheckBox, "AngleMeasure.flagShowEquatorialPA");
-	connectBoolProperty(ui->showPositionAngleHorizontalCheckBox, "AngleMeasure.flagShowHorizontalPA");
-	connectBoolProperty(ui->showEquatorial_GroupBox, "AngleMeasure.flagShowEquatorial");
-	connectBoolProperty(ui->showHorizontal_GroupBox, "AngleMeasure.flagShowHorizontal");
-	connectBoolProperty(ui->azAltStartOnSkyCheckBox, "AngleMeasure.flagShowHorizontalStartSkylinked");
-	connectBoolProperty(ui->azAltEndOnSkyCheckBox,   "AngleMeasure.flagShowHorizontalEndSkylinked");
-	connectColorButton(ui->equatorialLineColorToolButton, "AngleMeasure.equatorialLineColor", "AngleMeasure/line_color");
-	connectColorButton(ui->equatorialTextColorToolButton, "AngleMeasure.equatorialTextColor", "AngleMeasure/text_color");
-	connectColorButton(ui->horizontalLineColorToolButton, "AngleMeasure.horizontalLineColor", "AngleMeasure/line_color_horizontal");
-	connectColorButton(ui->horizontalTextColorToolButton, "AngleMeasure.horizontalTextColor", "AngleMeasure/text_color_horizontal");
+	connectBoolProperty(ui->followCursorCheckBox, 			"AngleMeasure.flagFollowCursor");
+	connectBoolProperty(ui->useDmsFormatCheckBox, 			"AngleMeasure.dmsFormat");
+	connectBoolProperty(ui->showPositionAngleCheckBox, 		"AngleMeasure.flagShowEquatorialPA");
+	connectBoolProperty(ui->showPositionAngleHorizontalCheckBox,	"AngleMeasure.flagShowHorizontalPA");
+	connectBoolProperty(ui->showEquatorial_GroupBox,		"AngleMeasure.flagShowEquatorial");
+	connectBoolProperty(ui->showHorizontal_GroupBox,		"AngleMeasure.flagShowHorizontal");
+	connectBoolProperty(ui->azAltStartOnSkyCheckBox,		"AngleMeasure.flagShowHorizontalStartSkylinked");
+	connectBoolProperty(ui->azAltEndOnSkyCheckBox,			"AngleMeasure.flagShowHorizontalEndSkylinked");
+
+	connectColorButton(ui->equatorialLineColorToolButton,	"AngleMeasure.equatorialLineColor", "AngleMeasure/line_color");
+	connectColorButton(ui->equatorialTextColorToolButton,	"AngleMeasure.equatorialTextColor", "AngleMeasure/text_color");
+	connectColorButton(ui->horizontalLineColorToolButton,	"AngleMeasure.horizontalLineColor", "AngleMeasure/line_color_horizontal");
+	connectColorButton(ui->horizontalTextColorToolButton,	"AngleMeasure.horizontalTextColor", "AngleMeasure/text_color_horizontal");
 
 	connect(ui->restoreDefaultsButton, SIGNAL(clicked()), this, SLOT(restoreDefaults()));
 

--- a/plugins/AngleMeasure/src/gui/angleMeasureDialog.ui
+++ b/plugins/AngleMeasure/src/gui/angleMeasureDialog.ui
@@ -354,9 +354,9 @@
         </widget>
        </item>
        <item>
-        <widget class="QGroupBox" name="formatBox">
+        <widget class="QGroupBox" name="optionsBox">
          <property name="title">
-          <string>Format</string>
+          <string>Options</string>
          </property>
          <property name="flat">
           <bool>true</bool>
@@ -383,8 +383,11 @@
           </item>
           <item row="1" column="0">
            <widget class="QCheckBox" name="followCursorCheckBox">
+            <property name="toolTip">
+             <string>When set, measurements are displayed near the cursor</string>
+            </property>
             <property name="text">
-             <string>Follow cursor</string>
+             <string>Measurements follow the cursor</string>
             </property>
            </widget>
           </item>

--- a/plugins/AngleMeasure/src/gui/angleMeasureDialog.ui
+++ b/plugins/AngleMeasure/src/gui/angleMeasureDialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>530</width>
-    <height>409</height>
+    <width>836</width>
+    <height>511</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -381,6 +381,13 @@
             </property>
            </widget>
           </item>
+          <item row="1" column="0">
+           <widget class="QCheckBox" name="followCursorCheckBox">
+            <property name="text">
+             <string>Follow cursor</string>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>
@@ -444,6 +451,23 @@
    <container>1</container>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>tabs</tabstop>
+  <tabstop>showEquatorial_GroupBox</tabstop>
+  <tabstop>showPositionAngleCheckBox</tabstop>
+  <tabstop>equatorialTextColorToolButton</tabstop>
+  <tabstop>equatorialLineColorToolButton</tabstop>
+  <tabstop>showHorizontal_GroupBox</tabstop>
+  <tabstop>showPositionAngleHorizontalCheckBox</tabstop>
+  <tabstop>horizontalTextColorToolButton</tabstop>
+  <tabstop>horizontalLineColorToolButton</tabstop>
+  <tabstop>azAltStartOnSkyCheckBox</tabstop>
+  <tabstop>azAltEndOnSkyCheckBox</tabstop>
+  <tabstop>useDmsFormatCheckBox</tabstop>
+  <tabstop>followCursorCheckBox</tabstop>
+  <tabstop>restoreDefaultsButton</tabstop>
+  <tabstop>aboutTextBrowser</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/plugins/AngleMeasure/src/gui/angleMeasureDialog.ui
+++ b/plugins/AngleMeasure/src/gui/angleMeasureDialog.ui
@@ -384,10 +384,10 @@
           <item row="1" column="0">
            <widget class="QCheckBox" name="followCursorCheckBox">
             <property name="toolTip">
-             <string>When set, measurements are displayed near the cursor</string>
+             <string>When set, measurements are shown near the end of the line instead of its starting point.</string>
             </property>
             <property name="text">
-             <string>Measurements follow the cursor</string>
+             <string>Show measurements near mouse</string>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
### Description
<!--- Please include a summary of the change and which issue is fixed. -->
This patch allows to attach the running measurements to the cursor instead of the base of the measurement.

<!--- Please also include relevant motivation and context. -->
This helps in searching for a point in the sky.
<!--- List any dependencies that are required for this change. -->

### Screenshots

![image](https://user-images.githubusercontent.com/3529789/120249477-52bfce80-c27b-11eb-9257-39549fa165d6.png)

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] This change requires a documentation update

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system: 
* Operating System: Kubuntu 20.04
KDE Plasma Version: 5.18.5
KDE Frameworks Version: 5.68.0
Qt Version: 5.12.8
Kernel Version: 5.4.0-73-generic
OS Type: 64-bit
Processors: 8 × Intel® Core™ i7-10510U CPU @ 1.80GHz
Memory: 15.3 GiB of RAM

* Graphics Card: <Manufacturer (likely Intel, NVidia, AMD?), Model (HD, Geforce, Radeon..., with model number), driver version?>

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
