### PR TITLE
Navstar Sun limb size and direction fix

### DIFF
--- a/plugins/NavStars/src/NavStars.cpp
+++ b/plugins/NavStars/src/NavStars.cpp
@@ -590,11 +590,11 @@ void NavStars::extraInfo(StelCore* core, const StelObjectP& selectedObject)
 
 	if ("Sun" == englishName || "Moon" == englishName) 
 	{
-		// Adjust Ho if target is Sun or Moon by adding/subtracting half the angular diameter.
-		double d = selectedObject->getAngularSize(core);
-		if (upperLimb)
-			d *= -1;
-		calc.addAltAppRad(((d / 2) * M_PI) / 180.);
+		// Adjust Ho if target is Sun or Moon by adding/subtracting the angular radius.
+		double obj_radius_in_degrees = selectedObject->getAngularSize(core);
+		if (!upperLimb)
+			obj_radius_in_degrees *= -1;
+		calc.addAltAppRad((obj_radius_in_degrees * M_PI) / 180.);
 		extraText = upperLimb ?
 			" (" + QString(qc_("upper limb", "the highest part of the Sun or Moon")) + ")" :
 			" (" + QString(qc_("lower limb", "the lowest part of the Sun or Moon")) + ")";

--- a/scripts/tests/navstars-sun-issue-2019-N.ssc
+++ b/scripts/tests/navstars-sun-issue-2019-N.ssc
@@ -1,0 +1,13 @@
+
+core.setObserverLocation(-29.75888, 19.945, 0);
+LandscapeMgr.setCurrentLandscapeName("Ocean");
+LandscapeMgr.setFlagLandscape(true);
+LandscapeMgr.setFlagAtmosphere(true);
+GridLinesMgr.setFlagHorizonLine(true);
+LandscapeMgr.setFlagCardinalsPoints(true);
+core.setDate("2021-11-08T19:31:41");
+core.setTimeRate(0);
+
+core.selectObjectByName("Sun", false);
+StelMovementMgr.setFlagTracking(true);
+

--- a/scripts/tests/navstars-sun-issue-2019-S.ssc
+++ b/scripts/tests/navstars-sun-issue-2019-S.ssc
@@ -1,0 +1,13 @@
+
+core.setObserverLocation(-29.75888, -19.945, 0);
+LandscapeMgr.setCurrentLandscapeName("Ocean");
+LandscapeMgr.setFlagLandscape(true);
+LandscapeMgr.setFlagAtmosphere(true);
+GridLinesMgr.setFlagHorizonLine(true);
+LandscapeMgr.setFlagCardinalsPoints(true);
+core.setDate("2021-11-08T19:31:41");
+core.setTimeRate(0);
+
+core.selectObjectByName("Sun", false);
+StelMovementMgr.setFlagTracking(true);
+


### PR DESCRIPTION
Use actual radius as returned and not assumed diameter. Also a bool logic correction for +/- direction

<!--- Provide a general summary of your changes in the Title above -->

### Description
The value of Ho as displayed in the extrainfo panel was incorrect and failed to match other tools such as the Pointing Tool or AltAz grid.

Fixes reported issue #2019 

<!--- Please include a summary of the change and which issue is fixed. -->
As patch;
selectedObject->getAngularSize(core); returns radius not diameter
Logic on upperLimb was inverted.

<!--- Please also include relevant motivation and context. -->
n/a

<!--- List any dependencies that are required for this change. -->
None.

Fixes # (issue)
#2019 

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Created new test scripts that setup Stellarium with place, date and time as reported in issue 2019.
Observed fault.
Fixed.
Run script again and observed correct.

Also created script for Northern hemisphere to double check the fix (the report was for a location in the Southern hemisphere but was broke in both).

<!--- Include details of your testing environment, and the tests you ran to -->
n/a

<!--- see how your change affects other areas of the code, etc. -->
n/a

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
