### PR TITLE
Enable multisampling for landscape too

### DIFF
--- a/src/core/modules/Landscape.hpp
+++ b/src/core/modules/Landscape.hpp
@@ -253,6 +253,7 @@ protected:
 	int fontSize;     //! Used for landscape labels (optionally indicating landscape features)
 	Vec3f labelColor; //! Color for the landscape labels.
 	unsigned int memorySize;   //!< holds an approximate value of memory consumption (for cache cost estimate)
+    bool multisamplingEnabled_;
 };
 
 //! @class LandscapeOldStyle


### PR DESCRIPTION
### Description
When I implemented multisampling for Planets, I didn't notice that landscapes also get aliased, particularly _Ocean_ and _Zero Horizon_. The reason was my always using perspective projection :) This patch fixes this overlook.

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### How Has This Been Tested?

**Test Configuration**:
* Operating system: GNU/Linux (LFS)
* Graphics Card: GeForce GTX 750Ti with `nvidia` binary driver

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
