### PR TITLE
Allow moving StelDialogSeparate to a separate screen

### DIFF
--- a/src/gui/Dialog.cpp
+++ b/src/gui/Dialog.cpp
@@ -42,21 +42,26 @@ void BarFrame::mouseMoveEvent(QMouseEvent *event)
 	QWidget* p = dynamic_cast<QWidget*>(QFrame::parent());
 	QPoint targetPos = p->pos() + dpos;
 	
-	// Prevent the title bar from being dragged to an unreachable position.
-	QWidget& mainWindow = StelMainView::getInstance();
-	int leftBoundX = 10 - width();
-	int rightBoundX = mainWindow.width() - 10;
-	if (targetPos.x() < leftBoundX)
-		targetPos.setX(leftBoundX);
-	else if (targetPos.x() > rightBoundX)
-		targetPos.setX(rightBoundX);
-	
-	int lowerBoundY = mainWindow.height() - height();
-	if (targetPos.y() < 0)
-		targetPos.setY(0);
-	else if (targetPos.y() > lowerBoundY)
-		targetPos.setY(lowerBoundY);
-	
+	QWidget *parent=parentWidget();
+	Q_ASSERT(parent);
+
+	if (!(parent->inherits("CustomDialog")))
+	{
+		// Prevent the title bar from being dragged to an unreachable position.
+		QWidget& mainWindow = StelMainView::getInstance();
+		int leftBoundX = 10 - width();
+		int rightBoundX = mainWindow.width() - 10;
+		if (targetPos.x() < leftBoundX)
+			targetPos.setX(leftBoundX);
+		else if (targetPos.x() > rightBoundX)
+			targetPos.setX(rightBoundX);
+
+		int lowerBoundY = mainWindow.height() - height();
+		if (targetPos.y() < 0)
+			targetPos.setY(0);
+		else if (targetPos.y() > lowerBoundY)
+			targetPos.setY(lowerBoundY);
+	}
 	p->move(targetPos);
 	//emit movedTo(targetPos);
 }

--- a/src/gui/Dialog.hpp
+++ b/src/gui/Dialog.hpp
@@ -65,10 +65,10 @@ public:
   
 	ResizeFrame(QWidget* parent) : QFrame(parent) {}
   
-	virtual void mousePressEvent(QMouseEvent *event) {
+	virtual void mousePressEvent(QMouseEvent *event) Q_DECL_OVERRIDE {
 		mousePos = event->pos();
 	}
-	virtual void mouseMoveEvent(QMouseEvent *event);
+	virtual void mouseMoveEvent(QMouseEvent *event) Q_DECL_OVERRIDE;
 };
 
 

--- a/src/gui/StelDialogSeparate.cpp
+++ b/src/gui/StelDialogSeparate.cpp
@@ -84,16 +84,6 @@ void StelDialogSeparate::setVisible(bool v)
 			if (gui)
 				dialog->setStyleSheet(gui->getStelStyle().qtStyleSheet);
 			dialog->show();
-			// If the main window has been resized, it is possible the dialog
-			// will be off screen.  Check for this and move it to a visible
-			// position if necessary
-			QPointF newPos = dialog->pos();
-			if (newPos.x()>=screenSize.width())
-				newPos.setX(screenSize.width() - dialog->size().width());
-			if (newPos.y()>=screenSize.height())
-				newPos.setY(screenSize.height() - dialog->size().height());
-			if (newPos != dialog->pos())
-				dialog->move(newPos.toPoint());
 		}
 		else
 		{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Please include a summary of the change and which issue is fixed. -->
<!--- Please also include relevant motivation and context. -->
<!--- List any dependencies that are required for this change. -->

Until now, the particular implementation of the BarFrame deliberately keeps a dialog window within the bounds of the main window. The OnlineQueries plugin provides content in a separate window. With this change, it can finally be really moved to a separate monitor. 

A StelDialogSeparate will be created if possible at the coordinates and size that was last stored. However, the screen number is not preserved, so it will be started inside the main window, and if needed rescaled to fit into this window. 

There are a few things to test: What happens if the program is ended in split-screen arrangement, and then launched with only 1 monitor? What happens switching from a large+small to one small monitor only? Is the dialog always rescalable? 

Fixes # (issue)

### Screenshots (if appropriate):

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
Each system should be tested with at least 2 screens (laptop+1, etc.). Screen config changes between Stellarium launches must preserve accessibility of the OnlineQueries window.
- [x] Win10/Geforce 960M
- [ ] Win10 WSL Ubuntu 20.04
- [ ] Ubuntu 20.04
- [ ] Ubuntu 20.04 MATE?
- [ ] Linux Mint?
- [ ] SuSE Linux?
- [x] MacOSX

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
