### PR TITLE
Fix StelLocationMgr.cpp:parseAngle for negative fractional-degree angles

### DIFF
--- a/src/core/StelLocationMgr.cpp
+++ b/src/core/StelLocationMgr.cpp
@@ -679,7 +679,10 @@ static float parseAngle(const QString& s, bool* ok)
 		if (!*ok) return 0;
 		float sec = match.captured(3).isEmpty()? 0 : match.captured(3).toFloat(ok);
 		if (!*ok) return 0;
-		return deg + min / 60 + sec / 3600;
+		if (deg < 0)
+			return deg - min / 60 - sec / 3600;
+		else
+			return deg + min / 60 + sec / 3600;
 	}
 	return 0;
 }


### PR DESCRIPTION
### Description

This patch fixes the root problem of #2239: the `parseAngle` function in `StelLocationMgr.cpp`.

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
