### PR TITLE
WIP: Switch from Bortle class to luminance as the quantity of light pollution

### DIFF
--- a/src/core/StelCore.cpp
+++ b/src/core/StelCore.cpp
@@ -1156,7 +1156,7 @@ void StelCore::moveObserverToSelected()
 				loc.state = "";
 				loc.longitude=ni->getLongitude();
 				loc.latitude=ni->getLatitude();
-				loc.bortleScaleIndex=1;
+				loc.lightPollutionLuminance = 0;
 
 				moveObserverTo(loc);
 				objmgr->unSelect(); // no use to keep it: Marker will flicker around the screen.
@@ -2645,6 +2645,65 @@ QString StelCore::getIAUConstellation(const Vec3d positionEqJnow) const
 	}
 	qDebug() << "getIAUconstellation error: Cannot determine, algorithm failed.";
 	return "(?)";
+}
+
+// NELM = naked-eye limiting magnitude
+int StelCore::nelmToBortleScaleIndex(const float nelm)
+{
+    // Ref: Bortle, John E. (February 2001). "Gauging Light Pollution: The Bortle Dark-Sky Scale".
+    //  Sky & Telescope. Sky Publishing Corporation.
+    // https://skyandtelescope.org/astronomy-resources/light-pollution-and-astronomy-the-bortle-dark-sky-scale/
+    if(nelm < 4.0) return 9;
+    if(nelm < 4.5) return 8;
+    if(nelm < 5.0) return 7;
+    if(nelm < 5.5) return 6;
+    if(nelm < 6.0) return 5;
+    if(nelm < 6.5) return 4;
+    if(nelm < 7.0) return 3;
+    if(nelm < 7.5) return 2;
+    return 1;
+}
+
+float StelCore::bortleScaleIndexToNELM(const int index)
+{
+    // This is kind of inverse of nelmToBortleScaleIndex(), where the "representative NELM" is chosen to be
+    // the middle of the interval of the NELM values for the inner indices (2-8), and the same distance from
+    // the boundary for outer indices (1 and 9).
+    switch(index)
+    {
+    case 1: return 7.75;
+    case 2: return 7.25;
+    case 3: return 6.75;
+    case 4: return 6.25;
+    case 5: return 5.75;
+    case 6: return 5.25;
+    case 7: return 4.75;
+    case 8: return 4.25;
+    case 9: return 3.75;
+    default:
+            qWarning().nospace() << "Bortle scale index " << index << " out of range";
+            return 0; // Let the problem be visible
+    }
+}
+
+float StelCore::luminanceToNELM(const float luminance)
+{
+    // Ref: Schaefer, B. E.. "Telescopic limiting magnitudes". Astronomical Society of the Pacific,
+    //  Publications (ISSN 0004-6280), vol. 102, Feb. 1990, p. 212-229.
+    // http://adsbit.harvard.edu/cgi-bin/nph-iarticle_query?bibcode=1990PASP..102..212S
+    //
+    // Using formula (18), assuming observer's acuity Fₛ=1 (as suggested in the text as "typical observer"),
+    // absorption term kᵥ=0.3 (as suggested for "typical weather"), coefficient for Bₛ is adjusted to take
+    // the value in cd/m².
+    //
+    return 8.32f - 2.17147240951626f*std::log(1 + 88.5588612190873f*std::sqrt(luminance));
+}
+
+float StelCore::nelmToLuminance(const float nelm)
+{
+    // This is just the inverse of luminanceToNELM()
+    const auto toSquare = std::exp(3.8315015947420905f-0.46051701859880895f*nelm) - 1;
+    return toSquare*toSquare*0.0001275075653676456f;
 }
 
 Vec3d StelCore::getMouseJ2000Pos() const

--- a/src/core/StelCore.hpp
+++ b/src/core/StelCore.hpp
@@ -731,6 +731,23 @@ public slots:
 	//! @param positionEqJnow position vector in rectangular equatorial coordinates of current epoch&equinox.
 	QString getIAUConstellation(const Vec3d positionEqJnow) const;
 
+    //! Returns naked-eye limiting magnitude corresponding to the given sky luminance in cd/m².
+    static float luminanceToNELM(float luminance);
+    //! Returns sky luminance in cd/m² corresponding to the given naked-eye limiting magnitude.
+    static float nelmToLuminance(float nelm);
+    //! Returns some representative naked-eye limiting magnitude for the given Bortle scale index.
+    static float bortleScaleIndexToNELM(int index);
+    //! Returns some representative value of zenith luminance in cd/m² for the given Bortle scale index.
+    static float bortleScaleIndexToLuminance(const int index) { return nelmToLuminance(bortleScaleIndexToNELM(index)); }
+    //! Classifies the sky using the Bortle scale using zenith naked-eye limiting magnitude as input.
+    static int nelmToBortleScaleIndex(float nelm);
+    //! Classifies the sky using the Bortle scale using zenith luminance in cd/m² as input.
+    static int luminanceToBortleScaleIndex(const float luminance) { return nelmToBortleScaleIndex(luminanceToNELM(luminance)); }
+    //! Converts luminance in cd/m² to magnitude/arcsec².
+    static float luminanceToMPSAS(const float cdm2) { return std::log10(cdm2/10.8e4f) / -0.4f; }
+    //! Converts magnitude/arcsec² to luminance in cd/m².
+    static float mpsasToLuminance(const float mag) { return 10.8e4f*std::pow(10.f, -0.4f*mag); }
+
 signals:
 	//! This signal is emitted when the observer location has changed.
 	void locationChanged(const StelLocation&);

--- a/src/core/StelLocation.cpp
+++ b/src/core/StelLocation.cpp
@@ -27,7 +27,7 @@
 #include <QTimeZone>
 #include <QStringList>
 
-const int StelLocation::DEFAULT_BORTLE_SCALE_INDEX = 2;
+const float StelLocation::DEFAULT_LIGHT_POLLUTION_LUMINANCE = StelCore::bortleScaleIndexToLuminance(2);
 
 int StelLocation::metaTypeId = initMetaType();
 int StelLocation::initMetaType()
@@ -50,7 +50,6 @@ QString StelLocation::serializeToLine() const
 			.arg(latitude<0 ? QString("%1S").arg(-latitude, 0, 'f', 6) : QString("%1N").arg(latitude, 0, 'f', 6))
 			.arg(longitude<0 ? QString("%1W").arg(-longitude, 0, 'f', 6) : QString("%1E").arg(longitude, 0, 'f', 6))
 			.arg(altitude)
-			.arg(bortleScaleIndex)
 			.arg(sanitizedTZ)
 			.arg(planetName)
 			.arg(landscapeKey);
@@ -70,13 +69,18 @@ QString StelLocation::getID() const
 // GZ TODO: These operators may require sanitizing for timezone names!
 QDataStream& operator<<(QDataStream& out, const StelLocation& loc)
 {
-	out << loc.name << loc.state << loc.country << loc.role << loc.population << loc.latitude << loc.longitude << loc.altitude << loc.bortleScaleIndex << loc.ianaTimeZone << loc.planetName << loc.landscapeKey << loc.isUserLocation;
+    const auto lum = loc.lightPollutionLuminance.toFloat();
+    const int bortleScaleIndex = loc.lightPollutionLuminance.isValid() ? StelCore::luminanceToBortleScaleIndex(lum) : -1;
+	out << loc.name << loc.state << loc.country << loc.role << loc.population << loc.latitude << loc.longitude << loc.altitude << bortleScaleIndex << loc.ianaTimeZone << loc.planetName << loc.landscapeKey << loc.isUserLocation;
 	return out;
 }
 
 QDataStream& operator>>(QDataStream& in, StelLocation& loc)
 {
-	in >> loc.name >> loc.state >> loc.country >> loc.role >> loc.population >> loc.latitude >> loc.longitude >> loc.altitude >> loc.bortleScaleIndex >> loc.ianaTimeZone >> loc.planetName >> loc.landscapeKey >> loc.isUserLocation;
+    int bortleScaleIndex;
+	in >> loc.name >> loc.state >> loc.country >> loc.role >> loc.population >> loc.latitude >> loc.longitude >> loc.altitude >> bortleScaleIndex >> loc.ianaTimeZone >> loc.planetName >> loc.landscapeKey >> loc.isUserLocation;
+    if(bortleScaleIndex > 0)
+        loc.lightPollutionLuminance = StelCore::bortleScaleIndexToLuminance(bortleScaleIndex);
 	return in;
 }
 
@@ -111,12 +115,12 @@ StelLocation StelLocation::createFromLine(const QString& rawline)
 	if (splitline.size()>8)
 	{
 		bool ok;
-		loc.bortleScaleIndex = splitline.at(8).toInt(&ok);
+		loc.lightPollutionLuminance = splitline.at(8).toFloat(&ok);
 		if (ok==false)
-			loc.bortleScaleIndex = DEFAULT_BORTLE_SCALE_INDEX;
+			loc.lightPollutionLuminance = DEFAULT_LIGHT_POLLUTION_LUMINANCE;
 	}
 	else
-		loc.bortleScaleIndex = DEFAULT_BORTLE_SCALE_INDEX;
+		loc.lightPollutionLuminance = DEFAULT_LIGHT_POLLUTION_LUMINANCE;
 
 	if (splitline.size()>9)
 	{

--- a/src/core/StelLocation.hpp
+++ b/src/core/StelLocation.hpp
@@ -20,6 +20,7 @@
 #define STELLOCATION_HPP
 
 #include <QString>
+#include <QVariant>
 #include <QMetaType>
 
 class Planet;
@@ -29,7 +30,7 @@ class Planet;
 class StelLocation
 {
 public:
-	StelLocation() : longitude(0.f), latitude(0.f), altitude(0), bortleScaleIndex(2), population(0.f), role('X'), isUserLocation(true) {;}
+	StelLocation() : longitude(0.f), latitude(0.f), altitude(0), population(0.f), role('X'), isUserLocation(true) {;}
 
 	//! Return a short string which can be used in a list view.
 	QString getID() const;
@@ -65,8 +66,8 @@ public:
 	float latitude;
 	//! Altitude in meter
 	int altitude;
-	//! Light pollution index following Bortle scale
-	int bortleScaleIndex;
+    //! Zenith luminance at moonless night as could be measured by a Sky Quality Meter, in cd/m²
+    QVariant lightPollutionLuminance;
 	//! A hint for associating a landscape to the location
 	QString landscapeKey;
 	//! Population in number of inhabitants
@@ -110,7 +111,7 @@ public:
 	//! Used privately by the StelLocationMgr
 	bool isUserLocation;
 
-	static const int DEFAULT_BORTLE_SCALE_INDEX;
+    static const float DEFAULT_LIGHT_POLLUTION_LUMINANCE;
 private:
 	//Register with Qt
 	static int metaTypeId;

--- a/src/core/StelLocationMgr.cpp
+++ b/src/core/StelLocationMgr.cpp
@@ -218,7 +218,7 @@ void LibGPSLookupHelper::query()
 	if (verbose)
 		qDebug() << "GPSD location" << QString("lat %1, long %2, alt %3").arg(loc.latitude).arg(loc.longitude).arg(loc.altitude);
 
-	loc.bortleScaleIndex=StelLocation::DEFAULT_BORTLE_SCALE_INDEX;
+	loc.lightPollutionLuminance=StelLocation::DEFAULT_LIGHT_POLLUTION_LUMINANCE;
 	// Usually you don't leave your time zone with GPS.
 	loc.ianaTimeZone=StelApp::getInstance().getCore()->getCurrentTimeZone();
 	loc.isUserLocation=true;
@@ -380,7 +380,7 @@ void NMEALookupHelper::nmeaUpdated(const QGeoPositionInfo &update)
 		loc.altitude=( qIsNaN(coord.altitude()) ? 0 : static_cast<int>(floor(coord.altitude())));
 		if (verbose)
 			qDebug() << "Location in progress: Long=" << loc.longitude << " Lat=" << loc.latitude << " Alt" << loc.altitude;
-		loc.bortleScaleIndex=StelLocation::DEFAULT_BORTLE_SCALE_INDEX;
+		loc.lightPollutionLuminance=StelLocation::DEFAULT_LIGHT_POLLUTION_LUMINANCE;
 		// Usually you don't leave your time zone with GPS.
 		loc.ianaTimeZone=core->getCurrentTimeZone();
 		loc.isUserLocation=true;
@@ -1007,7 +1007,7 @@ void StelLocationMgr::changeLocationFromNetworkLookup()
 			loc.latitude = latitude;
 			loc.longitude = longitude;
 			loc.altitude = 0;
-			loc.bortleScaleIndex = StelLocation::DEFAULT_BORTLE_SCALE_INDEX;
+			loc.lightPollutionLuminance = StelLocation::DEFAULT_LIGHT_POLLUTION_LUMINANCE;
 			loc.ianaTimeZone = (ipTimeZone.isEmpty() ? "" : ipTimeZone);
 			loc.planetName = "Earth";
 			loc.landscapeKey = "";

--- a/src/core/StelSkyDrawer.cpp
+++ b/src/core/StelSkyDrawer.cpp
@@ -67,7 +67,6 @@ StelSkyDrawer::StelSkyDrawer(StelCore* acore) :
 	customStarMagLimit(0.0),
 	customNebulaMagLimit(0.0),
 	customPlanetMagLimit(0.0),
-	bortleScaleIndex(3),
 	inScale(1.f),
 	starShaderProgram(Q_NULLPTR),
 	starShaderVars(StarShaderVars()),
@@ -100,7 +99,7 @@ StelSkyDrawer::StelSkyDrawer(StelCore* acore) :
 	setFlagNebulaMagnitudeLimit((conf->value("astro/flag_nebula_magnitude_limit", false).toBool()));
 	setCustomNebulaMagnitudeLimit(conf->value("astro/nebula_magnitude_limit", 8.5).toDouble());
 
-	setBortleScaleIndex(conf->value("stars/init_bortle_scale", 3).toInt());
+	setLightPollutionLuminance(conf->value("stars/init_light_pollution_luminance", StelCore::bortleScaleIndexToLuminance(3)).toFloat());
 	setRelativeStarScale(conf->value("stars/relative_scale", 1.0).toDouble());
 	setAbsoluteStarScale(conf->value("stars/absolute_scale", 1.0).toDouble());
 	setExtinctionCoefficient(conf->value("landscape/atmospheric_extinction_coefficient", 0.13).toDouble());
@@ -216,7 +215,10 @@ void StelSkyDrawer::update(double)
 	// They should roughly match the scale described at http://en.wikipedia.org/wiki/Bortle_Dark-Sky_Scale
 	static const float bortleToInScale[9] = {2.45f, 1.55f, 1.0f, 0.63f, 0.40f, 0.24f, 0.23f, 0.145f, 0.09f};
 	if (getFlagHasAtmosphere() && core->getJD()>2387627.5) // JD given is J1825.0; ignore Bortle scale index before that.
+    {
+        const auto bortleScaleIndex = StelCore::luminanceToBortleScaleIndex(lightPollutionLuminance);
 	    setInputScale(bortleToInScale[bortleScaleIndex-1]);
+    }
 	else
 	    setInputScale(bortleToInScale[0]);
 
@@ -642,25 +644,17 @@ void StelSkyDrawer::preDraw()
 }
 
 
-// Set the parameters so that the stars disappear at about the limit given by the bortle scale
-// See http://en.wikipedia.org/wiki/Bortle_Dark-Sky_Scale
-void StelSkyDrawer::setBortleScaleIndex(int bIndex)
+void StelSkyDrawer::setLightPollutionLuminance(const double luminance)
 {
-	if(bortleScaleIndex!=bIndex)
-	{
-		// Associate the Bortle index (1 to 9) to inScale value
-		if ((bIndex<1) || (bIndex>9))
-		{
-			qWarning() << "WARNING: Bortle scale index range is [1;9], given" << bIndex;
-		}
-		bortleScaleIndex = qBound(1, bIndex, 9);
-		emit bortleScaleIndexChanged(bortleScaleIndex);
-		// GZ: I moved this block to update()
-		// These value have been calibrated by hand, looking at the faintest star in stellarium at around 40 deg FOV
-		// They should roughly match the scale described at http://en.wikipedia.org/wiki/Bortle_Dark-Sky_Scale
-		// static const float bortleToInScale[9] = {2.45, 1.55, 1.0, 0.63, 0.40, 0.24, 0.23, 0.145, 0.09};
-		// setInputScale(bortleToInScale[bIndex-1]);
-	}
+	if(lightPollutionLuminance==luminance)
+        return;
+    lightPollutionLuminance=luminance;
+    emit lightPollutionLuminanceChanged(luminance);
+}
+
+int StelSkyDrawer::getBortleScaleIndex() const
+{
+    return StelCore::luminanceToBortleScaleIndex(lightPollutionLuminance);
 }
 
 void StelSkyDrawer::setFlagStarSpiky(bool b)
@@ -671,18 +665,6 @@ void StelSkyDrawer::setFlagStarSpiky(bool b)
 		texHalo = StelApp::getInstance().getTextureManager().createTexture(flagStarSpiky ? texImgHaloSpiky : texImgHalo);
 		emit flagStarSpikyChanged(flagStarSpiky);
 	}
-}
-
-float StelSkyDrawer::getNELMFromBortleScale() const
-{
-	return getNELMFromBortleScale(getBortleScaleIndex());
-}
-
-float StelSkyDrawer::getNELMFromBortleScale(int idx)
-{
-	const float nelms[9] = {7.8f, 7.3f, 6.8f, 6.3f, 5.8f, 5.3f, 4.8f, 4.3f, 4.0f};
-	idx = qBound(1, idx, 9);
-	return nelms[idx-1];
 }
 
 // colors for B-V display

--- a/src/core/StelSkyDrawer.hpp
+++ b/src/core/StelSkyDrawer.hpp
@@ -54,7 +54,7 @@ class StelSkyDrawer : public QObject, protected QOpenGLFunctions
 	Q_PROPERTY(double absoluteStarScale READ getAbsoluteStarScale WRITE setAbsoluteStarScale NOTIFY absoluteStarScaleChanged)
 	Q_PROPERTY(double twinkleAmount READ getTwinkleAmount WRITE setTwinkleAmount NOTIFY twinkleAmountChanged)
 	Q_PROPERTY(bool flagStarTwinkle READ getFlagTwinkle WRITE setFlagTwinkle NOTIFY flagTwinkleChanged)
-	Q_PROPERTY(int bortleScaleIndex READ getBortleScaleIndex WRITE setBortleScaleIndex NOTIFY bortleScaleIndexChanged)
+	Q_PROPERTY(double lightPollutionLuminance READ getLightPollutionLuminance WRITE setLightPollutionLuminance NOTIFY lightPollutionLuminanceChanged)
 	Q_PROPERTY(bool flagDrawBigStarHalo READ getFlagDrawBigStarHalo WRITE setFlagDrawBigStarHalo NOTIFY flagDrawBigStarHaloChanged)
 	Q_PROPERTY(bool flagStarSpiky READ getFlagStarSpiky WRITE setFlagStarSpiky NOTIFY flagStarSpikyChanged)
 
@@ -187,36 +187,14 @@ public slots:
 	//! @note option for planetariums
 	bool getFlagForcedTwinkle() const {return flagForcedTwinkle;}
 
-	//! Set the parameters so that the stars disappear at about the limit given by the bortle scale
+    //! Set the parameters so that the stars disappear at about the naked-eye limiting magnitude corresponding
+    //! to the given zenith luminance at moonless night.
 	//! The limit is valid only at a given zoom level (around 60 deg)
-	//! @see https://en.wikipedia.org/wiki/Bortle_scale
-	void setBortleScaleIndex(int index);
-	//! Get the current Bortle scale index
-	//! @see https://en.wikipedia.org/wiki/Bortle_scale
-	int getBortleScaleIndex() const {return bortleScaleIndex;}
-	//! Get the average Naked-Eye Limiting Magnitude (NELM) for current Bortle scale index:
-	//! Class 1 = NELM 7.6-8.0; average NELM is 7.8
-	//! Class 2 = NELM 7.1-7.5; average NELM is 7.3
-	//! Class 3 = NELM 6.6-7.0; average NELM is 6.8
-	//! Class 4 = NELM 6.1-6.5; average NELM is 6.3
-	//! Class 5 = NELM 5.6-6.0; average NELM is 5.8
-	//! Class 6 = NELM 5.1-5.5; average NELM is 5.3
-	//! Class 7 = NELM 4.6-5.0; average NELM is 4.8
-	//! Class 8 = NELM 4.1-4.5; average NELM is 4.3
-	//! Class 9 = NELM 4.0
-	float getNELMFromBortleScale() const;
-	//! Get the average Naked-Eye Limiting Magnitude (NELM) for given Bortle scale index [1..9]
-	//! Class 1 = NELM 7.6-8.0; average NELM is 7.8
-	//! Class 2 = NELM 7.1-7.5; average NELM is 7.3
-	//! Class 3 = NELM 6.6-7.0; average NELM is 6.8
-	//! Class 4 = NELM 6.1-6.5; average NELM is 6.3
-	//! Class 5 = NELM 5.6-6.0; average NELM is 5.8
-	//! Class 6 = NELM 5.1-5.5; average NELM is 5.3
-	//! Class 7 = NELM 4.6-5.0; average NELM is 4.8
-	//! Class 8 = NELM 4.1-4.5; average NELM is 4.3
-	//! Class 9 = NELM 4.0
-	//! @arg idx Bortle Scale Index (valid: 1..9, will be forced to valid range)
-	static float getNELMFromBortleScale(int idx);
+	void setLightPollutionLuminance(double luminance);
+	//! Get the current zenith luminance at moonless night.
+	double getLightPollutionLuminance() const {return lightPollutionLuminance;}
+
+    Q_DECL_DEPRECATED int getBortleScaleIndex() const;
 
 	//! Set flag for drawing a halo around bright stars.
 	void setFlagDrawBigStarHalo(bool b) {if(b!=flagDrawBigStarHalo){ flagDrawBigStarHalo=b; emit flagDrawBigStarHaloChanged(b);}}
@@ -322,8 +300,8 @@ signals:
 	void twinkleAmountChanged(double b);
 	//! Emitted whenever the twinkle flag is toggled
 	void flagTwinkleChanged(bool b);
-	//! Emitted whenever the Bortle scale index changed
-	void bortleScaleIndexChanged(int index);
+	//! Emitted whenever light pollution luminance changed
+	void lightPollutionLuminanceChanged(double luminance);
 	//! Emitted when flag to draw big halo around stars changed
 	void flagDrawBigStarHaloChanged(bool b);
 	//! Emitted on change of star texture
@@ -464,8 +442,8 @@ private:
 	//! Contains the list of colors matching a given B-V index
 	static Vec3f colorTable[128];
 
-	//! The current Bortle Scale index
-	int bortleScaleIndex;
+	//! The current light pollution luminance
+	double lightPollutionLuminance;
 
 	//! The scaling applied to input luminance before they are converted by the StelToneReproducer
 	float inScale;

--- a/src/core/modules/Landscape.cpp
+++ b/src/core/modules/Landscape.cpp
@@ -51,7 +51,6 @@ Landscape::Landscape(float _radius)
 	, angleRotateZ(0.)
 	, angleRotateZOffset(0.)
 	, sinMinAltitudeLimit(-0.035) //sin(-2 degrees))
-	, defaultBortleIndex(-1)
 	, defaultFogSetting(-1)
 	, defaultExtinctionCoefficient(-1.)
 	, defaultTemperature(-1000.)
@@ -118,9 +117,22 @@ void Landscape::loadCommon(const QSettings& landscapeIni, const QString& landsca
 		if ((tzString.length() > 0))
 			location.ianaTimeZone=StelLocationMgr::sanitizeTimezoneStringFromLocationDB(tzString);
 
-		defaultBortleIndex = landscapeIni.value("location/light_pollution", -1).toInt();
+		auto defaultBortleIndex = landscapeIni.value("location/light_pollution", -1).toInt();
 		if (defaultBortleIndex<=0) defaultBortleIndex=-1; // neg. values in ini file signal "no change".
 		if (defaultBortleIndex>9) defaultBortleIndex=9; // correct bad values.
+        const auto lum = landscapeIni.value("location/light_pollution_luminance");
+        if (lum.isValid())
+        {
+            defaultLightPollutionLuminance = lum;
+
+            if (defaultBortleIndex>=0)
+            {
+                qWarning() << "Landscape light pollution is specified both as luminance and as Bortle scale index."
+                              "Only one value should be specified, preferably luminance.";
+            }
+        }
+        else if (defaultBortleIndex>=0)
+            defaultLightPollutionLuminance = StelCore::bortleScaleIndexToLuminance(defaultBortleIndex);
 
 		defaultFogSetting = landscapeIni.value("location/display_fog", -1).toInt();
 		defaultExtinctionCoefficient = landscapeIni.value("location/atmospheric_extinction_coefficient", -1.0).toDouble();

--- a/src/core/modules/Landscape.hpp
+++ b/src/core/modules/Landscape.hpp
@@ -34,6 +34,7 @@
 #include <QImage>
 #include <QList>
 #include <QFont>
+#include <QVariant>
 
 class QSettings;
 class StelLocation;
@@ -140,8 +141,8 @@ public:
 	const StelLocation& getLocation() const {return location;}
 	//! Return if the location is valid (a valid location has a valid planetName!)
 	bool hasLocation() const {return (!(location.planetName.isEmpty()));}
-  	//! Return default Bortle index (light pollution value) or -1 (unknown/no change)
-	int getDefaultBortleIndex() const {return defaultBortleIndex;}
+    //! Return default light pollution luminance in cd/m², if present
+    QVariant getDefaultLightPollutionLuminance() const {return defaultLightPollutionLuminance;}
 	//! Return default fog setting (0/1) or -1 (no change)
 	int getDefaultFogSetting() const {return defaultFogSetting;}
 	//! Return default atmosperic extinction [mag/airmass], or -1 (no change)
@@ -233,7 +234,9 @@ protected:
 	double sinMinAltitudeLimit; //! Minimal altitude of landscape cover. Can be used to construct bounding caps, so that e.g. no stars are drawn below this altitude. Default -0.035, i.e. sin(-2 degrees).
 
 	StelLocation location; //! OPTIONAL. If present, can be used to set location.
-	int defaultBortleIndex; //! May be given in landscape.ini:[location]light_pollution. Default: -1 (no change).
+    /** May be given in landscape.ini:light_pollution_luminance in cd/m². Default: no change.
+      * Another way (deprecated) is to use landscape.ini:[location]light_pollution to set Bortle scale index. Default: -1 (no change). */
+    QVariant defaultLightPollutionLuminance;
 	int defaultFogSetting;  //! May be given in landscape.ini:[location]display_fog: -1(no change), 0(off), 1(on). Default: -1.
 	double defaultExtinctionCoefficient; //! May be given in landscape.ini:[location]atmospheric_extinction_coefficient. Default -1 (no change).
 	double defaultTemperature; //! [Celsius] May be given in landscape.ini:[location]atmospheric_temperature. default: -1000.0 (no change)

--- a/src/core/modules/LandscapeMgr.cpp
+++ b/src/core/modules/LandscapeMgr.cpp
@@ -602,10 +602,10 @@ void LandscapeMgr::init()
 	//Bortle scale is managed by SkyDrawer
 	StelSkyDrawer* drawer = app->getCore()->getSkyDrawer();
 	Q_ASSERT(drawer);
-	setAtmosphereBortleLightPollution(drawer->getBortleScaleIndex());
+	setAtmosphereLightPollutionLuminance(drawer->getLightPollutionLuminance());
 	connect(app->getCore(), SIGNAL(locationChanged(StelLocation)), this, SLOT(onLocationChanged(StelLocation)));
 	connect(app->getCore(), SIGNAL(targetLocationChanged(StelLocation)), this, SLOT(onTargetLocationChanged(StelLocation)));
-	connect(drawer, SIGNAL(bortleScaleIndexChanged(int)), this, SLOT(setAtmosphereBortleLightPollution(int)));
+	connect(drawer, &StelSkyDrawer::lightPollutionLuminanceChanged, this, &LandscapeMgr::setAtmosphereLightPollutionLuminance);
 	connect(app, SIGNAL(languageChanged()), this, SLOT(updateI18n()));
 
 	QString displayGroup = N_("Display Options");
@@ -705,9 +705,9 @@ bool LandscapeMgr::setCurrentLandscapeID(const QString& id, const double changeL
 			setFlagFog(static_cast<bool>(landscape->getDefaultFogSetting()));
 			landscape->setFlagShowFog(static_cast<bool>(landscape->getDefaultFogSetting()));
 		}
-		if (landscape->getDefaultBortleIndex() > 0)
+		if (landscape->getDefaultLightPollutionLuminance().isValid())
 		{
-			drawer->setBortleScaleIndex(landscape->getDefaultBortleIndex());
+			drawer->setLightPollutionLuminance(landscape->getDefaultLightPollutionLuminance().toFloat());
 		}
 		if (landscape->getDefaultAtmosphericExtinction() >= 0.0)
 		{
@@ -868,13 +868,15 @@ void LandscapeMgr::onLocationChanged(const StelLocation &loc)
 	{
 		//this was previously logic in ViewDialog, but should really be on a non-GUI layer
 		StelCore* core = StelApp::getInstance().getCore();
-		int bIdx = loc.bortleScaleIndex;
+        float lum;
 		if (!loc.planetName.contains("Earth")) // location not on Earth...
-			bIdx = 1;
-		if (bIdx<1) // ...or it observatory, or it unknown location
-			bIdx = loc.DEFAULT_BORTLE_SCALE_INDEX;
+			lum = 0;
+        else if(loc.lightPollutionLuminance.isValid())
+            lum = loc.lightPollutionLuminance.toFloat();
+        else // ...or it observatory, or it unknown location
+			lum = loc.DEFAULT_LIGHT_POLLUTION_LUMINANCE;
 
-		core->getSkyDrawer()->setBortleScaleIndex(bIdx);
+		core->getSkyDrawer()->setLightPollutionLuminance(lum);
 	}
 }
 
@@ -1076,9 +1078,9 @@ QString LandscapeMgr::getCurrentLandscapeHtmlDescription() const
 		if (atmosphere.size()>0)
 			desc += QString("<b>%1</b>: %2<br />").arg(q_("Atmospheric conditions"), atmosphere.join(", "));
 
-		int bortle = landscape->getDefaultBortleIndex();
-		if (bortle>-1)
-			desc += QString("<b>%1</b>: %2 (%3)").arg(q_("Light pollution")).arg(bortle).arg(q_("by Bortle scale"));
+		const auto lightPollutionLum = landscape->getDefaultLightPollutionLuminance();
+		if (lightPollutionLum.isValid())
+			desc += q_("<b>Light pollution</b>: %1 cd/m<sup>2</sup>").arg(lightPollutionLum.toFloat());
 	}	
 	return desc;
 }
@@ -1196,13 +1198,6 @@ void LandscapeMgr::setAtmosphereLightPollutionLuminance(const float f)
 float LandscapeMgr::getAtmosphereLightPollutionLuminance() const
 {
 	return atmosphere->getLightPollutionLuminance();
-}
-
-//! Set the light pollution following the Bortle Scale
-void LandscapeMgr::setAtmosphereBortleLightPollution(const int bIndex)
-{
-	// This is an empirical formula
-	setAtmosphereLightPollutionLuminance(qMax(0.f,0.0004f*powf(bIndex-1, 2.1f)));
 }
 
 void LandscapeMgr::setZRotation(const float d)
@@ -1619,28 +1614,34 @@ QString LandscapeMgr::getDescription() const
 void LandscapeMgr::increaseLightPollution()
 {
 	StelCore* core = StelApp::getInstance().getCore();
-	int bidx = core->getSkyDrawer()->getBortleScaleIndex() + 1;
+	const auto lum = core->getSkyDrawer()->getLightPollutionLuminance();
+    auto bidx = core->luminanceToBortleScaleIndex(lum) + 1;
 	if (bidx>9)
 		bidx = 9;
-	core->getSkyDrawer()->setBortleScaleIndex(bidx);
+    const auto newLum = core->bortleScaleIndexToLuminance(bidx);
+	core->getSkyDrawer()->setLightPollutionLuminance(newLum);
 }
 
 void LandscapeMgr::reduceLightPollution()
 {
 	StelCore* core = StelApp::getInstance().getCore();
-	int bidx = core->getSkyDrawer()->getBortleScaleIndex() - 1;
+	const auto lum = core->getSkyDrawer()->getLightPollutionLuminance();
+    auto bidx = core->luminanceToBortleScaleIndex(lum) - 1;
 	if (bidx<1)
 		bidx = 1;
-	core->getSkyDrawer()->setBortleScaleIndex(bidx);
+    const auto newLum = core->bortleScaleIndexToLuminance(bidx);
+	core->getSkyDrawer()->setLightPollutionLuminance(newLum);
 }
 
 void LandscapeMgr::cyclicChangeLightPollution()
 {
 	StelCore* core = StelApp::getInstance().getCore();
-	int bidx = core->getSkyDrawer()->getBortleScaleIndex() + 1;
+	const auto lum = core->getSkyDrawer()->getLightPollutionLuminance();
+    auto bidx = core->luminanceToBortleScaleIndex(lum) + 1;
 	if (bidx>9)
 		bidx = 1;
-	core->getSkyDrawer()->setBortleScaleIndex(bidx);
+    const auto newLum = core->bortleScaleIndexToLuminance(bidx);
+	core->getSkyDrawer()->setLightPollutionLuminance(newLum);
 }
 
 /*

--- a/src/core/modules/LandscapeMgr.hpp
+++ b/src/core/modules/LandscapeMgr.hpp
@@ -546,10 +546,6 @@ signals:
 	void currentLandscapeChanged(QString currentLandscapeID,QString currentLandscapeName);
 
 private slots:
-	//! Set the light pollution following the Bortle Scale.
-	//! This should not be called from script code, use StelMainScriptAPI::setBortleScaleIndex if you want to change the light pollution.
-	void setAtmosphereBortleLightPollution(const int bIndex);
-
 	//! Reacts to StelCore::locationChanged.
 	void onLocationChanged(const StelLocation &loc);
 	void onTargetLocationChanged(const StelLocation &loc);
@@ -562,11 +558,10 @@ private slots:
 	void cyclicChangeLightPollution();
 
 private:
-	//! Get light pollution luminance level.
+	//! Get light pollution luminance level in cd/m².
 	float getAtmosphereLightPollutionLuminance() const;
-	//! Set light pollution luminance level.
+	//! Set light pollution luminance level in cd/m².
 	void setAtmosphereLightPollutionLuminance(const float f);
-
 
 	//! For a given landscape name, return the landscape ID.
 	//! This takes a name of the landscape, as described in the landscape:name item in the

--- a/src/core/modules/Nebula.cpp
+++ b/src/core/modules/Nebula.cpp
@@ -586,9 +586,8 @@ float Nebula::getContrastIndex(const StelCore* core) const
 	// Compute an extended object's contrast index: http://www.unihedron.com/projects/darksky/NELM2BCalc.html
 
 	// Sky brightness
-	// Source: Schaefer, B.E. Feb. 1990. Telescopic Limiting Magnitude. PASP 102:212-229
-	// URL: http://adsbit.harvard.edu/cgi-bin/nph-iarticle_query?bibcode=1990PASP..102..212S [1990PASP..102..212S]
-	const float B_mpsas = 21.58f - 5*log10(std::pow(10.f, 1.586f - static_cast<float>(core->getSkyDrawer()->getNELMFromBortleScale())*0.2f)-1);
+    const auto luminance = core->getSkyDrawer()->getLightPollutionLuminance();
+	const float B_mpsas = StelCore::luminanceToMPSAS(luminance);
 	// Compute an extended object's contrast index
 	// Source: Clark, R.N., 1990. Appendix E in Visual Astronomy of the Deep Sky, Cambridge University Press and Sky Publishing.
 	// URL: http://www.clarkvision.com/visastro/appendix-e.html

--- a/src/gui/ConfigurationDialog.cpp
+++ b/src/gui/ConfigurationDialog.cpp
@@ -1017,7 +1017,7 @@ void ConfigurationDialog::saveAllSettings()
 	conf->setValue("landscape/minimal_brightness",			propMgr->getStelPropertyValue("LandscapeMgr.defaultMinimalBrightness").toFloat());
 	conf->setValue("landscape/flag_polyline_only",			propMgr->getStelPropertyValue("LandscapeMgr.flagPolyLineDisplayedOnly").toBool());
 	conf->setValue("landscape/polyline_thickness",			propMgr->getStelPropertyValue("LandscapeMgr.polyLineThickness").toInt());
-	conf->setValue("stars/init_bortle_scale",			propMgr->getStelPropertyValue("StelSkyDrawer.bortleScaleIndex").toInt());
+	conf->setValue("stars/init_light_pollution_luminance",	propMgr->getStelPropertyValue("StelSkyDrawer.lightPollutionLuminance").toFloat());
 	conf->setValue("landscape/atmospheric_extinction_coefficient",	propMgr->getStelPropertyValue("StelSkyDrawer.extinctionCoefficient").toFloat());
 	conf->setValue("landscape/pressure_mbar",			propMgr->getStelPropertyValue("StelSkyDrawer.atmospherePressure").toFloat());
 	conf->setValue("landscape/temperature_C",			propMgr->getStelPropertyValue("StelSkyDrawer.atmosphereTemperature").toFloat());

--- a/src/gui/ViewDialog.cpp
+++ b/src/gui/ViewDialog.cpp
@@ -96,7 +96,7 @@ void ViewDialog::retranslate()
 		populateToolTips();
 		populatePlanetMagnitudeAlgorithmsList();
 		populatePlanetMagnitudeAlgorithmDescription();
-		setBortleScaleToolTip(StelApp::getInstance().getCore()->getSkyDrawer()->getBortleScaleIndex());
+		updateBortleScaleToolTip();
 		populateHipsGroups();
 		updateHips();
 		//Hack to shrink the tabs to optimal size after language change
@@ -188,8 +188,8 @@ void ViewDialog::createDialogContent()
 	populateLightPollution();
 	connectBoolProperty(ui->useLightPollutionFromLocationDataCheckBox, "LandscapeMgr.flagUseLightPollutionFromDatabase");
 	connect(lmgr, SIGNAL(flagUseLightPollutionFromDatabaseChanged(bool)), this, SLOT(populateLightPollution()));
-	connectIntProperty(ui->lightPollutionSpinBox, "StelSkyDrawer.bortleScaleIndex");
-	connect(drawer, SIGNAL(bortleScaleIndexChanged(int)), this, SLOT(setBortleScaleToolTip(int)));
+	connectDoubleProperty(ui->lightPollutionLuminanceDoubleSpinBox, "StelSkyDrawer.lightPollutionLuminance");
+	connect(drawer, &StelSkyDrawer::lightPollutionLuminanceChanged, this, &ViewDialog::updateBortleScaleToolTip);
 
 	// atmosphere details
 	connect(ui->pushButtonAtmosphereDetails, SIGNAL(clicked()), this, SLOT(showAtmosphereDialog()));
@@ -837,33 +837,38 @@ void ViewDialog::updateSelectedTypesCheckBoxes()
 	ui->checkBoxOtherType->setChecked(flags & Nebula::TypeOther);
 }
 
+double ViewDialog::lightPollutionLuminance() const
+{
+    return ui->lightPollutionLuminanceDoubleSpinBox->value();
+}
+
 // 20160411. New function introduced with trunk merge. Not sure yet if useful or bad with property connections?.
 void ViewDialog::populateLightPollution()
 {
 	StelCore *core = StelApp::getInstance().getCore();
 	StelModule *lmgr = StelApp::getInstance().getModule("LandscapeMgr");
-	int bIdx = core->getSkyDrawer()->getBortleScaleIndex();
+	auto lum = core->getSkyDrawer()->getLightPollutionLuminance();
 	if (lmgr->property("flagUseLightPollutionFromDatabase").toBool())
 	{
 		StelLocation loc = core->getCurrentLocation();
-		bIdx = loc.bortleScaleIndex;
 		if (!loc.planetName.contains("Earth")) // location not on Earth...
-			bIdx = 1;
-		if (bIdx<1) // ...or it observatory, or it unknown location
-			bIdx = loc.DEFAULT_BORTLE_SCALE_INDEX;
-		ui->lightPollutionSpinBox->setEnabled(false);
+			lum = 0;
+        else if (!loc.lightPollutionLuminance.isValid()) // ...or it observatory, or it unknown location
+			lum = loc.DEFAULT_LIGHT_POLLUTION_LUMINANCE;
+        else
+            lum = loc.lightPollutionLuminance.toFloat();
+		ui->lightPollutionLuminanceDoubleSpinBox->setEnabled(false);
 	}
 	else
-		ui->lightPollutionSpinBox->setEnabled(true);
+		ui->lightPollutionLuminanceDoubleSpinBox->setEnabled(true);
 
-	ui->lightPollutionSpinBox->setValue(bIdx);
-	setBortleScaleToolTip(bIdx);
+	ui->lightPollutionLuminanceDoubleSpinBox->setValue(lum);
+	updateBortleScaleToolTip();
 }
 
-void ViewDialog::setBortleScaleToolTip(int Bindex)
+void ViewDialog::updateBortleScaleToolTip()
 {
-	int i = Bindex-1;
-	QStringList list, nelm;
+	QStringList list;
 	//TRANSLATORS: Short description for Class 1 of the Bortle scale
 	list.append(q_("Excellent dark-sky site"));
 	//TRANSLATORS: Short description for Class 2 of the Bortle scale
@@ -883,22 +888,16 @@ void ViewDialog::setBortleScaleToolTip(int Bindex)
 	//TRANSLATORS: Short description for Class 9 of the Bortle scale
 	list.append(q_("Inner-city sky"));
 
-	nelm.append("7.6-8.0");
-	nelm.append("7.1-7.5");
-	nelm.append("6.6-7.0");
-	nelm.append("6.1-6.5");
-	nelm.append("5.6-6.0");
-	nelm.append("5.1-5.5");
-	nelm.append("4.6-5.0");
-	nelm.append("4.1-4.5");
-	nelm.append("4.0");
+    const auto lum = lightPollutionLuminance();
+    const auto nelm = StelCore::luminanceToNELM(lum);
+    const auto bortleIndex = StelCore::nelmToBortleScaleIndex(nelm);
 
 	QString tooltip = QString("%1 (%2 %3)")
-			.arg(list.at(i))
+			.arg(list.at(bortleIndex - 1))
 			.arg(q_("The naked-eye limiting magnitude is"))
-			.arg(nelm.at(i));
+			.arg(nelm);
 
-	ui->lightPollutionSpinBox->setToolTip(tooltip);
+	ui->lightPollutionLuminanceDoubleSpinBox->setToolTip(tooltip);
 }
 
 void ViewDialog::populateToolTips()

--- a/src/gui/ViewDialog.hpp
+++ b/src/gui/ViewDialog.hpp
@@ -42,6 +42,7 @@ public:
 	virtual ~ViewDialog() Q_DECL_OVERRIDE;
 	//! Notify that the application style changed
 	virtual void styleChanged() Q_DECL_OVERRIDE;
+    double lightPollutionLuminance() const;
 
 public slots:
 	virtual void retranslate() Q_DECL_OVERRIDE;
@@ -59,7 +60,7 @@ private slots:
 	void changeLandscape(QListWidgetItem* item);
 	void landscapeChanged(QString id,QString name);
 	void updateZhrDescription(int zhr);
-	void setBortleScaleToolTip(int Bindex);
+	void updateBortleScaleToolTip();
 	void setCurrentLandscapeAsDefault(void);
 	void setCurrentCultureAsDefault(void);
 	void updateDefaultSkyCulture();

--- a/src/gui/viewDialog.ui
+++ b/src/gui/viewDialog.ui
@@ -639,24 +639,18 @@
                 </widget>
                </item>
                <item>
-                <widget class="QSpinBox" name="lightPollutionSpinBox">
-                 <property name="maximumSize">
-                  <size>
-                   <width>75</width>
-                   <height>16777215</height>
-                  </size>
-                 </property>
+                <widget class="QDoubleSpinBox" name="lightPollutionLuminanceDoubleSpinBox">
                  <property name="alignment">
                   <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                  </property>
-                 <property name="minimum">
-                  <number>1</number>
+                 <property name="suffix">
+                  <string> cd/m²</string>
+                 </property>
+                 <property name="decimals">
+                  <number>7</number>
                  </property>
                  <property name="maximum">
-                  <number>9</number>
-                 </property>
-                 <property name="value">
-                  <number>1</number>
+                  <double>1.000000000000000</double>
                  </property>
                 </widget>
                </item>
@@ -681,12 +675,6 @@
                 <spacer name="horizontalSpacer_12">
                  <property name="orientation">
                   <enum>Qt::Horizontal</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>40</width>
-                   <height>20</height>
-                  </size>
                  </property>
                 </spacer>
                </item>
@@ -4951,7 +4939,7 @@
   <tabstop>zodiacalLightCheckBox</tabstop>
   <tabstop>zodiacalLightBrightnessDoubleSpinBox</tabstop>
   <tabstop>adaptationCheckbox</tabstop>
-  <tabstop>lightPollutionSpinBox</tabstop>
+  <tabstop>lightPollutionLuminanceDoubleSpinBox</tabstop>
   <tabstop>zhrSlider</tabstop>
   <tabstop>zhrSpinBox</tabstop>
   <tabstop>page_DSO</tabstop>

--- a/src/scripting/StelMainScriptAPI.cpp
+++ b/src/scripting/StelMainScriptAPI.cpp
@@ -1281,7 +1281,8 @@ int StelMainScriptAPI::getBortleScaleIndex()
 
 void StelMainScriptAPI::setBortleScaleIndex(int index)
 {
-	StelApp::getInstance().getCore()->getSkyDrawer()->setBortleScaleIndex(index);
+    const auto lum = StelCore::bortleScaleIndexToLuminance(index);
+	StelApp::getInstance().getCore()->getSkyDrawer()->setLightPollutionLuminance(lum);
 }
 
 double StelMainScriptAPI::refraction(double altitude, bool apparent)


### PR DESCRIPTION
This PR addresses #1586.

### WIP

This PR is not complete, but I'd like to get some feedback on it before I proceed. What's planned but not yet done is:

* GUI as proposed in https://github.com/Stellarium/stellarium/issues/1586#issuecomment-813623246 (currently it's just a 7-digit `QDoubleSpinbox`)
* User Guide should reflect the change in the interface, particularly for the Landscape config files.

### Description

Bortle scale has several disadvantages:

1. It was designed as a guide for humans, not input for machines. From this follows the next disadvantage.
2. It's discrete: each point on the scale corresponds to a range of NELM values, which makes it imprecise a program's input.
3. It's subjective: based on naked-eye limiting magnitude that depends on observer's visual acuity.
4. It isn't as widely used (and thus validated) as photometric units.

OTOH, luminance is the quantity that defines all the relevant effects of light pollution.

This commit makes luminance in cd/m² the input parameter, leaving for backwards compatibility the option of supplying Bortle class in Landscapes. Some changes to calculations had to be introduced, as listed below.

1. `StelSkyDrawer::getNELMFromBortleScale` was reimplemented in `StelCore::bortleScaleIndexToNELM` using a bit different representative values of NELM - to simplify the comment documenting the choice. The values are almost the same: each old value except one will be reproduced by adding 0.05 to the new ones.
2. Calculation of `B_mpsas` in `Nebula.cpp` was trying to convert from Bortle class to magnitude scale using some formula from Schaefer paper, the same paper as I used in `StelCore::luminanceToNELM`, but without explaining the steps to get the formula. The old expression form `Nebula.cpp` (which is widespread over the Internet) doesn't work near NELM==8 (see the discussion at https://astronomy.stackexchange.com/q/43313), while the one I used does. Anyway, `Nebula`'s logic is tied to luminance, so if the user supplies luminance instead of Bortle class, it'll be as intended.

For some reason, stars/init_bortle_scale setting defaulted to 3 while StelLocation::DEFAULT_BORTLE_SCALE_INDEX is 2. I've retained these preferences.

Technical note: I had to use `QVariant` instead of an `optional` type because Stellarium isn't using C++≥17 (C++17 has `std::optional`), nor anything from Boost (which has `boost::optional`). The other alternative was to make my own `optional`, but that seemed like overkill.

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] This change requires a documentation update

## Checklist:
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules