### PR TITLE
InfoString fixes

### DIFF
--- a/guide/app_config_ini.tex
+++ b/guide/app_config_ini.tex
@@ -309,26 +309,30 @@ You can fine-tune the bits of information to display for the selected object in 
 
 \begin{longtable}{l|l|l}\toprule
 \emph{ID} & \emph{Type} & \emph{Description}\\\midrule
-flag\_show\_absolutemagnitude & bool & absolute magnitude for objects.\\%\midrule
-flag\_show\_altaz             & bool & horizontal coordinates for objects.\\%\midrule
-flag\_show\_catalognumber     & bool & catalog designations for objects.\\%\midrule
-flag\_show\_distance          & bool & distance to object.\\%\midrule
-flag\_show\_extra             & bool & extra info for object.\\%\midrule
-flag\_show\_hourangle         & bool & hour angle for object.\\%\midrule
-flag\_show\_magnitude         & bool & magnitude for object.\\%\midrule
-flag\_show\_name              & bool & common name for object.\\%\midrule
-flag\_show\_radecj2000        & bool & equatorial coordinates (J2000.0 frame) of object.\\%\midrule
-flag\_show\_radecofdate       & bool & equatorial coordinates (of date) of object.\\%\midrule
-flag\_show\_galcoord          & bool & galactic coordinates (System~II) of object.\\%\midrule
-flag\_show\_supergalcoord     & bool & supergalactic coordinates of object.\\%\midrule
-flag\_show\_eclcoordj2000     & bool & ecliptic coordinates (J2000.0 frame) of object.\\%\midrule
-flag\_show\_eclcoordofdate    & bool & ecliptic coordinates (of date) of object.\\%\midrule
-flag\_show\_type              & bool & type of object.\\%\midrule
-flag\_show\_size              & bool & size of object.\\%\midrule
-flag\_show\_sidereal\_time    & bool & sidereal time.\\%\midrule
-flag\_show\_rts\_time         & bool & rise, transit and set times.\\%\midrule
-flag\_show\_velocity          & bool & velocity of object.\\%\midrule
-flag\_show\_constellation     & bool & show 3-letter IAU\index{IAU} constellation label.\\\bottomrule
+flag\_show\_name              & bool & common name for object.\\
+flag\_show\_catalognumber     & bool & catalog designations for objects.\\
+flag\_show\_type              & bool & type of object.\\
+flag\_show\_magnitude         & bool & magnitude for object.\\
+flag\_show\_absolutemagnitude & bool & absolute magnitude for objects.\\
+flag\_show\_radecj2000        & bool & equatorial coordinates (J2000.0 frame) of object.\\
+flag\_show\_radecofdate       & bool & equatorial coordinates (of date) of object.\\
+flag\_show\_hourangle         & bool & hour angle for object.\\
+flag\_show\_altaz             & bool & horizontal coordinates for objects.\\
+flag\_show\_eclcoordj2000     & bool & ecliptic coordinates (J2000.0 frame) of object.\\
+flag\_show\_eclcoordofdate    & bool & ecliptic coordinates (of date) of object.\\
+flag\_show\_galcoord          & bool & galactic coordinates (System~II) of object.\\
+flag\_show\_supergalcoord     & bool & supergalactic coordinates of object.\\
+flag\_show\_othercoord        & bool & other coordinates of object (from plugins).\\
+flag\_show\_constellation     & bool & show 3-letter IAU\index{IAU} constellation label.\\
+flag\_show\_sidereal\_time    & bool & sidereal time.\\
+flag\_show\_elongation        & bool & elongation from the Sun for solar system objects.\\
+flag\_show\_distance          & bool & distance to object.\\
+flag\_show\_velocity          & bool & velocity of object.\\
+flag\_show\_propermotion      & bool & proper motion of object.\\
+flag\_show\_size              & bool & size of object.\\
+flag\_show\_rts\_time         & bool & rise, transit and set times.\\
+flag\_show\_solar\_lunar      & bool & horizontal coordinates for Sun and Moon.\\
+flag\_show\_extra             & bool & extra info for object.\\\bottomrule
 \end{longtable}
 
 \subsection{\big[custom\_time\_correction\big]}
@@ -487,8 +491,8 @@ flag\_show\_compass\_button            & bool  & false & Show a button to toggle
 flag\_show\_buttons\_background        & bool  & true  & If \emph{true}, use background under buttons on bottom bar.\\\midrule
 flag\_overwrite\_info\_color           & bool  & false & Set \emph{true} to use one color for test in info panel for all objects.\\\midrule
 %
-selected\_object\_info            & string & all  & Values: \emph{all}, \emph{short}, \emph{none}, 
-                                                    and \emph{custom} (since V0.12.0; see~\ref{sec:gui:configuration:info}).\\\midrule
+selected\_object\_info            & string & all  & Values: \emph{default}, \emph{all}, \emph{short}, \emph{none}, 
+                                                    and \emph{custom} (see~\ref{sec:gui:configuration:info}).\\\midrule
 custom\_marker\_size             & float   & 5.0 & Size of custom marker.\\%\midrule
 custom\_marker\_radius\_limit    & int   & 15 & Limit the click radius for mouse cursor position in any direction for removing of closest custom marker.\\\midrule
 %% NO LONGER HERE!

--- a/src/core/StelObject.cpp
+++ b/src/core/StelObject.cpp
@@ -1118,7 +1118,7 @@ QString StelObject::getSolarLunarInfoString(const StelCore *core, const InfoStri
 	    altStr = (withDecimalDegree ? StelUtils::radToDecDegStr(alt, 2) : StelUtils::radToDmsStr(alt,false));
 
 	    // TRANSLATORS: Azimuth/Altitude
-	    const QString SolarAzAlt = (withDesignations ? "Solar A/a" : qc_("Solar Az./Alt.", "celestial coordinate system"));
+	    const QString SolarAzAlt = (withDesignations ? qc_("Solar A/a", "celestial coordinate system") : qc_("Solar Az./Alt.", "celestial coordinate system"));
 	    if (withTables)
 	    {
 		oss << QString("<tr><td>%1:</td><td style='text-align:right;'>%2/</td><td style='text-align:right;'>%3</td></tr>").arg(SolarAzAlt, azStr, altStr);
@@ -1136,7 +1136,7 @@ QString StelObject::getSolarLunarInfoString(const StelCore *core, const InfoStri
 	    altStr = (withDecimalDegree ? StelUtils::radToDecDegStr(alt, 2) : StelUtils::radToDmsStr(alt,false));
 
 	    // TRANSLATORS: Azimuth/Altitude
-	    const QString LunarAzAlt = (withDesignations ? "Lunar A/a" : qc_("Lunar Az./Alt.", "celestial coordinate system"));
+	    const QString LunarAzAlt = (withDesignations ? qc_("Lunar A/a", "celestial coordinate system") : qc_("Lunar Az./Alt.", "celestial coordinate system"));
 	    if (withTables)
 	    {
 		oss << QString("<tr><td>%1:</td><td style='text-align:right;'>%2/</td><td style='text-align:right;'>%3</td></tr>").arg(LunarAzAlt, azStr, altStr);

--- a/src/core/StelObject.hpp
+++ b/src/core/StelObject.hpp
@@ -78,12 +78,16 @@ public:
 	};
 	Q_DECLARE_FLAGS(InfoStringGroup, InfoStringGroupFlags)
 
-	//! A pre-defined set of specifiers for the getInfoString flags argument to getInfoString
+	//! A pre-defined "all available" set of specifiers for the getInfoString flags argument to getInfoString
 	static const InfoStringGroupFlags AllInfo = static_cast<InfoStringGroupFlags>(Name|CatalogNumber|Magnitude|RaDecJ2000|RaDecOfDate|AltAzi|
 									   Distance|Elongation|Size|Velocity|ProperMotion|Extra|HourAngle|AbsoluteMagnitude|
 									   GalacticCoord|SupergalacticCoord|OtherCoord|ObjectType|EclipticCoordJ2000|
 									   EclipticCoordOfDate|IAUConstellation|SiderealTime|RTSTime|SolarLunarPosition);
-	//! A pre-defined set of specifiers for the getInfoString flags argument to getInfoString
+	//! A pre-defined "default" set of specifiers for the getInfoString flags argument to getInfoString
+	//! It appears useful to propose this set as post-install settings and let users configure more on demand.
+	static const InfoStringGroupFlags DefaultInfo = static_cast<InfoStringGroupFlags>(Name|CatalogNumber|Magnitude|RaDecOfDate|HourAngle|AltAzi|OtherCoord|
+											  Distance|Elongation|Size|Velocity|Extra|IAUConstellation|SiderealTime|RTSTime);
+	//! A pre-defined "shortest useful" set of specifiers for the getInfoString flags argument to getInfoString
 	static const InfoStringGroupFlags ShortInfo = static_cast<InfoStringGroupFlags>(Name|CatalogNumber|Magnitude|RaDecJ2000);
 
 	virtual ~StelObject() Q_DECL_OVERRIDE {}

--- a/src/gui/ConfigurationDialog.cpp
+++ b/src/gui/ConfigurationDialog.cpp
@@ -202,9 +202,13 @@ void ConfigurationDialog::createDialogContent()
 	connectBoolProperty(ui->topocentricCheckBox, "StelCore.flagUseTopocentricCoordinates");
 
 	// Selected object info
-	if (gui->getInfoTextFilters() == StelObject::InfoStringGroup(Q_NULLPTR))
+	if (gui->getInfoTextFilters() == StelObject::InfoStringGroup(StelObject::None))
 	{
 		ui->noSelectedInfoRadio->setChecked(true);
+	}
+	else if (gui->getInfoTextFilters() == StelObject::DefaultInfo)
+	{
+	    ui->defaultSelectedInfoRadio->setChecked(true);
 	}
 	else if (gui->getInfoTextFilters() == StelObject::ShortInfo)
 	{
@@ -229,6 +233,7 @@ void ConfigurationDialog::createDialogContent()
 
 	connect(ui->noSelectedInfoRadio, SIGNAL(released()), this, SLOT(setNoSelectedInfo()));
 	connect(ui->allSelectedInfoRadio, SIGNAL(released()), this, SLOT(setAllSelectedInfo()));
+	connect(ui->defaultSelectedInfoRadio, SIGNAL(released()), this, SLOT(setDefaultSelectedInfo()));
 	connect(ui->briefSelectedInfoRadio, SIGNAL(released()), this, SLOT(setBriefSelectedInfo()));
 	connect(ui->customSelectedInfoRadio, SIGNAL(released()), this, SLOT(setCustomSelectedInfo()));
 	connect(ui->buttonGroupDisplayedFields, SIGNAL(buttonClicked(int)), this, SLOT(setSelectedInfoFromCheckBoxes()));
@@ -535,21 +540,27 @@ void ConfigurationDialog::setSphericMirror(bool b)
 	}
 }
 
-void ConfigurationDialog::setNoSelectedInfo(void)
+void ConfigurationDialog::setNoSelectedInfo()
 {
 	gui->setInfoTextFilters(StelObject::InfoStringGroup(StelObject::None));
 	updateSelectedInfoCheckBoxes();
 }
 
-void ConfigurationDialog::setAllSelectedInfo(void)
+void ConfigurationDialog::setAllSelectedInfo()
 {
 	gui->setInfoTextFilters(StelObject::InfoStringGroup(StelObject::AllInfo));
 	updateSelectedInfoCheckBoxes();
 }
 
-void ConfigurationDialog::setBriefSelectedInfo(void)
+void ConfigurationDialog::setBriefSelectedInfo()
 {
 	gui->setInfoTextFilters(StelObject::InfoStringGroup(StelObject::ShortInfo));
+	updateSelectedInfoCheckBoxes();
+}
+
+void ConfigurationDialog::setDefaultSelectedInfo()
+{
+	gui->setInfoTextFilters(StelObject::InfoStringGroup(StelObject::DefaultInfo));
 	updateSelectedInfoCheckBoxes();
 }
 
@@ -1055,8 +1066,10 @@ void ConfigurationDialog::saveAllSettings()
 
 	// configuration dialog / selected object info tab
 	const StelObject::InfoStringGroup& flags = gui->getInfoTextFilters();
-	if (flags == StelObject::InfoStringGroup(Q_NULLPTR))
+	if (flags == StelObject::InfoStringGroup(StelObject::None))
 		conf->setValue("gui/selected_object_info", "none");
+	else if (flags == StelObject::InfoStringGroup(StelObject::DefaultInfo))
+	    conf->setValue("gui/selected_object_info", "default");
 	else if (flags == StelObject::InfoStringGroup(StelObject::ShortInfo))
 		conf->setValue("gui/selected_object_info", "short");
 	else if (flags == StelObject::InfoStringGroup(StelObject::AllInfo))

--- a/src/gui/ConfigurationDialog.hpp
+++ b/src/gui/ConfigurationDialog.hpp
@@ -74,6 +74,7 @@ private slots:
 	void setNoSelectedInfo();
 	void setAllSelectedInfo();
 	void setBriefSelectedInfo();
+	void setDefaultSelectedInfo();
 	void setCustomSelectedInfo();
 	//! Set the selected object info fields from the "Displayed Fields" boxes.
 	//! Called when any of the boxes has been clicked. Sets the

--- a/src/gui/SkyGui.cpp
+++ b/src/gui/SkyGui.cpp
@@ -36,7 +36,7 @@ InfoPanel::InfoPanel(QGraphicsItem* parent) : QGraphicsTextItem("", parent),
 {
 	QSettings* conf = StelApp::getInstance().getSettings();
 	Q_ASSERT(conf);
-	QString objectInfo = conf->value("gui/selected_object_info", "all").toString();
+	QString objectInfo = conf->value("gui/selected_object_info", "default").toString();
 	if (objectInfo == "all")
 	{
 		infoTextFilters = StelObject::InfoStringGroup(StelObject::AllInfo);
@@ -100,12 +100,15 @@ InfoPanel::InfoPanel(QGraphicsItem* parent) : QGraphicsTextItem("", parent),
 			infoTextFilters |= StelObject::SiderealTime;
 		if (conf->value("flag_show_rts_time", false).toBool())
 			infoTextFilters |= StelObject::RTSTime;
+		if (conf->value("flag_show_solar_lunar", false).toBool())
+		    infoTextFilters |= StelObject::SolarLunarPosition;
 		conf->endGroup();
 	}
 	else
 	{
-		qWarning() << "config.ini option gui/selected_object_info is invalid, using \"all\"";
-		infoTextFilters = StelObject::InfoStringGroup(StelObject::AllInfo);
+		if (objectInfo != "default")
+			qWarning() << "config.ini option gui/selected_object_info is invalid, using \"default\"";
+		infoTextFilters = StelObject::InfoStringGroup(StelObject::DefaultInfo);
 	}
 	if (qApp->property("text_texture")==true) // CLI option -t given?
 		infoPixmap=new QGraphicsPixmapItem(this);

--- a/src/gui/configurationDialog.ui
+++ b/src/gui/configurationDialog.ui
@@ -702,7 +702,7 @@
                 <string>Display user customized information</string>
                </property>
                <property name="text">
-                <string>Customized</string>
+                <string comment="info group name">Customized</string>
                </property>
               </widget>
              </item>
@@ -712,7 +712,7 @@
                 <string>Display all information available</string>
                </property>
                <property name="text">
-                <string>All available</string>
+                <string comment="info group name">All available</string>
                </property>
               </widget>
              </item>
@@ -722,7 +722,7 @@
                 <string>Display no information</string>
                </property>
                <property name="text">
-                <string>None</string>
+                <string comment="info group name">None</string>
                </property>
               </widget>
              </item>
@@ -732,7 +732,7 @@
                 <string>Display less information</string>
                </property>
                <property name="text">
-                <string>Short</string>
+                <string comment="info group name">Short</string>
                </property>
               </widget>
              </item>
@@ -742,7 +742,7 @@
                 <string>Display a preconfigured set of information</string>
                </property>
                <property name="text">
-                <string>Default</string>
+                <string comment="info group name">Default</string>
                </property>
               </widget>
              </item>

--- a/src/gui/configurationDialog.ui
+++ b/src/gui/configurationDialog.ui
@@ -696,13 +696,13 @@
              <property name="bottomMargin">
               <number>0</number>
              </property>
-             <item row="0" column="1">
-              <widget class="QRadioButton" name="briefSelectedInfoRadio">
+             <item row="0" column="4">
+              <widget class="QRadioButton" name="customSelectedInfoRadio">
                <property name="toolTip">
-                <string>Display less information</string>
+                <string>Display user customized information</string>
                </property>
                <property name="text">
-                <string>Short</string>
+                <string>Customized</string>
                </property>
               </widget>
              </item>
@@ -716,7 +716,7 @@
                </property>
               </widget>
              </item>
-             <item row="0" column="2">
+             <item row="0" column="3">
               <widget class="QRadioButton" name="noSelectedInfoRadio">
                <property name="toolTip">
                 <string>Display no information</string>
@@ -726,13 +726,23 @@
                </property>
               </widget>
              </item>
-             <item row="0" column="3">
-              <widget class="QRadioButton" name="customSelectedInfoRadio">
+             <item row="0" column="2">
+              <widget class="QRadioButton" name="briefSelectedInfoRadio">
                <property name="toolTip">
-                <string>Display user settings information</string>
+                <string>Display less information</string>
                </property>
                <property name="text">
-                <string>Customized</string>
+                <string>Short</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="1">
+              <widget class="QRadioButton" name="defaultSelectedInfoRadio">
+               <property name="toolTip">
+                <string>Display a preconfigured set of information</string>
+               </property>
+               <property name="text">
+                <string>Default</string>
                </property>
               </widget>
              </item>
@@ -1040,6 +1050,9 @@
                <property name="text">
                 <string>Solar and Lunar position</string>
                </property>
+               <attribute name="buttonGroup">
+                <string notr="true">buttonGroupDisplayedFields</string>
+               </attribute>
               </widget>
              </item>
             </layout>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Please include a summary of the change and which issue is fixed. -->
<!--- Please also include relevant motivation and context. -->
<!--- List any dependencies that are required for this change. -->

Second part of the prematurely merged InfoString additions (#2037), i.e. bugfix for the checkbox and SUG additions. 

#### Plus:

The beginning user may be overwhelmed by too much information. Also, some users with average screens will have info colliding with the left slide-out menu bar. This little branch introduces a default set of display options and lets the user find out more. The exact setting of defaults should be geared towards beginning users and may be subject to discussion before merge.

Fixes #2037, #1455 

### Screenshots (if appropriate):

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] This change requires a documentation update

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system: Windows 10 (irrelevant)
* Graphics Card: irrelevant

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
