### PR TITLE
Added scriptable method to replace textures on-the-fly

### DIFF
--- a/src/core/StelFileMgr.cpp
+++ b/src/core/StelFileMgr.cpp
@@ -271,7 +271,7 @@ QStringList StelFileMgr::findFileInAllPaths(const QString &path, const Flags &fl
 		return filePaths;
 	}
 
-	for (const auto& locationPath : fileLocations)
+	for (const auto& locationPath : qAsConst(fileLocations))
 	{
 		const QFileInfo finfo(locationPath + "/" + path);
 		if (fileFlagsCheck(finfo, flags))

--- a/src/core/modules/Planet.cpp
+++ b/src/core/modules/Planet.cpp
@@ -270,22 +270,30 @@ Planet::Planet(const QString& englishName,
 
 	//only try loading textures when there is actually something to load!
 	//prevents some overhead when starting
+	texMapFileOrig = QString();
 	if(!texMapName.isEmpty())
 	{
 		// TODO: use StelFileMgr::findFileInAllPaths() after introducing an Add-On Manager
 		QString texMapFile = StelFileMgr::findFile("textures/"+texMapName, StelFileMgr::File);
 		if (!texMapFile.isEmpty())
+		{
 			texMap = StelApp::getInstance().getTextureManager().createTextureThread(texMapFile, StelTexture::StelTextureParams(true, GL_LINEAR, GL_REPEAT));
+			texMapFileOrig = texMapFile;
+		}
 		else
 			qWarning()<<"Cannot resolve path to texture file"<<texMapName<<"of object"<<englishName;
 	}
 
+	normalMapFileOrig = QString();
 	if(!normalMapName.isEmpty())
 	{
 		// TODO: use StelFileMgr::findFileInAllPaths() after introducing an Add-On Manager
 		QString normalMapFile = StelFileMgr::findFile("textures/"+normalMapName, StelFileMgr::File);
 		if (!normalMapFile.isEmpty())
+		{
 			normalMap = StelApp::getInstance().getTextureManager().createTextureThread(normalMapFile, StelTexture::StelTextureParams(true, GL_LINEAR, GL_REPEAT));
+			normalMapFileOrig = normalMapFile;
+		}
 	}
 	//the OBJ is lazily loaded when first required
 	if(!aobjModelName.isEmpty())
@@ -319,6 +327,30 @@ Planet::~Planet()
 {
 	delete rings;
 	delete objModel;
+}
+
+void Planet::resetTextures()
+{
+	// restore texture
+	if (!texMapFileOrig.isEmpty())
+		texMap = StelApp::getInstance().getTextureManager().createTextureThread(texMapFileOrig, StelTexture::StelTextureParams(true, GL_LINEAR, GL_REPEAT));
+
+	// restore normal map
+	if (!normalMapFileOrig.isEmpty())
+		normalMap = StelApp::getInstance().getTextureManager().createTextureThread(normalMapFileOrig, StelTexture::StelTextureParams(true, GL_LINEAR, GL_REPEAT));
+}
+
+void Planet::replaceTexture(const QString &texName)
+{
+	if(!texName.isEmpty())
+	{
+		QString texMapFile = StelFileMgr::findFile("scripts/" + texName, StelFileMgr::File);
+		if (!texMapFile.isEmpty())
+			texMap = StelApp::getInstance().getTextureManager().createTextureThread(texMapFile, StelTexture::StelTextureParams(true, GL_LINEAR, GL_REPEAT));
+		else
+			qWarning()<<"Cannot resolve path to texture file"<<texName<<"of object"<<englishName;
+
+	}
 }
 
 void Planet::translateName(const StelTranslator& trans)

--- a/src/core/modules/Planet.hpp
+++ b/src/core/modules/Planet.hpp
@@ -561,6 +561,9 @@ public:
 	//! @note This is based on Meeus, Astronomical Algorithms (2nd ed.), but deviates in details.
 	//! @note Limitation for efficiency: If this is a planet moon from another planet, we compute RTS for the parent planet instead!
 	virtual Vec4d getRTSTime(const StelCore* core, const double altitude=0.) const Q_DECL_OVERRIDE;
+
+	void resetTextures();
+	void replaceTexture(const QString& texName);
 	
 protected:
 	// These components for getInfoString() can be overridden in subclasses
@@ -734,6 +737,9 @@ protected:
 private:
 	class StelPropertyMgr* propMgr;
 	QString iauMoonNumber;
+	// File path for texture and normal map; both variables used for saving original names of files
+	QString texMapFileOrig;
+	QString normalMapFileOrig;
 
 	const QString getContextString() const;
 	QPair<double, double> getLunarEclipseMagnitudes() const;

--- a/src/core/modules/SolarSystem.cpp
+++ b/src/core/modules/SolarSystem.cpp
@@ -353,7 +353,7 @@ void SolarSystem::setTextureForPlanet(const QString& planetName, const QString& 
 	if (!planet.isNull())
 		planet->replaceTexture(texName);
 	else
-		qWarning() << "The planet" << planetName << "is not found. Please check the name.";
+		qWarning() << "The planet" << planetName << "was not found. Please check the name.";
 }
 
 void SolarSystem::recreateTrails()

--- a/src/core/modules/SolarSystem.cpp
+++ b/src/core/modules/SolarSystem.cpp
@@ -129,7 +129,7 @@ SolarSystem::~SolarSystem()
 	// release selected:
 	selected.clear();
 	selectedSSO.clear();
-	for (auto* orb : orbits)
+	for (auto* orb : qAsConst(orbits))
 	{
 		delete orb;
 		orb = Q_NULLPTR;
@@ -148,7 +148,7 @@ SolarSystem::~SolarSystem()
 	allTrails = Q_NULLPTR;
 
 	// Get rid of circular reference between the shared pointers which prevent proper destruction of the Planet objects.
-	for (const auto& p : systemPlanets)
+	for (const auto& p : qAsConst(systemPlanets))
 	{
 		p->satellites.clear();
 	}
@@ -327,6 +327,33 @@ void SolarSystem::deinit()
 {
 	Planet::deinitShader();
 	Planet::deinitFBO();
+}
+
+void SolarSystem::resetTextures(const QString &planetName)
+{
+	if (planetName.isEmpty())
+	{
+		for (const auto& p : qAsConst(systemPlanets))
+		{
+			p->resetTextures();
+		}
+	}
+	else
+	{
+		PlanetP planet = searchByEnglishName(planetName);
+		if (!planet.isNull())
+			planet->resetTextures();
+	}
+
+}
+
+void SolarSystem::setTextureForPlanet(const QString& planetName, const QString& texName)
+{
+	PlanetP planet = searchByEnglishName(planetName);
+	if (!planet.isNull())
+		planet->replaceTexture(texName);
+	else
+		qWarning() << "The planet" << planetName << "is not found. Please check the name.";
 }
 
 void SolarSystem::recreateTrails()

--- a/src/core/modules/SolarSystem.hpp
+++ b/src/core/modules/SolarSystem.hpp
@@ -732,12 +732,13 @@ public slots:
 	void recreateTrails();
 
 	//! Reset textures for planet @param planetName
-	//! @note if @param planetName is empty then reset will happen for all solar system
+	//! @note if @param planetName is empty then reset will happen for all solar system objects
 	void resetTextures(const QString& planetName);
 
 	//! Replace the texture for the planet @param planetName
 	//! @param planetName - English name of the planet
-	//! @param texName - file path for texure
+	//! @param texName - file path for texture
+	//! The texture path starts in the scripts directory.
 	void setTextureForPlanet(const QString &planetName, const QString &texName);
 
 signals:

--- a/src/core/modules/SolarSystem.hpp
+++ b/src/core/modules/SolarSystem.hpp
@@ -731,6 +731,15 @@ public slots:
 	//! Reset and recreate trails
 	void recreateTrails();
 
+	//! Reset textures for planet @param planetName
+	//! @note if @param planetName is empty then reset will happen for all solar system
+	void resetTextures(const QString& planetName);
+
+	//! Replace the texture for the planet @param planetName
+	//! @param planetName - English name of the planet
+	//! @param texName - file path for texure
+	void setTextureForPlanet(const QString &planetName, const QString &texName);
+
 signals:
 	void labelsDisplayedChanged(bool b);
 	void nomenclatureDisplayedChanged(bool b);


### PR DESCRIPTION
### Description
I've added 2 scriptable methods for SolarSystem class to ability replacing planetary textures on-the-fly in scripts. The method `setTextureForPlanet(planetName, texName);` replace the texture for object with name `planetName`. The method `resetTextures(planetName);` loaded default texture for object with name `planetName`. In latest method parameter `planetName` can be empty - in this case default textures will be loaded for all solar system bodies.

Fixes #1060 (issue)

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### How Has This Been Tested?
Please unpack archive [texture_test.zip](https://github.com/Stellarium/stellarium/files/7769653/texture_test.zip) into scripts directory and run the script `texture.ssc` within Stellarium

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

