### PR TITLE
star trails

### DIFF
--- a/guide/ch_advanced_use.tex
+++ b/guide/ch_advanced_use.tex
@@ -819,12 +819,12 @@ In \file{config.ini}, it is stored in
 sky_background_color  = 0.000000,0.000000,0.000000
 \end{configfile}
 
-\subsection{Star Streaks}
-\label{sec:CommandLineOptions:Special:StarStreaks}
+\subsection{Star Trails}
+\label{sec:CommandLineOptions:Special:StarTrails}
 
 One of the oldest\newFeature{26.2}  and previously simplest techniques from the time of film-based night photography is the recording 
 of Earth's rotation by long-time exposure with an untracked camera. 
-This will, for example, identify the Polar Star as just not quite on the north celestial pole, but else show thousands of circular star streaks. 
+This will, for example, identify the Polar Star as just not quite on the north celestial pole, but else show thousands of circular star trails. 
 While an exposure time of many hours is possible under dark skies, when the sky is too bright by remaining twilight or light pollution, 
 the exposure time meanwhile is often limited to minutes, else the picture is just flooded with unwanted background. 
 
@@ -838,9 +838,10 @@ The trick implemented in this special mode draws one frame in ``normal'' mode, a
 which cause only smeared images like screen labels. A moderately long ``exposure'' can therefore still successfully show constellations or star labels.  
 
 This is an option probably only used by instructors or presenters and therefore not preconfigured for beginners. 
-To make use of it, you must assign a keyboard shortcut to the action ``Toggle background clearing''
+To make use of it, you must assign a keyboard shortcut to the action ``Toggle star trails''
 found in the ``Display Options'' key shortcut actions (see \ref{sec:gui:help:hotkeys}).
 
+Note that screenshots have to be made with system means while this mode is running. 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 

--- a/guide/ch_advanced_use.tex
+++ b/guide/ch_advanced_use.tex
@@ -802,6 +802,48 @@ Note that Spout use disables any multisampling setting (see Appendix~\ref{sec:co
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
+\section{Show effects} 
+\label{sec:CommandLineOptions:Special:Show}
+
+\subsection{Sky Background}
+\label{sec:CommandLineOptions:Special:ColoredBackground}
+
+Stellarium is sometimes used for entertainment or artistic music performances. 
+From this community a request was placed to allow a non-black background. We can do that, but you must revert the color yourself.
+Setting a background color is not available in the usual GUI to avoid inadvertent changes that later confuse users. 
+You can play with the sky background in the Text User Interface (see section \ref{sec:plugins:TUI:commands}, feature 5.26). 
+In \file{config.ini}, it is stored in
+
+\begin{configfile}
+[color]
+sky_background_color  = 0.000000,0.000000,0.000000
+\end{configfile}
+
+\subsection{Star Streaks}
+\label{sec:CommandLineOptions:Special:StarStreaks}
+
+One of the oldest\newFeature{26.2}  and previously simplest techniques from the time of film-based night photography is the recording 
+of Earth's rotation by long-time exposure with an untracked camera. 
+This will, for example, identify the Polar Star as just not quite on the north celestial pole, but else show thousands of circular star streaks. 
+While an exposure time of many hours is possible under dark skies, when the sky is too bright by remaining twilight or light pollution, 
+the exposure time meanwhile is often limited to minutes, else the picture is just flooded with unwanted background. 
+
+Stellarium can be made to simulate such images by a somewhat ``dirty trick'': Usually the image area is cleared between frames, 
+then the Milky Way, stars, Zodiacal light, grids, planets, atmosphere, landscape etc., and finally GUI panels are rendered into the scene. 
+By not clearing the image area, we can just add up everything that is rendered on-screen, like in a long-time exposure. 
+However, just as cars, airplanes, satellites or people with flashlights can ruin your awesome star streak photo, 
+some elements usually visible in Stellarium's sky would also create unwanted views. 
+Image a celestial grid or the Milky Way rotating with the sky, and twilight stacking all up and flooding the long-time exposure. 
+The trick implemented in this special mode draws one frame in ``normal'' mode, and then suppresses those elements and other details 
+which cause only smeared images like screen labels. A moderately long ``exposure'' can therefore still successfully show constellations or star labels.  
+
+This is an option probably only used by instructors or presenters and therefore not preconfigured for beginners. 
+To make use of it, you must assign a keyboard shortcut to the action ``Toggle background clearing''
+found in the ``Display Options'' key shortcut actions (see \ref{sec:gui:help:hotkeys}).
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
 \iffalse
 
 %% NOTE: We cannot provide accurate documentation on this topic at this time. 
@@ -849,7 +891,7 @@ Piper runs a web server which allows integration to \program{speechd}.
 
 With Stellarium it’s very easy to project the sky on a dome and create your own planetarium.
 
-\subsubsection{360° Projection}
+\subsection{360° Projection}
 You can use either a very expensive fisheye lens projector -- or a standard projector with a spherical mirror.
 Not only is spherical mirror projection less expensive, 
 but it produces a higher resolution image on the dome\footnote{\url{https://domeclub.com/#PxComp}},
@@ -872,7 +914,7 @@ it's quite easy to build your
 own\footnote{\url{https://docs.worldwidetelescope.org/diy-planetarium-dome/1/dome/#setting-up-the-projector-and-mirrors}} 
 -- and you can use a cheap convex safety mirror for testing before investing in a first-surface mirror.
 
-\subsubsection{Projector Specifications}
+\subsection{Projector Specifications}
 A major challenge with digital planetariums (360° cinemas) is the cross-reflection of light on the dome. 
 This is why projector \emph{contrast ratio} and \emph{colour saturation} are more important than brightness (lumens). 
 Light `bouncing' around the dome causes the planetarium image to `wash out' (lose colour) -- 
@@ -882,7 +924,7 @@ Similarly, the higher the contrast ratio, the sharper and crisper the planetariu
 4K projectors are now very affordable, allowing you to deliver the same high-quality visuals in your small
 dome as large planetariums!
 
-\subsubsection{Computer Configuration}
+\subsection{Computer Configuration}
 The best way to operate a planetarium is with a dual display arrangement, i.e., 
 computer screen as the primary (main) display, and projector as the secondary (extended) display.
 
@@ -893,7 +935,7 @@ the dome (even with no application open), use a high-resolution image of stars a
 To function as a planetarium, Stellarium should be configured to open in full screen mode on the extended
 display (see below).
 
-\subsubsection{System Configuration}
+\subsection{System Configuration}
 To minimise image distortion at the back of the dome, it’s worth carrying out the slightly complex
 \program{Meshmapper} configuration\footnote{\url{https://paulbourke.net/dome/meshmapper}}. 
 This creates a custom distortion file for your specific system (i.e., your dome
@@ -901,7 +943,7 @@ diameter, stand height, spherical mirror dimensions);
 and the image improvement will be remarkable\footnote{\url{https://domeclub.com/images/Meshmapper-1152w.jpg}}. 
 This custom distortion file (‘warp mesh data file’) can then be used with dome applications like Stellarium.
 
-\subsubsection{Stellarium Configuration}
+\subsection{Stellarium Configuration}
 To enable planetarium spherical mirror projection, the \file{config.ini} file needs to include the following:
 
 \begin{configfile}
@@ -962,7 +1004,7 @@ star_twinkle_amount = 0.50
 \end{configfile}
 
 
-\subsubsection{Further notes}
+\subsection{Further notes}
 This feature is rarely used by the current developers and cannot be tested on standard hardware. 
 See ongoing discussion on Github\footnote{\url{https://github.com/Stellarium/stellarium/issues/1914} and \\
 \url{https://github.com/Stellarium/stellarium/issues/3535}} and get involved.

--- a/guide/ch_advanced_use.tex
+++ b/guide/ch_advanced_use.tex
@@ -831,7 +831,7 @@ the exposure time meanwhile is often limited to minutes, else the picture is jus
 Stellarium can be made to simulate such images by a somewhat ``dirty trick'': Usually the image area is cleared between frames, 
 then the Milky Way, stars, Zodiacal light, grids, planets, atmosphere, landscape etc., and finally GUI panels are rendered into the scene. 
 By not clearing the image area, we can just add up everything that is rendered on-screen, like in a long-time exposure. 
-However, just as cars, airplanes, satellites or people with flashlights can ruin your awesome star streak photo, 
+However, just as cars, airplanes, satellites or people with flashlights can ruin your awesome star trail photo, 
 some elements usually visible in Stellarium's sky would also create unwanted views. 
 Image a celestial grid or the Milky Way rotating with the sky, and twilight stacking all up and flooding the long-time exposure. 
 The trick implemented in this special mode draws one frame in ``normal'' mode, and then suppresses those elements and other details 
@@ -839,7 +839,12 @@ which cause only smeared images like screen labels. A moderately long ``exposure
 
 This is an option probably only used by instructors or presenters and therefore not preconfigured for beginners. 
 To make use of it, you must assign a keyboard shortcut to the action ``Toggle star trails''
-found in the ``Display Options'' key shortcut actions (see \ref{sec:gui:help:hotkeys}).
+found in the ``Display Options'' key shortcut actions (see \ref{sec:gui:help:hotkeys}). 
+While the mode is on, tapping \key{Ctrl} resets the trails. 
+It can make a nice ending scene in a presentation: show a moderately slow moving sky, and activate it.  
+The sky will fill with curves, hopefully impressing your audience. 
+You can also utilize it when talking about the problem of satellite constellations now destroying the sky. (Use realistic view, not icons, for satellites.) 
+Here your time speed should not be too fast, else satellites will just show up as dot chain. 
 
 Note that screenshots have to be made with system means while this mode is running. 
 

--- a/plugins/AngleMeasure/src/AngleMeasure.cpp
+++ b/plugins/AngleMeasure/src/AngleMeasure.cpp
@@ -289,6 +289,8 @@ void AngleMeasure::drawOne(StelCore *core, const StelCore::FrameType frameType, 
 //! Draw any parts on the screen which are for our module
 void AngleMeasure::draw(StelCore* core)
 {
+	if(!core->getFlagClearSky())
+		return;
 	if (startPoint.normSquared()==0.0) // avoid crash on switch-on, lp:#1455839
 		return;
 	if (lineVisible.getInterstate() < 0.000001f && messageFader.getInterstate() < 0.000001f)

--- a/plugins/ArchaeoLines/src/ArchaeoLines.cpp
+++ b/plugins/ArchaeoLines/src/ArchaeoLines.cpp
@@ -484,7 +484,7 @@ void ArchaeoLines::update(double deltaTime)
 //! Draw any parts on the screen which are for our module
 void ArchaeoLines::draw(StelCore* core)
 {
-	if (core->getCurrentPlanet()->getEnglishName()!="Earth")
+	if (core->getCurrentPlanet()->getEnglishName()!="Earth" || !core->getFlagClearSky())
 		return;
 
 	equinoxLine->draw(core, lineFader.getInterstate());

--- a/plugins/ArchaeoLines/src/ArchaeoLines.cpp
+++ b/plugins/ArchaeoLines/src/ArchaeoLines.cpp
@@ -484,7 +484,10 @@ void ArchaeoLines::update(double deltaTime)
 //! Draw any parts on the screen which are for our module
 void ArchaeoLines::draw(StelCore* core)
 {
-	if (core->getCurrentPlanet()->getEnglishName()!="Earth" || !core->getFlagClearSky())
+	if (!core->getFlagClearSky())
+		return;
+
+	if (core->getCurrentPlanet()->getEnglishName()!="Earth")
 		return;
 
 	equinoxLine->draw(core, lineFader.getInterstate());

--- a/plugins/Exoplanets/src/Exoplanets.cpp
+++ b/plugins/Exoplanets/src/Exoplanets.cpp
@@ -234,7 +234,10 @@ void Exoplanets::init()
 
 void Exoplanets::draw(StelCore* core)
 {
-	if (!flagShowExoplanets || (!core->getFlagClearSky()))
+	if (!core->getFlagClearSky())
+		return;
+
+	if (!flagShowExoplanets)
 		return;
 
 	StelProjectorP prj = core->getProjection(StelCore::FrameJ2000);

--- a/plugins/Exoplanets/src/Exoplanets.cpp
+++ b/plugins/Exoplanets/src/Exoplanets.cpp
@@ -234,7 +234,7 @@ void Exoplanets::init()
 
 void Exoplanets::draw(StelCore* core)
 {
-	if (!flagShowExoplanets)
+	if (!flagShowExoplanets || (!core->getFlagClearSky()))
 		return;
 
 	StelProjectorP prj = core->getProjection(StelCore::FrameJ2000);

--- a/plugins/MeteorShowers/src/MeteorShowers.cpp
+++ b/plugins/MeteorShowers/src/MeteorShowers.cpp
@@ -50,6 +50,9 @@ void MeteorShowers::update(double deltaTime)
 
 void MeteorShowers::draw(StelCore* core)
 {
+	if(!core->getFlagClearSky())
+		return;
+
 	for (const auto& ms : std::as_const(m_meteorShowers))
 	{
 		ms->draw(core);

--- a/plugins/MosaicCamera/src/MosaicCamera.cpp
+++ b/plugins/MosaicCamera/src/MosaicCamera.cpp
@@ -608,7 +608,10 @@ void MosaicCamera::setCurrentVisibility(bool visible)
 
 void MosaicCamera::draw(StelCore* core)
 {
-	if (!isEnabled() || (!core->getFlagClearSky()))
+	if (!core->getFlagClearSky())
+		return;
+
+	if (!isEnabled())
 		return;
 
 	const StelProjectorP prj = core->getProjection(StelCore::FrameJ2000);

--- a/plugins/MosaicCamera/src/MosaicCamera.cpp
+++ b/plugins/MosaicCamera/src/MosaicCamera.cpp
@@ -608,7 +608,7 @@ void MosaicCamera::setCurrentVisibility(bool visible)
 
 void MosaicCamera::draw(StelCore* core)
 {
-	if (!isEnabled())
+	if (!isEnabled() || (!core->getFlagClearSky()))
 		return;
 
 	const StelProjectorP prj = core->getProjection(StelCore::FrameJ2000);

--- a/plugins/NavStars/src/NavStars.cpp
+++ b/plugins/NavStars/src/NavStars.cpp
@@ -173,9 +173,11 @@ bool NavStars::configureGui(bool show)
 }
 
 void NavStars::draw(StelCore* core)
-{	
+{
+	if (!core->getFlagClearSky())
+		return;
 	// Drawing is enabled?
-	if ((markerFader.getInterstate() <= 0.0f) || (!core->getFlagClearSky()))
+	if (markerFader.getInterstate() <= 0.0f)
 	{
 		return;
 	}

--- a/plugins/NavStars/src/NavStars.cpp
+++ b/plugins/NavStars/src/NavStars.cpp
@@ -173,9 +173,9 @@ bool NavStars::configureGui(bool show)
 }
 
 void NavStars::draw(StelCore* core)
-{
+{	
 	// Drawing is enabled?
-	if (markerFader.getInterstate() <= 0.0f)
+	if ((markerFader.getInterstate() <= 0.0f) || (!core->getFlagClearSky()))
 	{
 		return;
 	}

--- a/plugins/PointerCoordinates/src/PointerCoordinates.cpp
+++ b/plugins/PointerCoordinates/src/PointerCoordinates.cpp
@@ -121,7 +121,10 @@ void PointerCoordinates::init()
 
 void PointerCoordinates::draw(StelCore *core)
 {
-	if (!isEnabled() || (!core->getFlagClearSky()))
+	if (!core->getFlagClearSky())
+		return;
+
+	if (!isEnabled())
 		return;
 
 	const StelProjectorP prj = core->getProjection(StelCore::FrameJ2000, StelCore::RefractionAuto);

--- a/plugins/PointerCoordinates/src/PointerCoordinates.cpp
+++ b/plugins/PointerCoordinates/src/PointerCoordinates.cpp
@@ -121,7 +121,7 @@ void PointerCoordinates::init()
 
 void PointerCoordinates::draw(StelCore *core)
 {
-	if (!isEnabled())
+	if (!isEnabled() || (!core->getFlagClearSky()))
 		return;
 
 	const StelProjectorP prj = core->getProjection(StelCore::FrameJ2000, StelCore::RefractionAuto);

--- a/plugins/Pulsars/src/Pulsars.cpp
+++ b/plugins/Pulsars/src/Pulsars.cpp
@@ -233,7 +233,10 @@ void Pulsars::init()
 */
 void Pulsars::draw(StelCore* core)
 {
-	if (!flagShowPulsars || (!core->getFlagClearSky()))
+	if (!core->getFlagClearSky())
+		return;
+
+	if (!flagShowPulsars)
 		return;
 
 	StelProjectorP prj = core->getProjection(StelCore::FrameJ2000);

--- a/plugins/Pulsars/src/Pulsars.cpp
+++ b/plugins/Pulsars/src/Pulsars.cpp
@@ -233,7 +233,7 @@ void Pulsars::init()
 */
 void Pulsars::draw(StelCore* core)
 {
-	if (!flagShowPulsars)
+	if (!flagShowPulsars || (!core->getFlagClearSky()))
 		return;
 
 	StelProjectorP prj = core->getProjection(StelCore::FrameJ2000);

--- a/plugins/Quasars/src/Quasars.cpp
+++ b/plugins/Quasars/src/Quasars.cpp
@@ -234,7 +234,10 @@ void Quasars::init()
 */
 void Quasars::draw(StelCore* core)
 {
-	if (!flagShowQuasars || (!core->getFlagClearSky()))
+	if (!core->getFlagClearSky())
+		return;
+
+	if (!flagShowQuasars)
 		return;
 
 	StelProjectorP prj = core->getProjection(StelCore::FrameJ2000);

--- a/plugins/Quasars/src/Quasars.cpp
+++ b/plugins/Quasars/src/Quasars.cpp
@@ -234,7 +234,7 @@ void Quasars::init()
 */
 void Quasars::draw(StelCore* core)
 {
-	if (!flagShowQuasars)
+	if (!flagShowQuasars || (!core->getFlagClearSky()))
 		return;
 
 	StelProjectorP prj = core->getProjection(StelCore::FrameJ2000);

--- a/plugins/Satellites/src/Satellite.cpp
+++ b/plugins/Satellites/src/Satellite.cpp
@@ -1211,7 +1211,7 @@ void Satellite::draw(StelCore* core, StelPainter& painter)
 		}
 	}
 
-	if (orbitDisplayed && Satellite::orbitLinesFlag && orbitValid)
+	if (orbitDisplayed && Satellite::orbitLinesFlag && orbitValid && core->getFlagClearSky())
 		drawOrbit(core, painter);
 }
 

--- a/plugins/Satellites/src/Satellites.cpp
+++ b/plugins/Satellites/src/Satellites.cpp
@@ -3341,6 +3341,10 @@ void Satellites::draw(StelCore* core)
 			sat->draw(core, painter);
 	}
 
+	// In screen accumulation mode (star trails), circles or pointer should be suppressed.
+	if (!core->getFlagClearSky())
+		return;
+
 	if (GETSTELMODULE(StelObjectMgr)->getFlagSelectedObjectPointer())
 		drawPointer(core, painter);
 

--- a/plugins/Scenery3d/src/Scenery3d.cpp
+++ b/plugins/Scenery3d/src/Scenery3d.cpp
@@ -226,6 +226,9 @@ void Scenery3d::update(double deltaTime)
 
 void Scenery3d::draw(StelCore* core)
 {
+	if(!core->getFlagClearSky())
+		return;
+
 	if (flagEnabled && currentScene)
 	{
 		renderer->draw(core,*currentScene);

--- a/src/StelMainView.cpp
+++ b/src/StelMainView.cpp
@@ -378,6 +378,19 @@ public:
 	{
 		prepareGeometryChange();
 		rect.setSize(size);
+		StelApp *app=&StelApp::getInstance();
+		if (app)
+		{
+			qDebug() << "got app";
+			StelCore *core=app->getCore();
+			qDebug() << "got core";
+			if (core && core->getJD()!=0.0)
+			{
+				qDebug() << "call core";
+				core->setClearSkyOnce();
+			}
+			qDebug() << "after core";
+		}
 	}
 
 	//! Set the sky background color. Everything else than black creates a work of art!

--- a/src/StelMainView.cpp
+++ b/src/StelMainView.cpp
@@ -381,15 +381,9 @@ public:
 		StelApp *app=&StelApp::getInstance();
 		if (app)
 		{
-			qDebug() << "got app";
 			StelCore *core=app->getCore();
-			qDebug() << "got core";
 			if (core && core->getJD()!=0.0)
-			{
-				qDebug() << "call core";
 				core->setClearSkyOnce();
-			}
-			qDebug() << "after core";
 		}
 	}
 

--- a/src/core/StelApp.cpp
+++ b/src/core/StelApp.cpp
@@ -1051,17 +1051,10 @@ void StelApp::highGraphicsModeDraw()
 
 	const QList<StelModule*> modules = moduleMgr->getCallOrders(StelModule::ActionDraw);
 
-	if (core->getFlagClearSky())
-		for (auto* module : modules)
-		{
-			module->draw(core);
-		}
-	else
-		for (auto* module : modules)
-		{
-			if (! QStringList({"MilkyWay", "ZodiacalLight", "GridLinesMgr", "NebulaMgr"}).contains(module->objectName()))
-				module->draw(core);
-		}
+	for (auto* module : modules)
+	{
+		module->draw(core);
+	}
 
 	if(sceneMultisampledFBO)
 	{

--- a/src/core/StelApp.cpp
+++ b/src/core/StelApp.cpp
@@ -1051,7 +1051,7 @@ void StelApp::highGraphicsModeDraw()
 
 	const QList<StelModule*> modules = moduleMgr->getCallOrders(StelModule::ActionDraw);
 
-	for (auto* module : modules)
+	for(auto* module : modules)
 	{
 		module->draw(core);
 	}
@@ -1123,17 +1123,10 @@ void StelApp::draw()
 	else
 	{
 		const QList<StelModule*> modules = moduleMgr->getCallOrders(StelModule::ActionDraw);
-		if (core->getFlagClearSky())
-			for (auto* module : modules)
-			{
-				module->draw(core);
-			}
-		else
-			for (auto* module : modules)
-			{
-				if (! QStringList({"MilkyWay", "ZodiacalLight", "GridLinesMgr", "NebulaMgr"}).contains(module->objectName()))
-					module->draw(core);
-			}
+		for (auto* module : modules)
+		{
+			module->draw(core);
+		}
 	}
 
 	core->postDraw();

--- a/src/core/StelApp.cpp
+++ b/src/core/StelApp.cpp
@@ -1059,7 +1059,7 @@ void StelApp::highGraphicsModeDraw()
 	else
 		for (auto* module : modules)
 		{
-			if (! QStringList({"MilkyWay", "ZodiacalLight", "LandscapeMgr", "GridlinesMgr"}).contains(module->objectName()))
+			if (! QStringList({"MilkyWay", "ZodiacalLight", "GridLinesMgr", "NebulaMgr"}).contains(module->objectName()))
 				module->draw(core);
 		}
 
@@ -1138,7 +1138,7 @@ void StelApp::draw()
 		else
 			for (auto* module : modules)
 			{
-				if (! QStringList({"MilkyWay", "ZodiacalLight", "LandscapeMgr", "GridlinesMgr"}).contains(module->objectName()))
+				if (! QStringList({"MilkyWay", "ZodiacalLight", "GridLinesMgr", "NebulaMgr"}).contains(module->objectName()))
 					module->draw(core);
 			}
 	}

--- a/src/core/StelApp.cpp
+++ b/src/core/StelApp.cpp
@@ -1051,10 +1051,17 @@ void StelApp::highGraphicsModeDraw()
 
 	const QList<StelModule*> modules = moduleMgr->getCallOrders(StelModule::ActionDraw);
 
-	for(auto* module : modules)
-	{
-		module->draw(core);
-	}
+	if (core->getFlagClearSky())
+		for (auto* module : modules)
+		{
+			module->draw(core);
+		}
+	else
+		for (auto* module : modules)
+		{
+			if (! QStringList({"MilkyWay", "ZodiacalLight", "LandscapeMgr", "GridlinesMgr"}).contains(module->objectName()))
+				module->draw(core);
+		}
 
 	if(sceneMultisampledFBO)
 	{
@@ -1123,10 +1130,17 @@ void StelApp::draw()
 	else
 	{
 		const QList<StelModule*> modules = moduleMgr->getCallOrders(StelModule::ActionDraw);
-		for (auto* module : modules)
-		{
-			module->draw(core);
-		}
+		if (core->getFlagClearSky())
+			for (auto* module : modules)
+			{
+				module->draw(core);
+			}
+		else
+			for (auto* module : modules)
+			{
+				if (! QStringList({"MilkyWay", "ZodiacalLight", "LandscapeMgr", "GridlinesMgr"}).contains(module->objectName()))
+					module->draw(core);
+			}
 	}
 
 	core->postDraw();

--- a/src/core/StelCore.cpp
+++ b/src/core/StelCore.cpp
@@ -116,6 +116,7 @@ StelCore::StelCore()
 	, de440Active(false)
 	, de441Active(false)
 	, flagClearSky(true)
+	, flagClearSkyOnce(0)
 {
 	setObjectName("StelCore");
 	registerMathMetaTypes();
@@ -565,8 +566,22 @@ void StelCore::preDraw()
 	Vec3f backColor = StelMainView::getInstance().getSkyBackgroundColor();
 	QOpenGLFunctions* gl = QOpenGLContext::currentContext()->functions();
 	gl->glClearColor(backColor[0], backColor[1], backColor[2], 0.f);
-	if (flagClearSky)
+
+	if (flagClearSkyOnce==1)
+	{
+		flagClearSky=false; // Allow drawing one frame with features
+		flagClearSkyOnce=0;
+	}
+
+	if (flagClearSky || (flagClearSkyOnce==2))
+	{
 		gl->glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
+		if (flagClearSkyOnce==2)
+		{
+			flagClearSkyOnce=1;
+			flagClearSky=true; // Let other modules draw once!
+		}
+	}
 	else
 	{
 		// TODO: dim whole framebuffer to 90%, else we are overexposed much too fast.
@@ -3363,4 +3378,11 @@ void StelCore::setFlagClearSky(const bool state)
 	flagClearSky = state;
 	qDebug() << "flagClearSky now" << state;
 	emit flagClearSkyChanged(state);
+}
+
+// Initiate a reset chain for preDraw()
+void StelCore::setClearSkyOnce()
+{
+	if (!flagClearSky)
+		flagClearSkyOnce = 2;
 }

--- a/src/core/StelCore.cpp
+++ b/src/core/StelCore.cpp
@@ -573,12 +573,12 @@ void StelCore::preDraw()
 		flagClearSkyOnce=0;
 	}
 
-	if (flagClearSky || (flagClearSkyOnce==2))
+	if (flagClearSky || (flagClearSkyOnce==3))
 	{
 		gl->glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
-		if (flagClearSkyOnce==2)
+		if (flagClearSkyOnce>=2)
 		{
-			flagClearSkyOnce=1;
+			flagClearSkyOnce--;
 			flagClearSky=true; // Let other modules draw once!
 		}
 	}
@@ -1505,6 +1505,7 @@ void StelCore::moveObserverTo(const StelLocation& target, double duration, doubl
 	else
 	{
 		setObserver(new StelObserver(target));
+		setClearSkyOnce();
 	}
 
 	// Auto-select observed planet for observer locations
@@ -3386,5 +3387,5 @@ void StelCore::setFlagClearSky(const bool state)
 void StelCore::setClearSkyOnce()
 {
 	if (!flagClearSky)
-		flagClearSkyOnce = 2;
+		flagClearSkyOnce = 3;
 }

--- a/src/core/StelCore.cpp
+++ b/src/core/StelCore.cpp
@@ -1246,6 +1246,7 @@ void StelCore::setJD(double newJD)
 	JD.first=newJD;
 	JD.second=computeDeltaT(newJD);	
 	resetSync();
+	setClearSkyOnce();
 }
 
 double StelCore::getJD() const
@@ -1259,6 +1260,7 @@ void StelCore::setJDE(double newJDE)
 	JD.second=computeDeltaT(newJDE);
 	JD.first=newJDE-JD.second/86400.0;
 	resetSync();
+	setClearSkyOnce();
 }
 
 double StelCore::getJDE() const

--- a/src/core/StelCore.cpp
+++ b/src/core/StelCore.cpp
@@ -584,7 +584,6 @@ void StelCore::preDraw()
 	}
 	else
 	{
-		// TODO: dim whole framebuffer to 90%, else we are overexposed much too fast.
 		gl->glClear(GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
 	}
 

--- a/src/core/StelCore.cpp
+++ b/src/core/StelCore.cpp
@@ -387,7 +387,7 @@ void StelCore::init()
 	actionsMgr->addAction("actionHorizontal_Flip", displayGroup, N_("Flip scene horizontally"), this, "flipHorz", "Ctrl+Shift+H", "", true);
 	actionsMgr->addAction("actionVertical_Flip", displayGroup, N_("Flip scene vertically"), this, "flipVert", "Ctrl+Shift+V", "", true);
 
-	actionsMgr->addAction("actionClear_Background", displayGroup, N_("Toggle background clearing"), this, "flagClearSky", "Ctrl+Alt+C", "", true);
+	actionsMgr->addAction("actionClear_Background", displayGroup, N_("Toggle star trails"), this, "flagClearSky", "", "", true);
 }
 
 QString StelCore::getDefaultProjectionTypeKey() const

--- a/src/core/StelCore.cpp
+++ b/src/core/StelCore.cpp
@@ -115,6 +115,7 @@ StelCore::StelCore()
 	, de441Available(false)
 	, de440Active(false)
 	, de441Active(false)
+	, flagClearSky(true)
 {
 	setObjectName("StelCore");
 	registerMathMetaTypes();
@@ -384,6 +385,8 @@ void StelCore::init()
 
 	actionsMgr->addAction("actionHorizontal_Flip", displayGroup, N_("Flip scene horizontally"), this, "flipHorz", "Ctrl+Shift+H", "", true);
 	actionsMgr->addAction("actionVertical_Flip", displayGroup, N_("Flip scene vertically"), this, "flipVert", "Ctrl+Shift+V", "", true);
+
+	actionsMgr->addAction("actionClear_Background", displayGroup, N_("Toggle background clearing"), this, "flagClearSky", "Ctrl+Alt+C", "", true);
 }
 
 QString StelCore::getDefaultProjectionTypeKey() const
@@ -562,7 +565,13 @@ void StelCore::preDraw()
 	Vec3f backColor = StelMainView::getInstance().getSkyBackgroundColor();
 	QOpenGLFunctions* gl = QOpenGLContext::currentContext()->functions();
 	gl->glClearColor(backColor[0], backColor[1], backColor[2], 0.f);
-	gl->glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
+	if (flagClearSky)
+		gl->glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
+	else
+	{
+		// TODO: dim whole framebuffer to 90%, else we are overexposed much too fast.
+		gl->glClear(GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
+	}
 
 	skyDrawer->preDraw();
 }
@@ -3347,4 +3356,11 @@ void StelCore::setAberrationUniforms(QOpenGLShaderProgram& program) const
 		velocity = getAberrationFactor() * cachedAberrationVec;
 	}
 	program.setUniformValue("STELCORE_currentPlanetBarycentricEclipticVelocity", velocity.toQVector());
+}
+
+void StelCore::setFlagClearSky(const bool state)
+{
+	flagClearSky = state;
+	qDebug() << "flagClearSky now" << state;
+	emit flagClearSkyChanged(state);
 }

--- a/src/core/StelCore.cpp
+++ b/src/core/StelCore.cpp
@@ -116,7 +116,7 @@ StelCore::StelCore()
 	, de440Active(false)
 	, de441Active(false)
 	, flagClearSky(true)
-	, flagClearSkyOnce(0)
+	, clearSkyOnceCounter(0)
 {
 	setObjectName("StelCore");
 	registerMathMetaTypes();
@@ -567,18 +567,18 @@ void StelCore::preDraw()
 	QOpenGLFunctions* gl = QOpenGLContext::currentContext()->functions();
 	gl->glClearColor(backColor[0], backColor[1], backColor[2], 0.f);
 
-	if (flagClearSkyOnce==1)
+	if (clearSkyOnceCounter==1)
 	{
 		flagClearSky=false; // Allow drawing one frame with features
-		flagClearSkyOnce=0;
+		clearSkyOnceCounter=0;
 	}
 
-	if (flagClearSky || (flagClearSkyOnce==3))
+	if (flagClearSky || (clearSkyOnceCounter==3))
 	{
 		gl->glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
-		if (flagClearSkyOnce>=2)
+		if (clearSkyOnceCounter>=2)
 		{
-			flagClearSkyOnce--;
+			clearSkyOnceCounter--;
 			flagClearSky=true; // Let other modules draw once!
 		}
 	}
@@ -3383,8 +3383,12 @@ void StelCore::setFlagClearSky(const bool state)
 }
 
 // Initiate a reset chain for preDraw()
+// The counter is started at 3 to draw 2 sky (atmosphere) frames before clearing and suppressing further area light components.
+// See preDraw() for the logic. (Improvements possible!)
+// The last before suppressing atmosphere is supposed to provide a sky background for the star trails.
+// A deep twilight looks good with satellite streaks.
 void StelCore::setClearSkyOnce()
 {
 	if (!flagClearSky)
-		flagClearSkyOnce = 3;
+		clearSkyOnceCounter = 3;
 }

--- a/src/core/StelCore.hpp
+++ b/src/core/StelCore.hpp
@@ -386,6 +386,11 @@ public:
 	//! get vector used to compute aberration effect
 	Vec3d getAberrationVec(double JD) const;
 
+	//! Force clearing framebuffer on next redraw.
+	//! This should be called while in no-clear mode (painting diurnal star streaks) on major changes which destroy the view:
+	//! Dialog closing or moving, zooming, moving view etc.
+	void setClearSkyOnce();
+
 public slots:
 	//! Smoothly move the observer to the given location
 	//! @param target the target location
@@ -1057,5 +1062,6 @@ private:
 	Vec3d calculateAberrationVec(double JD) const; // Actual calculation
 
 	bool flagClearSky; // Keep this true unless you want to render star streaks.
+	int flagClearSkyOnce; // Set this true to force redraw. It will be reset to false automatically.
 };
 #endif // STELCORE_HPP

--- a/src/core/StelCore.hpp
+++ b/src/core/StelCore.hpp
@@ -70,6 +70,7 @@ class StelCore : public QObject
 	Q_PROPERTY(bool flagUseDST READ getUseDST WRITE setUseDST NOTIFY flagUseDSTChanged)
 	Q_PROPERTY(bool startupTimeStop READ getStartupTimeStop WRITE setStartupTimeStop NOTIFY startupTimeStopChanged)
 	Q_PROPERTY(DitheringMode ditheringMode READ getDitheringMode WRITE setDitheringMode NOTIFY ditheringModeChanged)
+	Q_PROPERTY(bool flagClearSky READ getFlagClearSky WRITE setFlagClearSky NOTIFY flagClearSkyChanged)
 
 public:
 	//! @enum FrameType
@@ -865,6 +866,11 @@ public slots:
 	//! Converts magnitude/arcsec² to luminance in cd/m².
 	static float mpsasToLuminance(const float mag) { return 10.8e4f*std::pow(10.f, -0.4f*mag); }
 
+	//! get state of the clear sky flag. For regular use it should be true, while false will overdraw the previous frame
+	bool getFlagClearSky() const {return flagClearSky;}
+	//! set state of the clear sky flag. For regular use it should be true, while false will overdraw the previous frame
+	void setFlagClearSky(const bool state);
+
 signals:
 	//! This signal is emitted when the observer location has changed.
 	void locationChanged(const StelLocation&);
@@ -922,6 +928,8 @@ signals:
 	void configurationDataSaved();
 	void updateSearchLists();
 	void ditheringModeChanged(DitheringMode mode);
+	//! Emitted when clear sky flag changed.
+	void flagClearSkyChanged(bool state);
 
 	//! Called just after algorithm/theory for ephemeris is changed in the GUI
 	void ephemAlgorithmChanged();
@@ -1038,7 +1046,7 @@ private:
 	
 	// Variables for caching the observer position relative to the star catalog reference frame
 	static Vec3d cachedParallaxDiff;
-    static double cachedParallaxJD; // Cached Julian Date
+	static double cachedParallaxJD; // Cached Julian Date
 	static PlanetP cachedParallaxPlanet;
 	Vec3d calculateParallaxDiff(double JD) const; // Actual calculation
 
@@ -1047,5 +1055,7 @@ private:
 	static double cachedAberrationJD;
 	static PlanetP cachedAberrationPlanet;
 	Vec3d calculateAberrationVec(double JD) const; // Actual calculation
+
+	bool flagClearSky; // Keep this true unless you want to render star streaks.
 };
 #endif // STELCORE_HPP

--- a/src/core/StelCore.hpp
+++ b/src/core/StelCore.hpp
@@ -387,7 +387,7 @@ public:
 	Vec3d getAberrationVec(double JD) const;
 
 	//! Force clearing framebuffer on next redraw.
-	//! This should be called while in no-clear mode (painting diurnal star streaks) on major changes which destroy the view:
+	//! This should also be called while in no-clear mode (painting diurnal star streaks) on major changes which destroy the view:
 	//! Dialog closing or moving, zooming, moving view etc.
 	void setClearSkyOnce();
 
@@ -1062,6 +1062,6 @@ private:
 	Vec3d calculateAberrationVec(double JD) const; // Actual calculation
 
 	bool flagClearSky; // Keep this true unless you want to render star trails.
-	int flagClearSkyOnce; // used to force full redraw during star trail mode.
+	int clearSkyOnceCounter; // used to force full redraw during star trail mode.
 };
 #endif // STELCORE_HPP

--- a/src/core/StelCore.hpp
+++ b/src/core/StelCore.hpp
@@ -1061,7 +1061,7 @@ private:
 	static PlanetP cachedAberrationPlanet;
 	Vec3d calculateAberrationVec(double JD) const; // Actual calculation
 
-	bool flagClearSky; // Keep this true unless you want to render star streaks.
-	int flagClearSkyOnce; // Set this true to force redraw. It will be reset to false automatically.
+	bool flagClearSky; // Keep this true unless you want to render star trails.
+	int flagClearSkyOnce; // used to force full redraw during star trail mode.
 };
 #endif // STELCORE_HPP

--- a/src/core/StelMovementMgr.cpp
+++ b/src/core/StelMovementMgr.cpp
@@ -256,6 +256,7 @@ void StelMovementMgr::resetInitViewPos()
 
 		//qDebug() << "   upVectorMountFrame becomes " << upVectorMountFrame[0] << "/" << upVectorMountFrame[1] << "/" << upVectorMountFrame[2];
 	}
+	core->setClearSkyOnce();
 }
 
 void StelMovementMgr::bindingFOVActions()
@@ -303,6 +304,7 @@ void StelMovementMgr::setEquatorialMount(bool b)
 		int yPosition = qRound(projectorParams.viewportCenter[1] - yPositionOffset - painter.getFontMetrics().height()/2);
 		lastMessageID = GETSTELMODULE(LabelMgr)->labelScreen(mode, xPosition, yPosition, true, StelApp::getInstance().getScreenFontSize() + 3, "#99FF99", true, 2000);
 	}
+	core->setClearSkyOnce();
 }
 
 void StelMovementMgr::setMountMode(MountMode m)
@@ -390,6 +392,7 @@ bool StelMovementMgr::handleMouseMoves(int x, int y, Qt::MouseButtons)
 			// We can hardly use the mouse exactly enough to go to the zenith/pole. Any mouse motion can safely reset the simplified up vector.
 			//qDebug() << "handleMouseMoves: resetting Up vector.";
 			setViewUpVector(Vec3d(0., 0., 1.));
+			core->setClearSkyOnce();
 			return true;
 		}
 	}
@@ -772,6 +775,7 @@ void StelMovementMgr::turnRight(bool s)
 	}
 	else
 		deltaAz = 0;
+	core->setClearSkyOnce();
 }
 
 void StelMovementMgr::turnLeft(bool s)
@@ -784,6 +788,7 @@ void StelMovementMgr::turnLeft(bool s)
 	}
 	else
 		deltaAz = 0;
+	core->setClearSkyOnce();
 }
 
 void StelMovementMgr::turnUp(bool s)
@@ -796,6 +801,7 @@ void StelMovementMgr::turnUp(bool s)
 	}
 	else
 		deltaAlt = 0;
+	core->setClearSkyOnce();
 }
 
 void StelMovementMgr::turnDown(bool s)
@@ -808,19 +814,26 @@ void StelMovementMgr::turnDown(bool s)
 	}
 	else
 		deltaAlt = 0;
+	core->setClearSkyOnce();
 }
 
 
 void StelMovementMgr::zoomIn(bool s)
 {
 	if (flagEnableZoomKeys)
+	{
 		deltaFov = -1*(s!=0);
+		core->setClearSkyOnce();
+	}
 }
 
 void StelMovementMgr::zoomOut(bool s)
 {
 	if (flagEnableZoomKeys)
+	{
 		deltaFov = (s!=0);
+		core->setClearSkyOnce();
+	}
 }
 
 void StelMovementMgr::lookEast(bool zero)

--- a/src/core/StelMovementMgr.hpp
+++ b/src/core/StelMovementMgr.hpp
@@ -466,6 +466,7 @@ public slots:
 		else
 			currentFov=qBound(minFov, f, maxFov);
 
+		core->setClearSkyOnce();
 		emit currentFovChanged(currentFov);
 	}
 

--- a/src/core/StelObserver.cpp
+++ b/src/core/StelObserver.cpp
@@ -292,6 +292,7 @@ bool SpaceShipObserver::update(double deltaTime)
 	{
 		timeToGo = 0.;
 		currentLocation = moveTargetLocation;
+		StelApp::getInstance().getCore()->setClearSkyOnce();
 	}
 	else
 	{

--- a/src/core/modules/AsterismMgr.cpp
+++ b/src/core/modules/AsterismMgr.cpp
@@ -284,6 +284,9 @@ void AsterismMgr::setRayHelperThickness(const int thickness)
 
 void AsterismMgr::draw(StelCore* core)
 {
+	if (!core->getFlagClearSky())
+		return;
+
 	const StelProjectorP prj = core->getProjection(StelCore::FrameJ2000);
 	StelPainter sPainter(prj);
 	QFont font=QGuiApplication::font();

--- a/src/core/modules/AtmospherePreetham.cpp
+++ b/src/core/modules/AtmospherePreetham.cpp
@@ -323,6 +323,7 @@ void AtmospherePreetham::computeColor(StelCore* core, const double JD, const Pla
 	float lumi=0.f;
 
 	// Compute the sky color for every point above the ground
+	if (core->getFlagClearSky())
 	for (unsigned int i=0; i<(1+skyResolutionX)*(1+skyResolutionY); ++i)
 	{
 		const Vec2f &v(posGrid[i]);

--- a/src/core/modules/AtmospherePreetham.cpp
+++ b/src/core/modules/AtmospherePreetham.cpp
@@ -390,7 +390,7 @@ void AtmospherePreetham::computeColor(StelCore* core, const double JD, const Pla
 // Draw the atmosphere using the precalc values stored in tab_sky
 void AtmospherePreetham::draw(StelCore* core)
 {
-	if (StelApp::getInstance().getVisionModeNight())
+	if (StelApp::getInstance().getVisionModeNight() || (!core->getFlagClearSky()))
 		return;
 
 	const float atm_intensity = fader.getInterstate();

--- a/src/core/modules/AtmospherePreetham.cpp
+++ b/src/core/modules/AtmospherePreetham.cpp
@@ -390,7 +390,9 @@ void AtmospherePreetham::computeColor(StelCore* core, const double JD, const Pla
 // Draw the atmosphere using the precalc values stored in tab_sky
 void AtmospherePreetham::draw(StelCore* core)
 {
-	if (StelApp::getInstance().getVisionModeNight() || (!core->getFlagClearSky()))
+	if (!core->getFlagClearSky())
+		return;
+	if (StelApp::getInstance().getVisionModeNight())
 		return;
 
 	const float atm_intensity = fader.getInterstate();

--- a/src/core/modules/AtmosphereShowMySky.cpp
+++ b/src/core/modules/AtmosphereShowMySky.cpp
@@ -800,7 +800,7 @@ void AtmosphereShowMySky::computeColor(StelCore* core, const double JD, const Pl
 void AtmosphereShowMySky::draw(StelCore* core)
 {
 	StelOpenGL::checkGLErrors(__FILE__,__LINE__);
-	if (StelApp::getInstance().getVisionModeNight())
+	if (StelApp::getInstance().getVisionModeNight() || (!core->getFlagClearSky()))
 		return;
 
 	StelToneReproducer* eye = core->getToneReproducer();

--- a/src/core/modules/AtmosphereShowMySky.cpp
+++ b/src/core/modules/AtmosphereShowMySky.cpp
@@ -800,7 +800,9 @@ void AtmosphereShowMySky::computeColor(StelCore* core, const double JD, const Pl
 void AtmosphereShowMySky::draw(StelCore* core)
 {
 	StelOpenGL::checkGLErrors(__FILE__,__LINE__);
-	if (StelApp::getInstance().getVisionModeNight() || (!core->getFlagClearSky()))
+	if (!core->getFlagClearSky())
+		return;
+	if (StelApp::getInstance().getVisionModeNight())
 		return;
 
 	StelToneReproducer* eye = core->getToneReproducer();

--- a/src/core/modules/AtmosphereShowMySky.cpp
+++ b/src/core/modules/AtmosphereShowMySky.cpp
@@ -758,7 +758,7 @@ void AtmosphereShowMySky::computeColor(StelCore* core, const double JD, const Pl
 		// TODO: compute eclipse factor also for Lunar eclipses! (lp:#1471546)
 
 		// No need to calculate if not visible
-		if (!fader.getInterstate())
+		if (!fader.getInterstate() || !core->getFlagClearSky())
 		{
 			// GZ 20180114: Why did we add light pollution if atmosphere was not visible?????
 			// And what is the meaning of 0.001? Approximate contribution of stellar background? Then why is it 0.0001 below???

--- a/src/core/modules/Comet.cpp
+++ b/src/core/modules/Comet.cpp
@@ -583,6 +583,7 @@ void Comet::draw(StelCore* core, float maxMagLabels, const QFont& planetNameFont
 
 		labelsFader = (flagLabels && ang_dist>0.25f && maxMagLabels>vMagnitude);
 
+		if (core->getFlagClearSky())
 		{ // encapsulate painter!
 			const StelProjectorP prjin = core->getProjection(StelCore::FrameJ2000);
 			StelPainter sPainter(prjin);

--- a/src/core/modules/ConstellationMgr.cpp
+++ b/src/core/modules/ConstellationMgr.cpp
@@ -692,6 +692,9 @@ void ConstellationMgr::loadLinesNamesAndArt(const StelSkyCulture &culture)
 
 void ConstellationMgr::draw(StelCore* core)
 {
+	if (!core->getFlagClearSky())
+		return;
+
 	const StelProjectorP prj = core->getProjection(StelCore::FrameJ2000);
 	StelPainter sPainter(prj);
 	//sPainter.setFont(asterFont);

--- a/src/core/modules/GridLinesMgr.cpp
+++ b/src/core/modules/GridLinesMgr.cpp
@@ -2155,7 +2155,9 @@ void GridLinesMgr::update(double deltaTime)
 
 void GridLinesMgr::draw(StelCore* core)
 {
-	if (!gridlinesDisplayed  || (!core->getFlagClearSky()))
+	if (!core->getFlagClearSky())
+		return;
+	if (!gridlinesDisplayed)
 		return;
 
 	// Draw elements from the outside in.

--- a/src/core/modules/GridLinesMgr.cpp
+++ b/src/core/modules/GridLinesMgr.cpp
@@ -2155,7 +2155,7 @@ void GridLinesMgr::update(double deltaTime)
 
 void GridLinesMgr::draw(StelCore* core)
 {
-	if (!gridlinesDisplayed)
+	if (!gridlinesDisplayed  || (!core->getFlagClearSky()))
 		return;
 
 	// Draw elements from the outside in.

--- a/src/core/modules/Landscape.cpp
+++ b/src/core/modules/Landscape.cpp
@@ -1046,7 +1046,7 @@ void main(void)
 		drawFog(core, firstFreeTexSampler);
 
 		// Self-luminous layer (Light pollution etc). This looks striking!
-		if (lightScapeBrightness>0.0f && (illumFader.getInterstate()>0.f))
+		if (lightScapeBrightness>0.0f && (illumFader.getInterstate()>0.f) && core->getFlagClearSky())
 		{
 			gl.glBlendFunc(GL_SRC_ALPHA, GL_ONE);
 			drawDecor(core, firstFreeTexSampler, true);
@@ -1065,6 +1065,8 @@ void main(void)
 // Draw the horizon fog
 void LandscapeOldStyle::drawFog(StelCore*const core, const int firstFreeTexSampler) const
 {
+	if (!core->getFlagClearSky())
+		return;
 	if (fogFader.getInterstate()==0.f)
 		return;
 	if(landFader.getInterstate()==0.f)
@@ -1121,11 +1123,15 @@ void LandscapeOldStyle::drawDecor(StelCore*const core, const int firstFreeTexSam
 	}
 	else
         {
-                renderProgram->setUniformValue(shaderVars.brightness,
-                                                landscapeBrightness*landscapeTint[0],
-                                                landscapeBrightness*landscapeTint[1],
-                                                landscapeBrightness*landscapeTint[2],
-                                                (1.f-landscapeTransparency)*landFader.getInterstate());
+		if (core->getFlagClearSky())
+			renderProgram->setUniformValue(shaderVars.brightness,
+				                        landscapeBrightness*landscapeTint[0],
+					                landscapeBrightness*landscapeTint[1],
+						        landscapeBrightness*landscapeTint[2],
+							(1.f-landscapeTransparency)*landFader.getInterstate());
+		else
+			renderProgram->setUniformValue(shaderVars.brightness, 0, 0, 0,
+							(1.f-landscapeTransparency)*landFader.getInterstate());
         }
 
 	renderProgram->setUniformValue(shaderVars.tanMode, tanMode);
@@ -1494,11 +1500,15 @@ void LandscapePolygonal::draw(StelCore* core, bool onlyPolygon)
 
 	if (!onlyPolygon) // The only useful application of the onlyPolygon is a demo which does not fill the polygon
         {
-                sPainter.setColor(
-                                landscapeBrightness*groundColor[0]*landscapeTint[0],
-                                landscapeBrightness*groundColor[1]*landscapeTint[1],
-                                landscapeBrightness*groundColor[2]*landscapeTint[2],
-                                (1.f-landscapeTransparency)*landFader.getInterstate());
+		if (core->getFlagClearSky())
+			sPainter.setColor(
+				        landscapeBrightness*groundColor[0]*landscapeTint[0],
+					landscapeBrightness*groundColor[1]*landscapeTint[1],
+				        landscapeBrightness*groundColor[2]*landscapeTint[2],
+					(1.f-landscapeTransparency)*landFader.getInterstate());
+		else
+			sPainter.setColor(0, 0, 0, (1.f-landscapeTransparency)*landFader.getInterstate());
+
 #ifdef GL_MULTISAMPLE
 		const auto gl = sPainter.glFuncs();
 		if (multisamplingEnabled_)
@@ -1513,8 +1523,11 @@ void LandscapePolygonal::draw(StelCore* core, bool onlyPolygon)
 #endif
 	}
 
-	drawHorizonLine(core, sPainter);
-	drawLabels(core, &sPainter);
+	if (core->getFlagClearSky())
+	{
+		drawHorizonLine(core, sPainter);
+		drawLabels(core, &sPainter);
+	}
 }
 
 float LandscapePolygonal::getOpacity(Vec3d azalt) const
@@ -1704,11 +1717,16 @@ void main(void)
 	{
 		auto& gl = *QOpenGLContext::currentContext()->functions();
 		renderProgram->bind();
-                renderProgram->setUniformValue(shaderVars.brightness,
-                                                landscapeBrightness*landscapeTint[0],
-                                                landscapeBrightness*landscapeTint[1],
-                                                landscapeBrightness*landscapeTint[2],
-                                                landFader.getInterstate());
+		if (core->getFlagClearSky())
+			renderProgram->setUniformValue(shaderVars.brightness,
+				                        landscapeBrightness*landscapeTint[0],
+					                landscapeBrightness*landscapeTint[1],
+						        landscapeBrightness*landscapeTint[2],
+							landFader.getInterstate());
+		else
+			renderProgram->setUniformValue(shaderVars.brightness, 0, 0, 0,
+							landFader.getInterstate());
+
 		const int mainTexSampler = 0;
 		mapTex->bind(mainTexSampler);
 		renderProgram->setUniformValue(shaderVars.mapTex, mainTexSampler);
@@ -1724,7 +1742,7 @@ void main(void)
 		gl.glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
 
 		// NEW since 0.13: Fog also for fisheye...
-		if ((mapTexFog) && (core->getSkyDrawer()->getFlagHasAtmosphere()))
+		if ((mapTexFog) && (core->getSkyDrawer()->getFlagHasAtmosphere()) && core->getFlagClearSky())
 		{
 			gl.glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_COLOR);
 			const float brightness = landFader.getInterstate()*fogFader.getInterstate()*(0.1f+0.1f*landscapeBrightness);
@@ -1735,7 +1753,7 @@ void main(void)
 			gl.glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
 		}
 
-		if (mapTexIllum && lightScapeBrightness>0.0f && (illumFader.getInterstate()>0.f))
+		if (mapTexIllum && lightScapeBrightness>0.0f && (illumFader.getInterstate()>0.f) && core->getFlagClearSky())
 		{
 			gl.glBlendFunc(GL_SRC_ALPHA, GL_ONE);
 			const float brightness = lightScapeBrightness*illumFader.getInterstate();
@@ -2059,16 +2077,17 @@ void main(void)
 	{
 		auto& gl = *QOpenGLContext::currentContext()->functions();
 		renderProgram->bind();
+		const float brightness=core->getFlagClearSky() ? landscapeBrightness : 0.0f;
 		renderProgram->setUniformValue(shaderVars.bottomCapColor,
-					       landscapeBrightness*bottomCapColor[0],
-					       landscapeBrightness*bottomCapColor[1],
-					       landscapeBrightness*bottomCapColor[2],
+					       brightness*bottomCapColor[0],
+					       brightness*bottomCapColor[1],
+					       brightness*bottomCapColor[2],
 					       bottomCapColor[0] < 0 ? 0 : landFader.getInterstate());
 
                 renderProgram->setUniformValue(shaderVars.brightness,
-                                               landscapeBrightness*landscapeTint[0],
-                                               landscapeBrightness*landscapeTint[1],
-                                               landscapeBrightness*landscapeTint[2],
+                                               brightness*landscapeTint[0],
+                                               brightness*landscapeTint[1],
+                                               brightness*landscapeTint[2],
                                                (1.f-landscapeTransparency)*landFader.getInterstate());
 		const int mainTexSampler = 0;
 		mapTex->bind(mainTexSampler);
@@ -2087,7 +2106,7 @@ void main(void)
 		gl.glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
 
 		// Since 0.13: Fog also for sphericals...
-		if ((mapTexFog) && (core->getSkyDrawer()->getFlagHasAtmosphere()))
+		if ((mapTexFog) && (core->getSkyDrawer()->getFlagHasAtmosphere()) && core->getFlagClearSky())
 		{
 			gl.glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_COLOR);
 			const float brightness =
@@ -2104,7 +2123,7 @@ void main(void)
 		}
 
 		// Self-luminous layer (Light pollution etc). This looks striking!
-		if (mapTexIllum && (lightScapeBrightness>0.0f) && (illumFader.getInterstate()>0.0f))
+		if (mapTexIllum && (lightScapeBrightness>0.0f) && (illumFader.getInterstate()>0.0f) && core->getFlagClearSky())
 		{
 			gl.glBlendFunc(GL_SRC_ALPHA, GL_ONE);
 			const float brightness = lightScapeBrightness*illumFader.getInterstate();

--- a/src/core/modules/Landscape.cpp
+++ b/src/core/modules/Landscape.cpp
@@ -1124,14 +1124,17 @@ void LandscapeOldStyle::drawDecor(StelCore*const core, const int firstFreeTexSam
 	else
         {
 		if (core->getFlagClearSky())
+		{
 			renderProgram->setUniformValue(shaderVars.brightness,
-				                        landscapeBrightness*landscapeTint[0],
-					                landscapeBrightness*landscapeTint[1],
-						        landscapeBrightness*landscapeTint[2],
-							(1.f-landscapeTransparency)*landFader.getInterstate());
+			                               landscapeBrightness*landscapeTint[0],
+			                               landscapeBrightness*landscapeTint[1],
+			                               landscapeBrightness*landscapeTint[2],
+			                               (1.f-landscapeTransparency)*landFader.getInterstate());
+		}
 		else
-			renderProgram->setUniformValue(shaderVars.brightness, 0, 0, 0,
-							(1.f-landscapeTransparency)*landFader.getInterstate());
+		{
+			renderProgram->setUniformValue(shaderVars.brightness, 0, 0, 0, 1);
+		}
         }
 
 	renderProgram->setUniformValue(shaderVars.tanMode, tanMode);
@@ -1227,13 +1230,17 @@ void LandscapeOldStyle::drawGround(StelCore*const core, const int firstFreeTexSa
 	renderProgram->setUniformValue(shaderVars.vshift, vshift);
 	renderProgram->setUniformValue(shaderVars.projectionMatrixInverse, prj->getProjectionMatrix().toQMatrix().inverted());
 	if (core->getFlagClearSky())
+	{
 		renderProgram->setUniformValue(shaderVars.brightness,
-					       landscapeBrightness*landscapeTint[0],
-					       landscapeBrightness*landscapeTint[1],
-					       landscapeBrightness*landscapeTint[2],
-					       (1.f-landscapeTransparency)*landFader.getInterstate());
+		                               landscapeBrightness*landscapeTint[0],
+		                               landscapeBrightness*landscapeTint[1],
+		                               landscapeBrightness*landscapeTint[2],
+		                               (1.f-landscapeTransparency)*landFader.getInterstate());
+	}
 	else
+	{
 		renderProgram->setUniformValue(shaderVars.brightness, 0, 0, 0, 1);
+	}
 	prj->setUnProjectUniforms(*renderProgram);
 	gl.glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
 }
@@ -1504,13 +1511,16 @@ void LandscapePolygonal::draw(StelCore* core, bool onlyPolygon)
 	if (!onlyPolygon) // The only useful application of the onlyPolygon is a demo which does not fill the polygon
         {
 		if (core->getFlagClearSky())
-			sPainter.setColor(
-				        landscapeBrightness*groundColor[0]*landscapeTint[0],
-					landscapeBrightness*groundColor[1]*landscapeTint[1],
-				        landscapeBrightness*groundColor[2]*landscapeTint[2],
-					(1.f-landscapeTransparency)*landFader.getInterstate());
+		{
+			sPainter.setColor(landscapeBrightness*groundColor[0]*landscapeTint[0],
+			                  landscapeBrightness*groundColor[1]*landscapeTint[1],
+			                  landscapeBrightness*groundColor[2]*landscapeTint[2],
+			                  (1.f-landscapeTransparency)*landFader.getInterstate());
+		}
 		else
-			sPainter.setColor(0, 0, 0, (1.f-landscapeTransparency)*landFader.getInterstate());
+		{
+			sPainter.setColor(0, 0, 0, 1);
+		}
 
 #ifdef GL_MULTISAMPLE
 		const auto gl = sPainter.glFuncs();
@@ -1721,14 +1731,17 @@ void main(void)
 		auto& gl = *QOpenGLContext::currentContext()->functions();
 		renderProgram->bind();
 		if (core->getFlagClearSky())
+		{
 			renderProgram->setUniformValue(shaderVars.brightness,
-				                        landscapeBrightness*landscapeTint[0],
-					                landscapeBrightness*landscapeTint[1],
-						        landscapeBrightness*landscapeTint[2],
-							landFader.getInterstate());
+			                               landscapeBrightness*landscapeTint[0],
+			                               landscapeBrightness*landscapeTint[1],
+			                               landscapeBrightness*landscapeTint[2],
+			                               landFader.getInterstate());
+		}
 		else
-			renderProgram->setUniformValue(shaderVars.brightness, 0, 0, 0,
-							landFader.getInterstate());
+		{
+			renderProgram->setUniformValue(shaderVars.brightness, 0, 0, 0, 1);
+		}
 
 		const int mainTexSampler = 0;
 		mapTex->bind(mainTexSampler);
@@ -2082,10 +2095,10 @@ void main(void)
 		renderProgram->bind();
 		const float brightness=core->getFlagClearSky() ? landscapeBrightness : 0.0f;
 		renderProgram->setUniformValue(shaderVars.bottomCapColor,
-					       brightness*bottomCapColor[0],
-					       brightness*bottomCapColor[1],
-					       brightness*bottomCapColor[2],
-					       bottomCapColor[0] < 0 ? 0 : landFader.getInterstate());
+		                               brightness*bottomCapColor[0],
+		                               brightness*bottomCapColor[1],
+		                               brightness*bottomCapColor[2],
+		                               bottomCapColor[0] < 0 ? 0 : landFader.getInterstate());
 
                 renderProgram->setUniformValue(shaderVars.brightness,
                                                brightness*landscapeTint[0],

--- a/src/core/modules/Landscape.cpp
+++ b/src/core/modules/Landscape.cpp
@@ -765,7 +765,7 @@ void LandscapeOldStyle::load(const QSettings& landscapeIni, const QString& lands
 
 void LandscapeOldStyle::draw(StelCore* core, bool onlyPolygon)
 {
-	if(!StelOpenGL::globalShaderPrefix(StelOpenGL::FRAGMENT_SHADER).contains("textureGrad_SUPPORTED"))
+	if(!StelOpenGL::globalShaderPrefix(StelOpenGL::FRAGMENT_SHADER).contains("textureGrad_SUPPORTED") || (!core->getFlagClearSky()))
 	{
 		drawLowGL(core, onlyPolygon);
 		return;
@@ -1204,7 +1204,7 @@ void LandscapeOldStyle::drawDecor(StelCore*const core, const int firstFreeTexSam
 // Draw the ground, assuming full-screen-quad VAO is bound and the common uniforms are configured
 void LandscapeOldStyle::drawGround(StelCore*const core, const int firstFreeTexSampler) const
 {
-	if (landFader.getInterstate()==0.f  || !core->getFlagClearSky())
+	if (landFader.getInterstate()==0.f  || (!core->getFlagClearSky()))
 		return;
 
 	if (!groundTex)
@@ -1226,11 +1226,21 @@ void LandscapeOldStyle::drawGround(StelCore*const core, const int firstFreeTexSa
 	renderProgram->setUniformValue(shaderVars.mapTex, texSampler);
 	renderProgram->setUniformValue(shaderVars.vshift, vshift);
 	renderProgram->setUniformValue(shaderVars.projectionMatrixInverse, prj->getProjectionMatrix().toQMatrix().inverted());
-	renderProgram->setUniformValue(shaderVars.brightness,
+
+	// Repetition. Does not help :-(
+	//gl.glEnable(GL_BLEND);
+	//gl.glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+
+	if (core->getFlagClearSky())
+		renderProgram->setUniformValue(shaderVars.brightness,
 				       landscapeBrightness*landscapeTint[0],
 				       landscapeBrightness*landscapeTint[1],
 				       landscapeBrightness*landscapeTint[2],
 				       (1.f-landscapeTransparency)*landFader.getInterstate());
+	else
+		renderProgram->setUniformValue(shaderVars.brightness, 0, 0, 0,
+					       (1.f-landscapeTransparency)*landFader.getInterstate());
+
 	prj->setUnProjectUniforms(*renderProgram);
 	gl.glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
 }
@@ -1285,6 +1295,8 @@ void LandscapeOldStyle::drawFogLowGL(StelCore* core, StelPainter& sPainter) cons
 		return;
 	if (!(core->getSkyDrawer()->getFlagHasAtmosphere()))
 		return;
+	if (!core->getFlagClearSky())
+		return;
 
 	const float vpos = static_cast<float>(radius) * ((tanMode||calibrated) ? std::tan(fogAngleShift*M_PI_180f) : std::sin(fogAngleShift*M_PI_180f));
 	StelProjector::ModelViewTranformP transfo = core->getAltAzModelViewTransform(StelCore::RefractionOff);
@@ -1317,8 +1329,10 @@ void LandscapeOldStyle::drawDecorLowGL(StelCore* core, StelPainter& sPainter, co
 	if (drawLight)
 		sPainter.setColor(Vec3f(illumFader.getInterstate()*lightScapeBrightness),
 				  (1.f-landscapeTransparency)*landFader.getInterstate());
-	else
+	else if (core->getFlagClearSky())
 		sPainter.setColor(Vec3f(landscapeBrightness), (1.f-landscapeTransparency)*landFader.getInterstate());
+	else
+		sPainter.setColor(Vec3f(0.f), (1.f-landscapeTransparency)*landFader.getInterstate());
 
 	for (const auto& side : precomputedSides)
 	{
@@ -1342,8 +1356,13 @@ void LandscapeOldStyle::drawGroundLowGL(StelCore* core, StelPainter& sPainter) c
 			  Mat4d::translation(Vec3d(0,0,static_cast<double>(vshift))));
 
 	sPainter.setProjector(core->getProjection(transfo));
-	sPainter.setColor(landscapeBrightness, landscapeBrightness, landscapeBrightness,
+	if (core->getFlagClearSky())
+		sPainter.setColor(landscapeBrightness, landscapeBrightness, landscapeBrightness,
 			  (1.f-landscapeTransparency)*landFader.getInterstate());
+	else
+		sPainter.setColor(0, 0, 0,
+			  (1.f-landscapeTransparency)*landFader.getInterstate());
+
 
 	if(groundTex.isNull())
 	{

--- a/src/core/modules/Landscape.cpp
+++ b/src/core/modules/Landscape.cpp
@@ -765,7 +765,7 @@ void LandscapeOldStyle::load(const QSettings& landscapeIni, const QString& lands
 
 void LandscapeOldStyle::draw(StelCore* core, bool onlyPolygon)
 {
-	if(!StelOpenGL::globalShaderPrefix(StelOpenGL::FRAGMENT_SHADER).contains("textureGrad_SUPPORTED") || (!core->getFlagClearSky()))
+	if(!StelOpenGL::globalShaderPrefix(StelOpenGL::FRAGMENT_SHADER).contains("textureGrad_SUPPORTED"))
 	{
 		drawLowGL(core, onlyPolygon);
 		return;
@@ -1204,7 +1204,7 @@ void LandscapeOldStyle::drawDecor(StelCore*const core, const int firstFreeTexSam
 // Draw the ground, assuming full-screen-quad VAO is bound and the common uniforms are configured
 void LandscapeOldStyle::drawGround(StelCore*const core, const int firstFreeTexSampler) const
 {
-	if (landFader.getInterstate()==0.f  || (!core->getFlagClearSky()))
+	if (landFader.getInterstate()==0.f  || !core->getFlagClearSky())
 		return;
 
 	if (!groundTex)
@@ -1226,21 +1226,11 @@ void LandscapeOldStyle::drawGround(StelCore*const core, const int firstFreeTexSa
 	renderProgram->setUniformValue(shaderVars.mapTex, texSampler);
 	renderProgram->setUniformValue(shaderVars.vshift, vshift);
 	renderProgram->setUniformValue(shaderVars.projectionMatrixInverse, prj->getProjectionMatrix().toQMatrix().inverted());
-
-	// Repetition. Does not help :-(
-	//gl.glEnable(GL_BLEND);
-	//gl.glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-
-	if (core->getFlagClearSky())
-		renderProgram->setUniformValue(shaderVars.brightness,
+	renderProgram->setUniformValue(shaderVars.brightness,
 				       landscapeBrightness*landscapeTint[0],
 				       landscapeBrightness*landscapeTint[1],
 				       landscapeBrightness*landscapeTint[2],
 				       (1.f-landscapeTransparency)*landFader.getInterstate());
-	else
-		renderProgram->setUniformValue(shaderVars.brightness, 0, 0, 0,
-					       (1.f-landscapeTransparency)*landFader.getInterstate());
-
 	prj->setUnProjectUniforms(*renderProgram);
 	gl.glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
 }
@@ -1295,8 +1285,6 @@ void LandscapeOldStyle::drawFogLowGL(StelCore* core, StelPainter& sPainter) cons
 		return;
 	if (!(core->getSkyDrawer()->getFlagHasAtmosphere()))
 		return;
-	if (!core->getFlagClearSky())
-		return;
 
 	const float vpos = static_cast<float>(radius) * ((tanMode||calibrated) ? std::tan(fogAngleShift*M_PI_180f) : std::sin(fogAngleShift*M_PI_180f));
 	StelProjector::ModelViewTranformP transfo = core->getAltAzModelViewTransform(StelCore::RefractionOff);
@@ -1329,10 +1317,8 @@ void LandscapeOldStyle::drawDecorLowGL(StelCore* core, StelPainter& sPainter, co
 	if (drawLight)
 		sPainter.setColor(Vec3f(illumFader.getInterstate()*lightScapeBrightness),
 				  (1.f-landscapeTransparency)*landFader.getInterstate());
-	else if (core->getFlagClearSky())
-		sPainter.setColor(Vec3f(landscapeBrightness), (1.f-landscapeTransparency)*landFader.getInterstate());
 	else
-		sPainter.setColor(Vec3f(0.f), (1.f-landscapeTransparency)*landFader.getInterstate());
+		sPainter.setColor(Vec3f(landscapeBrightness), (1.f-landscapeTransparency)*landFader.getInterstate());
 
 	for (const auto& side : precomputedSides)
 	{
@@ -1356,13 +1342,8 @@ void LandscapeOldStyle::drawGroundLowGL(StelCore* core, StelPainter& sPainter) c
 			  Mat4d::translation(Vec3d(0,0,static_cast<double>(vshift))));
 
 	sPainter.setProjector(core->getProjection(transfo));
-	if (core->getFlagClearSky())
-		sPainter.setColor(landscapeBrightness, landscapeBrightness, landscapeBrightness,
+	sPainter.setColor(landscapeBrightness, landscapeBrightness, landscapeBrightness,
 			  (1.f-landscapeTransparency)*landFader.getInterstate());
-	else
-		sPainter.setColor(0, 0, 0,
-			  (1.f-landscapeTransparency)*landFader.getInterstate());
-
 
 	if(groundTex.isNull())
 	{

--- a/src/core/modules/Landscape.cpp
+++ b/src/core/modules/Landscape.cpp
@@ -1204,7 +1204,7 @@ void LandscapeOldStyle::drawDecor(StelCore*const core, const int firstFreeTexSam
 // Draw the ground, assuming full-screen-quad VAO is bound and the common uniforms are configured
 void LandscapeOldStyle::drawGround(StelCore*const core, const int firstFreeTexSampler) const
 {
-	if (landFader.getInterstate()==0.f)
+	if (landFader.getInterstate()==0.f  || !core->getFlagClearSky())
 		return;
 
 	if (!groundTex)

--- a/src/core/modules/Landscape.cpp
+++ b/src/core/modules/Landscape.cpp
@@ -1204,7 +1204,7 @@ void LandscapeOldStyle::drawDecor(StelCore*const core, const int firstFreeTexSam
 // Draw the ground, assuming full-screen-quad VAO is bound and the common uniforms are configured
 void LandscapeOldStyle::drawGround(StelCore*const core, const int firstFreeTexSampler) const
 {
-	if (landFader.getInterstate()==0.f  || !core->getFlagClearSky())
+	if (landFader.getInterstate()==0.f)
 		return;
 
 	if (!groundTex)
@@ -1226,11 +1226,14 @@ void LandscapeOldStyle::drawGround(StelCore*const core, const int firstFreeTexSa
 	renderProgram->setUniformValue(shaderVars.mapTex, texSampler);
 	renderProgram->setUniformValue(shaderVars.vshift, vshift);
 	renderProgram->setUniformValue(shaderVars.projectionMatrixInverse, prj->getProjectionMatrix().toQMatrix().inverted());
-	renderProgram->setUniformValue(shaderVars.brightness,
-				       landscapeBrightness*landscapeTint[0],
-				       landscapeBrightness*landscapeTint[1],
-				       landscapeBrightness*landscapeTint[2],
-				       (1.f-landscapeTransparency)*landFader.getInterstate());
+	if (core->getFlagClearSky())
+		renderProgram->setUniformValue(shaderVars.brightness,
+					       landscapeBrightness*landscapeTint[0],
+					       landscapeBrightness*landscapeTint[1],
+					       landscapeBrightness*landscapeTint[2],
+					       (1.f-landscapeTransparency)*landFader.getInterstate());
+	else
+		renderProgram->setUniformValue(shaderVars.brightness, 0, 0, 0, 1);
 	prj->setUnProjectUniforms(*renderProgram);
 	gl.glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
 }

--- a/src/core/modules/LandscapeMgr.cpp
+++ b/src/core/modules/LandscapeMgr.cpp
@@ -159,6 +159,9 @@ void Cardinals::setFadeDuration(float duration)
 // Handles special cases at poles
 void Cardinals::draw(const StelCore* core, double latitude) const
 {
+	if (!core->getFlagClearSky())
+		return;
+
 	// fun polar special cases: no cardinals!
 	if ((fabs(latitude - 90.0) < 1e-10) || (fabs(latitude + 90.0) < 1e-10))
 		return;

--- a/src/core/modules/LandscapeMgr.cpp
+++ b/src/core/modules/LandscapeMgr.cpp
@@ -675,7 +675,7 @@ void LandscapeMgr::draw(StelCore* core)
 	QFont font=QGuiApplication::font();
 
 	// Draw the atmosphere
-	if (!getFlagAtmosphereNoScatter())
+	if (!getFlagAtmosphereNoScatter() && core->getFlagClearSky())
 	    atmosphere->draw(core);
 
 	// GZ 2016-01: When we draw the atmosphere with a low sun, it is possible that the glaring red ball is overpainted and thus invisible.

--- a/src/core/modules/MilkyWay.cpp
+++ b/src/core/modules/MilkyWay.cpp
@@ -204,7 +204,10 @@ void MilkyWay::setColor(const Vec3f& c)
 
 void MilkyWay::draw(StelCore* core)
 {
-	if (!fader->getInterstate() || (!core->getFlagClearSky()))
+	if (!core->getFlagClearSky())
+		return;
+
+	if (!fader->getInterstate())
 		return;
 
 	const auto modelView = core->getJ2000ModelViewTransform();

--- a/src/core/modules/MilkyWay.cpp
+++ b/src/core/modules/MilkyWay.cpp
@@ -204,7 +204,7 @@ void MilkyWay::setColor(const Vec3f& c)
 
 void MilkyWay::draw(StelCore* core)
 {
-	if (!fader->getInterstate())
+	if (!fader->getInterstate() || (!core->getFlagClearSky()))
 		return;
 
 	const auto modelView = core->getJ2000ModelViewTransform();

--- a/src/core/modules/NebulaMgr.cpp
+++ b/src/core/modules/NebulaMgr.cpp
@@ -845,6 +845,9 @@ float NebulaMgr::computeMaxMagHint(const StelSkyDrawer* skyDrawer) const
 // Draw all the Nebulae and call drawing the pointer if needed
 void NebulaMgr::draw(StelCore* core)
 {
+	if (!core->getFlagClearSky())
+		return;
+
 	const StelProjectorP prj = core->getProjection(StelCore::FrameJ2000);
 	StelPainter sPainter(prj);
 	QFont font=QGuiApplication::font();

--- a/src/core/modules/Planet.cpp
+++ b/src/core/modules/Planet.cpp
@@ -3897,12 +3897,16 @@ void Planet::draw(StelCore* core, float maxMagLabels, const QFont& planetNameFon
 		// by putting here, only draw orbit if Planet is visible for clarity
 		drawOrbit(core);  // TODO - fade in here also...
 
-		labelsFader = (flagLabels && ang_dist>0.25f && maxMagLabels>getVMagnitudeWithExtinction(core, vMagnitude));
+		if (flagLabels && ang_dist>0.25f && maxMagLabels>getVMagnitudeWithExtinction(core, vMagnitude) && core->getFlagClearSky())
+			labelsFader=true;
+		else
+			labelsFader=false;
 
 		{ // scope the StelPainter here!
 			const StelProjectorP prj = core->getProjection(StelCore::FrameJ2000);
 			StelPainter sPainter(prj);
-			drawHints(core, sPainter, planetNameFont);
+			if (core->getFlagClearSky())
+				drawHints(core, sPainter, planetNameFont);
 			// TODO: Decide whether isComet should be moved up in the enum list to allow exclusion!
 			if (pType>=Planet::isAsteroid)
 			{
@@ -4451,7 +4455,7 @@ void Planet::draw3dModel(StelCore* core, StelProjector::ModelViewTranformP trans
 	}
 
 	// Draw the halo if it enabled in the ssystem.ini file (+ special case for backward compatible for the Sun)
-	if (isSun && drawSunHalo && core->getSkyDrawer()->getFlagEarlySunHalo())
+	if (isSun && drawSunHalo && core->getSkyDrawer()->getFlagEarlySunHalo() && core->getFlagClearSky())
 	{
 		// Prepare openGL lighting parameters according to luminance
 		float surfArcMin2 = static_cast<float>(getSpheroidAngularRadius(core))*60.f;
@@ -4591,7 +4595,7 @@ void Planet::draw3dModel(StelCore* core, StelProjector::ModelViewTranformP trans
 		#endif
 	}
 
-	bool allowDrawHalo = !isSun || !core->getSkyDrawer()->getFlagEarlySunHalo(); // We had drawn the sun already before the sphere.
+	bool allowDrawHalo = core->getFlagClearSky() && ( !isSun || !core->getSkyDrawer()->getFlagEarlySunHalo()); // We had drawn the sun already before the sphere.
 	if (!isSun && !isMoon && currentLocationIsEarth)
 	{
 		// Let's hide halo when inner planet between Sun and observer (or moon between planet and observer).

--- a/src/core/modules/SpecialMarkersMgr.cpp
+++ b/src/core/modules/SpecialMarkersMgr.cpp
@@ -329,6 +329,8 @@ void SpecialMarkersMgr::update(double deltaTime)
 
 void SpecialMarkersMgr::draw(StelCore* core)
 {
+	if (!core->getFlagClearSky())
+		return;
 	fovCenterMarker->draw(core);
 	fovCircularMarker->draw(core);
 	fovRectangularMarker->draw(core);

--- a/src/core/modules/StarMgr.cpp
+++ b/src/core/modules/StarMgr.cpp
@@ -1379,6 +1379,7 @@ void StarMgr::draw(StelCore* core)
 
 	// Prepare a table for storing precomputed RCMag for all ZoneArrays
 	RCMag rcmag_table[RCMAG_TABLE_SIZE];
+	const float starStreakScale = core->getFlagClearSky()? 1.0f:0.6f;
 	
 	// Draw all the stars of all the selected zones
 	for (const auto* z : std::as_const(gridLevels))
@@ -1406,7 +1407,8 @@ void StarMgr::draw(StelCore* core)
 				}
 				break;
 			}
-			rcmag_table[i].radius *= starsFader.getInterstate();
+			rcmag_table[i].radius *= starsFader.getInterstate() * starStreakScale;
+			rcmag_table[i].luminance *= starStreakScale;
 		}
 		lastMaxSearchLevel = z->level;
 

--- a/src/core/modules/ZodiacalLight.cpp
+++ b/src/core/modules/ZodiacalLight.cpp
@@ -237,7 +237,7 @@ void ZodiacalLight::setIntensity(double aintensity)
 
 void ZodiacalLight::draw(StelCore* core)
 {
-	if ((fader->getInterstate() == 0.f) || (getIntensity()<0.01) || !(propMgr->getStelPropertyValue("SolarSystem.planetsDisplayed").toBool()))
+	if ((fader->getInterstate() == 0.f) || (getIntensity()<0.01) || !(propMgr->getStelPropertyValue("SolarSystem.planetsDisplayed").toBool()) || (!core->getFlagClearSky()))
 		return;
 
 	// Test if we are not on Earth. Texture would not fit, so don't draw then.

--- a/src/core/modules/ZodiacalLight.cpp
+++ b/src/core/modules/ZodiacalLight.cpp
@@ -237,7 +237,10 @@ void ZodiacalLight::setIntensity(double aintensity)
 
 void ZodiacalLight::draw(StelCore* core)
 {
-	if ((fader->getInterstate() == 0.f) || (getIntensity()<0.01) || !(propMgr->getStelPropertyValue("SolarSystem.planetsDisplayed").toBool()) || (!core->getFlagClearSky()))
+	if (!core->getFlagClearSky())
+		return;
+
+	if ((fader->getInterstate() == 0.f) || (getIntensity()<0.01) || !(propMgr->getStelPropertyValue("SolarSystem.planetsDisplayed").toBool()))
 		return;
 
 	// Test if we are not on Earth. Texture would not fit, so don't draw then.

--- a/src/core/modules/ZoneArray.cpp
+++ b/src/core/modules/ZoneArray.cpp
@@ -559,7 +559,7 @@ void SpecialZoneArray<Star>::draw(StelPainter* sPainter, int index, bool isInsid
 			twinkleFactor=qMin(1.0, 1.0-0.9*altAz[2]); // suppress twinkling in higher altitudes. Keep 0.1 twinkle amount in zenith.
 		}
 
-		if (drawer->drawPointSource(sPainter, v, *tmpRcmag, s->getBVIndex(), !isInsideViewport, twinkleFactor) && s->hasName() && extinctedMagIndex < maxMagStarName && s->hasComponentID()<=1)
+		if (drawer->drawPointSource(sPainter, v, *tmpRcmag, s->getBVIndex(), !isInsideViewport, twinkleFactor) && core->getFlagClearSky() && s->hasName() && extinctedMagIndex < maxMagStarName && s->hasComponentID()<=1)
 		{
 			const float offset = tmpRcmag->radius*0.7f;
 			const Vec3f color = StelSkyDrawer::indexToColor(s->getBVIndex())*0.75f;

--- a/src/gui/StelDialog.cpp
+++ b/src/gui/StelDialog.cpp
@@ -19,6 +19,7 @@
 
 
 #include "StelDialog.hpp"
+#include "StelCore.hpp"
 #include "StelDialog_p.hpp"
 #include "StelMainView.hpp"
 #include "StelGui.hpp"
@@ -200,6 +201,7 @@ void StelDialog::setVisible(bool v)
 		dialog->hide();
 		//proxy->clearFocus();
 		StelMainView::getInstance().focusSky();
+		StelApp::getInstance().getCore()->setClearSkyOnce();
 	}
 	emit visibleChanged(v);
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Please include a summary of the change and which issue is fixed. -->
<!--- Please also include relevant motivation and context. -->
<!--- List any dependencies that are required for this change. -->

This little branch adds an interesting "wow" effect by not blanking frames. You can configure a keyboard shortcut to toggle this, and then render star trails.

This is a bit "hacky"! One problem are extended objects: Zodiacal light, Milky Way, atmosphere, DSO images need to be switched off first. This is handled automatically and easy to solve.

The worst problem is that the scene becomes too bright too quickly when any extended objects would be plotted.  A solution would be to not just "forget" blanking, but add a slight dimming of the scene. This should then result in an afterglow effect where star trails don't get infinitely long. Maybe the dimming can be made configurable. 

Due to the nature of this method, screenshots have to be made with operating system tools, not Stellarium's own screenshot renderer.

OpenGL/Qt experts please continue on this. Change StelCore::preDraw() and implement the methods in the StelViewportFaderEffect class, or maybe directly in StelCore::preDraw().

### Screenshots (if appropriate):
![Screenshot (221) (Klein)](https://user-images.githubusercontent.com/18099873/133320943-edf1c95a-838a-42d6-94ff-a668fa9fcddb.png)

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] This change requires a documentation update

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system: Windows 10 21H1; Windows 11 25H2
* Graphics Card: Nvidia Geforce 960M; Geforce RTX 3070Ti
 
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
