### PR TITLE
Refactor: getAngularSize->getAngularRadius

### DIFF
--- a/plugins/Exoplanets/src/Exoplanet.cpp
+++ b/plugins/Exoplanets/src/Exoplanet.cpp
@@ -557,11 +557,6 @@ bool Exoplanet::isVMagnitudeDefined() const
 	return Vmag<98.;
 }
 
-double Exoplanet::getAngularRadius(const StelCore*) const
-{
-	return 0.0001;
-}
-
 bool Exoplanet::isDiscovered(const StelCore *core)
 {
 	int year, month, day;
@@ -606,13 +601,12 @@ void Exoplanet::draw(StelCore* core, StelPainter *painter)
 	StelSkyDrawer* sd = core->getSkyDrawer();
 	const float mlimit = sd->getLimitMagnitude();
 	const float mag = getVMagnitudeWithExtinction(core);
+	const float shift = 8.f;
 
 	if (mag <= mlimit)
 	{		
 		Exoplanet::markerTexture->bind();
 		Vec3f color = (hasHabitableExoplanets ? habitableExoplanetMarkerColor : exoplanetMarkerColor);
-		float size = static_cast<float>(getAngularRadius(Q_NULLPTR))*M_PIf/180.f*painter->getProjector()->getPixelPerRadAtCenter();
-		float shift = 5.f + size/1.6f;
 
 		painter->setBlending(true, GL_ONE, GL_ONE);
 		painter->setColor(color, 1);

--- a/plugins/Exoplanets/src/Exoplanet.cpp
+++ b/plugins/Exoplanets/src/Exoplanet.cpp
@@ -557,7 +557,7 @@ bool Exoplanet::isVMagnitudeDefined() const
 	return Vmag<98.;
 }
 
-double Exoplanet::getAngularSize(const StelCore*) const
+double Exoplanet::getAngularRadius(const StelCore*) const
 {
 	return 0.0001;
 }
@@ -611,7 +611,7 @@ void Exoplanet::draw(StelCore* core, StelPainter *painter)
 	{		
 		Exoplanet::markerTexture->bind();
 		Vec3f color = (hasHabitableExoplanets ? habitableExoplanetMarkerColor : exoplanetMarkerColor);
-		float size = static_cast<float>(getAngularSize(Q_NULLPTR))*M_PIf/180.f*painter->getProjector()->getPixelPerRadAtCenter();
+		float size = static_cast<float>(getAngularRadius(Q_NULLPTR))*M_PIf/180.f*painter->getProjector()->getPixelPerRadAtCenter();
 		float shift = 5.f + size/1.6f;
 
 		painter->setBlending(true, GL_ONE, GL_ONE);

--- a/plugins/Exoplanets/src/Exoplanet.hpp
+++ b/plugins/Exoplanets/src/Exoplanet.hpp
@@ -105,7 +105,7 @@ public:
 	//! Get the visual magnitude
 	virtual float getVMagnitude(const StelCore* core) const Q_DECL_OVERRIDE;
 	//! Get the angular size of host star
-	virtual double getAngularSize(const StelCore* core) const Q_DECL_OVERRIDE;
+	virtual double getAngularRadius(const StelCore* core) const Q_DECL_OVERRIDE;
 	//! Get the localized name of host star
 	virtual QString getNameI18n(void) const Q_DECL_OVERRIDE;
 	//! Get the english name

--- a/plugins/Exoplanets/src/Exoplanet.hpp
+++ b/plugins/Exoplanets/src/Exoplanet.hpp
@@ -104,8 +104,6 @@ public:
 	virtual Vec3d getJ2000EquatorialPos(const StelCore* core) const Q_DECL_OVERRIDE;
 	//! Get the visual magnitude
 	virtual float getVMagnitude(const StelCore* core) const Q_DECL_OVERRIDE;
-	//! Get the angular size of host star
-	virtual double getAngularRadius(const StelCore* core) const Q_DECL_OVERRIDE;
 	//! Get the localized name of host star
 	virtual QString getNameI18n(void) const Q_DECL_OVERRIDE;
 	//! Get the english name

--- a/plugins/MeteorShowers/src/MeteorShower.cpp
+++ b/plugins/MeteorShowers/src/MeteorShower.cpp
@@ -376,7 +376,7 @@ void MeteorShower::drawRadiant(StelCore *core)
 		{
 			painter.setColor(rgb);
 			painter.setFont(m_mgr->getFont());
-			const float size = static_cast<float>(getAngularSize(Q_NULLPTR))*M_PI_180f*static_cast<float>(painter.getProjector()->getPixelPerRadAtCenter());
+			const float size = static_cast<float>(getAngularRadius(Q_NULLPTR))*M_PI_180f*static_cast<float>(painter.getProjector()->getPixelPerRadAtCenter());
 			const float shift = 8.f + size/1.8f;
 			if ((mag+1.f)<mlimit)
 				painter.drawText(static_cast<float>(XY[0])+shift, static_cast<float>(XY[1])+shift, getNameI18n(), 0, 0, 0, false);

--- a/plugins/MeteorShowers/src/MeteorShower.cpp
+++ b/plugins/MeteorShowers/src/MeteorShower.cpp
@@ -376,8 +376,7 @@ void MeteorShower::drawRadiant(StelCore *core)
 		{
 			painter.setColor(rgb);
 			painter.setFont(m_mgr->getFont());
-			const float size = static_cast<float>(getAngularRadius(Q_NULLPTR))*M_PI_180f*static_cast<float>(painter.getProjector()->getPixelPerRadAtCenter());
-			const float shift = 8.f + size/1.8f;
+			const float shift = 8.f;
 			if ((mag+1.f)<mlimit)
 				painter.drawText(static_cast<float>(XY[0])+shift, static_cast<float>(XY[1])+shift, getNameI18n(), 0, 0, 0, false);
 		}

--- a/plugins/MeteorShowers/src/MeteorShower.hpp
+++ b/plugins/MeteorShowers/src/MeteorShower.hpp
@@ -125,7 +125,8 @@ public:
 	virtual Vec3d getJ2000EquatorialPos(const StelCore*) const Q_DECL_OVERRIDE { return m_position; }
 	virtual float getSelectPriority(const StelCore*) const Q_DECL_OVERRIDE { return -4.0; }
 	virtual Vec3f getInfoColor(void) const Q_DECL_OVERRIDE;
-	virtual double getAngularSize(const StelCore*) const Q_DECL_OVERRIDE { return 0.001; }
+	// TODO Describe why not zero size?
+	virtual double getAngularRadius(const StelCore*) const Q_DECL_OVERRIDE { return 0.001; }
 
 private:
 	MeteorShowersMgr* m_mgr;           //! MeteorShowersMgr instance

--- a/plugins/MeteorShowers/src/MeteorShower.hpp
+++ b/plugins/MeteorShowers/src/MeteorShower.hpp
@@ -125,8 +125,6 @@ public:
 	virtual Vec3d getJ2000EquatorialPos(const StelCore*) const Q_DECL_OVERRIDE { return m_position; }
 	virtual float getSelectPriority(const StelCore*) const Q_DECL_OVERRIDE { return -4.0; }
 	virtual Vec3f getInfoColor(void) const Q_DECL_OVERRIDE;
-	// TODO Describe why not zero size?
-	virtual double getAngularRadius(const StelCore*) const Q_DECL_OVERRIDE { return 0.001; }
 
 private:
 	MeteorShowersMgr* m_mgr;           //! MeteorShowersMgr instance

--- a/plugins/MeteorShowers/src/MeteorShowers.cpp
+++ b/plugins/MeteorShowers/src/MeteorShowers.cpp
@@ -84,7 +84,7 @@ void MeteorShowers::drawPointer(StelCore* core)
 
 	painter.setBlending(true);
 
-	float size = static_cast<float>(obj->getAngularSize(core)) * M_PI_180f * static_cast<float>(painter.getProjector()->getPixelPerRadAtCenter());
+	float size = static_cast<float>(obj->getAngularRadius(core)) * M_PI_180f * static_cast<float>(painter.getProjector()->getPixelPerRadAtCenter());
 	size += 20.f + 10.f * sinf(2.f * static_cast<float>(StelApp::getInstance().getTotalRunTime()));
 
 	painter.drawSprite2dMode(static_cast<float>(screenpos[0])-size/2, static_cast<float>(screenpos[1])-size/2, 10.f, 90);

--- a/plugins/MeteorShowers/src/MeteorShowers.cpp
+++ b/plugins/MeteorShowers/src/MeteorShowers.cpp
@@ -83,10 +83,7 @@ void MeteorShowers::drawPointer(StelCore* core)
 	m_mgr->getPointerTexture()->bind();
 
 	painter.setBlending(true);
-
-	float size = static_cast<float>(obj->getAngularRadius(core)) * M_PI_180f * static_cast<float>(painter.getProjector()->getPixelPerRadAtCenter());
-	size += 20.f + 10.f * sinf(2.f * static_cast<float>(StelApp::getInstance().getTotalRunTime()));
-
+	const float size = 20.f + 10.f * sinf(2.f * static_cast<float>(StelApp::getInstance().getTotalRunTime()));
 	painter.drawSprite2dMode(static_cast<float>(screenpos[0])-size/2, static_cast<float>(screenpos[1])-size/2, 10.f, 90);
 	painter.drawSprite2dMode(static_cast<float>(screenpos[0])-size/2, static_cast<float>(screenpos[1])+size/2, 10.f, 0);
 	painter.drawSprite2dMode(static_cast<float>(screenpos[0])+size/2, static_cast<float>(screenpos[1])+size/2, 10.f, -90);

--- a/plugins/NavStars/src/NavStars.cpp
+++ b/plugins/NavStars/src/NavStars.cpp
@@ -591,7 +591,7 @@ void NavStars::extraInfo(StelCore* core, const StelObjectP& selectedObject)
 	if ("Sun" == englishName || "Moon" == englishName) 
 	{
 		// Adjust Ho if target is Sun or Moon by adding/subtracting the angular radius.
-		double obj_radius_in_degrees = selectedObject->getAngularSize(core);
+		double obj_radius_in_degrees = selectedObject->getAngularRadius(core);
 		if (!upperLimb)
 			obj_radius_in_degrees *= -1;
 		calc.addAltAppRad((obj_radius_in_degrees * M_PI) / 180.);

--- a/plugins/Novae/src/Nova.cpp
+++ b/plugins/Novae/src/Nova.cpp
@@ -309,12 +309,6 @@ float Nova::getVMagnitude(const StelCore* core) const
 	return vmag;
 }
 
-// TODO: Why not zero like for stars?
-double Nova::getAngularRadius(const StelCore*) const
-{
-	return 0.00001;
-}
-
 void Nova::update(double deltaTime)
 {
 	labelsFader.update(static_cast<int>(deltaTime*1000));
@@ -325,6 +319,7 @@ void Nova::draw(StelCore* core, StelPainter* painter)
 	StelSkyDrawer* sd = core->getSkyDrawer();
 	const float mlimit = sd->getLimitMagnitude();
 	float mag = getVMagnitudeWithExtinction(core);
+	const float shift = 8.f;
 
 	if (mag <= mlimit)
 	{
@@ -340,8 +335,6 @@ void Nova::draw(StelCore* core, StelPainter* painter)
 		sd->drawPointSource(painter, vf, rcMag, color, true, qMin(1.0f, 1.0f-0.9f*altAz[2]));
 		sd->postDrawPointSource(painter);
 		painter->setColor(color, 1.f);
-		float size = getAngularRadius(Q_NULLPTR)*M_PI_180f*painter->getProjector()->getPixelPerRadAtCenter();
-		float shift = 6.f + size/1.8f;
 		StarMgr* smgr = GETSTELMODULE(StarMgr); // It's need for checking displaying of labels for stars
 		if (labelsFader.getInterstate()<=0.f && (mag+5.f)<mlimit && smgr->getFlagLabels())
 		{

--- a/plugins/Novae/src/Nova.cpp
+++ b/plugins/Novae/src/Nova.cpp
@@ -309,7 +309,8 @@ float Nova::getVMagnitude(const StelCore* core) const
 	return vmag;
 }
 
-double Nova::getAngularSize(const StelCore*) const
+// TODO: Why not zero like for stars?
+double Nova::getAngularRadius(const StelCore*) const
 {
 	return 0.00001;
 }
@@ -339,7 +340,7 @@ void Nova::draw(StelCore* core, StelPainter* painter)
 		sd->drawPointSource(painter, vf, rcMag, color, true, qMin(1.0f, 1.0f-0.9f*altAz[2]));
 		sd->postDrawPointSource(painter);
 		painter->setColor(color, 1.f);
-		float size = getAngularSize(Q_NULLPTR)*M_PI_180f*painter->getProjector()->getPixelPerRadAtCenter();
+		float size = getAngularRadius(Q_NULLPTR)*M_PI_180f*painter->getProjector()->getPixelPerRadAtCenter();
 		float shift = 6.f + size/1.8f;
 		StarMgr* smgr = GETSTELMODULE(StarMgr); // It's need for checking displaying of labels for stars
 		if (labelsFader.getInterstate()<=0.f && (mag+5.f)<mlimit && smgr->getFlagLabels())

--- a/plugins/Novae/src/Nova.hpp
+++ b/plugins/Novae/src/Nova.hpp
@@ -82,7 +82,6 @@ public:
 	virtual Vec3f getInfoColor(void) const Q_DECL_OVERRIDE;
 	virtual Vec3d getJ2000EquatorialPos(const StelCore *core) const Q_DECL_OVERRIDE;
 	virtual float getVMagnitude(const StelCore* core) const Q_DECL_OVERRIDE;
-	virtual double getAngularRadius(const StelCore* core) const Q_DECL_OVERRIDE;
 	virtual QString getNameI18n(void) const Q_DECL_OVERRIDE;
 	virtual QString getEnglishName(void) const Q_DECL_OVERRIDE;
 	QString getDesignation(void) const;

--- a/plugins/Novae/src/Nova.hpp
+++ b/plugins/Novae/src/Nova.hpp
@@ -82,7 +82,7 @@ public:
 	virtual Vec3f getInfoColor(void) const Q_DECL_OVERRIDE;
 	virtual Vec3d getJ2000EquatorialPos(const StelCore *core) const Q_DECL_OVERRIDE;
 	virtual float getVMagnitude(const StelCore* core) const Q_DECL_OVERRIDE;
-	virtual double getAngularSize(const StelCore* core) const Q_DECL_OVERRIDE;
+	virtual double getAngularRadius(const StelCore* core) const Q_DECL_OVERRIDE;
 	virtual QString getNameI18n(void) const Q_DECL_OVERRIDE;
 	virtual QString getEnglishName(void) const Q_DECL_OVERRIDE;
 	QString getDesignation(void) const;

--- a/plugins/Pulsars/src/Pulsar.cpp
+++ b/plugins/Pulsars/src/Pulsar.cpp
@@ -424,7 +424,8 @@ QString Pulsar::getPulsarTypeInfoString(QString pcode) const
 	return out.join(",<br />");
 }
 
-double Pulsar::getAngularSize(const StelCore*) const
+// TODO: Why not zero like for stars?
+double Pulsar::getAngularRadius(const StelCore*) const
 {
 	return 0.00001;
 }
@@ -451,7 +452,7 @@ void Pulsar::draw(StelCore* core, StelPainter *painter)
 	if (mag <= mlimit && visible)
 	{		
 		Pulsar::markerTexture->bind();
-		float size = getAngularSize(Q_NULLPTR)*M_PI/180.*painter->getProjector()->getPixelPerRadAtCenter();
+		float size = static_cast<float>(getAngularRadius(Q_NULLPTR))*M_PI_180f*painter->getProjector()->getPixelPerRadAtCenter();
 		float shift = 5.f + size/1.6f;		
 
 		if (glitch>0 && glitchFlag)

--- a/plugins/Pulsars/src/Pulsar.cpp
+++ b/plugins/Pulsars/src/Pulsar.cpp
@@ -424,12 +424,6 @@ QString Pulsar::getPulsarTypeInfoString(QString pcode) const
 	return out.join(",<br />");
 }
 
-// TODO: Why not zero like for stars?
-double Pulsar::getAngularRadius(const StelCore*) const
-{
-	return 0.00001;
-}
-
 void Pulsar::update(double deltaTime)
 {
 	labelsFader.update(static_cast<int>(deltaTime*1000));
@@ -445,6 +439,7 @@ void Pulsar::draw(StelCore* core, StelPainter *painter)
 	float mag = getVMagnitudeWithExtinction(core);
 	StelSkyDrawer* sd = core->getSkyDrawer();
 	const float mlimit = sd->getLimitMagnitude();
+	const float shift = 8.f;
 	bool visible = true;
 	if (filteredMode && s400<filterValue)
 		visible = false;
@@ -452,9 +447,6 @@ void Pulsar::draw(StelCore* core, StelPainter *painter)
 	if (mag <= mlimit && visible)
 	{		
 		Pulsar::markerTexture->bind();
-		float size = static_cast<float>(getAngularRadius(Q_NULLPTR))*M_PI_180f*painter->getProjector()->getPixelPerRadAtCenter();
-		float shift = 5.f + size/1.6f;		
-
 		if (glitch>0 && glitchFlag)
 			painter->setColor(glitchColor, 1.f);
 		else

--- a/plugins/Pulsars/src/Pulsar.hpp
+++ b/plugins/Pulsars/src/Pulsar.hpp
@@ -48,7 +48,7 @@ public:
 
 	//! @param id The official designation for a pulsar, e.g. "PSR J1919+21"
 	Pulsar(const QVariantMap& map);
-	~Pulsar();
+	~Pulsar() Q_DECL_OVERRIDE;
 
 	//! Get a QVariantMap which describes the pulsar. Could be used to create a duplicate.
 	//! - designation: pulsar name based on J2000 coordinates
@@ -74,35 +74,35 @@ public:
 	QVariantMap getMap(void) const;
 
 	//! Get the type of object
-	virtual QString getType(void) const
+	virtual QString getType(void) const Q_DECL_OVERRIDE
 	{
 		return PULSAR_TYPE;
 	}
 
-	virtual QString getID(void) const
+	virtual QString getID(void) const Q_DECL_OVERRIDE
 	{
 		return designation;
 	}
 
-	virtual float getSelectPriority(const StelCore* core) const;
+	virtual float getSelectPriority(const StelCore* core) const Q_DECL_OVERRIDE;
 
 	//! Get an HTML string to describe the object
 	//! @param core A pointer to the core
 	//! @flags a set of flags with information types to include.
-	virtual QString getInfoString(const StelCore* core, const InfoStringGroup& flags) const;
+	virtual QString getInfoString(const StelCore* core, const InfoStringGroup& flags) const Q_DECL_OVERRIDE;
 	//! Return a map like StelObject::getInfoMap(), but with a few extra tags also available in getMap(), except for designation, RA and DE fields.
-	virtual QVariantMap getInfoMap(const StelCore *core) const;
-	virtual Vec3f getInfoColor(void) const;
-	virtual Vec3d getJ2000EquatorialPos(const StelCore* core) const;
+	virtual QVariantMap getInfoMap(const StelCore *core) const Q_DECL_OVERRIDE;
+	virtual Vec3f getInfoColor(void) const Q_DECL_OVERRIDE;
+	virtual Vec3d getJ2000EquatorialPos(const StelCore* core) const Q_DECL_OVERRIDE;
 	//! Get the visual magnitude of pulsar
-	virtual float getVMagnitude(const StelCore* core) const;
+	virtual float getVMagnitude(const StelCore* core) const Q_DECL_OVERRIDE;
 	virtual float getVMagnitudeWithExtinction(const StelCore *core) const;
 	//! Get the angular size of pulsar
-	virtual double getAngularSize(const StelCore* core) const;
+	virtual double getAngularRadius(const StelCore* core) const Q_DECL_OVERRIDE;
 	//! Get the localized name of pulsar
-	virtual QString getNameI18n(void) const;
+	virtual QString getNameI18n(void) const Q_DECL_OVERRIDE;
 	//! Get the english name of pulsar
-	virtual QString getEnglishName(void) const;
+	virtual QString getEnglishName(void) const Q_DECL_OVERRIDE;
 	//! Get the designation of pulsar
 	QString getDesignation(void) const { return designation; }
 

--- a/plugins/Pulsars/src/Pulsar.hpp
+++ b/plugins/Pulsars/src/Pulsar.hpp
@@ -97,8 +97,6 @@ public:
 	//! Get the visual magnitude of pulsar
 	virtual float getVMagnitude(const StelCore* core) const Q_DECL_OVERRIDE;
 	virtual float getVMagnitudeWithExtinction(const StelCore *core) const;
-	//! Get the angular size of pulsar
-	virtual double getAngularRadius(const StelCore* core) const Q_DECL_OVERRIDE;
 	//! Get the localized name of pulsar
 	virtual QString getNameI18n(void) const Q_DECL_OVERRIDE;
 	//! Get the english name of pulsar

--- a/plugins/Quasars/src/Quasar.cpp
+++ b/plugins/Quasars/src/Quasar.cpp
@@ -182,12 +182,6 @@ float Quasar::getVMagnitude(const StelCore* core) const
 	return VMagnitude;
 }
 
-// TODO: Why not Zero like for stars? Or provide real values.
-double Quasar::getAngularRadius(const StelCore*) const
-{
-	return 0.00001;
-}
-
 float Quasar::getSelectPriority(const StelCore* core) const
 {
 	float mag = getVMagnitudeWithExtinction(core);
@@ -214,6 +208,7 @@ void Quasar::draw(StelCore* core, StelPainter& painter)
 
 	StelSkyDrawer* sd = core->getSkyDrawer();
 	const float mlimit = sd->getLimitMagnitude();
+	const float shift = 8.f;
 	float mag = getVMagnitudeWithExtinction(core);
 	if (useMarkers)
 		mag -= shiftVisibility;
@@ -223,16 +218,12 @@ void Quasar::draw(StelCore* core, StelPainter& painter)
 
 	if (mag <= mlimit)
 	{
-		float size, shift=0;
 		if (distributionMode || useMarkers)
 		{
 			painter.setBlending(true, GL_ONE, GL_ONE);
 			painter.setColor(markerColor, 1);
 
 			Quasar::markerTexture->bind();
-			size = getAngularRadius(Q_NULLPTR)*M_PI/180.*painter.getProjector()->getPixelPerRadAtCenter();
-			shift = 5.f + size/1.6f;
-
 			painter.drawSprite2dMode(getJ2000EquatorialPos(core), distributionMode ? 4.f : 5.f);
 		}
 		else
@@ -249,8 +240,6 @@ void Quasar::draw(StelCore* core, StelPainter& painter)
 			sd->drawPointSource(&painter, vf, rcMag, sd->indexToColor(BvToColorIndex(bV)), true, qMin(1.0f, 1.0f-0.9f*altAz[2]));
 			sd->postDrawPointSource(&painter);
 			painter.setColor(color[0], color[1], color[2], 1);
-			size = getAngularRadius(Q_NULLPTR)*M_PI_180f*painter.getProjector()->getPixelPerRadAtCenter();
-			shift = 6.f + size/1.8f;
 		}
 
 		if (labelsFader.getInterstate()<=0.f && !distributionMode && (mag+2.f)<mlimit)

--- a/plugins/Quasars/src/Quasar.cpp
+++ b/plugins/Quasars/src/Quasar.cpp
@@ -182,7 +182,8 @@ float Quasar::getVMagnitude(const StelCore* core) const
 	return VMagnitude;
 }
 
-double Quasar::getAngularSize(const StelCore*) const
+// TODO: Why not Zero like for stars? Or provide real values.
+double Quasar::getAngularRadius(const StelCore*) const
 {
 	return 0.00001;
 }
@@ -229,7 +230,7 @@ void Quasar::draw(StelCore* core, StelPainter& painter)
 			painter.setColor(markerColor, 1);
 
 			Quasar::markerTexture->bind();
-			size = getAngularSize(Q_NULLPTR)*M_PI/180.*painter.getProjector()->getPixelPerRadAtCenter();
+			size = getAngularRadius(Q_NULLPTR)*M_PI/180.*painter.getProjector()->getPixelPerRadAtCenter();
 			shift = 5.f + size/1.6f;
 
 			painter.drawSprite2dMode(getJ2000EquatorialPos(core), distributionMode ? 4.f : 5.f);
@@ -248,7 +249,7 @@ void Quasar::draw(StelCore* core, StelPainter& painter)
 			sd->drawPointSource(&painter, vf, rcMag, sd->indexToColor(BvToColorIndex(bV)), true, qMin(1.0f, 1.0f-0.9f*altAz[2]));
 			sd->postDrawPointSource(&painter);
 			painter.setColor(color[0], color[1], color[2], 1);
-			size = getAngularSize(Q_NULLPTR)*M_PI_180f*painter.getProjector()->getPixelPerRadAtCenter();
+			size = getAngularRadius(Q_NULLPTR)*M_PI_180f*painter.getProjector()->getPixelPerRadAtCenter();
 			shift = 6.f + size/1.8f;
 		}
 

--- a/plugins/Quasars/src/Quasar.hpp
+++ b/plugins/Quasars/src/Quasar.hpp
@@ -86,7 +86,6 @@ public:
 	virtual Vec3f getInfoColor(void) const Q_DECL_OVERRIDE;
 	virtual Vec3d getJ2000EquatorialPos(const StelCore* core) const Q_DECL_OVERRIDE;
 	virtual float getVMagnitude(const StelCore* core) const Q_DECL_OVERRIDE;
-	virtual double getAngularRadius(const StelCore* core) const Q_DECL_OVERRIDE;
 	virtual QString getNameI18n(void) const Q_DECL_OVERRIDE
 	{
 		return designation;

--- a/plugins/Quasars/src/Quasar.hpp
+++ b/plugins/Quasars/src/Quasar.hpp
@@ -46,7 +46,7 @@ public:
 
 	//! @param id The official designation for a quasar, e.g. "RXS J00066+4342"
 	Quasar(const QVariantMap& map);
-	~Quasar();
+	~Quasar() Q_DECL_OVERRIDE;
 
 	//! Get a QVariantMap which describes the Quasar.  Could be used to create a duplicate.
 	//! - designation
@@ -61,37 +61,37 @@ public:
 	//! - sclass
 	QVariantMap getMap(void) const;
 
-	virtual QString getType(void) const
+	virtual QString getType(void) const Q_DECL_OVERRIDE
 	{
 		return QUASAR_TYPE;
 	}
 
-	virtual QString getID(void) const
+	virtual QString getID(void) const Q_DECL_OVERRIDE
 	{
 		return designation;
 	}
 
-	virtual float getSelectPriority(const StelCore *core) const;
+	virtual float getSelectPriority(const StelCore *core) const Q_DECL_OVERRIDE;
 
 	//! Get an HTML string to describe the object
 	//! @param core A pointer to the core
 	//! @flags a set of flags with information types to include.
-	virtual QString getInfoString(const StelCore* core, const InfoStringGroup& flags) const;
+	virtual QString getInfoString(const StelCore* core, const InfoStringGroup& flags) const Q_DECL_OVERRIDE;
 	//! Return a map like StelObject::getInfoMap(), but with a few extra tags also available in getMap().
 	// TODO: Describe the fields.
 	//! - amag
 	//! - bV
 	//! - redshift
-	virtual QVariantMap getInfoMap(const StelCore *core) const;
-	virtual Vec3f getInfoColor(void) const;
-	virtual Vec3d getJ2000EquatorialPos(const StelCore* core) const;
-        virtual float getVMagnitude(const StelCore* core) const;
-	virtual double getAngularSize(const StelCore* core) const;
-	virtual QString getNameI18n(void) const
+	virtual QVariantMap getInfoMap(const StelCore *core) const Q_DECL_OVERRIDE;
+	virtual Vec3f getInfoColor(void) const Q_DECL_OVERRIDE;
+	virtual Vec3d getJ2000EquatorialPos(const StelCore* core) const Q_DECL_OVERRIDE;
+	virtual float getVMagnitude(const StelCore* core) const Q_DECL_OVERRIDE;
+	virtual double getAngularRadius(const StelCore* core) const Q_DECL_OVERRIDE;
+	virtual QString getNameI18n(void) const Q_DECL_OVERRIDE
 	{
 		return designation;
 	}
-	virtual QString getEnglishName(void) const
+	virtual QString getEnglishName(void) const Q_DECL_OVERRIDE
 	{
 		return designation;
 	}

--- a/plugins/Satellites/src/Satellite.cpp
+++ b/plugins/Satellites/src/Satellite.cpp
@@ -627,11 +627,9 @@ float Satellite::getVMagnitude(const StelCore* core) const
 			// fracil = fraction of satellite illuminated,
 			//	    [ 0 <= fracil <= 1 ]
 			//
-			// Original dscription: http://www.prismnet.com/~mmccants/tles/mccdesc.html
+			// Original description: http://www.prismnet.com/~mmccants/tles/mccdesc.html
 
-			double fracil = calculateIlluminatedFraction();
-			if (fracil==0)
-				fracil = 0.000001;
+			double fracil = qMax(0.000001, static_cast<double>(calculateIlluminatedFraction()));
 
 #if(SATELLITES_PLUGIN_IRIDIUM == 1)
 			if (pSatWrapper && name.startsWith("IRIDIUM"))
@@ -713,9 +711,9 @@ float Satellite::getVMagnitude(const StelCore* core) const
 			}
 			else // not Iridium
 #endif
-				vmag = stdMag;
+				vmag = static_cast<float>(stdMag);
 
-			vmag = static_cast<float>(vmag - 15.75 + 2.5 * std::log10(range * range / fracil));
+			vmag += -15.75f + 2.5f * static_cast<float>(std::log10(range * range / fracil));
 		}
 		else if (RCS>0.) // OK, artificial satellite has RCS value and no standard magnitude
 		{

--- a/plugins/Satellites/src/Satellite.cpp
+++ b/plugins/Satellites/src/Satellite.cpp
@@ -334,7 +334,7 @@ QString Satellite::getInfoString(const StelCore *core, const InfoStringGroup& fl
 
 	if (flags&Size && RCS>0.)
 	{
-		const double angularSize = getAngularSize(core)*M_PI_180;
+		const double angularSize = getAngularRadius(core)*M_PI_180;
 		QString sizeStr = "";
 		if (withDecimalDegree)
 			sizeStr = StelUtils::radToDecDegStr(angularSize, 5, false, true);
@@ -755,7 +755,7 @@ QString Satellite::getOperationalStatus() const
 	return map.value(status,              qc_("unknown", "operational status"));
 }
 
-double Satellite::getAngularSize(const StelCore*) const
+double Satellite::getAngularRadius(const StelCore*) const
 {
 	if (RCS>0.)
 	{
@@ -951,10 +951,10 @@ void Satellite::draw(StelCore* core, StelPainter& painter)
 		{
 			Vec3f color(1.f,1.f,1.f);
 			// Special case: crossing of the satellite of the Moon or the Sun
-			if (XYZ.angle(moon->getJ2000EquatorialPos(core))*M_180_PI <= moon->getSpheroidAngularSize(core) || XYZ.angle(sun->getJ2000EquatorialPos(core))*M_180_PI <= sun->getSpheroidAngularSize(core))
+			if (XYZ.angle(moon->getJ2000EquatorialPos(core))*M_180_PI <= moon->getSpheroidAngularRadius(core) || XYZ.angle(sun->getJ2000EquatorialPos(core))*M_180_PI <= sun->getSpheroidAngularRadius(core))
 			{
 				painter.setColor(transitSatelliteColor, 1.f);
-				int screenSizeSat = static_cast<int>((getAngularSize(core)*M_PI_180)*painter.getProjector()->getPixelPerRadAtCenter());
+				int screenSizeSat = static_cast<int>((getAngularRadius(core)*M_PI_180)*static_cast<double>(painter.getProjector()->getPixelPerRadAtCenter()));
 				if (screenSizeSat>0)
 				{
 					painter.setBlending(true, GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
@@ -1008,7 +1008,7 @@ void Satellite::draw(StelCore* core, StelPainter& painter)
 		{
 			Vec3f drawColor = (visibility == gSatWrapper::VISIBLE) ? hintColor : invisibleSatelliteColor; // Use hintColor for visible satellites only
 			painter.setColor(drawColor*hintBrightness, hintBrightness);
-			if (XYZ.angle(moon->getJ2000EquatorialPos(core))*M_180_PI <= moon->getSpheroidAngularSize(core) || XYZ.angle(sun->getJ2000EquatorialPos(core))*M_180_PI <= sun->getSpheroidAngularSize(core))
+			if (XYZ.angle(moon->getJ2000EquatorialPos(core))*M_180_PI <= moon->getSpheroidAngularRadius(core) || XYZ.angle(sun->getJ2000EquatorialPos(core))*M_180_PI <= sun->getSpheroidAngularRadius(core))
 				painter.setColor(transitSatelliteColor, 1.f);
 
 			if (showLabels)

--- a/plugins/Satellites/src/Satellite.hpp
+++ b/plugins/Satellites/src/Satellite.hpp
@@ -131,23 +131,23 @@ public:
 	//! \param data a QMap which contains the details of the satellite
 	//! (TLE set, description etc.)
 	Satellite(const QString& identifier, const QVariantMap& data);
-	~Satellite();
+	~Satellite() Q_DECL_OVERRIDE;
 
 	//! Get a QVariantMap which describes the satellite.  Could be used to
 	//! create a duplicate.
 	QVariantMap getMap(void);
 
-	virtual QString getType(void) const
+	virtual QString getType(void) const Q_DECL_OVERRIDE
 	{
 		return SATELLITE_TYPE;
 	}
 
-	virtual QString getID(void) const
+	virtual QString getID(void) const Q_DECL_OVERRIDE
 	{
 		return id;
 	}
 
-	virtual float getSelectPriority(const StelCore* core) const;
+	virtual float getSelectPriority(const StelCore* core) const Q_DECL_OVERRIDE;
 
 	//! Get an HTML string to describe the object
 	//! @param core A pointer to the core
@@ -156,7 +156,7 @@ public:
 	//! - Name: designation in large type with the description underneath
 	//! - RaDecJ2000, RaDecOfDate, HourAngle, AltAzi
 	//! - Extra: range, range rate and altitude of satellite above the Earth, comms frequencies, modulation types and so on.
-	virtual QString getInfoString(const StelCore *core, const InfoStringGroup& flags) const;
+	virtual QString getInfoString(const StelCore *core, const InfoStringGroup& flags) const Q_DECL_OVERRIDE;
 	//! Return a map like StelObject::getInfoMap(), but with a few extra tags also available in getInfoString().
 	//! - description
 	//! - catalog
@@ -181,14 +181,14 @@ public:
 	//! - operational-status
 	//! - visibility (descriptive string)
 	//! - comm (Radio information, optional, if available. There may be several comm entries!)
-	virtual QVariantMap getInfoMap(const StelCore *core) const;
-	virtual Vec3f getInfoColor(void) const;
-	virtual Vec3d getJ2000EquatorialPos(const StelCore*) const;
-	virtual float getVMagnitude(const StelCore* core) const;
+	virtual QVariantMap getInfoMap(const StelCore *core) const Q_DECL_OVERRIDE;
+	virtual Vec3f getInfoColor(void) const Q_DECL_OVERRIDE;
+	virtual Vec3d getJ2000EquatorialPos(const StelCore*) const Q_DECL_OVERRIDE;
+	virtual float getVMagnitude(const StelCore* core) const Q_DECL_OVERRIDE;
 	//! Get angular size, degrees
-	virtual double getAngularSize(const StelCore*) const;
-	virtual QString getNameI18n(void) const;
-	virtual QString getEnglishName(void) const
+	virtual double getAngularRadius(const StelCore*) const Q_DECL_OVERRIDE;
+	virtual QString getNameI18n(void) const Q_DECL_OVERRIDE;
+	virtual QString getEnglishName(void) const Q_DECL_OVERRIDE
 	{
 		return name;
 	}

--- a/plugins/Satellites/src/Satellite.hpp
+++ b/plugins/Satellites/src/Satellite.hpp
@@ -281,6 +281,7 @@ private:
 	double jdLaunchYearJan1;
 	//! Standard visual magnitude of the satellite.
 	double stdMag;
+	//! Radar cross-section value of the satellite (in meters).
 	double RCS;
 	double perigee;
 	double apogee;

--- a/plugins/Satellites/src/Satellite.hpp
+++ b/plugins/Satellites/src/Satellite.hpp
@@ -185,7 +185,7 @@ public:
 	virtual Vec3f getInfoColor(void) const Q_DECL_OVERRIDE;
 	virtual Vec3d getJ2000EquatorialPos(const StelCore*) const Q_DECL_OVERRIDE;
 	virtual float getVMagnitude(const StelCore* core) const Q_DECL_OVERRIDE;
-	//! Get angular size, degrees
+	//! Get angular half-size, degrees
 	virtual double getAngularRadius(const StelCore*) const Q_DECL_OVERRIDE;
 	virtual QString getNameI18n(void) const Q_DECL_OVERRIDE;
 	virtual QString getEnglishName(void) const Q_DECL_OVERRIDE
@@ -281,7 +281,7 @@ private:
 	double jdLaunchYearJan1;
 	//! Standard visual magnitude of the satellite.
 	double stdMag;
-	//! Radar cross-section value of the satellite (in meters).
+	//! Radar cross-section value of the satellite (in meters squared).
 	double RCS;
 	double perigee;
 	double apogee;

--- a/plugins/Satellites/src/Satellites.cpp
+++ b/plugins/Satellites/src/Satellites.cpp
@@ -2115,7 +2115,7 @@ void Satellites::drawPointer(StelCore* core, StelPainter& painter)
 		painter.setBlending(true);
 
 		// Size on screen
-		double size = obj->getAngularRadius(core)*M_PI/180.*static_cast<double>(prj->getPixelPerRadAtCenter());
+		double size = obj->getAngularRadius(core)*(2.*M_PI_180)*static_cast<double>(prj->getPixelPerRadAtCenter());
 		size += 12. + 3.*std::sin(2. * StelApp::getInstance().getTotalRunTime());
 		// size+=20.f + 10.f*std::sin(2.f * StelApp::getInstance().getTotalRunTime());
 		painter.drawSprite2dMode(static_cast<float>(screenpos[0]-size/2), static_cast<float>(screenpos[1]-size/2), 20, 90);

--- a/plugins/Satellites/src/Satellites.cpp
+++ b/plugins/Satellites/src/Satellites.cpp
@@ -2115,7 +2115,7 @@ void Satellites::drawPointer(StelCore* core, StelPainter& painter)
 		painter.setBlending(true);
 
 		// Size on screen
-		double size = obj->getAngularSize(core)*M_PI/180.*static_cast<double>(prj->getPixelPerRadAtCenter());
+		double size = obj->getAngularRadius(core)*M_PI/180.*static_cast<double>(prj->getPixelPerRadAtCenter());
 		size += 12. + 3.*std::sin(2. * StelApp::getInstance().getTotalRunTime());
 		// size+=20.f + 10.f*std::sin(2.f * StelApp::getInstance().getTotalRunTime());
 		painter.drawSprite2dMode(static_cast<float>(screenpos[0]-size/2), static_cast<float>(screenpos[1]-size/2), 20, 90);

--- a/plugins/Supernovae/src/Supernova.cpp
+++ b/plugins/Supernovae/src/Supernova.cpp
@@ -241,7 +241,8 @@ float Supernova::getVMagnitude(const StelCore* core) const
 	return static_cast<float>(vmag);
 }
 
-double Supernova::getAngularSize(const StelCore*) const
+// TODO: Why not zero like for stars?
+double Supernova::getAngularRadius(const StelCore*) const
 {
 	return 0.00001;
 }
@@ -271,7 +272,7 @@ void Supernova::draw(StelCore* core, StelPainter& painter)
 		sd->drawPointSource(&painter, vf, rcMag, color, true, qMin(1.0f, 1.0f-0.9f*altAz[2]));
 		sd->postDrawPointSource(&painter);
 		painter.setColor(color, 1.f);
-		float size = static_cast<float>(getAngularSize(Q_NULLPTR))*M_PI_180f*painter.getProjector()->getPixelPerRadAtCenter();
+		float size = static_cast<float>(getAngularRadius(Q_NULLPTR))*M_PI_180f*painter.getProjector()->getPixelPerRadAtCenter();
 		float shift = 6.f + size/1.8f;
 		StarMgr* smgr = GETSTELMODULE(StarMgr); // It's need for checking displaying of labels for stars
 		if (labelsFader.getInterstate()<=0.f && (mag+5.f)<mlimit && smgr->getFlagLabels())

--- a/plugins/Supernovae/src/Supernova.cpp
+++ b/plugins/Supernovae/src/Supernova.cpp
@@ -241,12 +241,6 @@ float Supernova::getVMagnitude(const StelCore* core) const
 	return static_cast<float>(vmag);
 }
 
-// TODO: Why not zero like for stars?
-double Supernova::getAngularRadius(const StelCore*) const
-{
-	return 0.00001;
-}
-
 void Supernova::update(double deltaTime)
 {
 	labelsFader.update(static_cast<int>(deltaTime*1000));
@@ -257,6 +251,7 @@ void Supernova::draw(StelCore* core, StelPainter& painter)
 	StelSkyDrawer* sd = core->getSkyDrawer();
 	const float mlimit = sd->getLimitMagnitude();
 	const float mag = getVMagnitudeWithExtinction(core);
+	const float shift = 8.f;
 	
 	if (mag <= mlimit)
 	{
@@ -272,8 +267,6 @@ void Supernova::draw(StelCore* core, StelPainter& painter)
 		sd->drawPointSource(&painter, vf, rcMag, color, true, qMin(1.0f, 1.0f-0.9f*altAz[2]));
 		sd->postDrawPointSource(&painter);
 		painter.setColor(color, 1.f);
-		float size = static_cast<float>(getAngularRadius(Q_NULLPTR))*M_PI_180f*painter.getProjector()->getPixelPerRadAtCenter();
-		float shift = 6.f + size/1.8f;
 		StarMgr* smgr = GETSTELMODULE(StarMgr); // It's need for checking displaying of labels for stars
 		if (labelsFader.getInterstate()<=0.f && (mag+5.f)<mlimit && smgr->getFlagLabels())
 			painter.drawText(getJ2000EquatorialPos(core), designation, 0, shift, shift, false);

--- a/plugins/Supernovae/src/Supernova.hpp
+++ b/plugins/Supernovae/src/Supernova.hpp
@@ -83,7 +83,6 @@ public:
 	virtual Vec3f getInfoColor(void) const Q_DECL_OVERRIDE;
 	virtual Vec3d getJ2000EquatorialPos(const StelCore *core) const Q_DECL_OVERRIDE;
 	virtual float getVMagnitude(const StelCore* core) const Q_DECL_OVERRIDE;
-	virtual double getAngularRadius(const StelCore* core) const Q_DECL_OVERRIDE;
 	virtual QString getNameI18n(void) const Q_DECL_OVERRIDE;
 	virtual QString getEnglishName(void) const Q_DECL_OVERRIDE;
 

--- a/plugins/Supernovae/src/Supernova.hpp
+++ b/plugins/Supernovae/src/Supernova.hpp
@@ -46,7 +46,7 @@ public:
 
 	//! @param id The official designation for a supernova, e.g. "SN 1054A"
 	Supernova(const QVariantMap& map);
-	~Supernova();
+	~Supernova() Q_DECL_OVERRIDE;
 
 	//! Get a QVariantMap which describes the supernova.  Could be used to create a duplicate.
 	//! - designation
@@ -59,12 +59,12 @@ public:
 	//! - distance
 	QVariantMap getMap(void) const;
 
-	virtual QString getType(void) const
+	virtual QString getType(void) const Q_DECL_OVERRIDE
 	{
 		return SUPERNOVA_TYPE;
 	}
 
-	virtual QString getID(void) const
+	virtual QString getID(void) const Q_DECL_OVERRIDE
 	{
 		return designation;
 	}
@@ -72,25 +72,25 @@ public:
 	//! Get an HTML string to describe the object
 	//! @param core A pointer to the core
 	//! @flags a set of flags with information types to include.
-	virtual QString getInfoString(const StelCore* core, const InfoStringGroup& flags) const;
+	virtual QString getInfoString(const StelCore* core, const InfoStringGroup& flags) const Q_DECL_OVERRIDE;
 	//! Return a map like StelObject::getInfoMap(), but with a few extra tags also available in getMap().
 	//! - sntype
 	//! - max-magnitude
 	//! - peakJD
 	//! - note
 	//! - distance
-	virtual QVariantMap getInfoMap(const StelCore *core) const;
-	virtual Vec3f getInfoColor(void) const;
-	virtual Vec3d getJ2000EquatorialPos(const StelCore *core) const;
-	virtual float getVMagnitude(const StelCore* core) const;
-	virtual double getAngularSize(const StelCore* core) const;
-	virtual QString getNameI18n(void) const;
-	virtual QString getEnglishName(void) const;
+	virtual QVariantMap getInfoMap(const StelCore *core) const Q_DECL_OVERRIDE;
+	virtual Vec3f getInfoColor(void) const Q_DECL_OVERRIDE;
+	virtual Vec3d getJ2000EquatorialPos(const StelCore *core) const Q_DECL_OVERRIDE;
+	virtual float getVMagnitude(const StelCore* core) const Q_DECL_OVERRIDE;
+	virtual double getAngularRadius(const StelCore* core) const Q_DECL_OVERRIDE;
+	virtual QString getNameI18n(void) const Q_DECL_OVERRIDE;
+	virtual QString getEnglishName(void) const Q_DECL_OVERRIDE;
 
 	void update(double deltaTime);
 
 protected:
-	virtual QString getMagnitudeInfoString(const StelCore *core, const InfoStringGroup& flags, const int decimals=1) const;
+	virtual QString getMagnitudeInfoString(const StelCore *core, const InfoStringGroup& flags, const int decimals=1) const Q_DECL_OVERRIDE;
 
 private:
 	bool initialized;

--- a/plugins/TelescopeControl/src/TelescopeClient.hpp
+++ b/plugins/TelescopeControl/src/TelescopeClient.hpp
@@ -76,7 +76,6 @@ public:
 	QString getInfoString(const StelCore* core, const InfoStringGroup& flags) const Q_DECL_OVERRIDE;
 	QString getType(void) const Q_DECL_OVERRIDE {return TELESCOPECLIENT_TYPE;}
 	QString getID() const Q_DECL_OVERRIDE {return name;}
-	virtual double getAngularSize(const StelCore*) const Q_DECL_OVERRIDE {Q_ASSERT(0); return 0;}	// TODO
 		
 	// Methods specific to telescope
 	virtual void telescopeGoto(const Vec3d &j2000Pos, StelObjectP selectObject) = 0;

--- a/src/core/StelObject.cpp
+++ b/src/core/StelObject.cpp
@@ -1020,15 +1020,10 @@ QVariantMap StelObject::getInfoMap(const StelCore *core) const
 	map.insert("vmage", getVMagnitudeWithExtinction(core));
 
 	// angular size
-	double angularSize = 2.*getAngularRadius(core)*M_PI_180;
-	bool sign;
-	double deg;
-	StelUtils::radToDecDeg(angularSize, sign, deg);
-	// TODO Under which circumstances can sign become negative?
-	if (!sign)
-		deg *= -1;
-	map.insert("size", angularSize); // TODO: What is the purpose/application of giving size in radians?
-	map.insert("size-dd", deg);
+	double angularSize = getAngularRadius(core)*(2.*M_PI_180);
+	Q_ASSERT(angularSize>=0.);
+	map.insert("size", angularSize);
+	map.insert("size-dd", angularSize*M_180_PI);
 	map.insert("size-deg", StelUtils::radToDecDegStr(angularSize, 5));
 	map.insert("size-dms", StelUtils::radToDmsPStr(angularSize, 2));
 

--- a/src/core/StelObject.cpp
+++ b/src/core/StelObject.cpp
@@ -1024,9 +1024,10 @@ QVariantMap StelObject::getInfoMap(const StelCore *core) const
 	bool sign;
 	double deg;
 	StelUtils::radToDecDeg(angularSize, sign, deg);
+	// TODO Under which circumstances can sign become negative?
 	if (!sign)
 		deg *= -1;
-	map.insert("size", angularSize);
+	map.insert("size", angularSize); // TODO: What is the purpose/application of giving size in radians?
 	map.insert("size-dd", deg);
 	map.insert("size-deg", StelUtils::radToDecDegStr(angularSize, 5));
 	map.insert("size-dms", StelUtils::radToDmsPStr(angularSize, 2));

--- a/src/core/StelObject.cpp
+++ b/src/core/StelObject.cpp
@@ -1020,7 +1020,7 @@ QVariantMap StelObject::getInfoMap(const StelCore *core) const
 	map.insert("vmage", getVMagnitudeWithExtinction(core));
 
 	// angular size
-	double angularSize = 2.*getAngularSize(core)*M_PI_180;
+	double angularSize = 2.*getAngularRadius(core)*M_PI_180;
 	bool sign;
 	double deg;
 	StelUtils::radToDecDeg(angularSize, sign, deg);

--- a/src/core/StelObject.hpp
+++ b/src/core/StelObject.hpp
@@ -266,7 +266,8 @@ public:
 	//! Return the angular radius of a circle containing the object as seen from the observer
 	//! with the circle center assumed to be at getJ2000EquatorialPos().
 	//! @return radius in degree. This value is the apparent angular size of the object, and is independent of the current FOV.
-	virtual double getAngularSize(const StelCore* core) const = 0;
+	//! @note The default implementation just returns zero.
+	virtual double getAngularRadius(const StelCore* core) const {Q_UNUSED(core) Q_ASSERT(0); return 0;}
 
 	//! Return airmass value for the object (for atmosphere-dependent calculations)
 	//! @param core

--- a/src/core/StelObject.hpp
+++ b/src/core/StelObject.hpp
@@ -138,10 +138,10 @@ public:
 	//! - elatJ2000 : ecliptic latitude (Earth's J2000 frame) in decimal degrees
 	//! - vmag : visual magnitude
 	//! - vmage : visual magnitude (after atmospheric extinction)
-	//! - size: angular size in radians
-	//! - size-dd : angular size in decimal degrees
-	//! - size-deg : angular size in decimal degrees (formatted string)
-	//! - size-dms : angular size in DMS format
+	//! - size: angular size (diameter) in radians
+	//! - size-dd : angular size (diameter) in decimal degrees
+	//! - size-deg : angular size (diameter) in decimal degrees (formatted string)
+	//! - size-dms : angular size (diameter) in DMS format
 	//! - rise : time of rise in HM format
 	//! - rise-dhr : time of rise in decimal hours
 	//! - transit : time of transit in HM format

--- a/src/core/modules/Asterism.hpp
+++ b/src/core/modules/Asterism.hpp
@@ -45,7 +45,7 @@ class Asterism : public StelObject
 private:
 	static const QString ASTERISM_TYPE;
 	Asterism();
-	~Asterism();
+	~Asterism() Q_DECL_OVERRIDE;
 
 	// StelObject method to override
 	//! Get a string with data about the Asterism.
@@ -54,17 +54,17 @@ private:
 	//! @param core the StelCore object
 	//! @param flags a set of InfoStringGroup items to include in the return value.
 	//! @return a QString a description of the constellation.
-	virtual QString getInfoString(const StelCore*, const InfoStringGroup& flags) const;
+	virtual QString getInfoString(const StelCore*, const InfoStringGroup& flags) const Q_DECL_OVERRIDE;
 
 	//! Get the module/object type string.
 	//! @return "Asterism"
-	virtual QString getType() const {return ASTERISM_TYPE;}
-	virtual QString getID() const { return abbreviation; }
+	virtual QString getType() const Q_DECL_OVERRIDE {return ASTERISM_TYPE;}
+	virtual QString getID() const Q_DECL_OVERRIDE { return abbreviation; }
 
 	//! observer centered J2000 coordinates.
-	virtual Vec3d getJ2000EquatorialPos(const StelCore*) const {return XYZname;}
+	virtual Vec3d getJ2000EquatorialPos(const StelCore*) const Q_DECL_OVERRIDE {return XYZname;}
 
-	virtual double getAngularSize(const StelCore*) const {Q_ASSERT(0); return 0;} // TODO
+	//virtual double getAngularRadius(const StelCore*) const {Q_ASSERT(0); return 0;} // TODO
 
 	//! @param record string containing the following whitespace
 	//! separated fields: abbreviation - a three character abbreviation
@@ -79,9 +79,9 @@ private:
 	void drawName(StelPainter& sPainter) const;
 
 	//! Get the translated name for the Asterism.
-	QString getNameI18n() const {return nameI18;}
+	QString getNameI18n() const Q_DECL_OVERRIDE {return nameI18;}
 	//! Get the English name for the Asterism.
-	QString getEnglishName() const {return englishName;}	
+	QString getEnglishName() const Q_DECL_OVERRIDE {return englishName;}
 	//! Draw the lines for the Asterism.
 	//! This method uses the coords of the stars (optimized for use through
 	//! the class AsterismMgr only).

--- a/src/core/modules/Asterism.hpp
+++ b/src/core/modules/Asterism.hpp
@@ -64,8 +64,6 @@ private:
 	//! observer centered J2000 coordinates.
 	virtual Vec3d getJ2000EquatorialPos(const StelCore*) const Q_DECL_OVERRIDE {return XYZname;}
 
-	//virtual double getAngularRadius(const StelCore*) const {Q_ASSERT(0); return 0;} // TODO
-
 	//! @param record string containing the following whitespace
 	//! separated fields: abbreviation - a three character abbreviation
 	//! for the asterism, a number of lines (pairs), and a list of Hipparcos

--- a/src/core/modules/Comet.cpp
+++ b/src/core/modules/Comet.cpp
@@ -424,15 +424,15 @@ void Comet::draw(StelCore* core, float maxMagLabels, const QFont& planetNameFont
 
 	// Compute the 2D position and check if in the screen
 	const StelProjectorP prj = core->getProjection(transfo);
-	const double screenSz = (getAngularSize(core))*M_PI_180*static_cast<double>(prj->getPixelPerRadAtCenter());
+	const double screenRd = (getAngularRadius(core))*M_PI_180*static_cast<double>(prj->getPixelPerRadAtCenter());
 	const double viewport_left = prj->getViewportPosX();
 	const double viewport_bottom = prj->getViewportPosY();
 	const bool projectionValid=prj->project(Vec3d(0.), screenPos);
 	if (projectionValid
-		&& screenPos[1] > viewport_bottom - screenSz
-		&& screenPos[1] < viewport_bottom + prj->getViewportHeight()+screenSz
-		&& screenPos[0] > viewport_left - screenSz
-		&& screenPos[0] < viewport_left + prj->getViewportWidth() + screenSz)
+		&& screenPos[1] > viewport_bottom - screenRd
+		&& screenPos[1] < viewport_bottom + prj->getViewportHeight()+screenRd
+		&& screenPos[0] > viewport_left - screenRd
+		&& screenPos[0] < viewport_left + prj->getViewportWidth() + screenRd)
 	{
 		// Draw the name, and the circle if it's not too close from the body it's turning around
 		// this prevents name overlapping (ie for jupiter satellites)
@@ -445,7 +445,7 @@ void Comet::draw(StelCore* core, float maxMagLabels, const QFont& planetNameFont
 		labelsFader = (flagLabels && ang_dist>0.25f && maxMagLabels>getVMagnitude(core));
 		drawHints(core, planetNameFont);
 
-		draw3dModel(core,transfo,static_cast<float>(screenSz));
+		draw3dModel(core,transfo,static_cast<float>(screenRd));
 	}
 	else
 		if (!projectionValid && prj.data()->getNameI18() == q_("Orthographic"))

--- a/src/core/modules/Constellation.hpp
+++ b/src/core/modules/Constellation.hpp
@@ -53,7 +53,7 @@ class Constellation : public StelObject
 private:
 	static const QString CONSTELLATION_TYPE;
 	Constellation();
-	~Constellation();
+	~Constellation() Q_DECL_OVERRIDE;
 
 	// StelObject method to override
 	//! Get a string with data about the Constellation.
@@ -62,17 +62,17 @@ private:
 	//! @param core the StelCore object
 	//! @param flags a set of InfoStringGroup items to include in the return value.
 	//! @return a QString a description of the constellation.
-	virtual QString getInfoString(const StelCore*, const InfoStringGroup& flags) const;
+	virtual QString getInfoString(const StelCore*, const InfoStringGroup& flags) const Q_DECL_OVERRIDE;
 
 	//! Get the module/object type string.
 	//! @return "Constellation"
-	virtual QString getType() const {return CONSTELLATION_TYPE;}
-	virtual QString getID() const { return abbreviation; }
+	virtual QString getType() const Q_DECL_OVERRIDE {return CONSTELLATION_TYPE;}
+	virtual QString getID() const Q_DECL_OVERRIDE { return abbreviation; }
 
 	//! observer centered J2000 coordinates.
-	virtual Vec3d getJ2000EquatorialPos(const StelCore*) const {return XYZname;}
+	virtual Vec3d getJ2000EquatorialPos(const StelCore*) const Q_DECL_OVERRIDE {return XYZname;}
 
-	virtual double getAngularSize(const StelCore*) const {Q_ASSERT(0); return 0.;} // TODO
+	// virtual double getAngularRadius(const StelCore*) const {Q_ASSERT(0); return 0.;} // TODO
 
 	//! @param record string containing the following whitespace
 	//! separated fields: abbreviation - a three character abbreviation

--- a/src/core/modules/Constellation.hpp
+++ b/src/core/modules/Constellation.hpp
@@ -72,8 +72,6 @@ private:
 	//! observer centered J2000 coordinates.
 	virtual Vec3d getJ2000EquatorialPos(const StelCore*) const Q_DECL_OVERRIDE {return XYZname;}
 
-	// virtual double getAngularRadius(const StelCore*) const {Q_ASSERT(0); return 0.;} // TODO
-
 	//! @param record string containing the following whitespace
 	//! separated fields: abbreviation - a three character abbreviation
 	//! for the constellation, a number of lines (pairs), and a list of Hipparcos

--- a/src/core/modules/CustomObject.cpp
+++ b/src/core/modules/CustomObject.cpp
@@ -116,7 +116,7 @@ float CustomObject::getVMagnitude(const StelCore* core) const
 		return 99.f;
 }
 
-double CustomObject::getAngularSize(const StelCore*) const
+double CustomObject::getAngularRadius(const StelCore*) const
 {
 	return 0.00001;
 }
@@ -139,7 +139,7 @@ void CustomObject::draw(StelCore* core, StelPainter *painter)
 	if (isMarker)
 	{
 		markerTexture->bind();
-		const float size = static_cast<float>(getAngularSize(Q_NULLPTR))*M_PI_180f*painter->getProjector()->getPixelPerRadAtCenter();
+		const float size = static_cast<float>(getAngularRadius(Q_NULLPTR))*M_PI_180f*painter->getProjector()->getPixelPerRadAtCenter();
 		const float shift = markerSize + size/1.6f;
 
 		painter->drawSprite2dMode(static_cast<float>(pos[0]), static_cast<float>(pos[1]), markerSize);

--- a/src/core/modules/CustomObject.cpp
+++ b/src/core/modules/CustomObject.cpp
@@ -116,11 +116,6 @@ float CustomObject::getVMagnitude(const StelCore* core) const
 		return 99.f;
 }
 
-double CustomObject::getAngularRadius(const StelCore*) const
-{
-	return 0.00001;
-}
-
 void CustomObject::update(double deltaTime)
 {
 	labelsFader.update(static_cast<int>(deltaTime*1000));
@@ -139,8 +134,7 @@ void CustomObject::draw(StelCore* core, StelPainter *painter)
 	if (isMarker)
 	{
 		markerTexture->bind();
-		const float size = static_cast<float>(getAngularRadius(Q_NULLPTR))*M_PI_180f*painter->getProjector()->getPixelPerRadAtCenter();
-		const float shift = markerSize + size/1.6f;
+		const float shift = markerSize + 2.f;
 
 		painter->drawSprite2dMode(static_cast<float>(pos[0]), static_cast<float>(pos[1]), markerSize);
 

--- a/src/core/modules/CustomObject.cpp
+++ b/src/core/modules/CustomObject.cpp
@@ -43,6 +43,7 @@ CustomObject::CustomObject(const QString& codesignation, const Vec3d& coordJ2000
 	, designation(codesignation)
 	, isMarker(isVisible)
 {
+	XYZ.normalize();
 	markerTexture = StelApp::getInstance().getTextureManager().createTexture(StelFileMgr::getInstallationDir()+"/textures/cross.png");	
 	initialized = true;
 }

--- a/src/core/modules/CustomObject.hpp
+++ b/src/core/modules/CustomObject.hpp
@@ -65,9 +65,6 @@ public:
 	virtual Vec3d getJ2000EquatorialPos(const StelCore* core) const Q_DECL_OVERRIDE;
 	//! Get the visual magnitude of custom object
 	virtual float getVMagnitude(const StelCore* core) const Q_DECL_OVERRIDE;
-	//! Get the angular half-size of custom object
-	//! TODO: Why is this not zero but some arbitrary small value?
-	virtual double getAngularRadius(const StelCore* core) const Q_DECL_OVERRIDE;
 	//! Get the localized name of custom object
 	virtual QString getNameI18n(void) const Q_DECL_OVERRIDE;
 	//! Get the english name of custom object

--- a/src/core/modules/CustomObject.hpp
+++ b/src/core/modules/CustomObject.hpp
@@ -65,8 +65,9 @@ public:
 	virtual Vec3d getJ2000EquatorialPos(const StelCore* core) const Q_DECL_OVERRIDE;
 	//! Get the visual magnitude of custom object
 	virtual float getVMagnitude(const StelCore* core) const Q_DECL_OVERRIDE;
-	//! Get the angular size of custom object
-	virtual double getAngularSize(const StelCore* core) const Q_DECL_OVERRIDE;
+	//! Get the angular half-size of custom object
+	//! TODO: Why is this not zero but some arbitrary small value?
+	virtual double getAngularRadius(const StelCore* core) const Q_DECL_OVERRIDE;
 	//! Get the localized name of custom object
 	virtual QString getNameI18n(void) const Q_DECL_OVERRIDE;
 	//! Get the english name of custom object

--- a/src/core/modules/LabelMgr.cpp
+++ b/src/core/modules/LabelMgr.cpp
@@ -298,7 +298,7 @@ bool SkyLabel::draw(StelCore* core, StelPainter& sPainter)
 	}
 	else
 	{
-		float shift = 4.f + static_cast<float>(labelObject->getAngularSize(core))*M_PI_180f*sPainter.getProjector()->getPixelPerRadAtCenter()/1.8f;
+		float shift = 4.f + static_cast<float>(labelObject->getAngularRadius(core))*M_PI_180f*sPainter.getProjector()->getPixelPerRadAtCenter()/1.8f;
 		// use the object size
 		xOffset *= static_cast<double>(shift);
 		yOffset *= static_cast<double>(shift);

--- a/src/core/modules/Nebula.cpp
+++ b/src/core/modules/Nebula.cpp
@@ -502,7 +502,7 @@ float Nebula::getBMagnitudeWithExtinction(const StelCore* core) const
 	return mag;
 }
 
-double Nebula::getAngularSize(const StelCore *) const
+double Nebula::getAngularRadius(const StelCore *) const
 {
 	float size = majorAxisSize;
 	if (!fuzzyEquals(majorAxisSize, minorAxisSize) || minorAxisSize>0)
@@ -725,7 +725,7 @@ void Nebula::drawHints(StelPainter& sPainter, float maxMagHints, StelCore *core)
 	const float size = 6.0f;
 	float scaledSize = 0.0f;
 	if (drawHintProportional)
-		scaledSize = static_cast<float>(getAngularSize(Q_NULLPTR)) *M_PI_180f*static_cast<float>(sPainter.getProjector()->getPixelPerRadAtCenter());
+		scaledSize = static_cast<float>(getAngularRadius(Q_NULLPTR)) *M_PI_180f*static_cast<float>(sPainter.getProjector()->getPixelPerRadAtCenter());
 	float finalSize=qMax(size, scaledSize);
 
 	switch (nType)
@@ -846,7 +846,7 @@ void Nebula::drawLabel(StelPainter& sPainter, float maxMagLabel) const
 
 	sPainter.setColor(labelColor, objectInDisplayedType() ? hintsBrightness : 0.f);
 
-	const float size = static_cast<float>(getAngularSize(Q_NULLPTR))*M_PI_180f*sPainter.getProjector()->getPixelPerRadAtCenter();
+	const float size = static_cast<float>(getAngularRadius(Q_NULLPTR))*M_PI_180f*sPainter.getProjector()->getPixelPerRadAtCenter();
 	const float shift = 5.f + (drawHintProportional ? size*0.9f : 0.f);
 
 	QString str = getNameI18n();

--- a/src/core/modules/Nebula.cpp
+++ b/src/core/modules/Nebula.cpp
@@ -504,10 +504,7 @@ float Nebula::getBMagnitudeWithExtinction(const StelCore* core) const
 
 double Nebula::getAngularRadius(const StelCore *) const
 {
-	float size = majorAxisSize;
-	if (!fuzzyEquals(majorAxisSize, minorAxisSize) || minorAxisSize>0)
-		size = (majorAxisSize+minorAxisSize)*0.5f;
-	return static_cast<double>(size);
+	return static_cast<double>(0.5f*majorAxisSize);
 }
 
 float Nebula::getSelectPriority(const StelCore* core) const
@@ -725,7 +722,7 @@ void Nebula::drawHints(StelPainter& sPainter, float maxMagHints, StelCore *core)
 	const float size = 6.0f;
 	float scaledSize = 0.0f;
 	if (drawHintProportional)
-		scaledSize = static_cast<float>(getAngularRadius(Q_NULLPTR)) *M_PI_180f*static_cast<float>(sPainter.getProjector()->getPixelPerRadAtCenter());
+		scaledSize = static_cast<float>(getAngularRadius(Q_NULLPTR)) *(M_PI_180f*2.f)*static_cast<float>(sPainter.getProjector()->getPixelPerRadAtCenter());
 	float finalSize=qMax(size, scaledSize);
 
 	switch (nType)
@@ -846,7 +843,7 @@ void Nebula::drawLabel(StelPainter& sPainter, float maxMagLabel) const
 
 	sPainter.setColor(labelColor, objectInDisplayedType() ? hintsBrightness : 0.f);
 
-	const float size = static_cast<float>(getAngularRadius(Q_NULLPTR))*M_PI_180f*sPainter.getProjector()->getPixelPerRadAtCenter();
+	const float size = static_cast<float>(getAngularRadius(Q_NULLPTR))*(M_PI_180f*2.f)*sPainter.getProjector()->getPixelPerRadAtCenter();
 	const float shift = 5.f + (drawHintProportional ? size*0.9f : 0.f);
 
 	QString str = getNameI18n();

--- a/src/core/modules/Nebula.hpp
+++ b/src/core/modules/Nebula.hpp
@@ -179,7 +179,7 @@ public:
 	virtual QString getEnglishName() const Q_DECL_OVERRIDE {return englishName;}
 	QString getEnglishAliases() const;
 	QString getI18nAliases() const;
-	virtual double getAngularSize(const StelCore*) const Q_DECL_OVERRIDE;
+	virtual double getAngularRadius(const StelCore*) const Q_DECL_OVERRIDE;
 	virtual SphericalRegionP getRegion() const Q_DECL_OVERRIDE {return pointRegion;}
 
 	// Methods specific to Nebula

--- a/src/core/modules/NebulaMgr.cpp
+++ b/src/core/modules/NebulaMgr.cpp
@@ -718,17 +718,17 @@ void NebulaMgr::drawPointer(const StelCore* core, StelPainter& sPainter)
 		sPainter.setBlending(true);
 
 		// Size on screen
-		float size = static_cast<float>(obj->getAngularRadius(core))*M_PI_180f*prj->getPixelPerRadAtCenter();
-		if (size>120.f) // avoid oversized marker
-			size = 120.f;
+		float screenRd = static_cast<float>(obj->getAngularRadius(core))*M_PI_180f*prj->getPixelPerRadAtCenter();
+		if (screenRd>120.f) // avoid oversized marker
+			screenRd = 120.f;
 
 		if (Nebula::drawHintProportional)
-			size*=1.2f;
-		size+=20.f + 10.f*std::sin(3.f * static_cast<float>(StelApp::getInstance().getAnimationTime()));
-		sPainter.drawSprite2dMode(static_cast<float>(pos[0])-size*0.5f, static_cast<float>(pos[1])-size*0.5f, 10, 90);
-		sPainter.drawSprite2dMode(static_cast<float>(pos[0])-size*0.5f, static_cast<float>(pos[1])+size*0.5f, 10, 0);
-		sPainter.drawSprite2dMode(static_cast<float>(pos[0])+size*0.5f, static_cast<float>(pos[1])+size*0.5f, 10, -90);
-		sPainter.drawSprite2dMode(static_cast<float>(pos[0])+size*0.5f, static_cast<float>(pos[1])-size*0.5f, 10, -180);
+			screenRd*=1.2f;
+		screenRd+=20.f + 10.f*std::sin(3.f * static_cast<float>(StelApp::getInstance().getAnimationTime()));
+		sPainter.drawSprite2dMode(static_cast<float>(pos[0])-screenRd*0.5f, static_cast<float>(pos[1])-screenRd*0.5f, 10, 90);
+		sPainter.drawSprite2dMode(static_cast<float>(pos[0])-screenRd*0.5f, static_cast<float>(pos[1])+screenRd*0.5f, 10, 0);
+		sPainter.drawSprite2dMode(static_cast<float>(pos[0])+screenRd*0.5f, static_cast<float>(pos[1])+screenRd*0.5f, 10, -90);
+		sPainter.drawSprite2dMode(static_cast<float>(pos[0])+screenRd*0.5f, static_cast<float>(pos[1])-screenRd*0.5f, 10, -180);
 	}
 }
 

--- a/src/core/modules/NebulaMgr.cpp
+++ b/src/core/modules/NebulaMgr.cpp
@@ -718,7 +718,7 @@ void NebulaMgr::drawPointer(const StelCore* core, StelPainter& sPainter)
 		sPainter.setBlending(true);
 
 		// Size on screen
-		float size = static_cast<float>(obj->getAngularSize(core))*M_PI_180f*prj->getPixelPerRadAtCenter();
+		float size = static_cast<float>(obj->getAngularRadius(core))*M_PI_180f*prj->getPixelPerRadAtCenter();
 		if (size>120.f) // avoid oversized marker
 			size = 120.f;
 

--- a/src/core/modules/NomenclatureItem.cpp
+++ b/src/core/modules/NomenclatureItem.cpp
@@ -167,7 +167,7 @@ float NomenclatureItem::getSelectPriority(const StelCore* core) const
 	float priority=planet->getSelectPriority(core)+5.f;
 	// check visibility of feature
 	const float scale = getAngularDiameterRatio(core);
-	const float planetScale = 2.f*static_cast<float>(planet->getAngularSize(core))/core->getProjection(StelCore::FrameJ2000)->getFov();
+	const float planetScale = 2.f*static_cast<float>(planet->getAngularRadius(core))/core->getProjection(StelCore::FrameJ2000)->getFov();
 
 	// Require the planet to cover 1/10 of the screen to make it worth clicking on features.
 	// scale 0.04 is equal to the rendering criterion. Allow 0.02 for clicking on smaller features.
@@ -341,14 +341,14 @@ Vec3d NomenclatureItem::getJ2000EquatorialPos(const StelCore* core) const
 }
 
 // Return apparent semidiameter
-double NomenclatureItem::getAngularSize(const StelCore* core) const
+double NomenclatureItem::getAngularRadius(const StelCore* core) const
 {
 	return std::atan2(0.5*size*planet->getSphereScale()/AU, getJ2000EquatorialPos(core).length()) * M_180_PI;
 }
 
 float NomenclatureItem::getAngularDiameterRatio(const StelCore *core) const
 {
-    return static_cast<float>(2.*getAngularSize(core))/core->getProjection(StelCore::FrameJ2000)->getFov();
+    return static_cast<float>(2.*getAngularRadius(core))/core->getProjection(StelCore::FrameJ2000)->getFov();
 }
 
 void NomenclatureItem::draw(StelCore* core, StelPainter *painter)

--- a/src/core/modules/NomenclatureItem.hpp
+++ b/src/core/modules/NomenclatureItem.hpp
@@ -157,7 +157,7 @@ public:
 	//! Return the angular radius of a circle containing the feature as seen from the observer
 	//! with the circle center assumed to be at getJ2000EquatorialPos().
 	//! @return radius in degree. This value is half of the apparent angular size of the object, and is independent of the current FOV.
-	virtual double getAngularSize(const StelCore* core) const Q_DECL_OVERRIDE;
+	virtual double getAngularRadius(const StelCore* core) const Q_DECL_OVERRIDE;
 	//! Get the localized name of nomenclature item.
 	virtual QString getNameI18n(void) const Q_DECL_OVERRIDE;
 	//! Get the english name of nomenclature item.

--- a/src/core/modules/Planet.cpp
+++ b/src/core/modules/Planet.cpp
@@ -694,7 +694,7 @@ QString Planet::getInfoStringSize(const StelCore *core, const InfoStringGroup& f
 	QString str;
 	QTextStream oss(&str);
 
-	const double angularSize = 2.*getAngularRadius(core)*M_PI_180;
+	const double angularSize = getAngularRadius(core)*(2.*M_PI_180);
 	if (flags&Size && angularSize>=4.8e-8)
 	{
 		QString s1, s2, sizeStr = "";
@@ -970,7 +970,7 @@ QString Planet::getInfoStringExtra(const StelCore *core, const InfoStringGroup& 
 	{
 		const bool withTables = StelApp::getInstance().getFlagUseFormattingOutput();
 		const bool withDecimalDegree = StelApp::getInstance().getFlagShowDecimalDegrees();
-		const double angularSize = 2.*getAngularRadius(core)*M_PI_180;
+		const double angularSize = getAngularRadius(core)*(2.*M_PI_180);
 		const double siderealPeriod = getSiderealPeriod(); // days required for revolution around parent.
 		const double siderealDay = getSiderealDay(); // =re.period
 		static SolarSystem *ssystem=GETSTELMODULE(SolarSystem);
@@ -1246,7 +1246,7 @@ QString Planet::getInfoStringExtra(const StelCore *core, const InfoStringGroup& 
 				{
 					const double eclipseMagnitude =
 							(0.5 * angularSize
-							 + (obj->getAngularRadius(core) * M_PI_180) / obj->getInfoMap(core)["scale"].toDouble()
+							 + (obj->getAngularRadius(core) * M_PI_180) / obj->getSphereScale()
 							- getJ2000EquatorialPos(core).angle(obj->getJ2000EquatorialPos(core)))
 							/ angularSize;
 					oss << QString("%1: %2<br />").arg(q_("Eclipse magnitude")).arg(QString::number(eclipseMagnitude, 'f', 3));
@@ -1367,7 +1367,7 @@ QVariantMap Planet::getInfoMap(const StelCore *core) const
 			if (core->getCurrentPlanet()==ssystem->getEarth() && obj==ssystem->getMoon())
 			{
 				double angularSize = 2.*getAngularRadius(core)*M_PI_180;
-				const double eclipseMagnitude = (0.5*angularSize + (obj->getAngularRadius(core)*M_PI_180)/obj->getInfoMap(core)["scale"].toDouble() - getJ2000EquatorialPos(core).angle(obj->getJ2000EquatorialPos(core)))/angularSize;
+				const double eclipseMagnitude = (0.5*angularSize + (obj->getAngularRadius(core)*M_PI_180)/obj->getSphereScale() - getJ2000EquatorialPos(core).angle(obj->getJ2000EquatorialPos(core)))/angularSize;
 				map.insert("eclipse-magnitude", eclipseMagnitude);
 			}
 			else

--- a/src/core/modules/Planet.cpp
+++ b/src/core/modules/Planet.cpp
@@ -694,13 +694,13 @@ QString Planet::getInfoStringSize(const StelCore *core, const InfoStringGroup& f
 	QString str;
 	QTextStream oss(&str);
 
-	const double angularSize = 2.*getAngularSize(core)*M_PI_180;
+	const double angularSize = 2.*getAngularRadius(core)*M_PI_180;
 	if (flags&Size && angularSize>=4.8e-8)
 	{
 		QString s1, s2, sizeStr = "";
 		if (rings)
 		{
-			const double withoutRings = 2.*getSpheroidAngularSize(core)*M_PI/180.;
+			const double withoutRings = 2.*getSpheroidAngularRadius(core)*M_PI/180.;
 			if (withDecimalDegree)
 			{
 				s1 = StelUtils::radToDecDegStr(withoutRings, 5, false, true);
@@ -970,7 +970,7 @@ QString Planet::getInfoStringExtra(const StelCore *core, const InfoStringGroup& 
 	{
 		const bool withTables = StelApp::getInstance().getFlagUseFormattingOutput();
 		const bool withDecimalDegree = StelApp::getInstance().getFlagShowDecimalDegrees();
-		const double angularSize = 2.*getAngularSize(core)*M_PI_180;
+		const double angularSize = 2.*getAngularRadius(core)*M_PI_180;
 		const double siderealPeriod = getSiderealPeriod(); // days required for revolution around parent.
 		const double siderealDay = getSiderealDay(); // =re.period
 		static SolarSystem *ssystem=GETSTELMODULE(SolarSystem);
@@ -1246,7 +1246,7 @@ QString Planet::getInfoStringExtra(const StelCore *core, const InfoStringGroup& 
 				{
 					const double eclipseMagnitude =
 							(0.5 * angularSize
-							 + (obj->getAngularSize(core) * M_PI_180) / obj->getInfoMap(core)["scale"].toDouble()
+							 + (obj->getAngularRadius(core) * M_PI_180) / obj->getInfoMap(core)["scale"].toDouble()
 							- getJ2000EquatorialPos(core).angle(obj->getJ2000EquatorialPos(core)))
 							/ angularSize;
 					oss << QString("%1: %2<br />").arg(q_("Eclipse magnitude")).arg(QString::number(eclipseMagnitude, 'f', 3));
@@ -1366,8 +1366,8 @@ QVariantMap Planet::getInfoMap(const StelCore *core) const
 			PlanetP obj = eclObj.second;
 			if (core->getCurrentPlanet()==ssystem->getEarth() && obj==ssystem->getMoon())
 			{
-				double angularSize = 2.*getAngularSize(core)*M_PI_180;
-				const double eclipseMagnitude = (0.5*angularSize + (obj->getAngularSize(core)*M_PI_180)/obj->getInfoMap(core)["scale"].toDouble() - getJ2000EquatorialPos(core).angle(obj->getJ2000EquatorialPos(core)))/angularSize;
+				double angularSize = 2.*getAngularRadius(core)*M_PI_180;
+				const double eclipseMagnitude = (0.5*angularSize + (obj->getAngularRadius(core)*M_PI_180)/obj->getInfoMap(core)["scale"].toDouble() - getJ2000EquatorialPos(core).angle(obj->getJ2000EquatorialPos(core)))/angularSize;
 				map.insert("eclipse-magnitude", eclipseMagnitude);
 			}
 			else
@@ -2641,14 +2641,14 @@ float Planet::getVMagnitude(const StelCore* core) const
 	return -26.73f - 2.5f * static_cast<float>(log10(F));
 }
 
-double Planet::getAngularSize(const StelCore* core) const
+double Planet::getAngularRadius(const StelCore* core) const
 {
 	const double rad = (rings ? rings->getSize() : equatorialRadius);
 	return std::atan2(rad*sphereScale,getJ2000EquatorialPos(core).length()) * M_180_PI;
 }
 
 
-double Planet::getSpheroidAngularSize(const StelCore* core) const
+double Planet::getSpheroidAngularRadius(const StelCore* core) const
 {
 	return std::atan2(equatorialRadius*sphereScale,getJ2000EquatorialPos(core).length()) * M_180_PI;
 }
@@ -2718,8 +2718,8 @@ void Planet::draw(StelCore* core, float maxMagLabels, const QFont& planetNameFon
 
 	// Compute the 2D position and check if in the screen
 	const StelProjectorP prj = core->getProjection(transfo);
-	const double screenSz = (getAngularSize(core))*M_PI_180*static_cast<double>(prj->getPixelPerRadAtCenter());
-	const double viewportBufferSz= (englishName=="Sun" ? screenSz+125. : screenSz);	// enlarge if this is sun with its huge halo.
+	const double screenRd = (getAngularRadius(core))*M_PI_180*static_cast<double>(prj->getPixelPerRadAtCenter());
+	const double viewportBufferSz= (englishName=="Sun" ? screenRd+125. : screenRd);	// enlarge if this is sun with its huge halo.
 	const double viewport_left = prj->getViewportPosX();
 	const double viewport_bottom = prj->getViewportPosY();
 
@@ -2742,7 +2742,7 @@ void Planet::draw(StelCore* core, float maxMagLabels, const QFont& planetNameFon
 			labelsFader=false;
 		drawHints(core, planetNameFont);
 
-		draw3dModel(core,transfo,static_cast<float>(screenSz));
+		draw3dModel(core,transfo,static_cast<float>(screenRd));
 	}
 	else if (permanentDrawingOrbits) // A special case for demos
 		drawOrbit(core);
@@ -3211,7 +3211,7 @@ void Planet::deinitFBO()
 	shadowInitialized = false;
 }
 
-void Planet::draw3dModel(StelCore* core, StelProjector::ModelViewTranformP transfo, float screenSz, bool drawOnlyRing)
+void Planet::draw3dModel(StelCore* core, StelProjector::ModelViewTranformP transfo, float screenRd, bool drawOnlyRing)
 {
 	// This is the main method drawing a planet 3d model
 	// Some work has to be done on this method to make the rendering nicer
@@ -3231,8 +3231,8 @@ void Planet::draw3dModel(StelCore* core, StelProjector::ModelViewTranformP trans
 	if (this==ssm->getSun() && drawSunHalo && core->getSkyDrawer()->getFlagEarlySunHalo())
 	{
 		// Prepare openGL lighting parameters according to luminance
-		float surfArcMin2 = getSpheroidAngularSize(core)*60;
-		surfArcMin2 = surfArcMin2*surfArcMin2*M_PI; // the total illuminated area in arcmin^2
+		float surfArcMin2 = static_cast<float>(getSpheroidAngularRadius(core))*60.f;
+		surfArcMin2 = surfArcMin2*surfArcMin2*M_PIf; // the total illuminated area in arcmin^2
 
 		StelPainter sPainter(core->getProjection(StelCore::FrameJ2000));
 		Vec3d tmp = getJ2000EquatorialPos(core);
@@ -3262,12 +3262,12 @@ void Planet::draw3dModel(StelCore* core, StelProjector::ModelViewTranformP trans
 			// We can safely assume beta=0 and ignore nutation.
 			const float q0=static_cast<float>(atan(-cos(lambdaJDE)*tan(eclJDE)));
 			rotationAngle -= q0*static_cast<float>(180.0/M_PI);
-			core->getSkyDrawer()->drawSunCorona(&sPainter, tmp.toVec3f(), 512.f/192.f*screenSz, haloColorToDraw, alpha*alpha, rotationAngle);
+			core->getSkyDrawer()->drawSunCorona(&sPainter, tmp.toVec3f(), 512.f/192.f*screenRd, haloColorToDraw, alpha*alpha, rotationAngle);
 		}
 	}
 
 	// Draw the real 3D object.
-	if (screenSz>1.f)
+	if (screenRd>1.f)
 	{
 		//make better use of depth buffer by adjusting clipping planes
 		//must be done before creating StelPainter
@@ -3348,20 +3348,20 @@ void Planet::draw3dModel(StelCore* core, StelProjector::ModelViewTranformP trans
 
 		if(ssm->getFlagUseObjModels() && !objModelPath.isEmpty())
 		{
-			if(!drawObjModel(&sPainter, screenSz))
+			if(!drawObjModel(&sPainter, screenRd))
 			{
-				drawSphere(&sPainter, screenSz, drawOnlyRing);
+				drawSphere(&sPainter, screenRd, drawOnlyRing);
 			}
 		}
 		else if (!survey || survey->getInterstate() < 1.0f)
 		{
-			drawSphere(&sPainter, screenSz, drawOnlyRing);
+			drawSphere(&sPainter, screenRd, drawOnlyRing);
 		}
 
 		if (survey && survey->getInterstate() > 0.0f)
 		{
 			drawSurvey(core, &sPainter);
-			drawSphere(&sPainter, screenSz, true);
+			drawSphere(&sPainter, screenRd, true);
 		}
 
 
@@ -3380,7 +3380,7 @@ void Planet::draw3dModel(StelCore* core, StelProjector::ModelViewTranformP trans
 		const Vec3d obj = getJ2000EquatorialPos(core);
 		const Vec3d par = getParent()->getJ2000EquatorialPos(core);
 		const double angle = obj.angle(par)*M_180_PI;
-		const double asize = getParent()->getSpheroidAngularSize(core);
+		const double asize = getParent()->getSpheroidAngularRadius(core);
 		if (angle<=asize)
 			allowDrawHalo = false;
 	}
@@ -3392,7 +3392,7 @@ void Planet::draw3dModel(StelCore* core, StelProjector::ModelViewTranformP trans
 	if ((hasHalo() || this==ssm->getSun()) && allowDrawHalo)
 	{
 		// Prepare OpenGL lighting parameters according to luminance. For scaled-up planets, reduce brightness of the halo.
-		float surfArcMin2 = static_cast<float>(getSpheroidAngularSize(core)*qMax(1.0, (englishName=="Moon" ? 1.0 : 0.025)*sphereScale))*60.f;
+		float surfArcMin2 = static_cast<float>(getSpheroidAngularRadius(core)*qMax(1.0, (englishName=="Moon" ? 1.0 : 0.025)*sphereScale))*60.f;
 		surfArcMin2 = surfArcMin2*surfArcMin2*M_PIf; // the total illuminated area in arcmin^2
 
 		StelPainter sPainter(core->getProjection(StelCore::FrameJ2000));
@@ -3437,7 +3437,7 @@ void Planet::draw3dModel(StelCore* core, StelProjector::ModelViewTranformP trans
 			const float q0=static_cast<float>(atan(-cos(lambdaJDE)*tan(eclJDE)));
 			rotationAngle -= q0*static_cast<float>(180.0/M_PI);
 
-			core->getSkyDrawer()->drawSunCorona(&sPainter, tmp.toVec3f(), 512.f/192.f*screenSz, haloColorToDraw, alpha*alpha, rotationAngle);
+			core->getSkyDrawer()->drawSunCorona(&sPainter, tmp.toVec3f(), 512.f/192.f*screenRd, haloColorToDraw, alpha*alpha, rotationAngle);
 		}
 	}
 }
@@ -3662,7 +3662,7 @@ Planet::RenderData Planet::setCommonShaderUniforms(const StelPainter& painter, Q
 	return data;
 }
 
-void Planet::drawSphere(StelPainter* painter, float screenSz, bool drawOnlyRing)
+void Planet::drawSphere(StelPainter* painter, float screenRd, bool drawOnlyRing)
 {
 	const float sphereScaleF=static_cast<float>(sphereScale);
 	if (texMap)
@@ -3679,7 +3679,7 @@ void Planet::drawSphere(StelPainter* painter, float screenSz, bool drawOnlyRing)
 
 	// Draw the spheroid itself
 	// Adapt the number of facets according with the size of the sphere for optimization
-	const unsigned short int nb_facet = static_cast<unsigned short int>(qBound(10u, static_cast<uint>(screenSz * 40.f/50.f * sqrt(sphereScaleF)), 100u));	// 40 facets for 1024 pixels diameter on screen
+	const unsigned short int nb_facet = static_cast<unsigned short int>(qBound(10u, static_cast<uint>(screenRd * 40.f/50.f * sqrt(sphereScaleF)), 100u));	// 40 facets for 1024 pixels diameter on screen
 
 	// Generates the vertices
 	Planet3DModel model;
@@ -3897,7 +3897,7 @@ void Planet::drawSurvey(StelCore* core, StelPainter* painter)
 	RenderData rData = setCommonShaderUniforms(*painter, shader, *shaderVars);
 	QVector<Vec3f> projectedVertsArray;
 	QVector<Vec3f> vertsArray;
-	double angle = getSpheroidAngularSize(core) * M_PI_180;
+	const double angle = getSpheroidAngularRadius(core) * M_PI_180;
 
 	if (rings)
 	{
@@ -4040,9 +4040,9 @@ bool Planet::ensureObjLoaded()
 	return true;
 }
 
-bool Planet::drawObjModel(StelPainter *painter, float screenSz)
+bool Planet::drawObjModel(StelPainter *painter, float screenRd)
 {
-	Q_UNUSED(screenSz); //screen size unused for now, use it for LOD or something?
+	Q_UNUSED(screenRd); //screen size unused for now, use it for LOD or something?
 
 	//make sure the OBJ is loaded, or start loading it
 	if(!ensureObjLoaded())
@@ -4316,7 +4316,7 @@ void Planet::drawHints(const StelCore* core, const QFont& planetNameFont)
 	StelPainter sPainter(prj);
 	sPainter.setFont(planetNameFont);
 	// Draw nameI18 + scaling if it's not == 1.
-	float tmp = (hintFader.getInterstate()<=0.f ? 7.f : 10.f) + static_cast<float>(getAngularSize(core)*M_PI/180.)*prj->getPixelPerRadAtCenter()/1.44f; // Shift for nameI18 printing
+	float tmp = (hintFader.getInterstate()<=0.f ? 7.f : 10.f) + static_cast<float>(getAngularRadius(core)*M_PI/180.)*prj->getPixelPerRadAtCenter()/1.44f; // Shift for nameI18 printing
 	sPainter.setColor(labelColor,labelsFader.getInterstate());
 	sPainter.drawText(static_cast<float>(screenPos[0]),static_cast<float>(screenPos[1]), getPlanetLabel(), 0, tmp, tmp, false);
 
@@ -4527,9 +4527,9 @@ Vec4d Planet::getRTSTime(const StelCore *core, const double altitude) const
 	if ( (getEnglishName()=="Moon") && (loc.planetName=="Earth")) // && core->getUseTopocentricCoordinates())
 		//ho = +0.7275*asin(6378.14/(eclipticPos.length()*AU)); // horizon parallax factor. This is needed for tabulations, but we must do something else.
 		//ho = -0.25*asin(6378.14/(eclipticPos.length()*AU)); // horizon parallax factor.
-		ho = - getAngularSize(core) * M_PI_180; // semidiameter;
+		ho = - getAngularRadius(core) * M_PI_180; // semidiameter;
 	else if (getEnglishName()=="Sun")
-		ho = - getAngularSize(core) * M_PI_180; // semidiameter; Canonical value 16', but this is accurate even from other planets...
+		ho = - getAngularRadius(core) * M_PI_180; // semidiameter; Canonical value 16', but this is accurate even from other planets...
 
 	if (core->getSkyDrawer()->getFlagHasAtmosphere())
 	{

--- a/src/core/modules/Planet.hpp
+++ b/src/core/modules/Planet.hpp
@@ -228,7 +228,7 @@ public:
 	QString getCommonEnglishName(void) const {return englishName;}
 	QString getCommonNameI18n(void) const {return nameI18;}
 	//! Get angular semidiameter, degrees. If planet display is artificially enlarged (e.g. Moon upscale), value will also be increased.
-	virtual double getAngularSize(const StelCore* core) const Q_DECL_OVERRIDE;
+	virtual double getAngularRadius(const StelCore* core) const Q_DECL_OVERRIDE;
 	virtual bool hasAtmosphere(void) {return atmosphere;}
 	virtual bool hasHalo(void) {return halo;}
 	//! Returns whether planet positions are valid and useful for the current simulation time.
@@ -377,7 +377,7 @@ public:
 	//! Get the elongation angle (radians) for an observer at pos obsPos in heliocentric coordinates (in AU)
 	double getElongation(const Vec3d& obsPos) const;
 	//! Get the angular radius (degrees) of the planet spheroid (i.e. without the rings)
-	double getSpheroidAngularSize(const StelCore* core) const;
+	double getSpheroidAngularRadius(const StelCore* core) const;
 	//! Get the planet phase (illuminated fraction of the planet disk, [0=dark..1=full]) for an observer at pos obsPos in heliocentric coordinates (in AU)
 	float getPhase(const Vec3d& obsPos) const;
 	//! Get the position angle of the illuminated limb of a planet
@@ -631,8 +631,8 @@ protected:
 
 	static StelTextureSP texEarthShadow;     // for lunar eclipses
 
-	// Used in drawSphere() to compute shadows, and inside a function to derive eclipse sizes.
-	// For reasons currently unknown we must handle solar eclipses as special case.
+	//! Used in drawSphere() to compute shadows, and inside a function to derive eclipse sizes.
+	//! @param solarEclipseCase For reasons currently unknown we must handle solar eclipses as special case.
 	void computeModelMatrix(Mat4d &result, bool solarEclipseCase) const;
 
 	//! Update the orbit position values.
@@ -640,15 +640,17 @@ protected:
 
 	Vec3f getCurrentOrbitColor() const;
 	
-	// Return the information string "ready to print" :)
+	//! Return the information string "ready to print"
 	QString getPlanetLabel() const;
 
-	// Draw the 3d model. Call the proper functions if there are rings etc..
-	void draw3dModel(StelCore* core, StelProjector::ModelViewTranformP transfo, float screenSz, bool drawOnlyRing=false);
+	//! Draw the 3d model. Call the proper functions if there are rings etc..
+	//! @param screenRd radius in screen pixels
+	void draw3dModel(StelCore* core, StelProjector::ModelViewTranformP transfo, float screenRd, bool drawOnlyRing=false);
 
-	// Draws the OBJ model, assuming it is available
-	// @return false if the model can currently not be drawn (not loaded)
-	bool drawObjModel(StelPainter* painter, float screenSz);
+	//! Draws the OBJ model, assuming it is available
+	//! @param screenRd radius in screen pixels.
+	//! @return false if the model can currently not be drawn (not loaded)
+	bool drawObjModel(StelPainter* painter, float screenRd);
 
 	bool drawObjShadowMap(StelPainter* painter, QMatrix4x4 &shadowMatrix);
 
@@ -656,13 +658,13 @@ protected:
 	//! Returns true when the OBJ is ready to draw
 	bool ensureObjLoaded();
 
-	// Draw the 3D sphere
-	void drawSphere(StelPainter* painter, float screenSz, bool drawOnlyRing=false);
+	//! Draw the 3D sphere
+	void drawSphere(StelPainter* painter, float screenRd, bool drawOnlyRing=false);
 
-	// Draw the Hips survey.
+	//! Draw the Hips survey.
 	void drawSurvey(StelCore* core, StelPainter* painter);
 
-	// Draw the circle and name of the Planet
+	//! Draw the circle and name of the Planet
 	void drawHints(const StelCore* core, const QFont& planetNameFont);
     
 	PlanetOBJModel* loadObjModel() const;

--- a/src/core/modules/SolarSystem.cpp
+++ b/src/core/modules/SolarSystem.cpp
@@ -495,7 +495,7 @@ void SolarSystem::drawPointer(const StelCore* core)
 		const StelObjectP obj = newSelected[0];
 		Vec3d pos=obj->getJ2000EquatorialPos(core);
 
-		Vec3d screenpos;
+		Vec3f screenpos;
 		// Compute 2D pos and return if outside screen
 		if (!prj->project(pos, screenpos))
 			return;
@@ -503,23 +503,23 @@ void SolarSystem::drawPointer(const StelCore* core)
 		StelPainter sPainter(prj);
 		sPainter.setColor(getPointerColor());
 
-		double size = obj->getAngularSize(core)*M_PI_180*prj->getPixelPerRadAtCenter()*2.;
+		float screenSize = static_cast<float>(obj->getAngularRadius(core))*prj->getPixelPerRadAtCenter()*M_PI_180f*2.f;
 		
-		const double scale = prj->getDevicePixelsPerPixel()*StelApp::getInstance().getGlobalScalingRatio();
-		size+= scale * (45. + 10.*std::sin(2. * StelApp::getInstance().getAnimationTime()));
+		const float scale = static_cast<float>(prj->getDevicePixelsPerPixel())*StelApp::getInstance().getGlobalScalingRatio();
+		screenSize+= scale * (45.f + 10.f*std::sin(2.f * static_cast<float>(StelApp::getInstance().getAnimationTime())));
 
 		texPointer->bind();
 
 		sPainter.setBlending(true);
 
-		size*=0.5;
-		const double angleBase = StelApp::getInstance().getAnimationTime() * 10;
+		screenSize*=0.5f;
+		const float angleBase = static_cast<float>(StelApp::getInstance().getAnimationTime()) * 10;
 		// We draw 4 instances of the sprite at the corners of the pointer
 		for (int i = 0; i < 4; ++i)
 		{
-			const double angle = angleBase + i * 90;
-			const double x = screenpos[0] + size * cos(angle / 180 * M_PI);
-			const double y = screenpos[1] + size * sin(angle / 180 * M_PI);
+			const float angle = angleBase + i * 90;
+			const float x = screenpos[0] + screenSize * cos(angle * M_PI_180f);
+			const float y = screenpos[1] + screenSize * sin(angle * M_PI_180f);
 			sPainter.drawSprite2dMode(x, y, 10, angle);
 		}
 	}
@@ -975,8 +975,8 @@ bool SolarSystem::loadPlanets(const QString& filePath)
 			minorBodies << englishName;
 
 			Vec3f color = Vec3f(1.f, 1.f, 1.f);
-			const float bV = pd.value(secname+"/color_index_bv", 99.f).toFloat();
-			if (bV<99.f)
+			const double bV = pd.value(secname+"/color_index_bv", 99.).toDouble();
+			if (bV<99.)
 				color = skyDrawer->indexToColor(BvToColorIndex(bV))*0.75f; // see ZoneArray.cpp:L490
 			else
 				color = Vec3f(pd.value(secname+"/color", "1.0,1.0,1.0").toString());
@@ -1012,7 +1012,7 @@ bool SolarSystem::loadPlanets(const QString& filePath)
 				mp->setAbsoluteMagnitudeAndSlope(magnitude, qBound(0.0f, slope, 1.0f));
 			}
 
-			mp->setColorIndexBV(bV);
+			mp->setColorIndexBV(static_cast<float>(bV));
 			mp->setSpectralType(pd.value(secname+"/spec_t", "").toString(), pd.value(secname+"/spec_b", "").toString());
 			if (semi_major_axis>0)
 				mp->deltaJDE = 2.0*semi_major_axis*StelCore::JD_SECOND;
@@ -1779,7 +1779,7 @@ QList<StelObjectP> SolarSystem::searchAround(const Vec3d& vv, double limitFov, c
 		equPos = p->getJ2000EquatorialPos(core);
 		equPos.normalize();
 
-		cosAngularSize = std::cos(p->getSpheroidAngularSize(core) * M_PI/180.);
+		cosAngularSize = std::cos(p->getSpheroidAngularRadius(core) * M_PI/180.);
 
 		if (equPos*v>=std::min(cosLimFov, cosAngularSize) && p->getEnglishName()!=weAreHere)
 		{
@@ -3104,7 +3104,7 @@ void SolarSystem::setCustomGrsLongitude(int longitude)
 
 int SolarSystem::getCustomGrsLongitude() const
 {
-	return RotationElements::customGrsLongitude;
+	return static_cast<int>(RotationElements::customGrsLongitude);
 }
 
 void SolarSystem::setCustomGrsDrift(double drift)

--- a/src/core/modules/StarWrapper.hpp
+++ b/src/core/modules/StarWrapper.hpp
@@ -109,7 +109,6 @@ protected:
 	virtual float getBV(void) const  Q_DECL_OVERRIDE {return s->getBV();}
 	virtual QString getEnglishName(void) const Q_DECL_OVERRIDE {return QString();}
 	virtual QString getNameI18n(void) const Q_DECL_OVERRIDE {return s->getNameI18n();}
-	virtual double getAngularSize(const StelCore*) const Q_DECL_OVERRIDE {return 0.;}
 protected:
 	const SpecialZoneArray<Star> *const a;
 	const SpecialZoneData<Star> *const z;

--- a/src/gui/AstroCalcDialog.cpp
+++ b/src/gui/AstroCalcDialog.cpp
@@ -709,15 +709,15 @@ void AstroCalcDialog::drawAziVsTimeDiagram()
 
 		int step = 180;
 		int limit = 485;
+#ifdef USE_STATIC_PLUGIN_SATELLITES
 		bool isSatellite = false;
 
-#ifdef USE_STATIC_PLUGIN_SATELLITES
 		SatelliteP sat;		
 		if (selectedObject->getType() == "Satellite") 
 		{
 			// get reference to satellite
 			isSatellite = true;
-			sat = GETSTELMODULE(Satellites)->getById(selectedObject->getInfoMap(core)["catalog"].toString());
+			sat = GETSTELMODULE(Satellites)->getById(selectedObject.staticCast<Satellite>()->getCatalogNumberString());
 		}
 #endif
 
@@ -730,13 +730,13 @@ void AstroCalcDialog::drawAziVsTimeDiagram()
 			double JD = noon + ltime / 86400 - shift - 0.5;
 			core->setJD(JD);
 			
+#ifdef USE_STATIC_PLUGIN_SATELLITES
 			if (isSatellite)
 			{
-#ifdef USE_STATIC_PLUGIN_SATELLITES
 				sat->update(0.0);
-#endif
 			}
 			else
+#endif
 				core->update(0.0);
 
 			StelUtils::rectToSphe(&az, &alt, selectedObject->getAltAzPosAuto(core));
@@ -2579,7 +2579,7 @@ void AstroCalcDialog::drawAltVsTimeDiagram()
 		{
 			// get reference to satellite
 			isSatellite = true;
-			sat = GETSTELMODULE(Satellites)->getById(selectedObject->getInfoMap(core)["catalog"].toString());
+			sat = GETSTELMODULE(Satellites)->getById(selectedObject.staticCast<Satellite>()->getCatalogNumberString());
 		}
 #endif
 

--- a/src/gui/AstroCalcDialog.cpp
+++ b/src/gui/AstroCalcDialog.cpp
@@ -1127,7 +1127,7 @@ void AstroCalcDialog::currentCelestialPositions()
 					extra = dash;
 
 				// Convert to arc-minutes the average angular size of deep-sky object
-				QString angularSize = QString::number(obj->getAngularSize(core) * 120., 'f', 3);
+				QString angularSize = QString::number(obj->getAngularRadius(core) * 120., 'f', 3);
 				if (angularSize.toFloat() < 0.01f)
 					angularSize = dash;
 
@@ -1219,7 +1219,7 @@ void AstroCalcDialog::currentCelestialPositions()
 				QString extra = QString::number(pos.length(), 'f', 5); // A.U.
 
 				// Convert to arc-seconds the angular size of Solar system object (with rings, if any)
-				QString angularSize = QString::number(planet->getAngularSize(core) * 120., 'f', 4);
+				QString angularSize = QString::number(planet->getAngularRadius(core) * 120., 'f', 4);
 				if (angularSize.toFloat() < 1e-4f || planet->getPlanetType() == Planet::isComet)
 					angularSize = dash;
 
@@ -3054,26 +3054,26 @@ double AstroCalcDialog::computeGraphValue(const PlanetP &ssObj, const int graphT
 	switch (graphType)
 	{
 		case GraphMagnitudeVsTime:
-			value = ssObj->getVMagnitude(core);
+			value = static_cast<double>(ssObj->getVMagnitude(core));
 			break;
 		case GraphPhaseVsTime:
-			value = ssObj->getPhase(core->getObserverHeliocentricEclipticPos()) * 100.;
+			value = static_cast<double>(ssObj->getPhase(core->getObserverHeliocentricEclipticPos())) * 100.;
 			break;
 		case GraphDistanceVsTime:
 			value =  ssObj->getJ2000EquatorialPos(core).length();
 			break;
 		case GraphElongationVsTime:
-			value = ssObj->getElongation(core->getObserverHeliocentricEclipticPos()) * 180. / M_PI;
+			value = ssObj->getElongation(core->getObserverHeliocentricEclipticPos()) * M_180_PI;
 			break;
 		case GraphAngularSizeVsTime:
 		{
-			value = ssObj->getAngularSize(core) * 360. / M_PI;
+			value = ssObj->getAngularRadius(core) * (360. / M_PI);
 			if (value < 1.)
 				value *= 60.;
 			break;
 		}
 		case GraphPhaseAngleVsTime:
-			value = ssObj->getPhaseAngle(core->getObserverHeliocentricEclipticPos()) * 180. / M_PI;
+			value = ssObj->getPhaseAngle(core->getObserverHeliocentricEclipticPos()) * M_180_PI;
 			break;
 		case GraphHDistanceVsTime:
 			value =  ssObj->getHeliocentricEclipticPos().length();
@@ -3182,7 +3182,7 @@ void AstroCalcDialog::prepareXVsTimeAxesAndGraph()
 			// equal to one million meters)
 			distMU = q_("Mm");
 		}
-		if ((ssObj->getAngularSize(core) * 360. / M_PI) < 1.) asMU = QString("\"");
+		if ((ssObj->getAngularRadius(core) * 360. / M_PI) < 1.) asMU = QString("\"");
 	}
 
 	bool direction1 = false;
@@ -3805,7 +3805,7 @@ void AstroCalcDialog::calculatePhenomena()
 				stars = carbonStars;
 			for (const auto& object : qAsConst(stars))
 			{
-				if (object->getVMagnitude(core) < (brightLimit - 5.0))
+				if (object->getVMagnitude(core) < static_cast<float>(brightLimit - 5.0))
 					star.append(object);
 			}
 			break;
@@ -3813,21 +3813,21 @@ void AstroCalcDialog::calculatePhenomena()
 		case PHCBrightDoubleStars: // Double stars
 			for (const auto& object : doubleHipStars)
 			{
-				if (object.firstKey()->getVMagnitude(core) < (brightLimit - 5.0))
+				if (object.firstKey()->getVMagnitude(core) < static_cast<float>(brightLimit - 5.0))
 					star.append(object.firstKey());
 			}
 			break;
 		case PHCBrightVariableStars: // Variable stars
 			for (const auto& object : variableHipStars)
 			{
-				if (object.firstKey()->getVMagnitude(core) < (brightLimit - 5.0))
+				if (object.firstKey()->getVMagnitude(core) < static_cast<float>(brightLimit - 5.0))
 					star.append(object.firstKey());
 			}
 			break;
 		case PHCBrightStarClusters: // Star clusters
 			for (const auto& object : allDSO)
 			{
-				if (object->getVMagnitude(core) < brightLimit && (object->getDSOType() == Nebula::NebCl || object->getDSOType() == Nebula::NebOc || object->getDSOType() == Nebula::NebGc || object->getDSOType() == Nebula::NebSA || object->getDSOType() == Nebula::NebSC || object->getDSOType() == Nebula::NebCn))
+			    if (object->getVMagnitude(core) < static_cast<float>(brightLimit) && (object->getDSOType() == Nebula::NebCl || object->getDSOType() == Nebula::NebOc || object->getDSOType() == Nebula::NebGc || object->getDSOType() == Nebula::NebSA || object->getDSOType() == Nebula::NebSC || object->getDSOType() == Nebula::NebCn))
 					dso.append(object);
 			}
 			break;
@@ -4118,8 +4118,8 @@ void AstroCalcDialog::fillPhenomenaTable(const QMap<double, double> list, const 
 		QString phenomenType = q_("Conjunction");
 		double separation = it.value();
 		bool occultation = false;
-		const double s1 = object1->getSpheroidAngularSize(core);
-		const double s2 = object2->getSpheroidAngularSize(core);
+		const double s1 = object1->getSpheroidAngularRadius(core);
+		const double s2 = object2->getSpheroidAngularRadius(core);
 		const double d1 = object1->getJ2000EquatorialPos(core).length();
 		const double d2 = object2->getJ2000EquatorialPos(core).length();
 		if (mode==PhenomenaTypeIndex::Shadows) // shadows
@@ -4293,7 +4293,7 @@ void AstroCalcDialog::fillPhenomenaTable(const QMap<double, double> list, const 
 		QString phenomenType = q_("Conjunction");
 		double separation = it.value();
 		bool occultation = false;
-		if (separation < (object2->getAngularSize(core) * M_PI / 180.) || separation < (object1->getSpheroidAngularSize(core) * M_PI / 180.))
+		if (separation < (object2->getAngularRadius(core) * M_PI / 180.) || separation < (object1->getSpheroidAngularRadius(core) * M_PI / 180.))
 		{
 			phenomenType = q_("Occultation");
 			occultation = true;
@@ -4373,8 +4373,8 @@ void AstroCalcDialog::fillPhenomenaTable(const QMap<double, double> list, const 
 		QString phenomenType = q_("Conjunction");
 		double separation = it.value();
 		bool occultation = false;		
-		const double s1 = object1->getSpheroidAngularSize(core);
-		const double s2 = object2->getAngularSize(core);
+		const double s1 = object1->getSpheroidAngularRadius(core);
+		const double s2 = object2->getAngularRadius(core);
 		const double d1 = object1->getJ2000EquatorialPos(core).length();
 		const double d2 = object2->getJ2000EquatorialPos(core).length();
 		if (mode==PhenomenaTypeIndex::Opposition)
@@ -5663,7 +5663,7 @@ void AstroCalcDialog::calculateWutObjects()
 								d = object->getDSODesignationWIC();
 							QString n = object->getNameI18n();
 
-							if ((angularSizeLimit) && (!StelUtils::isWithin(object->getAngularSize(core), angularSizeLimitMin, angularSizeLimitMax)))
+							if ((angularSizeLimit) && (!StelUtils::isWithin(object->getAngularRadius(core), angularSizeLimitMin, angularSizeLimitMax)))
 								continue;
 
 							if (d.isEmpty() && n.isEmpty())
@@ -5677,11 +5677,11 @@ void AstroCalcDialog::calculateWutObjects()
 								constellation = core->getIAUConstellation(object->getEquinoxEquatorialPos(core));
 
 								if (d.isEmpty())
-									fillWUTTable(n, n, mag, rts, alt, object->getAngularSize(core), constellation, withDecimalDegree);
+									fillWUTTable(n, n, mag, rts, alt, object->getAngularRadius(core), constellation, withDecimalDegree);
 								else if (n.isEmpty())
-									fillWUTTable(d, d, mag, rts, alt, object->getAngularSize(core), constellation, withDecimalDegree);
+									fillWUTTable(d, d, mag, rts, alt, object->getAngularRadius(core), constellation, withDecimalDegree);
 								else
-									fillWUTTable(QString("%1 (%2)").arg(d, n), d, mag, rts, alt, object->getAngularSize(core), constellation, withDecimalDegree);
+									fillWUTTable(QString("%1 (%2)").arg(d, n), d, mag, rts, alt, object->getAngularRadius(core), constellation, withDecimalDegree);
 
 								objectsList.insert(designation);
 							}
@@ -5725,7 +5725,7 @@ void AstroCalcDialog::calculateWutObjects()
 						mag = object->getVMagnitude(core);
 						if (object->getPlanetType() == pType && mag <= magLimit && object->isAboveRealHorizon(core))
 						{
-							if ((angularSizeLimit) && (!StelUtils::isWithin(object->getAngularSize(core), angularSizeLimitMin, angularSizeLimitMax)))
+							if ((angularSizeLimit) && (!StelUtils::isWithin(object->getAngularRadius(core), angularSizeLimitMin, angularSizeLimitMax)))
 								continue;
 
 							designation = object->getEnglishName();
@@ -5735,7 +5735,7 @@ void AstroCalcDialog::calculateWutObjects()
 								alt = computeMaxElevation(qSharedPointerCast<StelObject>(object));
 								constellation = core->getIAUConstellation(object->getEquinoxEquatorialPos(core));
 
-								fillWUTTable(object->getNameI18n(), designation, mag, rts, alt, 2.0*object->getAngularSize(core), constellation, withDecimalDegree);
+								fillWUTTable(object->getNameI18n(), designation, mag, rts, alt, 2.0*object->getAngularRadius(core), constellation, withDecimalDegree);
 								objectsList.insert(designation);
 							}
 						}
@@ -5863,7 +5863,7 @@ void AstroCalcDialog::calculateWutObjects()
 								d = object->getDSODesignationWIC();
 							QString n = object->getNameI18n();
 
-							if ((angularSizeLimit) && (!StelUtils::isWithin(object->getAngularSize(core), angularSizeLimitMin, angularSizeLimitMax)))
+							if ((angularSizeLimit) && (!StelUtils::isWithin(object->getAngularRadius(core), angularSizeLimitMin, angularSizeLimitMax)))
 								continue;
 
 							if (d.isEmpty() && n.isEmpty())
@@ -5877,11 +5877,11 @@ void AstroCalcDialog::calculateWutObjects()
 								constellation = core->getIAUConstellation(object->getEquinoxEquatorialPos(core));
 
 								if (d.isEmpty())
-									fillWUTTable(n, n, mag, rts, alt, object->getAngularSize(core), constellation, withDecimalDegree);
+									fillWUTTable(n, n, mag, rts, alt, object->getAngularRadius(core), constellation, withDecimalDegree);
 								else if (n.isEmpty())
-									fillWUTTable(d, d, mag, rts, alt, object->getAngularSize(core), constellation, withDecimalDegree);
+									fillWUTTable(d, d, mag, rts, alt, object->getAngularRadius(core), constellation, withDecimalDegree);
 								else
-									fillWUTTable(QString("%1 (%2)").arg(d, n), d, mag, rts, alt, object->getAngularSize(core), constellation, withDecimalDegree);
+									fillWUTTable(QString("%1 (%2)").arg(d, n), d, mag, rts, alt, object->getAngularRadius(core), constellation, withDecimalDegree);
 
 								objectsList.insert(designation);
 							}
@@ -6045,7 +6045,7 @@ void AstroCalcDialog::calculateWutObjects()
 								d = object->getDSODesignationWIC();
 							QString n = object->getNameI18n();
 
-							if ((angularSizeLimit) && (!StelUtils::isWithin(object->getAngularSize(core), angularSizeLimitMin, angularSizeLimitMax)))
+							if ((angularSizeLimit) && (!StelUtils::isWithin(object->getAngularRadius(core), angularSizeLimitMin, angularSizeLimitMax)))
 								continue;
 
 							if (d.isEmpty() && n.isEmpty())
@@ -6059,11 +6059,11 @@ void AstroCalcDialog::calculateWutObjects()
 								constellation = core->getIAUConstellation(object->getEquinoxEquatorialPos(core));
 
 								if (d.isEmpty())
-									fillWUTTable(n, n, mag, rts, alt, object->getAngularSize(core), constellation, withDecimalDegree);
+									fillWUTTable(n, n, mag, rts, alt, object->getAngularRadius(core), constellation, withDecimalDegree);
 								else if (n.isEmpty())
-									fillWUTTable(d, d, mag, rts, alt, object->getAngularSize(core), constellation, withDecimalDegree);
+									fillWUTTable(d, d, mag, rts, alt, object->getAngularRadius(core), constellation, withDecimalDegree);
 								else
-									fillWUTTable(QString("%1 (%2)").arg(d, n), d, mag, rts, alt, object->getAngularSize(core), constellation, withDecimalDegree);
+									fillWUTTable(QString("%1 (%2)").arg(d, n), d, mag, rts, alt, object->getAngularRadius(core), constellation, withDecimalDegree);
 
 								objectsList.insert(designation);
 							}


### PR DESCRIPTION
It occurred to me that we need to rename this method to clarify that these values are in fact radii, not sizes
See the documentation in StelObject.h


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Please include a summary of the change and which issue is fixed. -->
<!--- Please also include relevant motivation and context. -->
<!--- List any dependencies that are required for this change. -->

Fixes # (issue)

### Screenshots (if appropriate):

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] This change requires a documentation update

### TODOs
- [x] Rename method
- [x] add default implementation to StelObject base class
- [x] clarify CustomObject's weird size
- [x] clarify Nebula's intermediate result. Better return majorAxisSize/2? Adapt other code accordingly.
- [x] clarify why MeteorShowers, Quasars, Pulsars, Exoplanet systems, Novae, Supernovae have non-zero but some distinct fixed small radii? Proposal: remove method override to inherit StelObject's zero size.
- [x] clarify for the Satellite class what RCS is (document the variables!!!) and how to derive radius, not diameter (as it is maybe now), from that. Adapt other places in the satellites code accordingly!

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system: Win10 (irrelevant)
* Graphics Card: irrelevant

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
