### PR TITLE
Fix solar longitude in Meteor Showers data

### DIFF
--- a/plugins/MeteorShowers/src/MeteorShower.cpp
+++ b/plugins/MeteorShowers/src/MeteorShower.cpp
@@ -491,6 +491,7 @@ QString MeteorShower::getSolarLongitude(QDate date)
 	// put it in the range 0 to 360 degrees
 	l /= 360.;
 	l = (l - static_cast<int>(l)) * 360. - 1.;
+	l = StelUtils::fmodpos(l, 360.0);
 
 	return QString::number(l, 'f', 2);
 }


### PR DESCRIPTION
### Description
Solar longitudes in Meteor Showers data are now showing negative values. They should be positive.

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)