### PR TITLE
Pass Sun, Moon and current planet objects as well as location directly to Atmosphere::computeColor

### DIFF
--- a/src/core/modules/Atmosphere.cpp
+++ b/src/core/modules/Atmosphere.cpp
@@ -214,8 +214,8 @@ void Atmosphere::computeColor(StelCore* core, const double JD, const Planet& cur
 
 		// Update the eclipse intensity factor to apply on atmosphere model
 		// these are for radii
-		const double sun_angular_size = atan(SUN_RADIUS/AU/sunPos.length());
-		const double moon_angular_size = atan(MOON_RADIUS/AU/moonPos.length());
+		const double sun_angular_size = atan(sun.getEquatorialRadius()/sunPos.length());
+		const double moon_angular_size = atan(moon->getEquatorialRadius()/moonPos.length());
 		const double touch_angle = sun_angular_size + moon_angular_size;
 
 		// determine luminance falloff during solar eclipses

--- a/src/core/modules/Atmosphere.cpp
+++ b/src/core/modules/Atmosphere.cpp
@@ -19,6 +19,7 @@
 
 #include "Atmosphere.hpp"
 #include "StelUtils.hpp"
+#include "Planet.hpp"
 #include "StelApp.hpp"
 #include "StelProjector.hpp"
 #include "StelToneReproducer.hpp"
@@ -123,8 +124,9 @@ Atmosphere::~Atmosphere(void)
 	atmoShaderProgram = Q_NULLPTR;
 }
 
-void Atmosphere::computeColor(double JD, Vec3d _sunPos, Vec3d moonPos, float moonPhase, float moonMagnitude,
-							   StelCore* core, float latitude, float altitude, float temperature, float relativeHumidity, float extinctionCoefficient, bool noScatter)
+void Atmosphere::computeColor(StelCore* core, const double JD, const Planet& currentPlanet, const Planet& sun, const Planet*const moon,
+							  const StelLocation& location, const float temperature, const float relativeHumidity,
+							  const float extinctionCoefficient, const bool noScatter)
 {
 	const StelProjectorP prj = core->getProjection(StelCore::FrameAltAz, StelCore::RefractionOff);
 	if (viewport != prj->getViewport())
@@ -192,50 +194,59 @@ void Atmosphere::computeColor(double JD, Vec3d _sunPos, Vec3d moonPos, float moo
 		colorGridBuffer.release();
 	}
 
-	if (qIsNaN(_sunPos.length()))
-		_sunPos.set(0.,0.,-1.*AU);
-	if (qIsNaN(moonPos.length()))
-		moonPos.set(0.,0.,-1.*AU);
+	auto sunPos  =  sun.getAltAzPosAuto(core);
+	if (qIsNaN(sunPos.length()))
+		sunPos.set(0.,0.,-1.*AU);
 
-	// Update the eclipse intensity factor to apply on atmosphere model
-	// these are for radii
-	const double sun_angular_size = atan(SUN_RADIUS/AU/_sunPos.length());
-	const double moon_angular_size = atan(MOON_RADIUS/AU/moonPos.length());
-	const double touch_angle = sun_angular_size + moon_angular_size;
-
-	// determine luminance falloff during solar eclipses
-	_sunPos.normalize();
-	moonPos.normalize();
+	Vec3d moonPos = sunPos;
 	// Calculate the atmosphere RGB for each point of the grid. We can use abbreviated numbers here.
-	Vec3f sunPosF=_sunPos.toVec3f();
-	Vec3f moonPosF=moonPos.toVec3f();
 
-	double separation_angle = std::acos(_sunPos.dot(moonPos));  // angle between them
 	// qDebug("touch at %f\tnow at %f (%f)\n", touch_angle, separation_angle, separation_angle/touch_angle);
 	// bright stars should be visible at total eclipse
 	// TODO: correct for atmospheric diffusion
 	// TODO: use better coverage function (non-linear)
 	// because of above issues, this algorithm darkens more quickly than reality
-	// Note: On Earth only, else moon would brighten other planets' atmospheres (LP:1673283)
-	if ((core->getCurrentLocation().planetName=="Earth") && (separation_angle < touch_angle))
+	if (moon)
 	{
-		double dark_angle = moon_angular_size - sun_angular_size;
-		double min = 0.0025; // 0.005f; // 0.0001f;  // so bright stars show up at total eclipse
-		if (dark_angle < 0.)
-		{
-			// annular eclipse
-			double asun = sun_angular_size*sun_angular_size;
-			min = (asun - moon_angular_size*moon_angular_size)/asun;  // minimum proportion of sun uncovered
-			dark_angle *= -1;
-		}
+		moonPos = moon->getAltAzPosAuto(core);
+		if (qIsNaN(moonPos.length()))
+			moonPos.set(0.,0.,-1.*AU);
 
-		if (separation_angle < dark_angle)
-			eclipseFactor = static_cast<float>(min);
-		else
-			eclipseFactor = static_cast<float>(min + (1.0-min)*(separation_angle-dark_angle)/(touch_angle-dark_angle));
+		// Update the eclipse intensity factor to apply on atmosphere model
+		// these are for radii
+		const double sun_angular_size = atan(SUN_RADIUS/AU/sunPos.length());
+		const double moon_angular_size = atan(MOON_RADIUS/AU/moonPos.length());
+		const double touch_angle = sun_angular_size + moon_angular_size;
+
+		// determine luminance falloff during solar eclipses
+		sunPos.normalize();
+		moonPos.normalize();
+		double separation_angle = std::acos(sunPos.dot(moonPos));  // angle between them
+
+		if(separation_angle < touch_angle)
+		{
+
+			double dark_angle = moon_angular_size - sun_angular_size;
+			double min = 0.0025; // 0.005f; // 0.0001f;  // so bright stars show up at total eclipse
+			if (dark_angle < 0.)
+			{
+				// annular eclipse
+				double asun = sun_angular_size*sun_angular_size;
+				min = (asun - moon_angular_size*moon_angular_size)/asun;  // minimum proportion of sun uncovered
+				dark_angle *= -1;
+			}
+
+			if (separation_angle < dark_angle)
+				eclipseFactor = static_cast<float>(min);
+			else
+				eclipseFactor = static_cast<float>(min + (1.0-min)*(separation_angle-dark_angle)/(touch_angle-dark_angle));
+		}
 	}
 	else
+	{
 		eclipseFactor = 1.f;
+		sunPos.normalize();
+	}
 	// TODO: compute eclipse factor also for Lunar eclipses! (lp:#1471546)
 
 	// No need to calculate if not visible
@@ -262,15 +273,19 @@ void Atmosphere::computeColor(double JD, Vec3d _sunPos, Vec3d moonPos, float moo
 	// Also, Preetham has optimized to T in[2..6], which translates now to k in [0.2-0.36].
 	// In Schaefer-Krisciunas Moon brightness paper, k=0.172 for Mauna Kea. Preetham will likely be too bright here.
 	//sky.setParamsv(sunPos, qBound(2.f, turbidity, 6.f));
+	Vec3f sunPosF=sunPos.toVec3f();
+	Vec3f moonPosF=moonPos.toVec3f();
 	sky.setParamsv(sunPosF, qBound(2.f, turbidity, 16.f));  // GZ-AT allow more turbidity for testing
 
-	skyb.setLocation(latitude * M_PI_180f, altitude, temperature, relativeHumidity);
+	skyb.setLocation(location.latitude * M_PI_180f, static_cast<float>(location.altitude), temperature, relativeHumidity);
 	skyb.setSunMoon(moonPosF[2], sunPosF[2]);
 
 	// Calculate the date from the julian day.
 	int year, month, day;
 	StelUtils::getDateFromJulianDay(JD, &year, &month, &day);
-	skyb.setDate(year, month, moonPhase, moonMagnitude);
+	const auto moonPhase = moon ? moon->getPhaseAngle(currentPlanet.getHeliocentricEclipticPos()) : 0.;
+	const auto moonMagnitude = moon ? moon->getVMagnitudeWithExtinction(core) : 100.f;
+	skyb.setDate(year, month, static_cast<float>(moonPhase), moonMagnitude);
 
 	// Variables used to compute the average sky luminance
 	float sum_lum = 0.f;

--- a/src/core/modules/Atmosphere.hpp
+++ b/src/core/modules/Atmosphere.hpp
@@ -31,7 +31,9 @@
 
 class StelProjector;
 class StelToneReproducer;
+class StelLocation;
 class StelCore;
+class Planet;
 
 //! Compute and display the daylight sky color using OpenGL.
 //! The sky brightness is computed with the SkyBright class, the color with the SkyLight.
@@ -44,9 +46,9 @@ public:
 	
 	//! Compute sky brightness values and average luminance.
 	//! @param noScatter true to suppress the actual sky brightness modelling. This will keep refraction/extinction working for didactic reasons.
-	void computeColor(double JD, Vec3d _sunPos, Vec3d moonPos, float moonPhase, float moonMagnitude, StelCore* core,
-		float latitude = 45.f, float altitude = 200.f,
-		float temperature = 15.f, float relativeHumidity = 40.f, float extinctionCoefficient = 0.32f, bool noScatter=false);
+	void computeColor(StelCore* core, double JD, const Planet& currentPlanet, const Planet& sun, const Planet* moon,
+					  const StelLocation& location, float temperature, float relativeHumidity, float extinctionCoefficient,
+					  bool noScatter);
 	void draw(StelCore* core);
 	void update(double deltaTime) {fader.update(static_cast<int>(deltaTime*1000));}
 


### PR DESCRIPTION
### Description

These two commits make `Atmosphere::computeColor` accept Sun, Moon and Earth as `Planet const&` instead of their positions + lunar magnitude + lunar phase. This is necessary to avoid the set of parameters growing hard when I add ShowMySky atmosphere model. The latter also wants distance between the Earth and the Moon, unextincted magnitude of the Moon, angular size of the Sun, and in the future may require geometric positions of the Sun and the Moon.

The Moon is passed as a pointer, which is null if current planet isn't the Earth.

Location is now also passed as `StelLocation const&` to reduce number of parameters.

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### How Has This Been Tested?

I tried to check that LP:1673283 doesn't reproduce, although it was a bit hard because on Mars it's rare to have the Sun far under the horizon while the Moon is above horizon. This seemed to be OK: I didn't notice any brightening due to the Moon.

**Test Configuration**:
* Operating system: GNU/Linux (LFS)
* Graphics Card: GeForce GTX 750Ti with proprietary `nvidia` driver

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
