### PR TITLE
keyboard shortcut editor: focus/tabs

### DIFF
--- a/src/gui/ShortcutsDialog.cpp
+++ b/src/gui/ShortcutsDialog.cpp
@@ -335,6 +335,9 @@ void ShortcutsDialog::createDialogContent()
 	QString style = "QLabel { color: rgb(238, 238, 238); }";
 	ui->primaryLabel->setStyleSheet(style);
 	ui->altLabel->setStyleSheet(style);
+
+	// set initial focus to action search
+	ui->lineEditSearch->setFocus();
 }
 
 void ShortcutsDialog::polish()

--- a/src/gui/ShortcutsDialog.hpp
+++ b/src/gui/ShortcutsDialog.hpp
@@ -95,7 +95,7 @@ private:
 	static bool itemIsEditable(QStandardItem *item);
 
 	//! Apply style changes.
-	//! See http://qt-project.org/faq/answer/how_can_my_stylesheet_account_for_custom_properties
+	//! See https://wiki.qt.io/Technical_FAQ#How_can_my_stylesheet_account_for_custom_properties.3F
 	void polish();
 
 	QStandardItem* updateGroup(const QString& group);
@@ -103,7 +103,7 @@ private:
 	//! search for first appearance of item with requested data.
 	QStandardItem* findItemByData(QVariant value, int role, int column = 0) const;
 
-	//! pointer to mgr, for not getting it from StelApp every time.
+	//! pointer to mgr, to avoid getting it from StelApp every time.
 	class StelActionMgr* actionMgr;
 
 	//! list for storing collisions items, so we can easy restore their colors.

--- a/src/gui/shortcutsDialog.ui
+++ b/src/gui/shortcutsDialog.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>654</width>
+    <width>737</width>
     <height>436</height>
    </rect>
   </property>
@@ -297,6 +297,18 @@
    </slots>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>shortcutsTreeView</tabstop>
+  <tabstop>lineEditSearch</tabstop>
+  <tabstop>primaryShortcutEdit</tabstop>
+  <tabstop>primaryBackspaceButton</tabstop>
+  <tabstop>applyButton</tabstop>
+  <tabstop>altShortcutEdit</tabstop>
+  <tabstop>altBackspaceButton</tabstop>
+  <tabstop>restoreDefaultsButton</tabstop>
+  <tabstop>restoreAllDefaultsButton</tabstop>
+  <tabstop>closeStelWindow</tabstop>
+ </tabstops>
  <resources>
   <include location="../../data/gui/guiRes.qrc"/>
  </resources>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
A recurring issue is that I need to click in the search field of the dialog to search for an action, and the tab order is odd (in fact, not specified, but grown over time).

This PR puts the initial focus in the search box, and improves the tab order.

<!--- Please also include relevant motivation and context. -->

An easy way to edit shortcuts is to search for a part of their name.
A SHIFT TAB allows the user to select a matching action, and the user can then TAB forward into the editor fields.

(Small note: on Linux, the BackspaceButtons do not seem to show a focus marker, but the focus is present and the buttons can be pushed via ENTER rather than SPACEBAR.)


<!--- List any dependencies that are required for this change. -->



### Screenshots (if appropriate):

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating System: Kubuntu 20.04
KDE Plasma Version: 5.18.5
KDE Frameworks Version: 5.68.0
Qt Version: 5.12.8
Kernel Version: 5.4.0-80-generic
OS Type: 64-bit
Processors: 8 × Intel® Core™ i7-10510U CPU @ 1.80GHz
Memory: 15.3 GiB of RAM


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
