### PR TITLE
Added new actions for jumping to specific events

### DIFF
--- a/src/core/StelObjectMgr.cpp
+++ b/src/core/StelObjectMgr.cpp
@@ -70,6 +70,13 @@ void StelObjectMgr::init()
 	actionsMgr->addAction("actionPrevious_MorningTwilight", timeGroup, N_("Previous morning twilight"), this, "previousMorningTwilight()");
 	actionsMgr->addAction("actionPrevious_EveningTwilight", timeGroup, N_("Previous evening twilight"), this, "previousEveningTwilight()");
 
+	actionsMgr->addAction("actionNext_MorningAtAltitude",     timeGroup, N_("Selected object at altitude at next morning"),      this, "nextMorningAtAltitude()");
+	actionsMgr->addAction("actionToday_MorningAtAltitude",    timeGroup, N_("Selected object at altitude this morning"),         this, "todayMorningAtAltitude()");
+	actionsMgr->addAction("actionPrevious_MorningAtAltitude", timeGroup, N_("Selected object at altitude at previous morning"),  this, "previousMorningAtAltitude()");
+	actionsMgr->addAction("actionNext_EveningAtAltitude",     timeGroup, N_("Selected object at altitude at next evening"),      this, "nextEveningAtAltitude()");
+	actionsMgr->addAction("actionToday_EveningAtAltitude",    timeGroup, N_("Selected object at altitude this evening"),         this, "todayEveningAtAltitude()");
+	actionsMgr->addAction("actionPrevious_EveningAtAltitude", timeGroup, N_("Selected object at altitude at previous evening"),  this, "previousEveningAtAltitude()");
+
 	QSettings* conf = StelApp::getInstance().getSettings();
 	Q_ASSERT(conf);
 	setFlagSelectedObjectPointer(conf->value("viewing/flag_show_selection_marker", true).toBool());
@@ -269,6 +276,116 @@ void StelObjectMgr::nextEveningTwilight()
 	Vec4d rts = sun->getRTSTime(core, twilightAltitude);
 	if (rts[3]>-1000.)
 		core->setJD(rts[2]);
+}
+
+void StelObjectMgr::todayMorningAtAltitude()
+{
+	const QList<StelObjectP> selected = getSelectedObject();
+	if (!selected.isEmpty() && selected[0]->getType()!="Satellite")
+	{
+		double az, alt, altitude;
+		bool sign;
+		StelCore* core = StelApp::getInstance().getCore();
+		StelUtils::rectToSphe(&az, &alt, selected[0]->getAltAzPosGeometric(core));
+		StelUtils::radToDecDeg(alt, sign, altitude);
+		if (!sign) { altitude *= -1.; }
+		Vec4d rts = selected[0]->getRTSTime(core, altitude);
+		if (rts[3]>-1000.)
+			core->setJD(rts[0]);
+	}
+}
+
+void StelObjectMgr::nextMorningAtAltitude()
+{
+	const QList<StelObjectP> selected = getSelectedObject();
+	if (!selected.isEmpty() && selected[0]->getType()!="Satellite")
+	{
+		double az, alt, altitude;
+		bool sign;
+		StelCore* core = StelApp::getInstance().getCore();
+		StelUtils::rectToSphe(&az, &alt, selected[0]->getAltAzPosGeometric(core));
+		StelUtils::radToDecDeg(alt, sign, altitude);
+		if (!sign) { altitude *= -1.; }
+		core->addSolarDays(1.0);
+		core->update(0);
+		Vec4d rts = selected[0]->getRTSTime(core, altitude);
+		if (rts[3]>-1000.)
+			core->setJD(rts[0]);
+	}
+}
+
+void StelObjectMgr::previousMorningAtAltitude()
+{
+	const QList<StelObjectP> selected = getSelectedObject();
+	if (!selected.isEmpty() && selected[0]->getType()!="Satellite")
+	{
+		double az, alt, altitude;
+		bool sign;
+		StelCore* core = StelApp::getInstance().getCore();
+		StelUtils::rectToSphe(&az, &alt, selected[0]->getAltAzPosGeometric(core));
+		StelUtils::radToDecDeg(alt, sign, altitude);
+		if (!sign) { altitude *= -1.; }
+		core->addSolarDays(-1.0);
+		core->update(0);
+		Vec4d rts = selected[0]->getRTSTime(core, altitude);
+		if (rts[3]>-1000.)
+			core->setJD(rts[0]);
+	}
+}
+
+void StelObjectMgr::todayEveningAtAltitude()
+{
+	const QList<StelObjectP> selected = getSelectedObject();
+	if (!selected.isEmpty() && selected[0]->getType()!="Satellite")
+	{
+		double az, alt, altitude;
+		bool sign;
+		StelCore* core = StelApp::getInstance().getCore();
+		StelUtils::rectToSphe(&az, &alt, selected[0]->getAltAzPosGeometric(core));
+		StelUtils::radToDecDeg(alt, sign, altitude);
+		if (!sign) { altitude *= -1.; }
+		Vec4d rts = selected[0]->getRTSTime(core, altitude);
+		if (rts[3]>-1000.)
+			core->setJD(rts[2]);
+	}
+}
+
+void StelObjectMgr::nextEveningAtAltitude()
+{
+	const QList<StelObjectP> selected = getSelectedObject();
+	if (!selected.isEmpty() && selected[0]->getType()!="Satellite")
+	{
+		double az, alt, altitude;
+		bool sign;
+		StelCore* core = StelApp::getInstance().getCore();
+		StelUtils::rectToSphe(&az, &alt, selected[0]->getAltAzPosGeometric(core));
+		StelUtils::radToDecDeg(alt, sign, altitude);
+		if (!sign) { altitude *= -1.; }
+		core->addSolarDays(1.0);
+		core->update(0);
+		Vec4d rts = selected[0]->getRTSTime(core, altitude);
+		if (rts[3]>-1000.)
+			core->setJD(rts[2]);
+	}
+}
+
+void StelObjectMgr::previousEveningAtAltitude()
+{
+	const QList<StelObjectP> selected = getSelectedObject();
+	if (!selected.isEmpty() && selected[0]->getType()!="Satellite")
+	{
+		double az, alt, altitude;
+		bool sign;
+		StelCore* core = StelApp::getInstance().getCore();
+		StelUtils::rectToSphe(&az, &alt, selected[0]->getAltAzPosGeometric(core));
+		StelUtils::radToDecDeg(alt, sign, altitude);
+		if (!sign) { altitude *= -1.; }
+		core->addSolarDays(-1.0);
+		core->update(0);
+		Vec4d rts = selected[0]->getRTSTime(core, altitude);
+		if (rts[3]>-1000.)
+			core->setJD(rts[2]);
+	}
 }
 
 /*************************************************************************

--- a/src/core/StelObjectMgr.hpp
+++ b/src/core/StelObjectMgr.hpp
@@ -209,6 +209,19 @@ public slots:
 	//! Set simulation time to the next day's evening when Sun reaches twilightAltitude
 	void nextEveningTwilight();
 
+	//! Set simulation time to this day's morning when selected object reaches current altitude
+	void todayMorningAtAltitude();
+	//! Set simulation time to the next morning when selected object reaches current altitude
+	void nextMorningAtAltitude();
+	//! Set simulation time to the previous morning when selected object reaches current altitude
+	void previousMorningAtAltitude();
+	//! Set simulation time to this day's evening when selected object reaches current altitude
+	void todayEveningAtAltitude();
+	//! Set simulation time to the next evening when selected object reaches current altitude
+	void nextEveningAtAltitude();
+	//! Set simulation time to the previous evening when selected object reaches current altitude
+	void previousEveningAtAltitude();
+
 	//! @note These functions were copied over from StelObject. Given that setExtraInfoString is non-const and some functions where these methods are useful are const, we can use the StelObjectMgr as "carrier object".
 	//! Allow additions to the Info String. Can be used by plugins to show extra info for the selected object, or for debugging.
 	//! Hard-set this string group to a single str, or delete all messages when str==""


### PR DESCRIPTION
Added new actions for jumping to defined moments in diurnal motion of selected objects.

### Description
I've added 6 new actions with empty shortcuts, which allow users jumping to defined moments in diurnal motion of selected objects. For example you selected Jupiter on some altitude this evening and you can now jumping to the moment when Jupiter reaches current altitude this morning, next evening and morning, and previous evening and morning. 

See idea in issue #484

### Screenshots (if appropriate):

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### How Has This Been Tested?
I've assign shortcuts to the new actions and runs these shortcuts

**Test Configuration**:
* Operating system: macOS Monterey (12.0.1)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
