### PR TITLE
Addressing feature request #2044

### DIFF
--- a/src/core/modules/SolarSystem.cpp
+++ b/src/core/modules/SolarSystem.cpp
@@ -94,7 +94,7 @@ SolarSystem::SolarSystem() : StelObjectModule()
 	, ephemerisDatesDisplayed(false)
 	, ephemerisMagnitudesDisplayed(false)
 	, ephemerisHorizontalCoordinates(false)
-	, ephemerisLineDisplayed(false)
+	, ephemerisLineDisplayed(false)	
 	, ephemerisLineThickness(1)
 	, ephemerisSkipDataDisplayed(false)
 	, ephemerisSkipMarkersDisplayed(false)
@@ -102,6 +102,7 @@ SolarSystem::SolarSystem() : StelObjectModule()
 	, ephemerisDataLimit(1)
 	, ephemerisSmartDatesDisplayed(true)
 	, ephemerisScaleMarkersDisplayed(false)
+	, ephemerisAlwaysOn(false)
 	, ephemerisGenericMarkerColor(Vec3f(1.0f, 1.0f, 0.0f))
 	, ephemerisSecondaryMarkerColor(Vec3f(0.7f, 0.7f, 1.0f))
 	, ephemerisSelectedMarkerColor(Vec3f(1.0f, 0.7f, 0.0f))
@@ -253,6 +254,7 @@ void SolarSystem::init()
 
 	// Ephemeris stuff
 	setFlagEphemerisMarkers(conf->value("astrocalc/flag_ephemeris_markers", true).toBool());
+	setFlagEphemerisAlwaysOn(conf->value("astrocalc/flag_ephemeris_alwayson", true).toBool());
 	setFlagEphemerisDates(conf->value("astrocalc/flag_ephemeris_dates", false).toBool());
 	setFlagEphemerisMagnitudes(conf->value("astrocalc/flag_ephemeris_magnitudes", false).toBool());
 	setFlagEphemerisHorizontalCoordinates(conf->value("astrocalc/flag_ephemeris_horizontal", false).toBool());
@@ -1284,6 +1286,17 @@ struct biggerDistance : public std::binary_function<PlanetP, PlanetP, bool>
 // We are supposed to be in heliocentric coordinate
 void SolarSystem::draw(StelCore* core)
 {
+	bool ephmerisDrawn = false;
+
+	if (getFlagEphemerisAlwaysOn())
+	{
+		ephmerisDrawn = true;
+		if (getFlagEphemerisMarkers())
+			drawEphemerisMarkers(core);
+		if (getFlagEphemerisLine())
+			drawEphemerisLine(core);
+	}
+
 	if (!flagShow)
 		return;
 
@@ -1325,11 +1338,14 @@ void SolarSystem::draw(StelCore* core)
 		drawPointer(core);
 
 	// AstroCalcDialog
-	if (getFlagEphemerisMarkers())
-		drawEphemerisMarkers(core);		
+	if (!ephmerisDrawn)
+	{
+		if (getFlagEphemerisMarkers())
+			drawEphemerisMarkers(core);		
 
-	if (getFlagEphemerisLine())
-		drawEphemerisLine(core);
+		if (getFlagEphemerisLine())
+			drawEphemerisLine(core);
+	}
 }
 
 Vec3f SolarSystem::getEphemerisMarkerColor(int index) const
@@ -2089,6 +2105,21 @@ void SolarSystem::setFlagEphemerisLine(bool b)
 bool SolarSystem::getFlagEphemerisLine() const
 {
 	return ephemerisLineDisplayed;
+}
+
+bool SolarSystem::getFlagEphemerisAlwaysOn() const
+{
+	return ephemerisAlwaysOn;
+}
+
+void SolarSystem::setFlagEphemerisAlwaysOn(bool b)
+{
+	if (b != ephemerisAlwaysOn)
+	{
+		ephemerisAlwaysOn = b;
+		conf->setValue("astrocalc/flag_ephemeris_alwayson", b); // Immediate saving of state
+		emit ephemerisAlwaysOnChanged(b);
+	}
 }
 
 void SolarSystem::setFlagEphemerisHorizontalCoordinates(bool b)

--- a/src/core/modules/SolarSystem.cpp
+++ b/src/core/modules/SolarSystem.cpp
@@ -1286,16 +1286,8 @@ struct biggerDistance : public std::binary_function<PlanetP, PlanetP, bool>
 // We are supposed to be in heliocentric coordinate
 void SolarSystem::draw(StelCore* core)
 {
-	bool ephmerisDrawn = false;
-
-	if (getFlagEphemerisAlwaysOn())
-	{
-		ephmerisDrawn = true;
-		if (getFlagEphemerisMarkers())
-			drawEphemerisMarkers(core);
-		if (getFlagEphemerisLine())
-			drawEphemerisLine(core);
-	}
+	// AstroCalcDialog
+	drawEphemerisItems(core);
 
 	if (!flagShow)
 		return;
@@ -1336,13 +1328,14 @@ void SolarSystem::draw(StelCore* core)
 
 	if (GETSTELMODULE(StelObjectMgr)->getFlagSelectedObjectPointer() && getFlagPointer())
 		drawPointer(core);
+}
 
-	// AstroCalcDialog
-	if (!ephmerisDrawn)
+void SolarSystem::drawEphemerisItems(const StelCore* core)
+{
+	if (flagShow || (!flagShow && getFlagEphemerisAlwaysOn()))
 	{
 		if (getFlagEphemerisMarkers())
-			drawEphemerisMarkers(core);		
-
+			drawEphemerisMarkers(core);
 		if (getFlagEphemerisLine())
 			drawEphemerisLine(core);
 	}

--- a/src/core/modules/SolarSystem.hpp
+++ b/src/core/modules/SolarSystem.hpp
@@ -1005,6 +1005,9 @@ private:
 	//! Draw a nice animated pointer around the object.
 	void drawPointer(const StelCore* core);
 
+	//! Draw ephemeris lines and markers
+	void drawEphemerisItems(const StelCore* core);
+
 	//! Draw a nice markers for ephemeris of objects.
 	void drawEphemerisMarkers(const StelCore* core);
 

--- a/src/core/modules/SolarSystem.hpp
+++ b/src/core/modules/SolarSystem.hpp
@@ -98,6 +98,7 @@ class SolarSystem : public StelObjectModule
 	Q_PROPERTY(int ephemerisDataLimit		READ getEphemerisDataLimit		WRITE setEphemerisDataLimit		NOTIFY ephemerisDataLimitChanged)
 	Q_PROPERTY(bool ephemerisSmartDates		READ getFlagEphemerisSmartDates		WRITE setFlagEphemerisSmartDates	NOTIFY ephemerisSmartDatesChanged)
 	Q_PROPERTY(bool ephemerisScaleMarkersDisplayed	READ getFlagEphemerisScaleMarkers	WRITE setFlagEphemerisScaleMarkers	NOTIFY ephemerisScaleMarkersChanged)
+	Q_PROPERTY(bool ephemerisAlwaysOn		READ getFlagEphemerisAlwaysOn		WRITE setFlagEphemerisAlwaysOn		NOTIFY ephemerisAlwaysOnChanged)
 	// Great Red Spot (GRS) properties
 	Q_PROPERTY(bool flagCustomGrsSettings		READ getFlagCustomGrsSettings		WRITE setFlagCustomGrsSettings		NOTIFY flagCustomGrsSettingsChanged)
 	Q_PROPERTY(int customGrsLongitude		READ getCustomGrsLongitude		WRITE setCustomGrsLongitude		NOTIFY customGrsLongitudeChanged)
@@ -767,6 +768,7 @@ signals:
 	void ephemerisDatesChanged(bool b);
 	void ephemerisMagnitudesChanged(bool b);
 	void ephemerisLineChanged(bool b);
+	void ephemerisAlwaysOnChanged(bool b);
 	void ephemerisLineThicknessChanged(int v);
 	void ephemerisSkipDataChanged(bool b);
 	void ephemerisSkipMarkersChanged(bool b);
@@ -902,6 +904,11 @@ private slots:
 	void setFlagEphemerisLine(bool b);
 	//! Get the current value of the flag which enabled the showing of ephemeris line between markers or not
 	bool getFlagEphemerisLine() const;
+
+	//! Set flag which enables ephemeris lines and marks always on
+	void setFlagEphemerisAlwaysOn(bool b);
+	//! Get the current value of the flag which makes ephemeris lines and marks always on
+	bool getFlagEphemerisAlwaysOn() const;
 
 	//! Set the thickness of ephemeris line
 	void setEphemerisLineThickness(int v);
@@ -1088,6 +1095,7 @@ private:
 	bool ephemerisMagnitudesDisplayed;
 	bool ephemerisHorizontalCoordinates;
 	bool ephemerisLineDisplayed;
+	bool ephemerisAlwaysOn;
 	int ephemerisLineThickness;
 	bool ephemerisSkipDataDisplayed;
 	bool ephemerisSkipMarkersDisplayed;

--- a/src/gui/AstroCalcExtraEphemerisDialog.cpp
+++ b/src/gui/AstroCalcExtraEphemerisDialog.cpp
@@ -50,7 +50,6 @@ void AstroCalcExtraEphemerisDialog::createDialogContent()
 	connect(&StelApp::getInstance(), SIGNAL(languageChanged()), this, SLOT(retranslate()));
 	connect(ui->closeStelWindow, SIGNAL(clicked()), this, SLOT(close()));
 	connect(ui->TitleBar, SIGNAL(movedTo(QPoint)), this, SLOT(handleMovedTo(QPoint)));
-	connect(ui->alwaysOnCheckBox, SIGNAL(clicked()), this, SLOT(setOptionAlwaysOn()));
 	connect(ui->skipDataCheckBox, SIGNAL(clicked()), this, SLOT(setOptionStatus()));
 
 	connectBoolProperty(ui->skipDataCheckBox,	"SolarSystem.ephemerisSkippedData");
@@ -67,9 +66,4 @@ void AstroCalcExtraEphemerisDialog::createDialogContent()
 void AstroCalcExtraEphemerisDialog::setOptionStatus()
 {
 	ui->skipMarkersCheckBox->setEnabled(ui->skipDataCheckBox->isChecked());
-}
-
-void AstroCalcExtraEphemerisDialog::setOptionAlwaysOn()
-{
-	ui->skipMarkersCheckBox->setEnabled(ui->alwaysOnCheckBox->isChecked());
 }

--- a/src/gui/AstroCalcExtraEphemerisDialog.cpp
+++ b/src/gui/AstroCalcExtraEphemerisDialog.cpp
@@ -50,7 +50,7 @@ void AstroCalcExtraEphemerisDialog::createDialogContent()
 	connect(&StelApp::getInstance(), SIGNAL(languageChanged()), this, SLOT(retranslate()));
 	connect(ui->closeStelWindow, SIGNAL(clicked()), this, SLOT(close()));
 	connect(ui->TitleBar, SIGNAL(movedTo(QPoint)), this, SLOT(handleMovedTo(QPoint)));
-
+	connect(ui->alwaysOnCheckBox, SIGNAL(clicked()), this, SLOT(setOptionAlwaysOn()));
 	connect(ui->skipDataCheckBox, SIGNAL(clicked()), this, SLOT(setOptionStatus()));
 
 	connectBoolProperty(ui->skipDataCheckBox,	"SolarSystem.ephemerisSkippedData");
@@ -58,6 +58,7 @@ void AstroCalcExtraEphemerisDialog::createDialogContent()
 	connectIntProperty(ui->dataStepSpinBox,		"SolarSystem.ephemerisDataStep");
 	connectBoolProperty(ui->smartDatesCheckBox,	"SolarSystem.ephemerisSmartDates");
 	connectBoolProperty(ui->scaleMarkersCheckBox,	"SolarSystem.ephemerisScaleMarkersDisplayed");
+	connectBoolProperty(ui->alwaysOnCheckBox, "SolarSystem.ephemerisAlwaysOn");
 	connectIntProperty(ui->lineThicknessSpinBox,	"SolarSystem.ephemerisLineThickness");
 
 	setOptionStatus();
@@ -66,4 +67,9 @@ void AstroCalcExtraEphemerisDialog::createDialogContent()
 void AstroCalcExtraEphemerisDialog::setOptionStatus()
 {
 	ui->skipMarkersCheckBox->setEnabled(ui->skipDataCheckBox->isChecked());
+}
+
+void AstroCalcExtraEphemerisDialog::setOptionAlwaysOn()
+{
+	ui->skipMarkersCheckBox->setEnabled(ui->alwaysOnCheckBox->isChecked());
 }

--- a/src/gui/AstroCalcExtraEphemerisDialog.hpp
+++ b/src/gui/AstroCalcExtraEphemerisDialog.hpp
@@ -39,6 +39,7 @@ public slots:
 
 private slots:
 	void setOptionStatus();
+	void setOptionAlwaysOn();
 
 protected:
 	//! Initialize the dialog widgets and connect the signals/slots.

--- a/src/gui/AstroCalcExtraEphemerisDialog.hpp
+++ b/src/gui/AstroCalcExtraEphemerisDialog.hpp
@@ -39,7 +39,6 @@ public slots:
 
 private slots:
 	void setOptionStatus();
-	void setOptionAlwaysOn();
 
 protected:
 	//! Initialize the dialog widgets and connect the signals/slots.

--- a/src/gui/astroCalcExtraEphemerisDialog.ui
+++ b/src/gui/astroCalcExtraEphemerisDialog.ui
@@ -226,15 +226,13 @@
         </property>
        </widget>
       </item>
- 
       <item>
        <widget class="QCheckBox" name="alwaysOnCheckBox">
         <property name="text">
-         <string>Always On</string>
+         <string>Lines and markers always on</string>
         </property>
        </widget>
       </item>
-
       <item>
        <layout class="QHBoxLayout" name="horizontalLayout_2">
         <item>

--- a/src/gui/astroCalcExtraEphemerisDialog.ui
+++ b/src/gui/astroCalcExtraEphemerisDialog.ui
@@ -226,6 +226,15 @@
         </property>
        </widget>
       </item>
+ 
+      <item>
+       <widget class="QCheckBox" name="alwaysOnCheckBox">
+        <property name="text">
+         <string>Always On</string>
+        </property>
+       </widget>
+      </item>
+
       <item>
        <layout class="QHBoxLayout" name="horizontalLayout_2">
         <item>


### PR DESCRIPTION
### Description
This PR addresses issue #2044 

It is implemented by adding a new checkbox to the AstroCalcEmphemerisExtra dialog labeled "Lines and markers always on".

This checkbox drives the newly added bool flag in SolarSystem.hpp  "ephemerisAlwaysOn"

This flag is then used in the draw() function to draw the lines and markers even if the SSO objects are selected to be off.

The newly added checkbox defaults to off to maintain previous functionality.

There is no change to the guide as this "Extra" dialog that exists today currently does not have a documentation entry.

### Screenshots (if appropriate):

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### How Has This Been Tested?
Following instructions on issue #2044 tested "before and after".

**Test Configuration**:
* Operating system: Windows 10
* Graphics Card: n/a

## Checklist:
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
