### PR TITLE
Astrocalc: findRightAscension replacement

### DIFF
--- a/src/gui/AstroCalcDialog.cpp
+++ b/src/gui/AstroCalcDialog.cpp
@@ -4808,13 +4808,40 @@ bool AstroCalcDialog::findPreciseStationaryPoint(QPair<double, double> *out, Pla
 	}
 }
 
+// return J2000 RA of a planetary object (without aberration)
 double AstroCalcDialog::findRightAscension(double JD, PlanetP object)
 {
 	// TODO: It would pay off to implement those directly using Planet::getHeliocentricEclipticPos(double dateJDE) for observer and target and doing the required Vector math.
-	core->setJD(JD);
-	core->update(0);
+	//core->setJD(JD);
+	//core->update(0);
+
+	const double JDE=JD+core->computeDeltaT(JD)/86400.;
+	//PlanetP obsPlanet=core->getCurrentPlanet();
+	//Vec3d obs, body, parent(0.), dummy;
+	//obsPlanet->computePosition(JDE, obs, dummy);
+	//object->computePosition(JDE, body, dummy);
+	//if (! ((object->getPlanetType()==Planet::isMoon) && (obsPlanet!=object->getParent())))
+	//{
+	//	object->getParent()->computePosition(JDE, parent, dummy);
+	//	body+=parent;
+	//}
+	//// light time correction, and repeat...
+	//const double distanceCorrection=(body-obs).length() * (AU / (SPEED_OF_LIGHT * 86400.));
+	//object->computePosition(JDE-distanceCorrection, body, dummy);
+	//if (! ((object->getPlanetType()==Planet::isMoon) && (obsPlanet!=object->getParent())))
+	//{
+	//	object->getParent()->computePosition(JDE-distanceCorrection, parent, dummy);
+	//	body+=parent;
+	//}
+	//// now we have obsPlanet and body coordinates.
+
+	const Vec3d obs=core->getCurrentPlanet()->getHeliocentricEclipticPos(JDE);
+	Vec3d body=object->getHeliocentricEclipticPos(JDE);
+	const double distanceCorrection=(body-obs).length() * (AU / (SPEED_OF_LIGHT * 86400.));
+	body=object->getHeliocentricEclipticPos(JDE-distanceCorrection);
+	Vec3d bodyJ2000=StelCore::matVsop87ToJ2000.multiplyWithoutTranslation(body - obs);
 	double ra, dec;
-	StelUtils::rectToSphe(&ra, &dec, object->getJ2000EquatorialPos(core));
+	StelUtils::rectToSphe(&ra, &dec, bodyJ2000);
 	return ra*M_180_PI;
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Please include a summary of the change and which issue is fixed. -->
<!--- Please also include relevant motivation and context. -->
<!--- List any dependencies that are required for this change. -->

Not really a bug fix but this may improve efficiency: A replacement of a function that avoids computing everything

Fixes #1901 

### Screenshots (if appropriate):

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Just run it. The problem is that I don't know exactly what to search for. 
The original function computed equatorial J2000 positions. Meanwhile this includes aberration, while the replacement function provided here does not (yet) include that. 

If the sole purpose of this function is finding <em>times</em> for standstills etc, we don't need aberration. If the numbers are important, I will continue to work on this and provide a solution including aberration. 


**Test Configuration**:
* Operating system: Win10 (irrelevant)
* Graphics Card: irrelevant

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
