### PR TITLE
Add Solar and Lunar info to InfoString (Fix #1455)

### DIFF
--- a/src/core/StelObject.hpp
+++ b/src/core/StelObject.hpp
@@ -70,10 +70,11 @@ public:
 		IAUConstellation        = 0x00100000, //!< Three-letter constellation code (And, Boo, Cas, ...)
 		SiderealTime		= 0x00200000, //!< Mean and Apparent Sidereal Time
 		RTSTime			= 0x00400000, //!< Time of rise, transit and set of celestial object
-		Script                  = 0x00800000, //!< Should be used by Scripts only which can inject extraInfoStrings.
-		DebugAid                = 0x01000000, //!< Can be used for development only, place messages into extraInfoStrings. Comment them away or delete for releases.
-		NoFont			= 0x02000000,
-		PlainText		= 0x04000000  //!< Strip HTML tags from output
+		SolarLunarPosition      = 0x00800000, //!< Show Solar and Lunar horizontal position (on Earth location only)
+		Script                  = 0x01000000, //!< Should be used by Scripts only which can inject extraInfoStrings.
+		DebugAid                = 0x02000000, //!< Can be used for development only, place messages into extraInfoStrings. Comment them away or delete for releases.
+		NoFont			= 0x04000000,
+		PlainText		= 0x08000000  //!< Strip HTML tags from output
 	};
 	Q_DECLARE_FLAGS(InfoStringGroup, InfoStringGroupFlags)
 
@@ -81,7 +82,7 @@ public:
 	static const InfoStringGroupFlags AllInfo = static_cast<InfoStringGroupFlags>(Name|CatalogNumber|Magnitude|RaDecJ2000|RaDecOfDate|AltAzi|
 									   Distance|Elongation|Size|Velocity|ProperMotion|Extra|HourAngle|AbsoluteMagnitude|
 									   GalacticCoord|SupergalacticCoord|OtherCoord|ObjectType|EclipticCoordJ2000|
-									   EclipticCoordOfDate|IAUConstellation|SiderealTime|RTSTime);
+									   EclipticCoordOfDate|IAUConstellation|SiderealTime|RTSTime|SolarLunarPosition);
 	//! A pre-defined set of specifiers for the getInfoString flags argument to getInfoString
 	static const InfoStringGroupFlags ShortInfo = static_cast<InfoStringGroupFlags>(Name|CatalogNumber|Magnitude|RaDecJ2000);
 
@@ -307,6 +308,10 @@ protected:
 	//! @param flags
 	//! @param decimals significant digits after the comma.
 	virtual QString getMagnitudeInfoString(const StelCore *core, const InfoStringGroup& flags, const int decimals=1) const;
+
+	//! Add a section to the InfoString with just horizontal data for the Sun and Moon, when observed from Earth.
+	//! The application of this is to have quick info while observing other objects.
+	QString getSolarLunarInfoString(const StelCore *core, const InfoStringGroup& flags) const;
 
 	//! Apply post processing on the info string.
 	//! This also removes all extraInfoStrings possibly injected by modules (plugins) etc., except for Script and DebugAid types.

--- a/src/core/modules/Asterism.cpp
+++ b/src/core/modules/Asterism.cpp
@@ -194,6 +194,7 @@ QString Asterism::getInfoString(const StelCore *core, const InfoStringGroup &fla
 	if (flags&ObjectType)
 		oss << QString("%1: <b>%2</b>").arg(q_("Type"), q_("asterism")) << "<br />";
 
+	oss << getSolarLunarInfoString(core, flags);
 	postProcessInfoString(str, flags);
 
 	return str;

--- a/src/core/modules/Constellation.cpp
+++ b/src/core/modules/Constellation.cpp
@@ -289,6 +289,7 @@ QString Constellation::getInfoString(const StelCore *core, const InfoStringGroup
 	if (flags&ObjectType)
 		oss << QString("%1: <b>%2</b>").arg(q_("Type"), q_("constellation")) << "<br />";
 
+	getSolarLunarInfoString(core, flags);
 	postProcessInfoString(str, flags);
 
 	return str;

--- a/src/core/modules/CustomObject.cpp
+++ b/src/core/modules/CustomObject.cpp
@@ -91,6 +91,7 @@ QString CustomObject::getInfoString(const StelCore* core, const InfoStringGroup&
 
 	// Ra/Dec etc.
 	oss << getCommonInfoString(core, flags);
+	oss << getSolarLunarInfoString(core, flags);
 	postProcessInfoString(str, flags);
 	return str;
 }

--- a/src/core/modules/Nebula.cpp
+++ b/src/core/modules/Nebula.cpp
@@ -393,6 +393,8 @@ QString Nebula::getInfoString(const StelCore *core, const InfoStringGroup& flags
 			oss << QString("%1: %2.").arg(q_("Morphological description"), getMorphologicalTypeDescription()) << "<br />";
 	}
 
+	oss << getSolarLunarInfoString(core, flags);
+
 	postProcessInfoString(str, flags);
 
 	return str;

--- a/src/core/modules/Planet.cpp
+++ b/src/core/modules/Planet.cpp
@@ -644,6 +644,7 @@ QString Planet::getInfoString(const StelCore* core, const InfoStringGroup& flags
 	oss << getInfoStringPeriods(core, flags);
 	oss << getInfoStringSize(core, flags);
 	oss << getInfoStringExtra(core, flags);
+	oss << getSolarLunarInfoString(core, flags);
 	if (!hasValidPositionalData(core->getJDE(), PositionQuality::Position))
 	{
 	    oss << q_("NOTE: orbital elements outdated -- consider updating!") << "<br/>";

--- a/src/core/modules/StarWrapper.cpp
+++ b/src/core/modules/StarWrapper.cpp
@@ -55,6 +55,7 @@ QString StarWrapperBase::getInfoString(const StelCore *core, const InfoStringGro
 		oss << QString("%1: <b>%2</b>").arg(q_("Color Index (B-V)"), QString::number(getBV(), 'f', 2)) << "<br />";
 	
 	oss << getCommonInfoString(core, flags);
+	oss << getSolarLunarInfoString(core, flags);
 
 	StelObject::postProcessInfoString(str, flags);
 
@@ -387,6 +388,8 @@ QString StarWrapper1::getInfoString(const StelCore *core, const InfoStringGroup&
 			}
 		}
 	}
+
+	oss << getSolarLunarInfoString(core, flags);
 
 	StelObject::postProcessInfoString(str, flags);
 

--- a/src/gui/ConfigurationDialog.cpp
+++ b/src/gui/ConfigurationDialog.cpp
@@ -608,6 +608,8 @@ void ConfigurationDialog::setSelectedInfoFromCheckBoxes()
 		flags |= StelObject::SiderealTime;
 	if (ui->checkBoxRTSTime->isChecked())
 		flags |= StelObject::RTSTime;
+	if (ui->checkBoxSolarLunarPosition->isChecked())
+		flags |= StelObject::SolarLunarPosition;
 
 	gui->setInfoTextFilters(flags);
 	// overwrite custom selected info settings
@@ -666,6 +668,8 @@ void ConfigurationDialog::setCustomSelectedInfo()
 		flags |= StelObject::SiderealTime;
 	if (conf->value("custom_selected_info/flag_show_rts_time", false).toBool())
 		flags |= StelObject::RTSTime;
+	if (conf->value("custom_selected_info/flag_show_solar_lunar", false).toBool())
+		flags |= StelObject::SolarLunarPosition;
 
 	gui->setInfoTextFilters(flags);
 	updateSelectedInfoCheckBoxes();
@@ -702,6 +706,7 @@ void ConfigurationDialog::saveCustomSelectedInfo()
 	conf->setValue("flag_show_constellation",		static_cast<bool>(flags & StelObject::IAUConstellation));
 	conf->setValue("flag_show_sidereal_time",		static_cast<bool>(flags & StelObject::SiderealTime));
 	conf->setValue("flag_show_rts_time",			static_cast<bool>(flags & StelObject::RTSTime));
+	conf->setValue("flag_show_solar_lunar",			static_cast<bool>(flags & StelObject::SolarLunarPosition));
 	conf->endGroup();
 }
 
@@ -1725,6 +1730,7 @@ void ConfigurationDialog::updateSelectedInfoCheckBoxes()
 	ui->checkBoxConstellation->setChecked(flags & StelObject::IAUConstellation);
 	ui->checkBoxSiderealTime->setChecked(flags & StelObject::SiderealTime);
 	ui->checkBoxRTSTime->setChecked(flags & StelObject::RTSTime);
+	ui->checkBoxSolarLunarPosition->setChecked(flags & StelObject::SolarLunarPosition);
 }
 
 void ConfigurationDialog::updateTabBarListWidgetWidth()

--- a/src/gui/configurationDialog.ui
+++ b/src/gui/configurationDialog.ui
@@ -963,19 +963,6 @@
                </attribute>
               </widget>
              </item>
-             <item row="12" column="1">
-              <widget class="QCheckBox" name="checkBoxExtra">
-               <property name="toolTip">
-                <string>Spectral class, nebula type, etc.</string>
-               </property>
-               <property name="text">
-                <string>Additional information</string>
-               </property>
-               <attribute name="buttonGroup">
-                <string notr="true">buttonGroupDisplayedFields</string>
-               </attribute>
-              </widget>
-             </item>
              <item row="0" column="1">
               <widget class="QCheckBox" name="checkBoxVisualMag">
                <property name="text">
@@ -1030,6 +1017,29 @@
                <attribute name="buttonGroup">
                 <string notr="true">buttonGroupDisplayedFields</string>
                </attribute>
+              </widget>
+             </item>
+             <item row="13" column="1">
+              <widget class="QCheckBox" name="checkBoxExtra">
+               <property name="toolTip">
+                <string>Spectral class, nebula type, etc.</string>
+               </property>
+               <property name="text">
+                <string>Additional information</string>
+               </property>
+               <attribute name="buttonGroup">
+                <string notr="true">buttonGroupDisplayedFields</string>
+               </attribute>
+              </widget>
+             </item>
+             <item row="12" column="1">
+              <widget class="QCheckBox" name="checkBoxSolarLunarPosition">
+               <property name="toolTip">
+                <string>Show Solar and Lunar positions if observed from Earth</string>
+               </property>
+               <property name="text">
+                <string>Solar and Lunar position</string>
+               </property>
               </widget>
              </item>
             </layout>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Please include a summary of the change and which issue is fixed. -->
<!--- Please also include relevant motivation and context. -->
<!--- List any dependencies that are required for this change. -->

Sometimes it is good to know horizontal coordinates of the Sun and Moon while observing other objects. 
This branch adds yet another group with this information to the InfoString. 

Maybe we should really start to deliver shortened object info by default. Info overlaps left menu. 

Fixes #1455  (issue)

### Screenshots (if appropriate):

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] This change requires a documentation update

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system: Windows 10 (irrelevant)
* Graphics Card: (irrelevant)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [!] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
