### PR TITLE
Add photorealistic halos feature

### DIFF
--- a/src/core/StelSkyDrawer.cpp
+++ b/src/core/StelSkyDrawer.cpp
@@ -55,6 +55,7 @@ StelSkyDrawer::StelSkyDrawer(StelCore* acore) :
 	flagForcedTwinkle(false),
 	twinkleAmount(0.0),
 	flagDrawBigStarHalo(true),
+	flagDrawPlanetHalo(true),
 	flagStarSpiky(false),
 	flagStarMagnitudeLimit(false),
 	flagNebulaMagnitudeLimit(false),
@@ -99,6 +100,7 @@ StelSkyDrawer::StelSkyDrawer(StelCore* acore) :
 	setCustomPlanetMagnitudeLimit(conf->value("astro/planet_magnitude_limit", 6.5).toDouble());
 	setFlagNebulaMagnitudeLimit((conf->value("astro/flag_nebula_magnitude_limit", false).toBool()));
 	setCustomNebulaMagnitudeLimit(conf->value("astro/nebula_magnitude_limit", 8.5).toDouble());
+	setFlagDrawPlanetHalo(conf->value("astro/flag_planet_halo",true).toBool());
 
 	setBortleScaleIndex(conf->value("stars/init_bortle_scale", 3).toInt());
 	setRelativeStarScale(conf->value("stars/relative_scale", 1.0).toDouble());
@@ -535,11 +537,11 @@ void StelSkyDrawer::postDrawSky3dModel(StelPainter* painter, const Vec3f& v, flo
 	}
 
 	// Fade the halo away when the disk is too big
-	if (pixRadius>=tStop)
+	if (!flagDrawPlanetHalo || pixRadius>=tStop)
 	{
 		rcm.luminance=0.f;
 	}
-	if (pixRadius>tStart && pixRadius<tStop)
+	if (flagDrawPlanetHalo && pixRadius>tStart && pixRadius<tStop)
 	{
 		rcm.luminance=(tStop-pixRadius)/(tStop-tStart);
 	}

--- a/src/core/StelSkyDrawer.hpp
+++ b/src/core/StelSkyDrawer.hpp
@@ -56,6 +56,7 @@ class StelSkyDrawer : public QObject, protected QOpenGLFunctions
 	Q_PROPERTY(bool flagStarTwinkle READ getFlagTwinkle WRITE setFlagTwinkle NOTIFY flagTwinkleChanged)
 	Q_PROPERTY(int bortleScaleIndex READ getBortleScaleIndex WRITE setBortleScaleIndex NOTIFY bortleScaleIndexChanged)
 	Q_PROPERTY(bool flagDrawBigStarHalo READ getFlagDrawBigStarHalo WRITE setFlagDrawBigStarHalo NOTIFY flagDrawBigStarHaloChanged)
+	Q_PROPERTY(bool flagDrawPlanetHalo READ getFlagDrawPlanetHalo WRITE setFlagDrawPlanetHalo NOTIFY flagDrawPlanetHaloChanged)
 	Q_PROPERTY(bool flagStarSpiky READ getFlagStarSpiky WRITE setFlagStarSpiky NOTIFY flagStarSpikyChanged)
 
 	Q_PROPERTY(bool flagStarMagnitudeLimit READ getFlagStarMagnitudeLimit WRITE setFlagStarMagnitudeLimit NOTIFY flagStarMagnitudeLimitChanged)
@@ -222,6 +223,10 @@ public slots:
 	void setFlagDrawBigStarHalo(bool b) {if(b!=flagDrawBigStarHalo){ flagDrawBigStarHalo=b; emit flagDrawBigStarHaloChanged(b);}}
 	//! Get flag for drawing a halo around bright stars.
 	bool getFlagDrawBigStarHalo() const {return flagDrawBigStarHalo;}
+	//! Set flag for drawing a halo around planets.
+	void setFlagDrawPlanetHalo(bool b) {if(b!=flagDrawPlanetHalo){ flagDrawPlanetHalo=b; emit flagDrawPlanetHaloChanged(b);}}
+	//! Get flag for drawing a halo around planets.
+	bool getFlagDrawPlanetHalo() const {return flagDrawPlanetHalo;}
 
 	//! Set flag to draw stars with rays
 	void setFlagStarSpiky(bool b);
@@ -326,6 +331,8 @@ signals:
 	void bortleScaleIndexChanged(int index);
 	//! Emitted when flag to draw big halo around stars changed
 	void flagDrawBigStarHaloChanged(bool b);
+	//! Emitted whenever the draw planet halo flag is toggled
+	void flagDrawPlanetHaloChanged(bool b);
 	//! Emitted on change of star texture
 	void flagStarSpikyChanged(bool b);
 
@@ -413,6 +420,7 @@ private:
 	bool flagForcedTwinkle;
 	double twinkleAmount;
 	bool flagDrawBigStarHalo;
+	bool flagDrawPlanetHalo;
 	bool flagStarSpiky;
 
 	//! Informing the drawer whether atmosphere is displayed.

--- a/src/core/modules/MinorPlanet.cpp
+++ b/src/core/modules/MinorPlanet.cpp
@@ -52,6 +52,7 @@ MinorPlanet::MinorPlanet(const QString& englishName,
 			 OsculatingFunctType *osculatingFunc,
 			 bool acloseOrbit,
 			 bool hidden,
+			 bool hasHalo,
 			 const QString &pTypeStr)
 	: Planet (englishName,
 		  radius,
@@ -68,7 +69,7 @@ MinorPlanet::MinorPlanet(const QString& englishName,
 		  acloseOrbit,
 		  hidden,
 		  false, //No atmosphere
-		  true,  //Halo
+		  hasHalo,
 		  pTypeStr),
 	minorPlanetNumber(0),
 	slopeParameter(-10.0f), // -10 == mark as uninitialized: used in getVMagnitude()

--- a/src/core/modules/MinorPlanet.hpp
+++ b/src/core/modules/MinorPlanet.hpp
@@ -52,6 +52,7 @@ public:
 		    OsculatingFunctType *osculatingFunc,
 		    bool closeOrbit,
 		    bool hidden,
+		    bool hasHalo,
 		    const QString &pTypeStr);
 
 	~MinorPlanet() Q_DECL_OVERRIDE;

--- a/src/core/modules/SolarSystem.cpp
+++ b/src/core/modules/SolarSystem.cpp
@@ -972,6 +972,7 @@ bool SolarSystem::loadPlanets(const QString& filePath)
 						    osculatingFunc, // should be Q_NULLPTR
 						    closeOrbit,
 						    hidden,
+						    pd.value(secname+"/halo", true).toBool(),
 						    type));
 			QSharedPointer<MinorPlanet> mp =  newP.dynamicCast<MinorPlanet>();
 			//Number, Provisional designation


### PR DESCRIPTION
Abstarct
In Stellarium there is no option to switch off stars' and planets' halos.
According to [this](https://github.com/Stellarium/stellarium/issues/105), [this](https://sourceforge.net/p/stellarium/discussion/278769/thread/c9d3d099/) and [this](https://sourceforge.net/p/stellarium/discussion/278769/thread/50c6aaa4/) conversations, the solution is to use flag_star_halo=false (which actually does nothing anymore) in config.ini or to change certain textures.
In my opinion, the availability of photorealistic mode would be great.
So this pull request will add astro/flag_photorealistic option in config.ini for this feature.

Added:
- [x] Add photorealistic mode.
       If enabled, planets wouldn't have halos and stars' halos would be much smaller.
       The flag is available through astro/flag_photorealistic in config.ini (default is false).
- [x] Add ability to choose whether minor planets have halos or not.
       The flag is available through <planet_section>/halo in ssystem_minor.ini (default is true).

Screenshots:
![image](https://user-images.githubusercontent.com/49411607/145811277-79c513b9-ae80-4906-b673-92a543f0d8c7.png)
![image](https://user-images.githubusercontent.com/49411607/145811321-a0a36066-014d-4165-9489-bf9f74bf5655.png)
![image](https://user-images.githubusercontent.com/49411607/145811360-282216a8-9ade-408f-8287-b8845a21d137.png)

Tests:
 - [x] Hope.
 Actually there is nothing to break.
