### PR TITLE
Exclude outdated solar system objects

### DIFF
--- a/src/core/modules/Orbit.cpp
+++ b/src/core/modules/Orbit.cpp
@@ -263,6 +263,18 @@ double KeplerOrbit::calculateSiderealPeriod() const
 	return calculateSiderealPeriod(a, centralMass);
 }
 
+Vec2d KeplerOrbit::objectDateValidRange() const
+{
+	double min=std::numeric_limits<double>::min();
+	double max=std::numeric_limits<double>::max();
+	if (orbitGood>0)
+	{
+		min=t0-orbitGood;
+		max=t0+orbitGood;
+	}
+	return Vec2d(min, max);
+}
+
 GimbalOrbit::GimbalOrbit(double distance, double longitude, double latitude):
 	distance(distance),
 	longitude(longitude),

--- a/src/core/modules/Orbit.hpp
+++ b/src/core/modules/Orbit.hpp
@@ -77,6 +77,8 @@ public:
 	virtual double getSemimajorAxis() const Q_DECL_OVERRIDE { return (e==1. ? 0. : q / (1.-e)); }
 	virtual double getEccentricity() const Q_DECL_OVERRIDE { return e; }
 	bool objectDateValid(const double JDE) const { return ((orbitGood<=0) || (fabs(t0-JDE)<orbitGood)); }
+	//! Return minimal and maximal JDE values where this orbit should be used. (if orbitGood is configured)
+	Vec2d objectDateValidRange() const;
 	//! Calculate sidereal period in days from semi-major axis and central mass. If SMA<=0 (hyperbolic orbit), return 0.
 	double calculateSiderealPeriod() const;
 	//! @param semiMajorAxis in AU. If SMA<=0 (hyperbolic orbit), return 0.

--- a/src/core/modules/Planet.cpp
+++ b/src/core/modules/Planet.cpp
@@ -4274,7 +4274,7 @@ void Planet::drawOrbit(const StelCore* core)
 	if (hidden || (pType==isObserver)) return;
 	if (orbitPtr && pType>=isArtificial)
 	{
-		if (!hasValidData())
+		if (!hasValidPositionalData())
 			return;
 	}
 
@@ -4328,7 +4328,7 @@ void Planet::drawOrbit(const StelCore* core)
 		sPainter.setLineWidth(1);
 }
 
-bool Planet::hasValidData()
+bool Planet::hasValidPositionalData()
 {
 	if (pType<isObserver)
 		return true;

--- a/src/core/modules/Planet.cpp
+++ b/src/core/modules/Planet.cpp
@@ -4338,7 +4338,7 @@ bool Planet::hasValidPositionalData(const double JDE)
 		return false;
 }
 
-Vec2d Planet::getValidPositionalData()
+Vec2d Planet::getValidPositionalDataRange()
 {
 	double min=std::numeric_limits<double>::min();
 	double max=std::numeric_limits<double>::max();

--- a/src/core/modules/Planet.cpp
+++ b/src/core/modules/Planet.cpp
@@ -4274,7 +4274,7 @@ void Planet::drawOrbit(const StelCore* core)
 	if (hidden || (pType==isObserver)) return;
 	if (orbitPtr && pType>=isArtificial)
 	{
-		if (!static_cast<KeplerOrbit*>(orbitPtr)->objectDateValid(lastJDE))
+		if (!hasValidData())
 			return;
 	}
 
@@ -4326,6 +4326,16 @@ void Planet::drawOrbit(const StelCore* core)
 	sPainter.enableClientStates(false);
 	if (orbitsThickness>1 || ppx>1.f)
 		sPainter.setLineWidth(1);
+}
+
+bool Planet::hasValidData()
+{
+	if (pType<isObserver)
+		return true;
+	else if (orbitPtr && pType>=isArtificial)
+		return static_cast<KeplerOrbit*>(orbitPtr)->objectDateValid(lastJDE);
+	else
+		return false;
 }
 
 void Planet::update(int deltaTime)

--- a/src/core/modules/Planet.cpp
+++ b/src/core/modules/Planet.cpp
@@ -4338,6 +4338,18 @@ bool Planet::hasValidPositionalData(const double JDE)
 		return false;
 }
 
+Vec2d Planet::getValidPositionalData()
+{
+	double min=std::numeric_limits<double>::min();
+	double max=std::numeric_limits<double>::max();
+
+	if (orbitPtr && pType>=isArtificial)
+	{
+		return static_cast<KeplerOrbit*>(orbitPtr)->objectDateValidRange();
+	}
+	return Vec2d(min, max);
+}
+
 void Planet::update(int deltaTime)
 {
 	hintFader.update(deltaTime);

--- a/src/core/modules/Planet.cpp
+++ b/src/core/modules/Planet.cpp
@@ -4274,7 +4274,7 @@ void Planet::drawOrbit(const StelCore* core)
 	if (hidden || (pType==isObserver)) return;
 	if (orbitPtr && pType>=isArtificial)
 	{
-		if (!hasValidPositionalData())
+		if (!hasValidPositionalData(lastJDE))
 			return;
 	}
 
@@ -4328,12 +4328,12 @@ void Planet::drawOrbit(const StelCore* core)
 		sPainter.setLineWidth(1);
 }
 
-bool Planet::hasValidPositionalData()
+bool Planet::hasValidPositionalData(const double JDE)
 {
 	if (pType<isObserver)
 		return true;
 	else if (orbitPtr && pType>=isArtificial)
-		return static_cast<KeplerOrbit*>(orbitPtr)->objectDateValid(lastJDE);
+		return static_cast<KeplerOrbit*>(orbitPtr)->objectDateValid(JDE);
 	else
 		return false;
 }

--- a/src/core/modules/Planet.hpp
+++ b/src/core/modules/Planet.hpp
@@ -222,6 +222,8 @@ public:
 	virtual double getAngularSize(const StelCore* core) const Q_DECL_OVERRIDE;
 	virtual bool hasAtmosphere(void) {return atmosphere;}
 	virtual bool hasHalo(void) {return halo;}
+	//! Returns whether planet positions are valid and useful for the current simulation time. E.g. outdated orbital elements for Kepler orbits (beyond their orbit_good .ini file entries) may lead to invalid positions which should better not be used.
+	//! @note for major planets and moons this method will be always return true
 	bool hasValidPositionalData();
 	float getAxisRotation(void) { return axisRotation;} //! return axisRotation last computed in computeTransMatrix().
 

--- a/src/core/modules/Planet.hpp
+++ b/src/core/modules/Planet.hpp
@@ -225,12 +225,12 @@ public:
 	//! Returns whether planet positions are valid and useful for the current simulation time.
 	//! E.g. outdated orbital elements for Kepler orbits (beyond their orbit_good .ini file entries)
 	//! may lead to invalid positions which should better not be used.
-	//! @note for major planets and moons this method will be always return true
+	//! @note for major planets and moons this method will always return true
 	bool hasValidPositionalData(const double JDE);
 	//! Returns JDE dates of presumably valid data for positional calculation.
-	//! For the major planets, this is always (std::minreal, std::maxreal)
+	//! For the major planets and moons, this is always (std::numeric_limits<double>::min(), std::numeric_limits<double>::max())
 	//! For planets with Keplerian orbits, this is (epoch-orbit_good, epoch+orbit_good)
-	Vec2d getValidPositionalData();
+	Vec2d getValidPositionalDataRange();
 	float getAxisRotation(void) { return axisRotation;} //! return axisRotation last computed in computeTransMatrix().
 
 	///////////////////////////////////////////////////////////////////////////

--- a/src/core/modules/Planet.hpp
+++ b/src/core/modules/Planet.hpp
@@ -222,9 +222,15 @@ public:
 	virtual double getAngularSize(const StelCore* core) const Q_DECL_OVERRIDE;
 	virtual bool hasAtmosphere(void) {return atmosphere;}
 	virtual bool hasHalo(void) {return halo;}
-	//! Returns whether planet positions are valid and useful for the current simulation time. E.g. outdated orbital elements for Kepler orbits (beyond their orbit_good .ini file entries) may lead to invalid positions which should better not be used.
+	//! Returns whether planet positions are valid and useful for the current simulation time.
+	//! E.g. outdated orbital elements for Kepler orbits (beyond their orbit_good .ini file entries)
+	//! may lead to invalid positions which should better not be used.
 	//! @note for major planets and moons this method will be always return true
 	bool hasValidPositionalData(const double JDE);
+	//! Returns JDE dates of presumably valid data for positional calculation.
+	//! For the major planets, this is always (std::minreal, std::maxreal)
+	//! For planets with Keplerian orbits, this is (epoch-orbit_good, epoch+orbit_good)
+	Vec2d getValidPositionalData();
 	float getAxisRotation(void) { return axisRotation;} //! return axisRotation last computed in computeTransMatrix().
 
 	///////////////////////////////////////////////////////////////////////////

--- a/src/core/modules/Planet.hpp
+++ b/src/core/modules/Planet.hpp
@@ -224,7 +224,7 @@ public:
 	virtual bool hasHalo(void) {return halo;}
 	//! Returns whether planet positions are valid and useful for the current simulation time. E.g. outdated orbital elements for Kepler orbits (beyond their orbit_good .ini file entries) may lead to invalid positions which should better not be used.
 	//! @note for major planets and moons this method will be always return true
-	bool hasValidPositionalData();
+	bool hasValidPositionalData(const double JDE);
 	float getAxisRotation(void) { return axisRotation;} //! return axisRotation last computed in computeTransMatrix().
 
 	///////////////////////////////////////////////////////////////////////////

--- a/src/core/modules/Planet.hpp
+++ b/src/core/modules/Planet.hpp
@@ -222,6 +222,7 @@ public:
 	virtual double getAngularSize(const StelCore* core) const Q_DECL_OVERRIDE;
 	virtual bool hasAtmosphere(void) {return atmosphere;}
 	virtual bool hasHalo(void) {return halo;}
+	bool hasValidData();
 	float getAxisRotation(void) { return axisRotation;} //! return axisRotation last computed in computeTransMatrix().
 
 	///////////////////////////////////////////////////////////////////////////

--- a/src/core/modules/Planet.hpp
+++ b/src/core/modules/Planet.hpp
@@ -222,7 +222,7 @@ public:
 	virtual double getAngularSize(const StelCore* core) const Q_DECL_OVERRIDE;
 	virtual bool hasAtmosphere(void) {return atmosphere;}
 	virtual bool hasHalo(void) {return halo;}
-	bool hasValidData();
+	bool hasValidPositionalData();
 	float getAxisRotation(void) { return axisRotation;} //! return axisRotation last computed in computeTransMatrix().
 
 	///////////////////////////////////////////////////////////////////////////

--- a/src/gui/AstroCalcDialog.cpp
+++ b/src/gui/AstroCalcDialog.cpp
@@ -4473,6 +4473,7 @@ double AstroCalcDialog::findInitialStep(double startJD, double stopJD, QStringLi
 	return step;
 }
 
+// TODO: Improving an accuracy and speed-up the method
 QMap<double, double> AstroCalcDialog::findClosestApproach(PlanetP& object1, StelObjectP& object2, double startJD, double stopJD, double maxSeparation, int mode)
 {
 	double dist, prevDist, step, step0;
@@ -4482,9 +4483,10 @@ QMap<double, double> AstroCalcDialog::findClosestApproach(PlanetP& object1, Stel
 
 	if (object2->getType()=="Planet")
 	{
+		// TODO: Improve filtering the Solar system objects by valid positional data
 		PlanetP planet = qSharedPointerCast<Planet>(object2);
-		if (!planet->hasValidPositionalData(startJD) || !planet->hasValidPositionalData(stopJD))
-			return separations;
+		if (!planet->hasValidPositionalData(startJD) && !planet->hasValidPositionalData(stopJD))
+			return separations; // exclude a Solar system body with full invalid positional data only
 	}
 
 	QStringList objects;

--- a/src/gui/AstroCalcDialog.cpp
+++ b/src/gui/AstroCalcDialog.cpp
@@ -1195,7 +1195,7 @@ void AstroCalcDialog::currentCelestialPositions()
 					break;
 			}
 
-			if (!planet->hasValidPositionalData())
+			if (!planet->hasValidPositionalData(JD))
 				passByType = false;
 
 			if (passByType && planet != core->getCurrentPlanet() && planet->getVMagnitudeWithExtinction(core) <= mag && planet->isAboveRealHorizon(core))
@@ -1721,7 +1721,7 @@ void AstroCalcDialog::generateEphemeris()
 			core->setJD(JD);
 			core->update(0); // force update to get new coordinates
 
-			if (!obj->hasValidPositionalData())
+			if (!obj->hasValidPositionalData(JD))
 				continue;
 
 			if (useHorizontalCoords)
@@ -4483,13 +4483,7 @@ QMap<double, double> AstroCalcDialog::findClosestApproach(PlanetP& object1, Stel
 	if (object2->getType()=="Planet")
 	{
 		PlanetP planet = qSharedPointerCast<Planet>(object2);
-		core->setJD(stopJD);
-		core->update(0);
-		if (!planet->hasValidPositionalData())
-			return separations;
-		core->setJD(startJD);
-		core->update(0);
-		if (!planet->hasValidPositionalData())
+		if (!planet->hasValidPositionalData(startJD) || !planet->hasValidPositionalData(stopJD))
 			return separations;
 	}
 

--- a/src/gui/AstroCalcDialog.cpp
+++ b/src/gui/AstroCalcDialog.cpp
@@ -1195,6 +1195,9 @@ void AstroCalcDialog::currentCelestialPositions()
 					break;
 			}
 
+			if (!planet->hasValidData())
+				passByType = false;
+
 			if (passByType && planet != core->getCurrentPlanet() && planet->getVMagnitudeWithExtinction(core) <= mag && planet->isAboveRealHorizon(core))
 			{
 				pos = planet->getJ2000EquatorialPos(core);
@@ -1717,6 +1720,10 @@ void AstroCalcDialog::generateEphemeris()
 			double JD = firstJD + i * currentStep;
 			core->setJD(JD);
 			core->update(0); // force update to get new coordinates
+
+			if (!obj->hasValidData())
+				continue;
+
 			if (useHorizontalCoords)
 			{
 				pos = obj->getAltAzPosAuto(core);

--- a/src/gui/AstroCalcDialog.cpp
+++ b/src/gui/AstroCalcDialog.cpp
@@ -4473,6 +4473,19 @@ QMap<double, double> AstroCalcDialog::findClosestApproach(PlanetP& object1, Stel
 	QMap<double, double> separations;
 	QPair<double, double> extremum;
 
+	if (object2->getType()=="Planet")
+	{
+		PlanetP planet = qSharedPointerCast<Planet>(object2);
+		core->setJD(startJD);
+		core->update(0);
+		if (!planet->hasValidData())
+			return separations;
+		core->setJD(stopJD);
+		core->update(0);
+		if (!planet->hasValidData())
+			return separations;
+	}
+
 	QStringList objects;
 	objects.clear();
 	objects.append(object1->getEnglishName());

--- a/src/gui/AstroCalcDialog.cpp
+++ b/src/gui/AstroCalcDialog.cpp
@@ -4483,11 +4483,11 @@ QMap<double, double> AstroCalcDialog::findClosestApproach(PlanetP& object1, Stel
 	if (object2->getType()=="Planet")
 	{
 		PlanetP planet = qSharedPointerCast<Planet>(object2);
-		core->setJD(startJD);
+		core->setJD(stopJD);
 		core->update(0);
 		if (!planet->hasValidData())
 			return separations;
-		core->setJD(stopJD);
+		core->setJD(startJD);
 		core->update(0);
 		if (!planet->hasValidData())
 			return separations;

--- a/src/gui/AstroCalcDialog.cpp
+++ b/src/gui/AstroCalcDialog.cpp
@@ -1195,7 +1195,7 @@ void AstroCalcDialog::currentCelestialPositions()
 					break;
 			}
 
-			if (!planet->hasValidData())
+			if (!planet->hasValidPositionalData())
 				passByType = false;
 
 			if (passByType && planet != core->getCurrentPlanet() && planet->getVMagnitudeWithExtinction(core) <= mag && planet->isAboveRealHorizon(core))
@@ -1721,7 +1721,7 @@ void AstroCalcDialog::generateEphemeris()
 			core->setJD(JD);
 			core->update(0); // force update to get new coordinates
 
-			if (!obj->hasValidData())
+			if (!obj->hasValidPositionalData())
 				continue;
 
 			if (useHorizontalCoords)
@@ -4485,11 +4485,11 @@ QMap<double, double> AstroCalcDialog::findClosestApproach(PlanetP& object1, Stel
 		PlanetP planet = qSharedPointerCast<Planet>(object2);
 		core->setJD(stopJD);
 		core->update(0);
-		if (!planet->hasValidData())
+		if (!planet->hasValidPositionalData())
 			return separations;
 		core->setJD(startJD);
 		core->update(0);
-		if (!planet->hasValidData())
+		if (!planet->hasValidPositionalData())
 			return separations;
 	}
 

--- a/src/gui/AstroCalcDialog.cpp
+++ b/src/gui/AstroCalcDialog.cpp
@@ -4473,7 +4473,7 @@ double AstroCalcDialog::findInitialStep(double startJD, double stopJD, QStringLi
 	return step;
 }
 
-// TODO: Improving an accuracy and speed-up the method
+// FIXME: Improving an accuracy and speed-up the method
 QMap<double, double> AstroCalcDialog::findClosestApproach(PlanetP& object1, StelObjectP& object2, double startJD, double stopJD, double maxSeparation, int mode)
 {
 	double dist, prevDist, step, step0;
@@ -4483,7 +4483,7 @@ QMap<double, double> AstroCalcDialog::findClosestApproach(PlanetP& object1, Stel
 
 	if (object2->getType()=="Planet")
 	{
-		// TODO: Improve filtering the Solar system objects by valid positional data
+		// FIXME: Improve filtering the Solar system objects by valid positional data
 		PlanetP planet = qSharedPointerCast<Planet>(object2);
 		if (!planet->hasValidPositionalData(startJD) && !planet->hasValidPositionalData(stopJD))
 			return separations; // exclude a Solar system body with full invalid positional data only

--- a/src/gui/AstroCalcDialog.cpp
+++ b/src/gui/AstroCalcDialog.cpp
@@ -4482,8 +4482,12 @@ QMap<double, double> AstroCalcDialog::findClosestApproach(PlanetP& object1, Stel
 
 	if (object2->getType()=="Planet")
 	{
-		// If we don't have at least partial overlap between planet valid dates and our interval, skip by returning an empty map.
 		PlanetP planet = qSharedPointerCast<Planet>(object2);
+		// We shouldn't compute eclipses and shadow transits not for planets and their moons
+		if (mode==PhenomenaTypeIndex::Shadows && object2->getEnglishName()!="Sun" && planet->getParent()!=object1)
+			return separations;
+
+		// If we don't have at least partial overlap between planet valid dates and our interval, skip by returning an empty map.		
 		const Vec2d planetValidityLimits=planet->getValidPositionalDataRange();
 		if ( (planetValidityLimits[0] > stopJD) || (planetValidityLimits[1] < startJD) )
 			return separations;

--- a/src/gui/AstroCalcDialog.hpp
+++ b/src/gui/AstroCalcDialog.hpp
@@ -121,7 +121,7 @@ public:
 	};
 
 	enum PhenomenaTypeIndex {
-		Conjuction		= 0,
+		Conjunction		= 0,
 		Opposition		= 1,
 		GreatestElongation	= 2,
 		StationaryPoint		= 3,
@@ -386,7 +386,7 @@ private:
 	//! angular separation ("conjunction" defined as equality of right ascension
 	//! of two bodies), and current solution is not accurate and slow.
 	//! @note modes: 0 - conjuction, 1 - opposition, 2 - greatest elongation
-	QMap<double, double> findClosestApproach(PlanetP& object1, StelObjectP& object2, double startJD, double stopJD, double maxSeparation, int mode);
+	QMap<double, double> findClosestApproach(PlanetP& object1, StelObjectP& object2, const double startJD, const double stopJD, const double maxSeparation, const int mode);
 	// TODO: Doc?
 	double findDistance(double JD, PlanetP object1, StelObjectP object2, int mode);
 	// TODO: Doc?


### PR DESCRIPTION
### Description
Excluding the Solar system objects with outdated data from ephemeris, positions and phenomena computations

Fixes #1564

### Screenshots (if appropriate):
v0.21.1:
![stellarium-006](https://user-images.githubusercontent.com/88731/132953223-2d09cc2b-6f7a-4f5a-b521-23910e246d65.jpg)

v0.21.1-122fe98:
![stellarium-007](https://user-images.githubusercontent.com/88731/132953276-fa92e6db-39b8-4cf7-8177-86a3ff8ce432.jpg)


### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### How Has This Been Tested?
Load 1000 comets data file.
Use AstroCalc/Phenomena (AstroCalc/Positions or AstroCalc/Ephemeris also) to search for phenomena around Jupiter's moons, e.g. June to September 2021.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
