### PR TITLE
Fix support for Qt<5.11

### DIFF
--- a/src/core/modules/LandscapeMgr.cpp
+++ b/src/core/modules/LandscapeMgr.cpp
@@ -327,7 +327,7 @@ void LandscapeMgr::update(double deltaTime)
 	const bool currentIsEarth = currentPlanet->getID() == earth->getID();
 	// First parameter in next call is used for particularly earth-bound computations in Schaefer's sky brightness model. Difference DeltaT makes no difference here.
 	// Temperature = 15°C, relative humidity = 40%
-	atmosphere->computeColor(core, core->getJDE(), *currentPlanet, *sun, currentIsEarth ? moon.get() : nullptr, core->getCurrentLocation(),
+	atmosphere->computeColor(core, core->getJDE(), *currentPlanet, *sun, currentIsEarth ? moon.data() : nullptr, core->getCurrentLocation(),
 							 15.f, 40.f, static_cast<float>(drawer->getExtinctionCoefficient()), atmosphereNoScatter);
 
 	core->getSkyDrawer()->reportLuminanceInFov(3.75f+atmosphere->getAverageLuminance()*3.5f, true);


### PR DESCRIPTION
`QSharedPointer::get()` appeared first in Qt 5.11, while Stellarium supports down to 5.9. This patch replaces this call with `QSharedPointer::data()`, which is equivalent, although non-API-compatible with standard pointers.