### PR TITLE
Automatic add the group of satellites

### DIFF
--- a/plugins/Satellites/src/Satellites.cpp
+++ b/plugins/Satellites/src/Satellites.cpp
@@ -1193,6 +1193,13 @@ bool Satellites::add(const TleData& tleData)
 		if (tleData.status==Satellite::StatusNonoperational)
 			satGroups.append("non-operational");
 	}
+	if (tleData.source.contains("celestrak.com", Qt::CaseInsensitive))
+	{
+		// add groups, based on Celestrak's groups
+		QString fileName = QUrl(tleData.source).fileName().toLower().replace(".txt", "");
+		if (!satGroups.contains(fileName))
+			satGroups.append(fileName);
+	}
 	if (!satGroups.isEmpty())
 	{
 		satProperties.insert("groups", satGroups);
@@ -1624,9 +1631,7 @@ void Satellites::saveDownloadedUpdate(QNetworkReply* reply)
 			continue;
 		if (updateSources[i].file->open(QFile::ReadOnly|QFile::Text))
 		{
-			parseTleFile(*updateSources[i].file,
-			             newData,
-			             updateSources[i].addNew);
+			parseTleFile(*updateSources[i].file, newData, updateSources[i].addNew, updateSources[i].url.toString(QUrl::None));
 			updateSources[i].file->close();
 			delete updateSources[i].file;
 			updateSources[i].file = Q_NULLPTR;
@@ -1825,9 +1830,7 @@ void Satellites::updateSatellites(TleDataHash& newTleSets)
 	emit(tleUpdateComplete(updatedCount, totalCount, addedCount, missingCount));
 }
 
-void Satellites::parseTleFile(QFile& openFile,
-                              TleDataHash& tleList,
-                              bool addFlagValue)
+void Satellites::parseTleFile(QFile& openFile, TleDataHash& tleList, bool addFlagValue, const QString &sourceTLE)
 {
 	if (!openFile.isOpen() || !openFile.isReadable())
 		return;
@@ -1835,7 +1838,6 @@ void Satellites::parseTleFile(QFile& openFile,
 	// Code mostly re-used from updateFromFiles()
 	int lineNumber = 0;
 	TleData lastData;
-	lastData.addThis = addFlagValue;
 
 	// Celestrak's "status code" list
 	const QMap<QString, Satellite::OptStatus> satOpStatusMap = {
@@ -1857,6 +1859,7 @@ void Satellites::parseTleFile(QFile& openFile,
 			// New entry in the list, so reset all fields
 			lastData = TleData();
 			lastData.addThis = addFlagValue;
+			lastData.source = sourceTLE;
 			
 			// The thing in square brackets after the name is actually
 			// Celestrak's "status code". Parse it!

--- a/plugins/Satellites/src/Satellites.cpp
+++ b/plugins/Satellites/src/Satellites.cpp
@@ -1193,10 +1193,10 @@ bool Satellites::add(const TleData& tleData)
 		if (tleData.status==Satellite::StatusNonoperational)
 			satGroups.append("non-operational");
 	}
-	if (tleData.source.contains("celestrak.com", Qt::CaseInsensitive))
+	if (tleData.sourceURL.contains("celestrak.com", Qt::CaseInsensitive))
 	{
 		// add groups, based on Celestrak's groups
-		QString fileName = QUrl(tleData.source).fileName().toLower().replace(".txt", "");
+		QString fileName = QUrl(tleData.sourceURL).fileName().toLower().replace(".txt", "");
 		if (!satGroups.contains(fileName))
 			satGroups.append(fileName);
 	}
@@ -1830,7 +1830,7 @@ void Satellites::updateSatellites(TleDataHash& newTleSets)
 	emit(tleUpdateComplete(updatedCount, totalCount, addedCount, missingCount));
 }
 
-void Satellites::parseTleFile(QFile& openFile, TleDataHash& tleList, bool addFlagValue, const QString &sourceTLE)
+void Satellites::parseTleFile(QFile& openFile, TleDataHash& tleList, bool addFlagValue, const QString &tleURL)
 {
 	if (!openFile.isOpen() || !openFile.isReadable())
 		return;
@@ -1859,7 +1859,7 @@ void Satellites::parseTleFile(QFile& openFile, TleDataHash& tleList, bool addFla
 			// New entry in the list, so reset all fields
 			lastData = TleData();
 			lastData.addThis = addFlagValue;
-			lastData.source = sourceTLE;
+			lastData.sourceURL = tleURL;
 			
 			// The thing in square brackets after the name is actually
 			// Celestrak's "status code". Parse it!

--- a/plugins/Satellites/src/Satellites.hpp
+++ b/plugins/Satellites/src/Satellites.hpp
@@ -101,6 +101,8 @@ struct TleData
 	//! Flag indicating whether this satellite should be added.
 	//! See Satellites::autoAddEnabled.
 	bool addThis;
+	//! Source of TLE (URL), can be used for assign satellites group
+	QString source;
 };
 
 //! @ingroup satellites
@@ -345,11 +347,10 @@ public:
 	//! \param openFile a reference to an \b open file.
 	//! @param[in,out] tleList a hash with satellite IDs as keys.
 	//! @param[in] addFlagValue value to be set to TleData::addThis for all.
+	//! @param[in] sourceTLE a source of TLE (e.g. Celestrak's URL)
 	//! @todo If this can accept a QIODevice, it will be able to read directly
 	//! QNetworkReply-s... --BM
-	static void parseTleFile(QFile& openFile,
-	                         TleDataHash& tleList,
-				 bool addFlagValue = false);
+	static void parseTleFile(QFile& openFile, TleDataHash& tleList, bool addFlagValue = false, const QString& sourceTLE = "");
 
 	//! Insert a three line TLE into the hash array.
 	//! @param[in] line The second line from the TLE

--- a/plugins/Satellites/src/Satellites.hpp
+++ b/plugins/Satellites/src/Satellites.hpp
@@ -102,7 +102,7 @@ struct TleData
 	//! See Satellites::autoAddEnabled.
 	bool addThis;
 	//! Source of TLE (URL), can be used for assign satellites group
-	QString source;
+	QString sourceURL;
 };
 
 //! @ingroup satellites
@@ -347,10 +347,10 @@ public:
 	//! \param openFile a reference to an \b open file.
 	//! @param[in,out] tleList a hash with satellite IDs as keys.
 	//! @param[in] addFlagValue value to be set to TleData::addThis for all.
-	//! @param[in] sourceTLE a source of TLE (e.g. Celestrak's URL)
+	//! @param[in] tleURL a URL of TLE's source (e.g. Celestrak URL)
 	//! @todo If this can accept a QIODevice, it will be able to read directly
 	//! QNetworkReply-s... --BM
-	static void parseTleFile(QFile& openFile, TleDataHash& tleList, bool addFlagValue = false, const QString& sourceTLE = "");
+	static void parseTleFile(QFile& openFile, TleDataHash& tleList, bool addFlagValue = false, const QString& tleURL = "");
 
 	//! Insert a three line TLE into the hash array.
 	//! @param[in] line The second line from the TLE


### PR DESCRIPTION
Added code to automatic add the group of satellites, based on Celestrak groups

### Description
I've added code to saving source of TLE into TleData struct and use this data to add new group of satellites as filename of URL. The feature works for Celestrak sources and for newly added satellites only.

Fixes #1636 (issue)

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### How Has This Been Tested?
For example satellite "ISS (NAUKA)" included into list of `stations` (see https://celestrak.com/NORAD/elements/stations.txt). If this satellite already added, then check his groups (he shouldn't contains any group), remove the satellite and update TLE. Find the ISS (NAUKA) and check the group.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
