### PR TITLE
Fix AngleSpinBox::stringToDouble() parsing of decimal degrees

### DIFF
--- a/src/gui/AngleSpinBox.cpp
+++ b/src/gui/AngleSpinBox.cpp
@@ -241,7 +241,7 @@ double AngleSpinBox::stringToDouble(QString input, QValidator::State* state, Pre
 		  QRegularExpression::CaseInsensitiveOption);
 	QRegularExpression hmsRx("^\\s*(\\d+)\\s*h(\\s*(\\d+(\\.\\d*)?)\\s*[m'](\\s*(\\d+(\\.\\d*)?)\\s*[s\"]\\s*)?)?$",
 		  QRegularExpression::CaseInsensitiveOption);
-	QRegularExpression decRx("^(\\d+(\\.\\d*)?)(\\s*[\\x00b0]\\s*)?$");
+	QRegularExpression decRx(u8"^(\\d+(\\.\\d*)?)\\s*\u00b0\\s*?$");
 	QRegularExpression badRx("[^hdms0-9 °'\"\\.]", QRegularExpression::CaseInsensitiveOption);
 	QRegularExpressionMatch dmsMatch=dmsRx.match(input);
 	QRegularExpressionMatch hmsMatch=hmsRx.match(input);


### PR DESCRIPTION
### Description
`QRegularExpression` doesn't seem to support `\xABCD` format for Unicode code points. This patch switches to UTF-8 encoding, which does work.

Fixes #2247

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system: GNU/Linux (LFS)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
