### PR TITLE
Fix issue #1842

### DIFF
--- a/src/core/modules/SolarSystem.cpp
+++ b/src/core/modules/SolarSystem.cpp
@@ -1907,7 +1907,7 @@ void SolarSystem::setFlagOrbits(bool b)
 			if (selected == p || selected == p->parent)
 				p->setFlagOrbits(b);
 			else
-				p->setFlagOrbits(false);
+				p->setFlagOrbits(true);
 		}
 	}
 	if(old != flagOrbits)


### PR DESCRIPTION
### Description

The change is to invert the logic calling setFlagOrbits() which seemed to be the wrong way around.


Fixes #1842

### Screenshots (if appropriate):
n/a

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested on Windows 10 Visual Studio before and after the change.


**Test Configuration**:
* Operating system: Windows 10
* Graphics Card:  n/a

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
