### PR TITLE
Calendar on ecliptic

### DIFF
--- a/src/core/modules/GridLinesMgr.cpp
+++ b/src/core/modules/GridLinesMgr.cpp
@@ -1257,21 +1257,6 @@ void SkyLine::draw(StelCore *core) const
 			{
 				int month = 0;
 				int monthDays = 0;
-				QString monthNames[] =
-				{
-					qc_("Jan","short month name"),
-					qc_("Feb","short month name"),
-					qc_("Mar","short month name"),
-					qc_("Apr","short month name"),
-					qc_("May","short month name"),
-					qc_("Jun","short month name"),
-					qc_("Jul","short month name"),
-					qc_("Aug","short month name"),
-					qc_("Sep","short month name"),
-					qc_("Oct","short month name"),
-					qc_("Nov","short month name"),
-					qc_("Dec","short month name")
-				};
 				for(int i = 0,d = 0; i < daysOfYear; ++i, ++d)
 				{
 					if(d >= monthDays)
@@ -1280,7 +1265,7 @@ void SkyLine::draw(StelCore *core) const
 						++month;
 						monthDays = StelUtils::numberOfDaysInMonthInYear(month, year);
 						sPainter.drawGreatCircleArc(partNewYear, partMonth, Q_NULLPTR, Q_NULLPTR, Q_NULLPTR);
-						QString label = QString("%1").arg(monthNames[month - 1]);
+						QString label = QString("%1").arg(StelLocaleMgr::shortMonthName(month));
 						if(showLabel)
 						{
 							float shiftx = static_cast<float>(sPainter.getFontMetrics().boundingRect(label).width()) * -1.0f;

--- a/src/core/modules/GridLinesMgr.cpp
+++ b/src/core/modules/GridLinesMgr.cpp
@@ -1244,8 +1244,8 @@ void SkyLine::draw(StelCore *core) const
 			Vec3d partNewYear=earth->getEclipticPos(newyearJD + core->computeDeltaT(newyearJD)/86400.0)*-1;
 			Vec3d partDay=partNewYear;
 			partDay.transfo4d(Mat4d::rotation(partAxis, -0.1*M_PI/180));
-			Vec3d partDayl=partNewYear;
-			partDayl.transfo4d(Mat4d::rotation(partAxis, -0.175*M_PI/180));
+			Vec3d partDayl=earth->getEclipticPos(newyearJD + 0.5 + core->computeDeltaT(newyearJD + 0.5)/86400.0)*-1;
+			partDayl.transfo4d(Mat4d::rotation(partAxis, -0.125*M_PI/180));
 			Vec3d partWeek=partNewYear;
 			partWeek.transfo4d(Mat4d::rotation(partAxis, -0.25*M_PI/180));
 			Vec3d partMonth=partNewYear;
@@ -1279,23 +1279,7 @@ void SkyLine::draw(StelCore *core) const
 							sPainter.drawText(partMonthl, label, textAngle*M_180_PIf - 90, shiftx, shifty, false);
 						}
 					}
-					else
-					{
-						sPainter.drawGreatCircleArc(partNewYear, partDay, Q_NULLPTR, Q_NULLPTR, Q_NULLPTR);
-						if(showLabel && d % 5 == 0 && (monthDays > 30 || d != 30))
-						{
-							QString label = QString("%1").arg(d);
-							float shiftx = static_cast<float>(sPainter.getFontMetrics().boundingRect(label).width()) * -1.0f;
-							float shifty = static_cast<float>(sPainter.getFontMetrics().height()) * 0.2f;
-							Vec3d screenPosTgt, screenPosTgtL;
-							prj->project(partDay, screenPosTgt);
-							prj->project(partDayl, screenPosTgtL);
-							double dx = screenPosTgtL[0] - screenPosTgt[0];
-							double dy = screenPosTgtL[1] - screenPosTgt[1];
-							float textAngle=static_cast<float>(atan2(dy, dx));
-							sPainter.drawText(partDayl, label, textAngle*M_180_PIf-90, shiftx, shifty, false);
-						}
-					}
+					sPainter.drawGreatCircleArc(partNewYear, partDay, Q_NULLPTR, Q_NULLPTR, Q_NULLPTR);
 					double step;
 					if(i<81||i>268)
 					{
@@ -1304,6 +1288,20 @@ void SkyLine::draw(StelCore *core) const
 					else
 					{
 						step = 1.0*M_PI/187.;
+					}
+					if(showLabel && (d+1)%5==0)
+					{
+						QString label = QString("%1").arg(d+1);
+						float shiftx = static_cast<float>(sPainter.getFontMetrics().boundingRect(label).width()) * -1.0f;
+						float shifty = static_cast<float>(sPainter.getFontMetrics().height()) * 0.2f;
+						Vec3d screenPosTgt, screenPosTgtL;
+						prj->project(partDay, screenPosTgt);
+						prj->project(partDayl, screenPosTgtL);
+						double dx = screenPosTgtL[0] - screenPosTgt[0];
+						double dy = screenPosTgtL[1] - screenPosTgt[1];
+						float textAngle=static_cast<float>(atan2(dy, dx));
+						// Use fixed number 177 to redress text angle rather than calculate in realtime
+						sPainter.drawText(partDayl, label, textAngle*M_180_PIf-177, shiftx, shifty, false);
 					}
 					const Mat4d& rotZ1 = Mat4d::rotation(partZAxis, step);
 					partNewYear.transfo4d(rotZ1);


### PR DESCRIPTION
### Description

Fixes #2175 

### Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/69779107/151338895-d7e639cb-ba57-4502-9225-7c1254c27e63.png)

Help wanted:

Is there any function which I could use to get the ecliptic longitude of the sun on a specific Julian day? I didn't find it, so I divided the ecliptic equally into 365 (366 if leap year) pieces. As we known that the earth moves at different angular velocities in different seasons on ecliptic, equally dividing would cause bad precision. Sometimes there would be up to 2 days deviation.

Many thanks!

I've tried to use `earth->getEclipticPos(<JDE>)` to get the `Vec3d` position of earth, and calculate the differences of each adjacent days, and use them as the steps to split the ecliptic, but the differences are widely variable. I possibly misunderstand something.

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### How Has This Been Tested?

**Test Configuration**: macOS Monterey 12.0.1
* Operating system: macOS Monterey 12.0.1
* Graphics Card: Apple M1 Max built-in

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
