### PR TITLE
Give names to some magic constants: radii of Earth, Moon and Sun

### DIFF
--- a/src/core/StelUtils.hpp
+++ b/src/core/StelUtils.hpp
@@ -38,6 +38,12 @@
 #define SPEED_OF_LIGHT 299792.458
 // Ecliptic obliquity of J2000.0, degrees
 #define EPS_0 23.4392803055555555555556
+// Equatorial radius of the Earth in km
+#define EARTH_RADIUS 6378.1366
+// Equatorial radius of the Sun in km
+#define SUN_RADIUS 696000.
+// Equatorial radius of the Moon in km
+#define MOON_RADIUS 1738.
 
 // Add a few frequently used extra math-type literals
 #ifndef M_PI_180

--- a/src/core/modules/Atmosphere.cpp
+++ b/src/core/modules/Atmosphere.cpp
@@ -199,8 +199,8 @@ void Atmosphere::computeColor(double JD, Vec3d _sunPos, Vec3d moonPos, float moo
 
 	// Update the eclipse intensity factor to apply on atmosphere model
 	// these are for radii
-	const double sun_angular_size = atan(696000./AU/_sunPos.length());
-	const double moon_angular_size = atan(1738./AU/moonPos.length());
+	const double sun_angular_size = atan(SUN_RADIUS/AU/_sunPos.length());
+	const double moon_angular_size = atan(MOON_RADIUS/AU/moonPos.length());
 	const double touch_angle = sun_angular_size + moon_angular_size;
 
 	// determine luminance falloff during solar eclipses

--- a/src/core/modules/Meteor.cpp
+++ b/src/core/modules/Meteor.cpp
@@ -27,6 +27,11 @@
 
 #include <QtMath>
 
+#define EARTH_RADIUSf 6378.f          //! earth_radius in km
+#define EARTH_RADIUS2 40678884.f     //! earth_radius^2 in km
+#define MAX_ALTITUDE 120.f           //! max meteor altitude in km
+#define MIN_ALTITUDE 80.f            //! min meteor altitude in km
+
 Meteor::Meteor(const StelCore* core, const StelTextureSP& bolideTexture)
 	: m_core(core)
 	, m_alive(false)
@@ -316,9 +321,9 @@ float Meteor::meteorZ(float zenithAngle, float altitude)
 	{
 		const float zcos = cos(zenithAngle);
 		distance = sqrt(EARTH_RADIUS2 * pow(zcos, 2)
-				 + 2 * EARTH_RADIUS * altitude
+				 + 2 * EARTH_RADIUSf * altitude
 				 + pow(altitude, 2));
-		distance -= EARTH_RADIUS * zcos;
+		distance -= EARTH_RADIUSf * zcos;
 	}
 	else
 	{

--- a/src/core/modules/Meteor.cpp
+++ b/src/core/modules/Meteor.cpp
@@ -27,8 +27,6 @@
 
 #include <QtMath>
 
-#define EARTH_RADIUSf 6378.f          //! earth_radius in km
-#define EARTH_RADIUS2 40678884.f     //! earth_radius^2 in km
 #define MAX_ALTITUDE 120.f           //! max meteor altitude in km
 #define MIN_ALTITUDE 80.f            //! min meteor altitude in km
 
@@ -320,10 +318,9 @@ float Meteor::meteorZ(float zenithAngle, float altitude)
 	if (zenithAngle > 1.13446401f) // > 65 degrees?
 	{
 		const float zcos = cos(zenithAngle);
-		distance = sqrt(EARTH_RADIUS2 * pow(zcos, 2)
-				 + 2 * EARTH_RADIUSf * altitude
-				 + pow(altitude, 2));
-		distance -= EARTH_RADIUSf * zcos;
+        constexpr auto R = static_cast<float>(EARTH_RADIUS);
+		distance = sqrt(pow(R * zcos, 2) + 2 * R * altitude + pow(altitude, 2));
+		distance -= R * zcos;
 	}
 	else
 	{

--- a/src/core/modules/Meteor.hpp
+++ b/src/core/modules/Meteor.hpp
@@ -29,11 +29,6 @@
 class StelCore;
 class StelPainter;
 
-#define EARTH_RADIUS 6378.f          //! earth_radius in km
-#define EARTH_RADIUS2 40678884.f     //! earth_radius^2 in km
-#define MAX_ALTITUDE 120.f           //! max meteor altitude in km
-#define MIN_ALTITUDE 80.f            //! min meteor altitude in km
-
 //! @class Meteor 
 //! Models a single meteor.
 //! Once created, a meteor object only lasts for some amount of time,

--- a/src/core/modules/Planet.cpp
+++ b/src/core/modules/Planet.cpp
@@ -886,7 +886,7 @@ public:
 
 		double sdistanceAu = ssystem->getSun()->getEquinoxEquatorialPos(core).length();
 		// Moon's distance in Earth's radius
-		double mdistanceER = ssystem->getMoon()->getEquinoxEquatorialPos(core).length() * AU / 6378.1366;
+		double mdistanceER = ssystem->getMoon()->getEquinoxEquatorialPos(core).length() * AU / EARTH_RADIUS;
 		// Greenwich Apparent Sidereal Time
 		double gast = get_apparent_sidereal_time(core->getJD(), core->getJDE());
 
@@ -1595,7 +1595,7 @@ static bool willCastShadow(const Planet* thisPlanet, const Planet* p, const Plan
 	ppVector.normalize();
 	
 	double shadowDistance = ppVector * thisPos;
-	static const double sunRadius = 696000./AU;
+	static const double sunRadius = SUN_RADIUS/AU;
 	const double d = planetPos.length() / (p->getEquatorialRadius()/sunRadius+1);
 	double penumbraRadius = (shadowDistance-d)/d*sunRadius;
 	// TODO: Note that Earth's shadow should be enlarged a bit. (6-7% following Danjon?)

--- a/src/core/modules/SolarSystem.cpp
+++ b/src/core/modules/SolarSystem.cpp
@@ -2021,7 +2021,7 @@ bool SolarSystem::nearLunarEclipse() const
 	Vec3d shadow = en * (e.length() + m.length());
 
 	// find shadow radii in AU
-	double r_penumbra = shadow.length()*702378.1/AU/e.length() - 696000./AU;
+	double r_penumbra = shadow.length()*702378.1/AU/e.length() - SUN_RADIUS/AU;
 
 	// modify shadow location for scaled moon
 	Vec3d mdist = shadow - mh;

--- a/src/gui/AstroCalcDialog.cpp
+++ b/src/gui/AstroCalcDialog.cpp
@@ -2934,7 +2934,7 @@ SolarEclipse BesselianElements() {
 
 	double sdistanceAu = ssystem->getSun()->getEquinoxEquatorialPos(core).length();
 	// Moon's distance in Earth's radius
-	double mdistanceER = ssystem->getMoon()->getEquinoxEquatorialPos(core).length() * AU / 6378.1366;
+	double mdistanceER = ssystem->getMoon()->getEquinoxEquatorialPos(core).length() * AU / EARTH_RADIUS;
 	// Greenwich Apparent Sidereal Time
 	const double gast = get_apparent_sidereal_time(core->getJD(), core->getJDE());
 
@@ -3188,7 +3188,7 @@ cSEparameter centralSolarEclipse(double JD) {
 		const double p2 = x * (xdot - xidot) / n;
 		const double p3 = eta1 * (ydot - etadot) / n;
 		const double p4 = (p2 + p3) * ( p2 + p3);
-		pathwidth = abs(6378.1366*2.*L2/sqrt(p1+p4));
+		pathwidth = abs(EARTH_RADIUS*2.*L2/sqrt(p1+p4));
 	}
 
 	result.diameterRatio = dratio;


### PR DESCRIPTION
### Description
These particular magic numbers are scattered over the code base. I came across them when splitting `Atmosphere` into the two implementations and trying to change the code related to solar eclipse. I'd really dislike to write code in this magic-number style, so I thought I'll fix at least these constants. The alternative would be to create a local constant definition, but this seemed not much better than proceeding with hard-coded values.

While doing this, I found that `Meteor` module uses its own `EARTH_RADIUS` constant, which lacks 4 significant digits that are present elsewhere. Besides, it does all the computations in `float`. I changed it to use the global constant (cast to `float`), so the value used will be a bit different now. I expect that this doesn't matter, since calculations in `float` imply that precision is "don't care" in this module.

I decided not to touch the Sun/Earth radii ratio, whose hard-coded values are also scattered over the code base. The numeric value there would change, and I wasn't sure how sensitive the modules that have this are to such changes.