### PR TITLE
Fix for Splash screen translation.

### DIFF
--- a/src/core/StelApp.cpp
+++ b/src/core/StelApp.cpp
@@ -422,6 +422,11 @@ void StelApp::init(QSettings* conf)
 	core = new StelCore();
 	if (!fuzzyEquals(saveProjW, -1.) && !fuzzyEquals(saveProjH, -1.))
 		core->windowHasBeenResized(0, 0, saveProjW, saveProjH);
+	
+	//Initializing locale at the begining to show all strings translated
+	localeMgr = new StelLocaleMgr();
+	localeMgr->init();
+	//SplashScreen::showMessage(q_("Initializing locales..."));
 
 	SplashScreen::showMessage(q_("Initializing textures..."));
 	// Initialize AFTER creation of openGL context
@@ -451,7 +456,6 @@ void StelApp::init(QSettings* conf)
 
 	//create non-StelModule managers
 	propMgr = new StelPropertyMgr();
-	localeMgr = new StelLocaleMgr();
 	skyCultureMgr = new StelSkyCultureMgr();
 	propMgr->registerObject(skyCultureMgr);
 	planetLocationMgr = new StelLocationMgr();
@@ -466,9 +470,6 @@ void StelApp::init(QSettings* conf)
 	stelObjectMgr = new StelObjectMgr();
 	stelObjectMgr->init();
 	getModuleMgr().registerModule(stelObjectMgr);	
-
-	SplashScreen::showMessage(q_("Initializing locales..."));
-	localeMgr->init();
 
 	// Hips surveys
 	SplashScreen::showMessage(q_("Initializing HiPS survey..."));


### PR DESCRIPTION
Initializing the locale at the beginning to show all strings translated

### Screenshots (if appropriate):
![before](https://user-images.githubusercontent.com/34002960/126994287-65d49a46-98e6-4520-ac5e-b4a8300c50c4.png)
![after](https://user-images.githubusercontent.com/34002960/126994311-043f90fd-4bec-4db5-b03e-fa87231a74cf.png)


### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### How Has This Been Tested?
**Test Configuration**:
* Operating system: <Ubuntu 20.04>

## Checklist:

- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
