### PR TITLE
Fix build instruction for CentOS/Fedora

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -75,8 +75,8 @@ sudo apt install build-essential cmake zlib1g-dev libgl1-mesa-dev libdrm-dev gcc
 
 ```
 sudo yum install cmake gcc graphviz doxygen gettext git \
-                 qt5-base-devel qt5-qttools-devel qt5-qtscript-devel qt5-qtsvg-devel qt5-qtmultimedia-devel \
-                 qt5-qtserialport-devel qt5-qtlocation-devel qt5-qtpositioning-devel qtwebengine5-devel
+                 qt5-qtbase-devel qt5-qttools-devel qt5-qtscript-devel qt5-qtsvg-devel qt5-qtmultimedia-devel \
+                 qt5-qtserialport-devel qt5-qtlocation-devel qt5-qtcharts-devel qt5-qtwebengine-devel
 ```
 
 #### Linux with outdated Qt

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -73,7 +73,8 @@ sudo apt install build-essential cmake zlib1g-dev libgl1-mesa-dev libdrm-dev gcc
 
 #### Fedora / CentOS
 
-Note: This sould work on RHEL/CentOS 8 or later and recent versions of Fedora. To build on CentOS 7 or order, see [Linux with outdated Qt](#linux-with-outdated-qt).
+Note: This should work on RHEL/CentOS 8 or later and recent versions of Fedora. To build on CentOS 7 or older,
+see [Linux with outdated Qt](#linux-with-outdated-qt).
 
 ```
 sudo dnf install cmake gcc graphviz doxygen gettext git \

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -73,8 +73,10 @@ sudo apt install build-essential cmake zlib1g-dev libgl1-mesa-dev libdrm-dev gcc
 
 #### Fedora / CentOS
 
+Note: This sould work on RHEL/CentOS 8 or later and recent versions of Fedora. To build on CentOS 7 or order, see [Linux with outdated Qt](#linux-with-outdated-qt).
+
 ```
-sudo yum install cmake gcc graphviz doxygen gettext git \
+sudo dnf install cmake gcc graphviz doxygen gettext git \
                  qt5-qtbase-devel qt5-qttools-devel qt5-qtscript-devel qt5-qtsvg-devel qt5-qtmultimedia-devel \
                  qt5-qtserialport-devel qt5-qtlocation-devel qt5-qtcharts-devel qt5-qtwebengine-devel
 ```


### PR DESCRIPTION
This PR includes some changes for build instructions for CentOS/Fedora, as the current version uses `yum` (which is deprecated) instead of `dnf`, and some packages listed there doesn't exist. I also added a note about RHEL.CentOS 7 (still supported) including outdated Qt libs, and directed users to "Linux with outdated Qt".

### Description
- Use `dnf` instead of `yum`
- Replace `qt5-base-devel` with `qt5-qtbase-devel`
- Replace `qt5-qtpositioning-devel` with `qt5-qtcharts-devel`
- Replace `qtwebengine5-devel` with `qt5-qtwebengine-devel`
- Add note about CentOS 7 having outdated Qt.
- Add note about CentOS/Fedora instructions working on CentOS 8 or newer, and recent Fedora versions

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] This change requires a documentation update
  - This is a documentation update

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system: Fedora 35 (x86_64)
* Graphics Card: Intel UHD Graphics 620, Linux 5.16.5, mesa 21.3.5

## Checklist:
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (header file)
- [x] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
