### PR TITLE
Restore lost lunar "previous" and "next" full moon information

### DIFF
--- a/plugins/Observability/src/Observability.cpp
+++ b/plugins/Observability/src/Observability.cpp
@@ -608,7 +608,7 @@ void Observability::draw(StelCore* core)
 ////////////////////////////////////////////////////////////
 // NOW WE ANALYZE THE SOURCE OBSERVABILITY FOR THE WHOLE YEAR:
 
-// Compute yearly ephemeris (only if necessary, and not for Sun nor Moon):
+// Compute yearly ephemeris (only if necessary, and not for Sun):
 
 
 	if (isSun) 
@@ -616,7 +616,14 @@ void Observability::draw(StelCore* core)
 		lineBestNight.clear();
 		lineObservableRange.clear();
 	}
-	else if (!isMoon && show_Year)
+	else if (isMoon)
+	{
+		lineObservableRange.clear();
+		lineAcroCos.clear();
+		lineHeli.clear();
+		solvedMoon = calculateSolarSystemEvents(core, 2);
+	}
+	else if (show_Year)
 	{
 		if (!isStar && (souChanged || yearChanged)) // Object moves.
 			updatePlanetData(core); // Re-compute ephemeris.

--- a/plugins/Observability/src/Observability.cpp
+++ b/plugins/Observability/src/Observability.cpp
@@ -618,10 +618,13 @@ void Observability::draw(StelCore* core)
 	}
 	else if (isMoon)
 	{
-		lineObservableRange.clear();
-		lineAcroCos.clear();
-		lineHeli.clear();
-		solvedMoon = calculateSolarSystemEvents(core, 2);
+		if (show_FullMoon)
+		{
+			lineObservableRange.clear();
+			lineAcroCos.clear();
+			lineHeli.clear();
+			calculateSolarSystemEvents(core, 2);
+		}
 	}
 	else if (show_Year)
 	{


### PR DESCRIPTION
Restores the previously displayed "previous" and "next" full moon information (when the Moon is selected) which was removed when the show_today = false (#1852) was implemented.

### Description
The "calculateSolarSystemEvents()" function is called when the Moon is selected to display the "previous" and "next" Full Moon information.

The current Stellarium Guide states that this Lunar information is displayed so #1852 introduced a minor regression.

Fixes #1929

### Screenshots (if appropriate):

See issue, screenshot there.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)
- [] This change requires a documentation update

### How Has This Been Tested?
1. Original issue poster agrees screenshot is as expected.
2. Now matches the Stellarium Guide.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- n/a I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
