### PR TITLE
Fix planetocentric rectangular coordinates

### DIFF
--- a/src/core/modules/Planet.cpp
+++ b/src/core/modules/Planet.cpp
@@ -1416,16 +1416,18 @@ QString Planet::getInfoStringExtra(const StelCore *core, const InfoStringGroup& 
 						// distance between center point and current location
 						double distance = loc.distanceKm(lngDeg, latDeg);
 						double azimuth = loc.getAzimuthForLocation(lngDeg, latDeg);
-
 						oss << QString("%1 %2 %3 %4°<br/>").arg(
 								 q_("Shadow center point is"),
 								 QString::number(distance, 'f', 1),
 								 q_("km towards azimuth"),
 								 QString::number(azimuth, 'f', 1));
-						oss << QString("%1: %2 %3<br/>").arg(
-								 q_("Width of umbra/antumbra"),
+						if (dRatio < 1.0)
+							oss << QString(q_("Width of antumbra"));
+						else
+							oss << QString(q_("Width of umbra"));
+						oss << QString(": %1 %2<br/>").arg(
 								 QString::number(pathWidth, 'f', 1),
-								 q_("km"));
+								 qc_("km", "distance"));
 					}
 				}
 				core1->setUseTopocentricCoordinates(useTopocentric);

--- a/src/core/modules/Planet.cpp
+++ b/src/core/modules/Planet.cpp
@@ -1350,7 +1350,6 @@ QString Planet::getInfoStringExtra(const StelCore *core, const InfoStringGroup& 
 			const double eclipseObscuration = 100.*(1.-eclObj.first);
 			if (eclipseObscuration>1.e-7) // needed to avoid false display of 1e-14 or so.
 			{
-				oss << QString("%1: %2%<br />").arg(q_("Eclipse obscuration"), QString::number(eclipseObscuration, 'f', 2));
 				PlanetP obj = eclObj.second;
 				if (onEarth && obj == ssystem->getMoon())
 				{
@@ -1361,6 +1360,7 @@ QString Planet::getInfoStringExtra(const StelCore *core, const InfoStringGroup& 
 							/ angularSize;
 					oss << QString("%1: %2<br />").arg(q_("Eclipse magnitude"), QString::number(eclipseMagnitude, 'f', 3));
 				}
+				oss << QString("%1: %2%<br />").arg(q_("Eclipse obscuration"), QString::number(eclipseObscuration, 'f', 2));
 			}
 
 			if (onEarth)
@@ -1385,6 +1385,28 @@ QString Planet::getInfoStringExtra(const StelCore *core, const InfoStringGroup& 
 
 					if (pathWidth > 0.) // only display when shadow axis is touching Earth
 					{
+						oss << QString("%1: %2 ").arg(
+								 q_("Moon/Sun diameter ratio"), // It seems magnitude of total/annular eclipses sometimes represented by this value
+								 QString::number(dRatio, 'f', 3));
+						if (dRatio < 1.0)
+							oss << QString(qc_("(annular)","type of solar eclipse"));
+						else
+							oss << QString(qc_("(total)","type of solar eclipse"));
+						oss << "<br/>";
+						double centralDuraton = abs(duration);
+						int durationMinute = int(centralDuraton);
+						int durationSecond = round((centralDuraton - durationMinute) * 60.);
+						if (durationSecond>59)
+						{
+							durationMinute += 1;
+							durationSecond = 0;
+						}
+						oss << QString("%1: %2%3 %4%5<br/>").arg(
+								 q_("Central eclipse duration"),
+								 QString::number(durationMinute),
+								 q_("m"),
+								 QString::number(durationSecond),
+								 q_("s"));
 						QString info = q_("Center of solar eclipse (Lat./Long.)");
 						if (withDecimalDegree)
 							oss << QString("%1: %2°/%3°<br />").arg(info).arg(latDeg, 5, 'f', 4).arg(lngDeg, 5, 'f', 4);
@@ -1404,29 +1426,6 @@ QString Planet::getInfoStringExtra(const StelCore *core, const InfoStringGroup& 
 								 q_("Width of umbra/antumbra"),
 								 QString::number(pathWidth, 'f', 1),
 								 q_("km"));
-						oss << QString("%1: %2 ").arg(
-								 q_("Moon/Sun diameter ratio"), // It seems magnitude of total/annular eclipses sometimes represented by this value
-								 QString::number(dRatio, 'f', 3));
-						if (dRatio < 1.0)
-							oss << QString(qc_("(annular)","type of solar eclipse"));
-						else
-							oss << QString(qc_("(total)","type of solar eclipse"));
-						oss << "<br/>";
-
-						double centralDuraton = abs(duration);
-						int durationMinute = int(centralDuraton);
-						int durationSecond = round((centralDuraton - durationMinute) * 60.);
-						if (durationSecond>59)
-						{
-							durationMinute += 1;
-							durationSecond = 0;
-						}
-						oss << QString("%1: %2%3 %4%5<br/>").arg(
-								 q_("Central eclipse duration"),
-								 QString::number(durationMinute),
-								 q_("m"),
-								 QString::number(durationSecond),
-								 q_("s"));
 					}
 				}
 				core1->setUseTopocentricCoordinates(useTopocentric);

--- a/src/core/modules/Planet.cpp
+++ b/src/core/modules/Planet.cpp
@@ -944,7 +944,7 @@ SolarEclipseBessel::SolarEclipseBessel(double &besX, double &besY,
 
 // Solar eclipse data at given time
 SolarEclipseData::SolarEclipseData(double JD, double &dRatio, double &latDeg,
-	double &longDeg, double &altitude, double &pathWidth, double &duration, double &magnitude)
+	double &lngDeg, double &altitude, double &pathWidth, double &duration, double &magnitude)
 {
 	StelCore* core = StelApp::getInstance().getCore();
 	const double currentJD = core->getJD();   // save current JD
@@ -978,9 +978,9 @@ SolarEclipseData::SolarEclipseData(double JD, double &dRatio, double &latDeg,
 		double L2a = L2 - zeta * tf2;
 		const double b = -y * sin(d) + zeta * cos(d);
 		double theta = atan2(x, b) * M_180_PI;
-		longDeg = theta - mu;
-		longDeg = StelUtils::fmodpos(longDeg, 360.);
-		if (longDeg > 180.) longDeg -= 360.;
+		lngDeg = theta - mu;
+		lngDeg = StelUtils::fmodpos(lngDeg, 360.);
+		if (lngDeg > 180.) lngDeg -= 360.;
 		const double sfn1 = eta1 * cd1 + zeta1 * sd1;
 		const double cfn1 = sqrt(1. - sfn1 * sfn1);
 		latDeg = atan(ff * sfn1 / cfn1) / M_PI_180;
@@ -1021,7 +1021,6 @@ SolarEclipseData::SolarEclipseData(double JD, double &dRatio, double &latDeg,
 		// Explanatory Supplement to the Astronomical Almanac
 		// Seidelmann, P. Kenneth, ed. (1992). University Science Books. ISBN 978-0-935702-68-2
 		// https://archive.org/details/131123ExplanatorySupplementAstronomicalAlmanac
-
 		// Path width for central solar eclipses which only part of umbra/antumbra touches Earth
 		// are too wide and could give a false impression, annular eclipse of 2003 May 31, for example.
 		// We have to check this in the next step by calculating northern/southern limit of umbra/antumbra.
@@ -1062,9 +1061,9 @@ SolarEclipseData::SolarEclipseData(double JD, double &dRatio, double &latDeg,
 		magnitude = (L1 - sqrt(u * u + v * v)) / (L1 + L2);
 		dRatio = 1.+ (magnitude - 1.)* 2.;
 		theta = theta / M_PI_180;
-		longDeg = theta - mu;
-		longDeg = StelUtils::fmodpos(longDeg, 360.);
-		if (longDeg > 180.) longDeg -= 360.;
+		lngDeg = theta - mu;
+		lngDeg = StelUtils::fmodpos(lngDeg, 360.);
+		if (lngDeg > 180.) lngDeg -= 360.;
 		latDeg = lat / M_PI_180;
 		duration = 0.;
 		pathWidth = 0.;
@@ -1381,20 +1380,20 @@ QString Planet::getInfoStringExtra(const StelCore *core, const InfoStringGroup& 
 				if (raDiff < 3. || raDiff > 357.)
 				{
 					double JD = core1->getJD();
-					double dRatio,latDeg,longDeg,altitude,pathWidth,duration,magnitude;
-					SolarEclipseData(JD,dRatio,latDeg,longDeg,altitude,pathWidth,duration,magnitude);
+					double dRatio,latDeg,lngDeg,altitude,pathWidth,duration,magnitude;
+					SolarEclipseData(JD,dRatio,latDeg,lngDeg,altitude,pathWidth,duration,magnitude);
 
 					if (pathWidth > 0.) // only display when shadow axis is touching Earth
 					{
 						QString info = q_("Center of solar eclipse (Lat./Long.)");
 						if (withDecimalDegree)
-							oss << QString("%1: %2°/%3°<br />").arg(info).arg(latDeg, 5, 'f', 4).arg(longDeg, 5, 'f', 4);
+							oss << QString("%1: %2°/%3°<br />").arg(info).arg(latDeg, 5, 'f', 4).arg(lngDeg, 5, 'f', 4);
 						else
-							oss << QString("%1: %2/%3<br />").arg(info, StelUtils::decDegToDmsStr(latDeg), StelUtils::decDegToDmsStr(longDeg));
+							oss << QString("%1: %2/%3<br />").arg(info, StelUtils::decDegToDmsStr(latDeg), StelUtils::decDegToDmsStr(lngDeg));
 						StelLocation loc = core->getCurrentLocation();
 						// distance between center point and current location
-						double distance = loc.distanceKm(longDeg, latDeg);
-						double azimuth = loc.getAzimuthForLocation(longDeg, latDeg);
+						double distance = loc.distanceKm(lngDeg, latDeg);
+						double azimuth = loc.getAzimuthForLocation(lngDeg, latDeg);
 
 						oss << QString("%1 %2 %3 %4°<br/>").arg(
 								 q_("Shadow center point is"),
@@ -1406,7 +1405,7 @@ QString Planet::getInfoStringExtra(const StelCore *core, const InfoStringGroup& 
 								 QString::number(pathWidth, 'f', 1),
 								 q_("km"));
 						oss << QString("%1: %2 ").arg(
-								 q_("Moon/Sun diameter ratio"),
+								 q_("Moon/Sun diameter ratio"), // It seems magnitude of total/annular eclipses sometimes represented by this value
 								 QString::number(dRatio, 'f', 3));
 						if (dRatio < 1.0)
 							oss << QString(qc_("(annular)","type of solar eclipse"));

--- a/src/core/modules/Planet.cpp
+++ b/src/core/modules/Planet.cpp
@@ -871,103 +871,208 @@ QString Planet::getInfoStringPeriods(const StelCore *core, const InfoStringGroup
 	return str;
 }
 
-class SolarEclipse
+SolarEclipseBessel::SolarEclipseBessel(double &besX, double &besY,
+	double &besD, double &bestf1, double &bestf2, double &besL1, double &besL2, double &besMu)
 {
-private:
-	static constexpr double SunEarth = 109.12278; // ratio of Sun-Earth radius 696000/6378.1366
+	// Besselian elements
+	// Source: Explanatory Supplement to the Astronomical Ephemeris 
+	// and the American Ephemeris and Nautical Almanac (1961)
 
-public:
-	static Vec3d point(const StelCore* core)
+	StelCore* core = StelApp::getInstance().getCore();
+	static SolarSystem* ssystem = GETSTELMODULE(SolarSystem);
+	core->setUseTopocentricCoordinates(false);
+	core->update(0);
+
+	double raMoon, deMoon, raSun, deSun;
+	StelUtils::rectToSphe(&raSun, &deSun, ssystem->getSun()->getEquinoxEquatorialPos(core));
+	StelUtils::rectToSphe(&raMoon, &deMoon, ssystem->getMoon()->getEquinoxEquatorialPos(core));
+
+	double sdistanceAu = ssystem->getSun()->getEquinoxEquatorialPos(core).length();
+	const double earthRadius = ssystem->getEarth()->getEquatorialRadius()*AU;
+	// Moon's distance in Earth's radius
+	double mdistanceER = ssystem->getMoon()->getEquinoxEquatorialPos(core).length() * AU / earthRadius;
+	// Greenwich Apparent Sidereal Time
+	const double gast = get_apparent_sidereal_time(core->getJD(), core->getJDE());
+
+	// Avoid bug for special cases happen around Vernal Equinox
+	double raDiff = StelUtils::fmodpos(raMoon-raSun, 2.*M_PI);
+	if (raDiff>M_PI) raDiff-=2.*M_PI;
+
+	constexpr double SunEarth = 109.12278;
+	// ratio of Sun-Earth radius : 109.12278 = 696000/6378.1366
+	// Another value is 109.075744787 = 695700/6378.1366
+	// Earth's equatorial radius = 6378.1366
+	// Source: IERS Conventions (2003)
+	// https://www.iers.org/IERS/EN/Publications/TechnicalNotes/tn32.html
+
+	// NASA's solar eclipse predictions use larger Sun with radius 696,000 km
+	// calculated from arctan of IAU 1976 solar radius (959.63 arcsec at 1 au)
+	// This value affects duration of total/annular eclipse ~ 2-3 seconds
+	// Stellarium's solar radius is 695,700 km, this may create discrepancies between prediction & visualization
+
+	const double rss = sdistanceAu * 23454.7925; // from 1 AU/Earth's radius : 149597870.8/6378.1366
+	const double b = mdistanceER / rss;
+	const double a = raSun - ((b * cos(deMoon) * raDiff) / ((1 - b) * cos(deSun)));
+	besD = deSun - (b * (deMoon - deSun) / (1 - b));
+	besX = cos(deMoon) * sin((raMoon - a));
+	besX *= mdistanceER;
+	besY = cos(besD) * sin(deMoon);
+	besY -= cos(deMoon) * sin(besD) * cos((raMoon - a));
+	besY *= mdistanceER;
+	double z = sin(deMoon) * sin(besD);
+	z += cos(deMoon) * cos(besD) * cos((raMoon - a));
+	z *= mdistanceER;
+	const double k = 0.2725076;
+	const double s = 0.272281;
+	// Ratio of Moon/Earth's radius 0.2725076 is recommended by IAU for both k & s
+	// s = 0.272281 is used by Fred Espenak/NASA for total eclipse to eliminate extreme cases
+	// when the Moon's apparent diameter is very close to the Sun but cannot completely cover it. 
+	// we will use two values (same with NASA), because durations seem to agree with NASA.
+	// Source: Solar Eclipse Predictions and the Mean Lunar Radius
+	// http://eclipsewise.com/solar/SEhelp/SEradius.html
+
+	// Parameters of the shadow cone
+	const double f1 = asin((SunEarth + k) / (rss * (1. - b)));
+	bestf1 = tan(f1);
+	const double f2 = asin((SunEarth - s) / (rss * (1. - b)));  
+	bestf2 = tan(f2);
+	besL1 = z * bestf1 + (k / cos(f1));
+	besL2 = z * bestf2 - (s / cos(f2));
+	besMu = gast - a * M_180_PI;
+	besMu = StelUtils::fmodpos(besMu, 360.);
+};
+
+// Solar eclipse data at given time
+SolarEclipseData::SolarEclipseData(double JD, double &dRatio, double &latDeg,
+	double &longDeg, double &altitude, double &pathWidth, double &duration, double &magnitude)
+{
+	StelCore* core = StelApp::getInstance().getCore();
+	const double currentJD = core->getJD();   // save current JD
+	const bool saveTopocentric = core->getUseTopocentricCoordinates();
+
+	core->setUseTopocentricCoordinates(false);
+	core->setJD(JD);
+	core->update(0);
+
+	double x,y,d,tf1,tf2,L1,L2,mu;
+	SolarEclipseBessel(x,y,d,tf1,tf2,L1,L2,mu);
+
+	static SolarSystem* ssystem = GETSTELMODULE(SolarSystem);
+	static const double f = 1.0 - ssystem->getEarth()->getOneMinusOblateness(); // flattening
+	const double earthRadius = ssystem->getEarth()->getEquatorialRadius()*AU;
+	static const double e2 = f*(2.-f);
+	static const double ff = 1./(1.-f);
+	const double rho1 = sqrt(1. - e2 * cos(d) *cos(d));
+	const double eta1 = y / rho1;
+	const double sd1 = sin(d) / rho1;
+	const double cd1 = sqrt(1. - e2) * cos(d) / rho1;
+	const double rho2 = sqrt(1.- e2 * sin(d) * sin(d));
+	const double sd1d2 = e2*sin(d)*cos(d)/(rho1*rho2);
+	const double cd1d2 = sqrt(1. - sd1d2 * sd1d2); 
+	const double p = 1. - x * x - eta1 * eta1;
+
+	if (p > 0.) // Central eclipse : Moon's shadow axis is touching Earth
 	{
-		static SolarSystem* ssystem = GETSTELMODULE(SolarSystem);
-		double raSun, deSun, raMoon, deMoon;
-		StelUtils::rectToSphe(&raSun, &deSun, ssystem->getSun()->getEquinoxEquatorialPos(core));
-		StelUtils::rectToSphe(&raMoon, &deMoon, ssystem->getMoon()->getEquinoxEquatorialPos(core));
+		const double zeta1 = sqrt(p);
+		const double zeta = rho2 * (zeta1 * cd1d2 - eta1 * sd1d2);
+		double L2a = L2 - zeta * tf2;
+		const double b = -y * sin(d) + zeta * cos(d);
+		double theta = atan2(x, b) * M_180_PI;
+		longDeg = theta - mu;
+		longDeg = StelUtils::fmodpos(longDeg, 360.);
+		if (longDeg > 180.) longDeg -= 360.;
+		const double sfn1 = eta1 * cd1 + zeta1 * sd1;
+		const double cfn1 = sqrt(1. - sfn1 * sfn1);
+		latDeg = atan(ff * sfn1 / cfn1) / M_PI_180;
+		double L1a = L1 - zeta * tf1;
+		magnitude = L1a / (L1a + L2a);
+		dRatio = 1.+(magnitude-1.)*2.;
 
-		double sdistanceAu = ssystem->getSun()->getEquinoxEquatorialPos(core).length();
-		// Moon's distance in Earth's radius
-		double mdistanceER = ssystem->getMoon()->getEquinoxEquatorialPos(core).length() * AU / EARTH_RADIUS;
-		// Greenwich Apparent Sidereal Time
-		double gast = get_apparent_sidereal_time(core->getJD(), core->getJDE());
+		core->setJD(JD - 5./1440.);
+		core->update(0);
 
-		// Avoid bug for special cases happen around Vernal Equinox
-		if (raSun>M_PI && raMoon<M_PI) raMoon+=2.*M_PI;
-		else if (raSun<M_PI && raMoon>M_PI) raSun+=2.*M_PI;
+		double x1,y1,d1,mu1;
+		SolarEclipseBessel(x1,y1,d1,tf1,tf2,L1,L2,mu1);
 
-		// Besselian elements
-		// based on Explanatory supplement to the astronomical ephemeris
-		// and the American ephemeris and nautical almanac (1961)
-		const double rss = sdistanceAu * 23454.7925; // from 1 AU/Earth's radius : 149597870.8/6378.1366
-		const double b = mdistanceER / rss;
-		const double a = raSun - ((b * cos(deMoon) * (raMoon - raSun)) / ((1 - b) * cos(deSun)));
-		const double d = deSun - (b * (deMoon - deSun) / (1 - b));
-		double x = cos(deMoon) * sin((raMoon - a));
-		x *= mdistanceER;
-		double y = cos(d) * sin(deMoon);
-		y -= cos(deMoon) * sin(d) * cos((raMoon - a));
-		y *= mdistanceER;
-		double z = sin(deMoon) * sin(d);
-		z += cos(deMoon) * cos(d) * cos((raMoon - a));
-		z *= mdistanceER;
-		// parameters of the shadow cone
-		const double f1 = asin((SunEarth + 0.2725076) / (rss * (1 - b)));
-		const double tf1 = tan(f1);
-		const double f2 = asin((SunEarth - 0.272281) / (rss * (1 - b)));
-		const double tf2 = tan(f2);
-		double L1 = z * tf1 + (0.2725076 / cos(f1));
-		double L2 = z * tf2 - (0.272281 / cos(f2));
-		double mu = gast - a / M_PI_180;
-		static const double f = 1. - ssystem->getEarth()->getOneMinusOblateness(); // flattening
-		static const double e2 = f*(2.-f);
-		// e^2 = 0.00669438 : Earth flattening parameter
-		// Inverse flattening 1/f = 298.257223563 : e^2 = 2f-f^2
-		// Source: 1984 World Geodetic System (WGS 84)
-		// https://web.archive.org/web/20200710203711/http://www.epsg-registry.org/export.htm?gml=urn:ogc:def:ellipsoid:EPSG::7030
-		// There is a modern value from IERS Conventions (2003)
-		// 1/f = 298.25642 But seem to be not widely used
-		// https://www.iers.org/IERS/EN/Publications/TechnicalNotes/tn32.html
-		// We use older value to be comparable with literatures and consistenc across Stellarium
-		static const double ff = 1./(1.-f);
+		core->setJD(JD + 5./1440.);
+		core->update(0);
 
-		// Find Lat./Long. of center line on Earth's surface
-		double cd = cos(d);
-		double rho1 = sqrt(1. - e2 * cd * cd);
-		double y1 = y / rho1;
-		double xi = x;
-		double eta1 = y1;
-		double sd = sin(d);
-		double sd1 = sd / rho1;
-		double cd1 = sqrt(1. - e2) * cd / rho1;
-		double rho2 = sqrt(1. - e2 * sd * sd);
-		double sd1d2 = e2 * sd * cd / (rho1 * rho2);
-		double cd1d2 = sqrt(1. - sd1d2 * sd1d2);
-		double lon = 0, mag = 0;
-		double lat = 99; // initialize an impossible latitude to indicate no central eclipse
+		double x2,y2,d2,mu2;
+		SolarEclipseBessel(x2,y2,d2,tf1,tf2,L1,L2,mu2);
 
-		if ((1. - x * x - y1 * y1) > 0)
-		{
-			const double zeta1 = sqrt(1 - x * x - y1 * y1);
-			const double zeta = rho2 * (zeta1 * cd1d2 - eta1 * sd1d2);
-			L2 = L2 - zeta * tf2;
-			double b = -y * sd + zeta * cd;
-			double theta = atan2(xi, b) / M_PI_180;
-			if (theta < 0.) theta += 360.;
-			if (mu > 360.) mu -= 360.;
-			lon = mu - theta;
-			if (lon < -180.) lon += 360.;
-			if (lon > 180.) lon -= 360.;
-			lon = -(lon); // + East, - West
-			double sfn1 = eta1 * cd1 + zeta1 * sd1;
-			double cfn1 = sqrt(1. - sfn1 * sfn1);
-			lat = ff * sfn1 / cfn1;
-			lat = atan(lat) / M_PI_180;
-			L1 = L1 - zeta * tf1;
-			// Magnitude of eclipse
-			// mag < 1 = annular
-			mag = L1 / (L1 + L2);
-		}
-		return Vec3d(lat, lon, mag);
+		// Hourly rate
+		const double xdot = (x2 - x1) * 6.;
+		const double ydot = (y2 - y1) * 6.;
+		const double ddot = (d2 - d1) * 6.;
+		double mudot = (mu2 - mu1);
+		if (mudot<0.) mudot += 360.; // make sure it is positive in case mu2 < mu1
+		mudot = mudot * 6.* M_PI_180;
+
+		// Duration of central eclipse in minutes
+		const double etadot = mudot * x * sin(d) - ddot * zeta;
+		const double xidot = mudot * (-y * sin(d) + zeta * cos(d));
+		const double n = sqrt((xdot - xidot) * (xdot - xidot) + (ydot - etadot) * (ydot - etadot));
+		duration = L2a*120./n; // positive = annular eclipse, negative = total eclipse
+
+		// Approximate altitude
+		altitude = asin(cfn1*cos(d)*cos(theta * M_PI_180)+sfn1*sin(d)) / M_PI_180;
+
+		// Path width in kilometers
+		// Explanatory Supplement to the Astronomical Almanac
+		// Seidelmann, P. Kenneth, ed. (1992). University Science Books. ISBN 978-0-935702-68-2
+		// https://archive.org/details/131123ExplanatorySupplementAstronomicalAlmanac
+
+		// Path width for central solar eclipses which only part of umbra/antumbra touches Earth
+		// are too wide and could give a false impression, annular eclipse of 2003 May 31, for example.
+		// We have to check this in the next step by calculating northern/southern limit of umbra/antumbra.
+		// Don't show the path width if there is no northern limit or southern limit.
+		// We will eventually have to calculate both limits, if we want to draw eclipse path on world map.
+		const double p1 = zeta * zeta;
+		const double p2 = x * (xdot - xidot) / n;
+		const double p3 = eta1 * (ydot - etadot) / n;
+		const double p4 = (p2 + p3) * (p2 + p3);
+		pathWidth = abs(earthRadius*2.*L2a/sqrt(p1+p4));
+		
 	}
+	else  // Partial eclipse or non-central eclipse
+	{
+		const double yy1 = y / rho1;
+		double xi = x / sqrt(x * x + yy1 * yy1);
+		const double eta1 = yy1 / sqrt(x * x + yy1 * yy1);
+		const double sd1 = sin(d) / rho1;
+		const double cd1 = sqrt(1.- e2) * cos(d) / rho1;
+		const double rho2 = sqrt(1.- e2 * sin(d) * sin(d));
+		const double sd1d2 = e2 * sin(d) * cos(d) / (rho1 * rho2);
+		double zeta = rho2 * (-(eta1) * sd1d2);
+		const double b = -eta1 * sd1;
+		double theta = atan2(xi, b);
+		const double sfn1 = eta1*cd1;
+		const double cfn1 = sqrt(1.- sfn1 * sfn1);
+		double lat = ff * sfn1 / cfn1;
+		lat = atan(lat);
+		L1 = L1 - zeta * tf1;
+		L2 = L2 - zeta * tf2;
+		const double c = 1. / sqrt(1.- e2 * sin(lat) * sin(lat));
+		const double s = (1.- e2) * c;
+		const double rs = s * sin(lat);
+		const double rc = c * cos(lat);
+		xi = rc * sin(theta);
+		const double eta = rs * cos(d) - rc * sin(d) * cos(theta);
+		const double u = x - xi;
+		const double v = y - eta;
+		magnitude = (L1 - sqrt(u * u + v * v)) / (L1 + L2);
+		dRatio = 1.+ (magnitude - 1.)* 2.;
+		theta = theta / M_PI_180;
+		longDeg = theta - mu;
+		longDeg = StelUtils::fmodpos(longDeg, 360.);
+		if (longDeg > 180.) longDeg -= 360.;
+		latDeg = lat / M_PI_180;
+		duration = 0.;
+		pathWidth = 0.;
+	}
+	core->setJD(currentJD);
+	core->setUseTopocentricCoordinates(saveTopocentric);
+	core->update(0);
 };
 
 QString Planet::getInfoStringExtra(const StelCore *core, const InfoStringGroup& flags) const
@@ -1276,34 +1381,54 @@ QString Planet::getInfoStringExtra(const StelCore *core, const InfoStringGroup& 
 				double raDiff = StelUtils::fmodpos((raMoon - raSun)/M_PI_180, 360.0);
 				if (raDiff < 3. || raDiff > 357.)
 				{
-					SolarEclipse solarEclipse;
-					Vec3d pos = solarEclipse.point(core1);
+					double JD = core1->getJD();
+					double dRatio,latDeg,longDeg,altitude,pathWidth,duration,magnitude;
+					SolarEclipseData(JD,dRatio,latDeg,longDeg,altitude,pathWidth,duration,magnitude);
 
-					if (pos[0] < 90.) // only display when shadow axis is touching Earth
+					if (pathWidth > 0.) // only display when shadow axis is touching Earth
 					{
 						QString info = q_("Center of solar eclipse (Lat./Long.)");
 						if (withDecimalDegree)
-							oss << QString("%1: %2°/%3°<br />").arg(info).arg(pos[0], 5, 'f', 4).arg(pos[1], 5, 'f', 4);
+							oss << QString("%1: %2°/%3°<br />").arg(info).arg(latDeg, 5, 'f', 4).arg(longDeg, 5, 'f', 4);
 						else
-							oss << QString("%1: %2/%3<br />").arg(info, StelUtils::decDegToDmsStr(pos[0]), StelUtils::decDegToDmsStr(pos[1]));
+							oss << QString("%1: %2/%3<br />").arg(info, StelUtils::decDegToDmsStr(latDeg), StelUtils::decDegToDmsStr(longDeg));
 						StelLocation loc = core->getCurrentLocation();
 						// distance between center point and current location
-						double distance = loc.distanceKm(pos[1], pos[0]);
-						double azimuth = loc.getAzimuthForLocation(pos[1], pos[0]);
+						double distance = loc.distanceKm(longDeg, latDeg);
+						double azimuth = loc.getAzimuthForLocation(longDeg, latDeg);
 
 						oss << QString("%1 %2 %3 %4°<br/>").arg(
 								 q_("Shadow center point is"),
 								 QString::number(distance, 'f', 1),
 								 q_("km towards azimuth"),
 								 QString::number(azimuth, 'f', 1));
+						oss << QString("%1: %2 %3<br/>").arg(
+								 q_("Width of umbra/antumbra"),
+								 QString::number(pathWidth, 'f', 1),
+								 q_("km"));
 						oss << QString("%1: %2 ").arg(
-								 q_("Magnitude of central eclipse"),
-								 QString::number(pos[2], 'f', 3));
-						if (pos[2] < 1.0)
+								 q_("Moon/Sun diameter ratio"),
+								 QString::number(dRatio, 'f', 3));
+						if (dRatio < 1.0)
 							oss << QString(qc_("(annular)","type of solar eclipse"));
 						else
 							oss << QString(qc_("(total)","type of solar eclipse"));
 						oss << "<br/>";
+
+						double centralDuraton = abs(duration);
+						int durationMinute = int(centralDuraton);
+						int durationSecond = round((centralDuraton - durationMinute) * 60.);
+						if (durationSecond>59)
+						{
+							durationMinute += 1;
+							durationSecond = 0;
+						}
+						oss << QString("%1: %2%3 %4%5<br/>").arg(
+								 q_("Central eclipse duration"),
+								 QString::number(durationMinute),
+								 q_("m"),
+								 QString::number(durationSecond),
+								 q_("s"));
 					}
 				}
 				core1->setUseTopocentricCoordinates(useTopocentric);

--- a/src/core/modules/Planet.cpp
+++ b/src/core/modules/Planet.cpp
@@ -948,7 +948,6 @@ public:
 		{
 			const double zeta1 = sqrt(1 - x * x - y1 * y1);
 			const double zeta = rho2 * (zeta1 * cd1d2 - eta1 * sd1d2);
-			//const double sd2 = sd * 1.0033641 / rho2;
 			L2 = L2 - zeta * tf2;
 			double b = -y * sd + zeta * cd;
 			double theta = atan2(xi, b) / M_PI_180;
@@ -961,7 +960,6 @@ public:
 			double sfn1 = eta1 * cd1 + zeta1 * sd1;
 			double cfn1 = sqrt(1. - sfn1 * sfn1);
 			lat = ff * sfn1 / cfn1;
-			// 1.0033640898 = 1/(1-1/f) See flattening parameter above
 			lat = atan(lat) / M_PI_180;
 			L1 = L1 - zeta * tf1;
 			// Magnitude of eclipse

--- a/src/core/modules/Planet.cpp
+++ b/src/core/modules/Planet.cpp
@@ -916,8 +916,8 @@ public:
 		double L1 = z * tf1 + (0.2725076 / cos(f1));
 		double L2 = z * tf2 - (0.272281 / cos(f2));
 		double mu = gast - a / M_PI_180;
-		const double f = 1. - ssystem->getEarth()->getOneMinusOblateness(); // flattening
-		const double e2 = 2.*f-(f*f);
+		static const double f = 1. - ssystem->getEarth()->getOneMinusOblateness(); // flattening
+		static const double e2 = f*(2.-f);
 		// e^2 = 0.00669438 : Earth flattening parameter
 		// Inverse flattening 1/f = 298.257223563 : e^2 = 2f-f^2
 		// Source: 1984 World Geodetic System (WGS 84)
@@ -926,7 +926,7 @@ public:
 		// 1/f = 298.25642 But seem to be not widely used
 		// https://www.iers.org/IERS/EN/Publications/TechnicalNotes/tn32.html
 		// We use older value to be comparable with literatures and consistenc across Stellarium
-		const double ff = 1./(1.-f);
+		static const double ff = 1./(1.-f);
 
 		// Find Lat./Long. of center line on Earth's surface
 		double cd = cos(d);

--- a/src/core/modules/Planet.cpp
+++ b/src/core/modules/Planet.cpp
@@ -890,8 +890,9 @@ public:
 		// Greenwich Apparent Sidereal Time
 		double gast = get_apparent_sidereal_time(core->getJD(), core->getJDE());
 
-		if (raSun < 0.) raSun += M_PI * 2.;
-		if (raMoon < 0.) raMoon += M_PI * 2.;
+		// Avoid bug for special cases happen around Vernal Equinox
+		if (raSun>M_PI && raMoon<M_PI) raMoon+=2.*M_PI;
+		else if (raSun<M_PI && raMoon>M_PI) raSun+=2.*M_PI;
 
 		// Besselian elements
 		// based on Explanatory supplement to the astronomical ephemeris
@@ -1750,7 +1751,7 @@ Vec4d Planet::getRectangularCoordinates(const double longDeg, const double latDe
 	// For unclear reasons latDeg can be nan. Safety measure:
 	const double latRad = std::isnan(latDeg) ? 0. : latDeg*M_PI_180;
 	Q_ASSERT_X(!std::isnan(latRad), "Planet.cpp", QString("NaN result for latRad. Object %1 latitude %2").arg(englishName).arg(QString::number(latDeg, 'f', 5)).toLatin1());
-	const double u = (abs(abs(latRad) - M_PI_2) < 1e-10 ? latRad : atan( bByA * tan(latRad)) );
+	const double u = (M_PI_2 - (abs(latRad)) < 1e-10 ? latRad : atan( bByA * tan(latRad)) );
 	//qDebug() << "getTopographicOffsetFromCenter: a=" << a*AU << "b/a=" << bByA << "b=" << bByA*a *AU  << "latRad=" << latRad << "u=" << u;
 	// There seem to be numerical issues around tan/atan. Relieve the test a bit.
 	Q_ASSERT_X( fabs(u)-fabs(latRad) <= 1e-10, "Planet.cpp", QString("u: %1 latRad: %2 bByA: %3 latRad-u: %4 (%5)")

--- a/src/core/modules/Planet.cpp
+++ b/src/core/modules/Planet.cpp
@@ -916,7 +916,8 @@ public:
 		double L1 = z * tf1 + (0.2725076 / cos(f1));
 		double L2 = z * tf2 - (0.272281 / cos(f2));
 		double mu = gast - a / M_PI_180;
-		constexpr double e2 = 0.00669438;
+		const double f = 1. - ssystem->getEarth()->getOneMinusOblateness(); // flattening
+		const double e2 = 2.*f-(f*f);
 		// e^2 = 0.00669438 : Earth flattening parameter
 		// Inverse flattening 1/f = 298.257223563 : e^2 = 2f-f^2
 		// Source: 1984 World Geodetic System (WGS 84)
@@ -924,7 +925,8 @@ public:
 		// There is a modern value from IERS Conventions (2003)
 		// 1/f = 298.25642 But seem to be not widely used
 		// https://www.iers.org/IERS/EN/Publications/TechnicalNotes/tn32.html
-		// We use older value to be comparable with literatures and consistence across Stellarium
+		// We use older value to be comparable with literatures and consistenc across Stellarium
+		const double ff = 1./(1.-f);
 
 		// Find Lat./Long. of center line on Earth's surface
 		double cd = cos(d);
@@ -957,7 +959,7 @@ public:
 			lon = -(lon); // + East, - West
 			double sfn1 = eta1 * cd1 + zeta1 * sd1;
 			double cfn1 = sqrt(1. - sfn1 * sfn1);
-			lat = 1.0033640898 * sfn1 / cfn1;
+			lat = ff * sfn1 / cfn1;
 			// 1.0033640898 = 1/(1-1/f) See flattening parameter above
 			lat = atan(lat) / M_PI_180;
 			L1 = L1 - zeta * tf1;
@@ -1748,7 +1750,7 @@ Vec4d Planet::getRectangularCoordinates(const double longDeg, const double latDe
 	// For unclear reasons latDeg can be nan. Safety measure:
 	const double latRad = std::isnan(latDeg) ? 0. : latDeg*M_PI_180;
 	Q_ASSERT_X(!std::isnan(latRad), "Planet.cpp", QString("NaN result for latRad. Object %1 latitude %2").arg(englishName).arg(QString::number(latDeg, 'f', 5)).toLatin1());
-	const double u = (abs(latRad) - M_PI_2 < 1e-10 ? latRad : atan( bByA * tan(latRad)) );
+	const double u = (abs(abs(latRad) - M_PI_2) < 1e-10 ? latRad : atan( bByA * tan(latRad)) );
 	//qDebug() << "getTopographicOffsetFromCenter: a=" << a*AU << "b/a=" << bByA << "b=" << bByA*a *AU  << "latRad=" << latRad << "u=" << u;
 	// There seem to be numerical issues around tan/atan. Relieve the test a bit.
 	Q_ASSERT_X( fabs(u)-fabs(latRad) <= 1e-10, "Planet.cpp", QString("u: %1 latRad: %2 bByA: %3 latRad-u: %4 (%5)")

--- a/src/core/modules/Planet.cpp
+++ b/src/core/modules/Planet.cpp
@@ -1032,7 +1032,6 @@ SolarEclipseData::SolarEclipseData(double JD, double &dRatio, double &latDeg,
 		const double p3 = eta1 * (ydot - etadot) / n;
 		const double p4 = (p2 + p3) * (p2 + p3);
 		pathWidth = abs(earthRadius*2.*L2a/sqrt(p1+p4));
-		
 	}
 	else  // Partial eclipse or non-central eclipse
 	{

--- a/src/core/modules/Planet.hpp
+++ b/src/core/modules/Planet.hpp
@@ -74,6 +74,21 @@ public:
 	StelTextureSP tex;
 };
 
+// Class to calculate Besselian elements of solar eclipse
+class SolarEclipseBessel
+{
+public:
+	SolarEclipseBessel(double &besX, double &besY,
+		double &besDec, double &besTf1, double &besTf2, double &besL1, double &besL2, double &besMu);
+};
+
+// Class to calculate solar eclipse data at given time
+class SolarEclipseData
+{
+public:
+	SolarEclipseData(double JD, double &dRatio, double &latDeg, double &lngDeg, double &altitude,
+		double &pathWidth, double &duration, double &magnitude);
+};
 
 class Planet : public StelObject
 {

--- a/src/gui/AstroCalcDialog.cpp
+++ b/src/gui/AstroCalcDialog.cpp
@@ -2904,310 +2904,8 @@ void AstroCalcDialog::initListSolarEclipse()
 	ui->solareclipseTreeWidget->header()->setDefaultAlignment(Qt::AlignCenter);
 }
 
-struct SolarEclipse {
-	double x;
-	double y;
-	double d;
-	double tf1;
-	double tf2;
-	double L1;
-	double L2;
-	double mu;
-};
-
-SolarEclipse BesselianElements() {
-	SolarEclipse result;
-
-	// Besselian elements
-	// Source: Explanatory Supplement to the Astronomical Ephemeris 
-	// and the American Ephemeris and Nautical Almanac (1961)
-
-	StelCore* core = StelApp::getInstance().getCore();
-	static SolarSystem* ssystem = GETSTELMODULE(SolarSystem);
-
-	core->setUseTopocentricCoordinates(false);
-	core->update(0);
-
-	double raMoon, deMoon, raSun, deSun;
-	StelUtils::rectToSphe(&raSun, &deSun, ssystem->getSun()->getEquinoxEquatorialPos(core));
-	StelUtils::rectToSphe(&raMoon, &deMoon, ssystem->getMoon()->getEquinoxEquatorialPos(core));
-
-	double sdistanceAu = ssystem->getSun()->getEquinoxEquatorialPos(core).length();
-	// Moon's distance in Earth's radius
-	double mdistanceER = ssystem->getMoon()->getEquinoxEquatorialPos(core).length() * AU / EARTH_RADIUS;
-	// Greenwich Apparent Sidereal Time
-	const double gast = get_apparent_sidereal_time(core->getJD(), core->getJDE());
-
-	// Avoid bug for special cases happen around Vernal Equinox
-	if (raSun>M_PI && raMoon<M_PI) raMoon+=2.*M_PI;
-	else if (raSun<M_PI && raMoon>M_PI) raSun+=2.*M_PI;
-
-	constexpr double SunEarth = 109.12278;
-	// ratio of Sun-Earth radius : 109.12278 = 696000/6378.1366
-	// Another value is 109.075744787 = 695700/6378.1366
-	// Earth's equatorial radius = 6378.1366
-	// Source: IERS Conventions (2003)
-	// https://www.iers.org/IERS/EN/Publications/TechnicalNotes/tn32.html
-
-	// NASA's solar eclipse predictions use larger Sun with radius 696,000 km
-	// calculated from arctan of IAU 1976 solar radius (959.63 arcsec at 1 au)
-	// This value affects duration of total/annular eclipse ~ 2-3 seconds
-	// Stellarium's solar radius is 695,700 km, this may create discrepancies between prediction & visualization
-
-	const double rss = sdistanceAu * 23454.7925; // from 1 AU/Earth's radius : 149597870.8/6378.1366
-	const double b = mdistanceER / rss;
-	const double a = raSun - ((b * cos(deMoon) * (raMoon-raSun)) / ((1 - b) * cos(deSun)));
-	const double d = deSun - (b * (deMoon - deSun) / (1 - b));
-	double x = cos(deMoon) * sin((raMoon - a));
-	x *= mdistanceER;
-	double y = cos(d) * sin(deMoon);
-	y -= cos(deMoon) * sin(d) * cos((raMoon - a));
-	y *= mdistanceER;
-	double z = sin(deMoon) * sin(d);
-	z += cos(deMoon) * cos(d) * cos((raMoon - a));
-	z *= mdistanceER;
-	// parameters of the shadow cone
-	// 0.2725076 is recommended by IAU, NASA uses 0.272281 for total eclipse to eliminate extreme cases
-	// when the Moon's apparent diameter is very close to the Sun but cannot completely cover it. 
-	// we will use two values (same with NASA), because durations seem to agree with NASA.
-	// Source: Solar Eclipse Predictions and the Mean Lunar Radius
-	// http://eclipsewise.com/solar/SEhelp/SEradius.html
-	const double f1 = asin((SunEarth + 0.2725076) / (rss * (1. - b)));
-	const double tf1 = tan(f1);
-	const double f2 = asin((SunEarth - 0.272281) / (rss * (1. - b)));  
-	const double tf2 = tan(f2);
-	const double L1 = z * tf1 + (0.2725076 / cos(f1));
-	const double L2 = z * tf2 - (0.272281 / cos(f2));
-	double mu = gast - StelUtils::fmodpos(a / M_PI_180, 360.);
-	mu = StelUtils::fmodpos(mu, 360.);
-
-	result.x = x;
-	result.y = y;
-	result.d = d;
-	result.tf1 = tf1;
-	result.tf2 = tf2;
-	result.L1 = L1;
-	result.L2 = L2;
-	result.mu = mu;
-
-	return result;
-}
-
-// Partial solar eclipse parameters
-struct pSEparameter {
-	double magnitude;
-	double diameterRatio;
-	double longitude;
-	double latitude;
-};
-
-pSEparameter partialSolarEclipse() {
-	pSEparameter result;
-
-	// Besselian elements
-	// Source: Explanatory Supplement to the Astronomical Ephemeris 
-	// and the American Ephemeris and Nautical Almanac (1961)
-
-	SolarEclipse bessel = BesselianElements();
-
-	const double x = bessel.x;
-	const double y = bessel.y;
-	const double d = bessel.d;
-	const double tf1 = bessel.tf1;
-	const double tf2 = bessel.tf2;
-	double L1 = bessel.L1;
-	double L2 = bessel.L2;
-	const double mu = bessel.mu;
-
-	static SolarSystem* ssystem = GETSTELMODULE(SolarSystem);
-	static const double f = 1.0 - ssystem->getEarth()->getOneMinusOblateness(); // flattening
-	static const double e2 = f*(2.-f);
-	// e^2 = 0.00669438 : Earth flattening parameter
-	// Inverse flattening 1/f = 298.257223563 : e^2 = 2f-f^2
-	// Source: 1984 World Geodetic System (WGS 84)
-	// https://web.archive.org/web/20200710203711/http://www.epsg-registry.org/export.htm?gml=urn:ogc:def:ellipsoid:EPSG::7030
-	// There is a modern value from IERS Conventions (2003)
-	// 1/f = 298.25642 But seem to be not widely used
-	// https://www.iers.org/IERS/EN/Publications/TechnicalNotes/tn32.html
-	// We use older value to be comparable with literatures and consistenc across Stellarium
-	static const double ff = 1./(1.-f);
-	const double rho1 = sqrt(1.- e2 * cos(d) * cos(d));
-	const double yy1 = y / rho1;
-	double m = sqrt(x * x + y * y);
-	double xi = x / sqrt(x * x + yy1 * yy1);
-	const double eta1 = yy1 / sqrt(x * x + yy1 * yy1);
-	const double sd1 = sin(d) / rho1;
-	const double cd1 = sqrt(1.- e2) * cos(d) / rho1;
-	const double rho2 = sqrt(1.- e2 * sin(d) * sin(d));
-	const double sd1d2 = e2 * sin(d) * cos(d) / (rho1 * rho2);
-	double zeta = rho2 * (-(eta1) * sd1d2);
-	const double b = -eta1 * sd1;
-	double theta = atan2(xi, b);
-	
-	const double sfn1 = eta1*cd1;
-	const double cfn1 = sqrt(1.- sfn1 * sfn1);
-	double lat = ff * sfn1 / cfn1;
-	lat = atan(lat);
-	L1 = L1 - zeta * tf1;
-	L2 = L2 - zeta * tf2;
-	const double c = 1. / sqrt(1.- e2 * sin(lat) * sin(lat));
-	const double s = (1.- e2) * c;
-	const double rs = s * sin(lat);
-	const double rc = c * cos(lat);
-	xi = rc * sin(theta);
-	const double eta = rs * cos(d) - rc * sin(d) * cos(theta);
-	const double u = x - xi;
-	const double v = y - eta;
-	m = sqrt(u * u + v * v);
-	const double magnitude = (L1 - m) / (L1 + L2);
-	const double dratio = 1.+ (magnitude - 1.)* 2.;
-	theta = theta / M_PI_180;
-	if (theta < 0.) theta += 360.;
-	double lon = mu - theta;
-	if (lon < -180.) lon += 360.;
-	if (lon > 180.) lon -= 360.;
-	lon = -(lon); // + East, - West
-
-	result.magnitude = magnitude;
-	result.diameterRatio = dratio;
-	result.latitude = lat / M_PI_180;
-	result.longitude = lon;
-
-	return result;
-}
-
-// Central solar eclipse parameters
-struct cSEparameter {
-	double diameterRatio;
-	double longitude;
-	double latitude;
-	double altitude;
-	double pathwidth;
-	double duration;
-};
-
-cSEparameter centralSolarEclipse(double JD) {
-	cSEparameter result;
-
-	// Besselian elements
-	// Source: Explanatory Supplement to the Astronomical Ephemeris 
-	// and the American Ephemeris and Nautical Almanac (1961)
-
-	StelCore* core = StelApp::getInstance().getCore();
-	core->setUseTopocentricCoordinates(false);
-	core->setJD(JD);
-	core->update(0);
-
-	SolarEclipse bessel = BesselianElements();
-
-	const double x = bessel.x;
-	const double y = bessel.y;
-	const double d = bessel.d;
-	const double tf1 = bessel.tf1;
-	const double tf2 = bessel.tf2;
-	double L1 = bessel.L1;
-	double L2 = bessel.L2;
-	const double mu = bessel.mu;
-
-	static SolarSystem* ssystem = GETSTELMODULE(SolarSystem);
-	static const double f = 1.0 - ssystem->getEarth()->getOneMinusOblateness(); // flattening
-	static const double e2 = f*(2.-f);
-	static const double ff = 1./(1.-f);
-	const double rho1 = sqrt(1. - e2 * cos(d) *cos(d));
-	const double y1 = y / rho1;
-	const double eta1 = y1;
-	const double sd1 = sin(d) / rho1;
-	const double cd1 = sqrt(1. - e2) * cos(d) / rho1;
-	const double rho2 = sqrt(1.- e2 * sin(d) * sin(d));
-	const double sd1d2 = e2*sin(d)*cos(d)/(rho1*rho2);
-	const double cd1d2 = sqrt(1. - sd1d2 * sd1d2); 
-	const double p = 1. - x * x - y1 * y1;
-	double dratio = 0.;
-	double lat = 99.;
-	double lon = 0.;
-	double duration = 0.;
-	double pathwidth = 0.;
-	double altitude = 0.;
-
-	if (p > 0.) // Moon's shadow axis is touching Earth
-	{
-		const double zeta1 = sqrt(p);
-		const double zeta = rho2 * (zeta1 * cd1d2 - eta1 * sd1d2);
-		L2 = L2 - zeta * tf2;
-		const double b = -y * sin(d) + zeta * cos(d);
-		double theta = atan2(x, b) / M_PI_180;
-		if (theta < 0.) theta += 360.;
-		//if (mu > 360.) mu -= 360.;
-		lon = mu - theta;
-		if (lon < -180.) lon += 360.;
-		if (lon > 180.) lon -= 360.;
-		lon = -(lon); // + East, - West
-		const double sfn1 = eta1 * cd1 + zeta1 * sd1;
-		const double cfn1 = sqrt(1. - sfn1 * sfn1);
-		lat = ff * sfn1 / cfn1;
-		lat = atan(lat) / M_PI_180;
-		L1 = L1 - zeta * tf1;
-		const double magnitude = L1 / (L1 + L2);
-		dratio = 1.+(magnitude-1.)*2.;
-
-		core->setJD(JD - 5./1440.);
-		core->update(0);
-
-		bessel = BesselianElements();
-		const double x1 = bessel.x;
-		const double y1 = bessel.y;
-		const double d1 = bessel.d;
-		const double mu1 = bessel.mu;
-
-		core->setJD(JD + 5./1440.);
-		core->update(0);
-
-		bessel = BesselianElements();
-		const double x2 = bessel.x;
-		const double y2 = bessel.y;
-		const double d2 = bessel.d;
-		const double mu2 = bessel.mu;
-
-		// Hourly rate of changes
-		const double xdot = (x2 - x1) * 6.;
-		const double ydot = (y2 - y1) * 6.;
-		const double ddot = (d2 - d1) * 6.;
-		double mudot = (mu2 - mu1) * 6.;
-		mudot = mudot * M_PI_180;
-		mudot = StelUtils::fmodpos(mudot, 2.*M_PI);
-
-		// Duration of central eclipse in minutes
-		const double etadot = mudot * x * sin(d) - ddot * zeta;
-		const double xidot = mudot * (-y * sin(d) + zeta * cos(d));
-		const double n = sqrt((xdot - xidot) * (xdot - xidot) + (ydot - etadot) * (ydot - etadot));
-		duration = L2*120./n; // positive = annular eclipse, negative = total eclipse
-
-		// Altitude
-		altitude = asin(cfn1*cos(d)*cos(theta * M_PI_180)+sfn1*sin(d)) / M_PI_180;
-
-		// Path width in kilometre
-		// Explanatory Supplement to the Astronomical Almanac
-		// Seidelmann, P. Kenneth, ed. (1992). University Science Books. ISBN 978-0-935702-68-2
-		// https://archive.org/details/131123ExplanatorySupplementAstronomicalAlmanac
-		const double p1 = zeta * zeta;
-		const double p2 = x * (xdot - xidot) / n;
-		const double p3 = eta1 * (ydot - etadot) / n;
-		const double p4 = (p2 + p3) * ( p2 + p3);
-		pathwidth = abs(EARTH_RADIUS*2.*L2/sqrt(p1+p4));
-	}
-
-	result.diameterRatio = dratio;
-	result.latitude = lat;
-	result.longitude = lon;
-	result.altitude = altitude;
-	result.pathwidth = pathwidth;
-	result.duration = duration;
-
-	return result;
-}
-
-// local solar eclipse parameters
-struct localSEparameter {
+// Local solar eclipse parameters
+struct LocalSEparams {
 	double dt;
 	double L1;
 	double L2;
@@ -3216,8 +2914,8 @@ struct localSEparameter {
 	double altitude;
 };
 
-localSEparameter localSolarEclipse(double JD,int contact,bool central) {
-	localSEparameter result;
+LocalSEparams localSolarEclipse(double JD,int contact,bool central) {
+	LocalSEparams result;
 	// contact : -1 for beginning, 0 for mid-eclipse, 1 for the end of partial or annular
 	// contact : -1 for the end, 0 for mid-eclipse, 1 for beginning of total
 	// central : true for total/annular eclipse
@@ -3241,41 +2939,26 @@ localSEparameter localSolarEclipse(double JD,int contact,bool central) {
 	core->setJD(JD);
 	core->update(0);
 
-	SolarEclipse bessel = BesselianElements();
-	const double x = bessel.x;
-	const double y = bessel.y;
-	const double d = bessel.d;
-	const double tf1 = bessel.tf1;
-	const double tf2 = bessel.tf2;
-	double L1 = bessel.L1;
-	double L2 = bessel.L2;
-	const double mu = bessel.mu;
+	double x,y,d,tf1,tf2,L1,L2,mu;
+	SolarEclipseBessel(x,y,d,tf1,tf2,L1,L2,mu);
 
 	core->setJD(JD - 5./1440.);
 	core->update(0);
-	bessel = BesselianElements();
-	const double x1 = bessel.x;
-	const double y1 = bessel.y;
-	const double d1 = bessel.d;
-	const double mu1 = bessel.mu;
+	double x1,y1,d1,bestf1,bestf2,besL1,besL2,mu1;
+	SolarEclipseBessel(x1,y1,d1,bestf1,bestf2,besL1,besL2,mu1);
 
 	core->setJD(JD + 5./1440.);
 	core->update(0);
-	bessel = BesselianElements();
-	const double x2 = bessel.x;
-	const double y2 = bessel.y;
-	const double d2 = bessel.d;
-	const double mu2 = bessel.mu;
+	double x2,y2,d2,mu2;
+	SolarEclipseBessel(x2,y2,d2,bestf1,bestf2,besL1,besL2,mu2);
 
 	// Hourly rate of changes
 	const double xdot = (x2 - x1) * 6.;
 	const double ydot = (y2 - y1) * 6.;
 	const double ddot = (d2 - d1) * 6.;
 	double mudot = mu2 - mu1;
-	if (mudot < 0.)
-		mudot += 360.;
-	mudot = mudot * 6.;
-	mudot = mudot * M_PI_180;
+	if (mudot < 0.) mudot += 360.; // make sure it is positive in case mu2 < mu1
+	mudot = mudot * 6. * M_PI_180;
 	double theta = (mu + lon) * M_PI_180;
 	theta = StelUtils::fmodpos(theta, 2.*M_PI);
 	const double xi = rc*sin(theta);
@@ -3351,7 +3034,6 @@ void AstroCalcDialog::generateSolarEclipses()
 			{
 				core->setUseTopocentricCoordinates(false);
 				core->update(0);
-				SolarEclipse bessel = BesselianElements();
 
 				// Find exact time of minimum distance between axis of lunar shadow cone to the center of Earth
 				double dt = 1.;
@@ -3360,21 +3042,18 @@ void AstroCalcDialog::generateSolarEclipses()
 				{
 					core->setJD(JD);
 					core->update(0);
-					SolarEclipse bessel = BesselianElements();
-					double x = bessel.x;
-					double y = bessel.y;
+					double x,y,d,tf1,tf2,L1,L2,mu;
+					SolarEclipseBessel(x,y,d,tf1,tf2,L1,L2,mu);
 
 					core->setJD(JD - 5./1440.);
 					core->update(0);
-					bessel = BesselianElements();
-					double x1 = bessel.x;
-					double y1 = bessel.y;
+					double x1,y1;
+					SolarEclipseBessel(x1,y1,d,tf1,tf2,L1,L2,mu);
 
 					core->setJD(JD + 5./1440.);
 					core->update(0);
-					bessel = BesselianElements();
-					double x2 = bessel.x;
-					double y2 = bessel.y;
+					double x2,y2;
+					SolarEclipseBessel(x2,y2,d,tf1,tf2,L1,L2,mu);
 
 					double xdot1 = (x - x1) * 12.;
 					double xdot2 = (x2 - x) * 12.;
@@ -3391,25 +3070,27 @@ void AstroCalcDialog::generateSolarEclipses()
 				core->setJD(JD);
 				core->update(0);
 
-				bessel = BesselianElements();
+				double x,y,d,tf1,tf2,L1,L2,mu;
+				SolarEclipseBessel(x,y,d,tf1,tf2,L1,L2,mu);
 
-				double gamma = sqrt(bessel.x * bessel.x + bessel.y * bessel.y);
-				if (bessel.y<0.) gamma = -(gamma);
-				pSEparameter eclipseData = partialSolarEclipse();
+				double gamma = sqrt(x * x + y * y);
+				if (y<0.) gamma = -(gamma);
+				double dRatio,latDeg,lngDeg,altitude,pathWidth,duration,magnitude;
+				SolarEclipseData(JD,dRatio,latDeg,lngDeg,altitude,pathWidth,duration,magnitude);
 
-				bool noncentraleclipse = false; // Non-central includes partial and total/annular eclipses that shadow axis misses Earth
+				bool noncentraleclipse = false; // Non-central includes partial and total/annular eclipses that shadow axis miss Earth
 
 				// Determine the type of solar eclipse
 				// Source: Astronomical Algorithms (1991), Jean Meeus
-				if (abs(gamma) <= (1.5433 + bessel.L2))
+				if (abs(gamma) <= (1.5433 + L2))
 				{
-					if (abs(gamma) > 0.9972 && abs(gamma) < (1.5433 + bessel.L2))
+					if (abs(gamma) > 0.9972 && abs(gamma) < (1.5433 + L2))
 					{
-						if (abs(gamma) < 0.9972 + abs(bessel.L2) && eclipseData.diameterRatio > 1.)
+						if (abs(gamma) < 0.9972 + abs(L2) && dRatio > 1.)
 						{
 							eclipseTypeStr = qc_("Total", "eclipse type"); // Non-central total eclipse
 						}
-						else if (abs(gamma) < 0.9972 + abs(bessel.L2) && eclipseData.diameterRatio < 1.)
+						else if (abs(gamma) < 0.9972 + abs(L2) && dRatio < 1.)
 						{
 							eclipseTypeStr = qc_("Annular", "eclipse type"); // Non-central annular eclipse
 						}
@@ -3419,17 +3100,17 @@ void AstroCalcDialog::generateSolarEclipses()
 					}
 					else
 					{
-						if (bessel.L2 < 0.)
+						if (L2 < 0.)
 						{
 							eclipseTypeStr = qc_("Total", "eclipse type");
 						}
-						else if (bessel.L2 > 0.0047)
+						else if (L2 > 0.0047)
 						{
 							eclipseTypeStr = qc_("Annular", "eclipse type");
 						}
-						else if (bessel.L2 > 0. && bessel.L2 < 0.0047)
+						else if (L2 > 0. && L2 < 0.0047)
 						{
-							if (bessel.L2 < (0.00464 * sqrt(1. - gamma * gamma)))
+							if (L2 < (0.00464 * sqrt(1. - gamma * gamma)))
 							{
 								eclipseTypeStr = qc_("Hybrid", "eclipse type");
 							}
@@ -3465,26 +3146,26 @@ void AstroCalcDialog::generateSolarEclipses()
 
 					if (noncentraleclipse)
 					{
-						magStr = QString("%1").arg(QString::number(eclipseData.magnitude, 'f', 3));
-						eclipseLatitude = eclipseData.latitude;
-						eclipseLongitude = eclipseData.longitude;
+						magStr = QString("%1").arg(QString::number(magnitude, 'f', 3));
+						eclipseLatitude = latDeg;
+						eclipseLongitude = lngDeg;
 						altitudeStr = "0°";
 						durationStr = dash;
 						pathWidthStr = dash;
 					}
 					else
 					{
-						cSEparameter eclipseData = centralSolarEclipse(JD);
-						magStr = QString("%1").arg(QString::number(eclipseData.diameterRatio, 'f', 3));
-						eclipseAltitude = eclipseData.altitude;
+						//double dRatio,latDeg,lngDeg,altitude,pathWidth,duration;
+						//SolarEclipseData(JD,dRatio,latDeg,lngDeg,altitude,pathWidth,duration,magnitude);
+						magStr = QString("%1").arg(QString::number(dRatio, 'f', 3));
+						eclipseAltitude = altitude;
 						altitudeStr = QString("%1°").arg(QString::number(round(eclipseAltitude)));
-						pathwidth = eclipseData.pathwidth;
-						pathWidthStr = QString("%1 %2").arg(QString::number(round(pathwidth)), km);
-						eclipseLatitude = eclipseData.latitude;
-						eclipseLongitude = eclipseData.longitude;
-						float duration = abs(eclipseData.duration);
-						int durationMinute = int(duration);
-						int durationSecond = round((duration - durationMinute) * 60.);
+						pathWidthStr = QString("%1 %2").arg(QString::number(round(pathWidth)), km);
+						eclipseLatitude = latDeg;
+						eclipseLongitude = lngDeg;
+						double centralDuration = abs(duration);
+						int durationMinute = int(centralDuration);
+						int durationSecond = round((centralDuration - durationMinute) * 60.);
 						if (durationSecond>59)
 						{
 							durationMinute += 1;
@@ -3629,7 +3310,6 @@ void AstroCalcDialog::generateSolarEclipsesLocal()
 			{
 				core->setUseTopocentricCoordinates(false);
 				core->update(0);
-				SolarEclipse bessel = BesselianElements();
 
 				// Find exact time of minimum distance between axis of lunar shadow cone to the center of Earth
 				double dt = 1.;
@@ -3638,21 +3318,18 @@ void AstroCalcDialog::generateSolarEclipsesLocal()
 				{
 					core->setJD(JD);
 					core->update(0);
-					SolarEclipse bessel = BesselianElements();
-					double x = bessel.x;
-					double y = bessel.y;
+					double x,y,d,tf1,tf2,L1,L2,mu;
+					SolarEclipseBessel(x,y,d,tf1,tf2,L1,L2,mu);
 
 					core->setJD(JD - 5./1440.);
 					core->update(0);
-					bessel = BesselianElements();
-					double x1 = bessel.x;
-					double y1 = bessel.y;
+					double x1,y1;
+					SolarEclipseBessel(x1,y1,d,tf1,tf2,L1,L2,mu);
 
 					core->setJD(JD + 5./1440.);
 					core->update(0);
-					bessel = BesselianElements();
-					double x2 = bessel.x;
-					double y2 = bessel.y;
+					double x2,y2;
+					SolarEclipseBessel(x2,y2,d,tf1,tf2,L1,L2,mu);
 
 					double xdot1 = (x - x1) * 12.;
 					double xdot2 = (x2 - x) * 12.;
@@ -3668,13 +3345,12 @@ void AstroCalcDialog::generateSolarEclipsesLocal()
 
 				core->setJD(JD);
 				core->update(0);
-				bessel = BesselianElements();
-				double gamma = sqrt(bessel.x * bessel.x + bessel.y * bessel.y);
+				double x,y,d,tf1,tf2,L1,L2,mu;
+				SolarEclipseBessel(x,y,d,tf1,tf2,L1,L2,mu);
+				double gamma = sqrt(x * x + y * y);
+				if (y<0.) gamma = -(gamma);
 
-				if (bessel.y<0.)
-					gamma = -(gamma);
-
-				if (abs(gamma) <= (1.5433 + bessel.L2)) // Solar eclipse occurs on this date
+				if (abs(gamma) <= (1.5433 + L2)) // Solar eclipse occurs on this date
 				{
 					double magLocal = 0., altitudeMideclipse = 0.;
 					double altitudeFirstcontact = 0.;
@@ -3683,7 +3359,7 @@ void AstroCalcDialog::generateSolarEclipsesLocal()
 					// Find time of maximum eclipse for current location
 					double dt = 1.;
 					int iteration = 0;
-					localSEparameter eclipseData = localSolarEclipse(JD,0,false);
+					LocalSEparams eclipseData = localSolarEclipse(JD,0,false);
 					while (abs(dt) > 0.000001 && (iteration < 20))
 					{
 						eclipseData = localSolarEclipse(JD,0,false);

--- a/src/gui/AstroCalcDialog.cpp
+++ b/src/gui/AstroCalcDialog.cpp
@@ -3230,8 +3230,6 @@ localSEparameter localSolarEclipse(double JD,int contact,bool central) {
 	double lat = static_cast<double>(core->getCurrentLocation().latitude);
 	double lon = static_cast<double>(core->getCurrentLocation().longitude);
 	double elevation = static_cast<double>(core->getCurrentLocation().altitude);
-	//lon = -(lon);
-	double L = 0.;
 
 	static SolarSystem* ssystem = GETSTELMODULE(SolarSystem);
 	Vec4d geocentricCoords = ssystem->getEarth()->getRectangularCoordinates(lon,lat,elevation);
@@ -3293,10 +3291,8 @@ localSEparameter localSolarEclipse(double JD,int contact,bool central) {
 	const double delta = (u * vdot - udot * v) / sqrt(udot * udot + vdot * vdot);
 	L1 = L1 - zeta * tf1;
 	L2 = L2 - zeta * tf2;
-	if (central)
-		L = L2;
-	else
-		L = L1;
+	double L = L1;
+	if (central) L = L2;
 	const double sfi = delta/L;
 	const double ce = 1.- sfi*sfi;
 	double cfi = 0.; 

--- a/src/gui/AstroCalcDialog.cpp
+++ b/src/gui/AstroCalcDialog.cpp
@@ -3020,8 +3020,8 @@ pSEparameter partialSolarEclipse() {
 	const double mu = bessel.mu;
 
 	static SolarSystem* ssystem = GETSTELMODULE(SolarSystem);
-	const double f = 1.0 - ssystem->getEarth()->getOneMinusOblateness(); // flattening
-	const double e2 = 2.*f-(f*f);
+	static const double f = 1.0 - ssystem->getEarth()->getOneMinusOblateness(); // flattening
+	static const double e2 = f*(2.-f);
 	// e^2 = 0.00669438 : Earth flattening parameter
 	// Inverse flattening 1/f = 298.257223563 : e^2 = 2f-f^2
 	// Source: 1984 World Geodetic System (WGS 84)
@@ -3030,7 +3030,7 @@ pSEparameter partialSolarEclipse() {
 	// 1/f = 298.25642 But seem to be not widely used
 	// https://www.iers.org/IERS/EN/Publications/TechnicalNotes/tn32.html
 	// We use older value to be comparable with literatures and consistenc across Stellarium
-	const double ff = 1./(1.-f);
+	static const double ff = 1./(1.-f);
 	const double rho1 = sqrt(1.- e2 * cos(d) * cos(d));
 	const double yy1 = y / rho1;
 	double m = sqrt(x * x + y * y);
@@ -3110,9 +3110,9 @@ cSEparameter centralSolarEclipse(double JD) {
 	const double mu = bessel.mu;
 
 	static SolarSystem* ssystem = GETSTELMODULE(SolarSystem);
-	const double f = 1.0 - ssystem->getEarth()->getOneMinusOblateness(); // flattening
-	const double e2 = 2.*f-(f*f);
-	const double ff = 1./(1.-f);
+	static const double f = 1.0 - ssystem->getEarth()->getOneMinusOblateness(); // flattening
+	static const double e2 = f*(2.-f);
+	static const double ff = 1./(1.-f);
 	const double rho1 = sqrt(1. - e2 * cos(d) *cos(d));
 	const double y1 = y / rho1;
 	const double eta1 = y1;
@@ -3234,11 +3234,10 @@ localSEparameter localSolarEclipse(double JD,int contact,bool central) {
 	double L = 0.;
 
 	static SolarSystem* ssystem = GETSTELMODULE(SolarSystem);
-	//PlanetP earth = ssystem->getEarth();
 	Vec4d geocentricCoords = ssystem->getEarth()->getRectangularCoordinates(lon,lat,elevation);
-	const double rc = geocentricCoords[0]/(EARTH_RADIUS/AU); // rhoCosPhiPrime
-	const double rs = geocentricCoords[1]/(EARTH_RADIUS/AU); // rhoSinPhiPrime
-	lat = lat * M_PI_180;
+	static const double earthRadius = ssystem->getEarth()->getEquatorialRadius();
+	static const double rc = geocentricCoords[0]/earthRadius; // rhoCosPhiPrime
+	static const double rs = geocentricCoords[1]/earthRadius; // rhoSinPhiPrime
 
 	core->setUseTopocentricCoordinates(false);
 	core->setJD(JD);

--- a/src/gui/AstroCalcDialog.cpp
+++ b/src/gui/AstroCalcDialog.cpp
@@ -3230,14 +3230,14 @@ localSEparameter localSolarEclipse(double JD,int contact,bool central) {
 	double lat = static_cast<double>(core->getCurrentLocation().latitude);
 	double lon = static_cast<double>(core->getCurrentLocation().longitude);
 	double elevation = static_cast<double>(core->getCurrentLocation().altitude);
-	lon = -(lon);
+	//lon = -(lon);
 	double L = 0.;
 
 	static SolarSystem* ssystem = GETSTELMODULE(SolarSystem);
 	Vec4d geocentricCoords = ssystem->getEarth()->getRectangularCoordinates(lon,lat,elevation);
 	static const double earthRadius = ssystem->getEarth()->getEquatorialRadius();
-	static const double rc = geocentricCoords[0]/earthRadius; // rhoCosPhiPrime
-	static const double rs = geocentricCoords[1]/earthRadius; // rhoSinPhiPrime
+	const double rc = geocentricCoords[0]/earthRadius; // rhoCosPhiPrime
+	const double rs = geocentricCoords[1]/earthRadius; // rhoSinPhiPrime
 
 	core->setUseTopocentricCoordinates(false);
 	core->setJD(JD);
@@ -3255,7 +3255,6 @@ localSEparameter localSolarEclipse(double JD,int contact,bool central) {
 
 	core->setJD(JD - 5./1440.);
 	core->update(0);
-
 	bessel = BesselianElements();
 	const double x1 = bessel.x;
 	const double y1 = bessel.y;
@@ -3264,7 +3263,6 @@ localSEparameter localSolarEclipse(double JD,int contact,bool central) {
 
 	core->setJD(JD + 5./1440.);
 	core->update(0);
-
 	bessel = BesselianElements();
 	const double x2 = bessel.x;
 	const double y2 = bessel.y;
@@ -3280,7 +3278,7 @@ localSEparameter localSolarEclipse(double JD,int contact,bool central) {
 		mudot += 360.;
 	mudot = mudot * 6.;
 	mudot = mudot * M_PI_180;
-	double theta = (mu - lon) * M_PI_180;
+	double theta = (mu + lon) * M_PI_180;
 	theta = StelUtils::fmodpos(theta, 2.*M_PI);
 	const double xi = rc*sin(theta);
 	const double eta = rs*cos(d)-rc*sin(d)*cos(theta);

--- a/src/gui/AstroCalcDialog.cpp
+++ b/src/gui/AstroCalcDialog.cpp
@@ -3155,8 +3155,6 @@ void AstroCalcDialog::generateSolarEclipses()
 					}
 					else
 					{
-						//double dRatio,latDeg,lngDeg,altitude,pathWidth,duration;
-						//SolarEclipseData(JD,dRatio,latDeg,lngDeg,altitude,pathWidth,duration,magnitude);
 						magStr = QString("%1").arg(QString::number(dRatio, 'f', 3));
 						eclipseAltitude = altitude;
 						altitudeStr = QString("%1°").arg(QString::number(round(eclipseAltitude)));


### PR DESCRIPTION
### Description
As mentioned in #2237 Sun & Moon are not aligned at greatest solar eclipse. I suspect that something is wrong with observer's coordinates on Earth and it's right.

There is a bug in planetocentric rectangular coordinate calculations that give wrong values of rhoCosPhiPrime and rhoSinPhiPrime. After fixing this issue, the Sun and Moon are aligned perfectly for all central solar eclipses! This should also improve the accuracy of topocentric coordinates for all objects.

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

**Test Configuration**:
* Operating system: Ubuntu 20.04

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
