### PR TITLE
Refactoring AstroCalc/Transits tool

### DIFF
--- a/src/gui/AstroCalcDialog.cpp
+++ b/src/gui/AstroCalcDialog.cpp
@@ -142,7 +142,7 @@ AstroCalcDialog::AstroCalcDialog(QObject* parent)
 	Q_ASSERT(phenomenaHeader.isEmpty());
 	Q_ASSERT(positionsHeader.isEmpty());
 	Q_ASSERT(wutHeader.isEmpty());
-	Q_ASSERT(transitHeader.isEmpty());
+	Q_ASSERT(rtsHeader.isEmpty());
 	Q_ASSERT(lunareclipseHeader.isEmpty());
 	Q_ASSERT(solareclipseHeader.isEmpty());
 	Q_ASSERT(solareclipselocalHeader.isEmpty());
@@ -169,7 +169,7 @@ void AstroCalcDialog::retranslate()
 		setCelestialPositionsHeaderNames();
 		setHECPositionsHeaderNames();
 		setEphemerisHeaderNames();
-		setTransitHeaderNames();
+		setRTSHeaderNames();
 		setPhenomenaHeaderNames();
 		setWUTHeaderNames();
 		setLunarEclipseHeaderNames();
@@ -202,8 +202,8 @@ void AstroCalcDialog::retranslate()
 		ui->dateToDateTimeEdit->setToolTip(validDates);
 		ui->phenomenFromDateEdit->setToolTip(validDates);
 		ui->phenomenToDateEdit->setToolTip(validDates);
-		ui->transitFromDateEdit->setToolTip(validDates);
-		ui->transitToDateEdit->setToolTip(validDates);
+		ui->rtsFromDateEdit->setToolTip(validDates);
+		ui->rtsToDateEdit->setToolTip(validDates);
 	}
 }
 
@@ -276,8 +276,8 @@ void AstroCalcDialog::createDialogContent()
 	ui->dateToDateTimeEdit->setDateTime(currentDT.addMonths(1));
 	ui->phenomenFromDateEdit->setDateTime(currentDT);
 	ui->phenomenToDateEdit->setDateTime(currentDT.addMonths(1));
-	ui->transitFromDateEdit->setDateTime(currentDT);
-	ui->transitToDateEdit->setDateTime(currentDT.addMonths(1));
+	ui->rtsFromDateEdit->setDateTime(currentDT);
+	ui->rtsToDateEdit->setDateTime(currentDT.addMonths(1));
 	ui->eclipseFromYearSpinBox->setValue(currentDT.date().year());
 	ui->monthlyElevationTimeInfo->setStyleSheet("font-size: 18pt; color: rgb(238, 238, 238);");
 
@@ -293,10 +293,10 @@ void AstroCalcDialog::createDialogContent()
 	ui->phenomenFromDateEdit->setToolTip(validDates);
 	ui->phenomenToDateEdit->setMinimumDate(minDate);
 	ui->phenomenToDateEdit->setToolTip(validDates);
-	ui->transitFromDateEdit->setMinimumDate(minDate);
-	ui->transitFromDateEdit->setToolTip(validDates);
-	ui->transitToDateEdit->setMinimumDate(minDate);
-	ui->transitToDateEdit->setToolTip(validDates);
+	ui->rtsFromDateEdit->setMinimumDate(minDate);
+	ui->rtsFromDateEdit->setToolTip(validDates);
+	ui->rtsToDateEdit->setMinimumDate(minDate);
+	ui->rtsToDateEdit->setToolTip(validDates);
 	ui->eclipseFromYearSpinBox->setToolTip(QString("%1 %2..%3").arg(q_("Valid range years:"), QString::number(ui->eclipseFromYearSpinBox->minimum()), QString::number(ui->eclipseFromYearSpinBox->maximum())));
 	ui->pushButtonExtraEphemerisDialog->setFixedSize(QSize(20, 20));
 	ui->pushButtonCustomStepsDialog->setFixedSize(QSize(26, 26));
@@ -353,12 +353,12 @@ void AstroCalcDialog::createDialogContent()
 	connectColorButton(ui->saturnMarkerColor, "SolarSystem.ephemerisSaturnMarkerColor", "color/ephemeris_saturn_marker_color");
 
 	// Tab: Transits
-	initListTransit();
-	connect(ui->transitsCalculateButton, SIGNAL(clicked()), this, SLOT(generateTransits()));
-	connect(ui->transitsCleanupButton, SIGNAL(clicked()), this, SLOT(cleanupTransits()));
-	connect(ui->transitsSaveButton, SIGNAL(clicked()), this, SLOT(saveTransits()));
-	connect(ui->transitTreeWidget, SIGNAL(doubleClicked(QModelIndex)), this, SLOT(selectCurrentTransit(QModelIndex)));
-	connect(objectMgr, SIGNAL(selectedObjectChanged(StelModule::StelModuleSelectAction)), this, SLOT(setTransitCelestialBodyName()));
+	initListRTS();
+	connect(ui->rtsCalculateButton, SIGNAL(clicked()), this, SLOT(generateRTS()));
+	connect(ui->rtsCleanupButton, SIGNAL(clicked()), this, SLOT(cleanupRTS()));
+	connect(ui->rtsSaveButton, SIGNAL(clicked()), this, SLOT(saveRTS()));
+	connect(ui->rtsTreeWidget, SIGNAL(doubleClicked(QModelIndex)), this, SLOT(selectCurrentRTS(QModelIndex)));
+	connect(objectMgr, SIGNAL(selectedObjectChanged(StelModule::StelModuleSelectAction)), this, SLOT(setRTSCelestialBodyName()));
 
 	// Tab: Eclipses
 	initListLunarEclipse();
@@ -567,7 +567,7 @@ void AstroCalcDialog::createDialogContent()
 	ui->celestialPositionsUpdateButton->setShortcut(QKeySequence("Shift+F10"));
 	ui->hecPositionsUpdateButton->setShortcut(QKeySequence("Shift+F10"));
 	ui->ephemerisPushButton->setShortcut(QKeySequence("Shift+F10"));
-	ui->transitsCalculateButton->setShortcut(QKeySequence("Shift+F10"));
+	ui->rtsCalculateButton->setShortcut(QKeySequence("Shift+F10"));
 	ui->phenomenaPushButton->setShortcut(QKeySequence("Shift+F10"));
 	ui->solareclipsesCalculateButton->setShortcut(QKeySequence("Shift+F10"));
 	ui->solareclipseslocalCalculateButton->setShortcut(QKeySequence("Shift+F10"));
@@ -591,7 +591,7 @@ void AstroCalcDialog::createDialogContent()
 	ui->angularDistanceLimitLabel->setStyleSheet(style);	
 	//ui->angularDistanceTitle->setStyleSheet(style);
 	ui->graphsNoteLabel->setStyleSheet(style);
-	ui->transitNotificationLabel->setStyleSheet(style);
+	ui->rtsNotificationLabel->setStyleSheet(style);
 	ui->gammaNoteLabel->setStyleSheet(style);
 	ui->gammaNoteSolarEclipseLabel->setStyleSheet(style);
 	ui->UncertaintiesNoteLabel->setStyleSheet(style);
@@ -2228,43 +2228,45 @@ void AstroCalcDialog::cleanupEphemeris()
 	ui->ephemerisTreeWidget->clear();
 }
 
-void AstroCalcDialog::setTransitHeaderNames()
+void AstroCalcDialog::setRTSHeaderNames()
 {
-	transitHeader.clear();
-	transitHeader << q_("Name");
-	transitHeader << q_("Date and Time");
+	rtsHeader.clear();
+	rtsHeader << q_("Name");
+	rtsHeader << qc_("Rise", "celestial event");
+	rtsHeader << qc_("Transit", "celestial event; passage across a meridian");
+	rtsHeader << qc_("Set", "celestial event");
 	// TRANSLATORS: altitude
-	transitHeader << q_("Altitude");
+	rtsHeader << q_("Altitude");
 	// TRANSLATORS: magnitude
-	transitHeader << q_("Mag.");
-	transitHeader << q_("Solar Elongation");
-	transitHeader << q_("Lunar Elongation");
-	ui->transitTreeWidget->setHeaderLabels(transitHeader);
+	rtsHeader << q_("Mag.");
+	rtsHeader << q_("Solar Elongation");
+	rtsHeader << q_("Lunar Elongation");
+	ui->rtsTreeWidget->setHeaderLabels(rtsHeader);
 
 	// adjust the column width
-	for (int i = 0; i < TransitCount; ++i)
+	for (int i = 0; i < RTSCount; ++i)
 	{
-		ui->transitTreeWidget->resizeColumnToContents(i);
+		ui->rtsTreeWidget->resizeColumnToContents(i);
 	}
 }
 
-void AstroCalcDialog::initListTransit()
+void AstroCalcDialog::initListRTS()
 {
-	ui->transitTreeWidget->clear();
-	ui->transitTreeWidget->setColumnCount(TransitCount);
-	setTransitHeaderNames();
-	ui->transitTreeWidget->header()->setSectionsMovable(false);
-	ui->transitTreeWidget->header()->setDefaultAlignment(Qt::AlignCenter);
+	ui->rtsTreeWidget->clear();
+	ui->rtsTreeWidget->setColumnCount(RTSCount);
+	setRTSHeaderNames();
+	ui->rtsTreeWidget->header()->setSectionsMovable(false);
+	ui->rtsTreeWidget->header()->setDefaultAlignment(Qt::AlignCenter);
 }
 
-void AstroCalcDialog::generateTransits()
+void AstroCalcDialog::generateRTS()
 {
 	QList<StelObjectP> selectedObjects = objectMgr->getSelectedObject();
 	if (!selectedObjects.isEmpty())
 	{
 		QString name, englishName;
 		StelObjectP selectedObject = selectedObjects[0];
-		name = ui->transitCelestialBodyNameLabel->text();
+		name = ui->rtsCelestialBodyNameLabel->text();
 		selectedObject->getEnglishName().isEmpty() ? englishName = name : englishName = selectedObject->getEnglishName();
 		//const bool isPlanet = (selectedObject->getType() == "Planet");
 
@@ -2272,7 +2274,7 @@ void AstroCalcDialog::generateTransits()
 		{
 			const bool withDecimalDegree = StelApp::getInstance().getFlagShowDecimalDegrees();
 
-			initListTransit();
+			initListRTS();
 
 			double currentStep = 1.0;
 			const PlanetP& planet = core->getCurrentPlanet();
@@ -2290,24 +2292,24 @@ void AstroCalcDialog::generateTransits()
 			const double currentJD = core->getJD();   // save current JD
 #if QT_VERSION >= QT_VERSION_CHECK(5,14,0)
 			// Note: It may even be possible to configure the time zone corrections into this call.
-			double startJD = StelUtils::qDateTimeToJd(ui->transitFromDateEdit->date().startOfDay(Qt::UTC));
-			double stopJD = StelUtils::qDateTimeToJd(ui->transitToDateEdit->date().startOfDay(Qt::UTC));
+			double startJD = StelUtils::qDateTimeToJd(ui->rtsFromDateEdit->date().startOfDay(Qt::UTC));
+			double stopJD = StelUtils::qDateTimeToJd(ui->rtsToDateEdit->date().startOfDay(Qt::UTC));
 #else
-			double startJD = StelUtils::qDateTimeToJd(QDateTime(ui->transitFromDateEdit->date()));
-			double stopJD = StelUtils::qDateTimeToJd(QDateTime(ui->transitToDateEdit->date()));
+			double startJD = StelUtils::qDateTimeToJd(QDateTime(ui->rtsFromDateEdit->date()));
+			double stopJD = StelUtils::qDateTimeToJd(QDateTime(ui->rtsToDateEdit->date()));
 #endif
 			startJD = startJD - core->getUTCOffset(startJD) / 24.;
 			stopJD = stopJD - core->getUTCOffset(stopJD) / 24.;
-			int elements = static_cast<int>((stopJD - startJD) / currentStep);
-			double JD, /*UTCshift,*/ az, alt;
+			int elements = 1 + static_cast<int>((stopJD - startJD) / currentStep);
+			double JD, az, alt, utcShift;
 			float magnitude;
-			QString altStr, magStr, elongSStr = dash, elongLStr =dash;
-			for (int i = 0; i <= elements; i++)
+			QString riseStr, setStr, altStr, magStr, elongSStr = dash, elongLStr = dash;
+			for (int i = 1; i <= elements; i++)
 			{
 				JD = startJD + i * currentStep;
 				core->setJD(JD);
 				core->update(0); // force update to get new coordinates
-				// UTCshift = core->getUTCOffset(JD) / 24.; // Fix DST shift...
+				utcShift = core->getUTCOffset(JD) / 24.; // Fix DST shift...
 				Vec4d rts = selectedObject->getRTSTime(core);
 				JD = rts[1]; // static_cast<int>(JD) + 0.5 + rts[1]/24. - UTCshift;
 				core->setJD(JD);
@@ -2329,46 +2331,65 @@ void AstroCalcDialog::generateTransits()
 				magnitude = selectedObject->getVMagnitudeWithExtinction(core);
 				magStr = (magnitude > 50.f || selectedObject->getEnglishName().contains("marker", Qt::CaseInsensitive)? dash : QString::number(magnitude, 'f', 2));
 
-				ACTransitTreeWidgetItem* treeItem = new ACTransitTreeWidgetItem(ui->transitTreeWidget);
-				treeItem->setText(TransitCOName, name);
-				treeItem->setData(TransitCOName, Qt::UserRole, englishName);
-				treeItem->setText(TransitDate, QString("%1 %2").arg(localeMgr->getPrintableDateLocal(JD), localeMgr->getPrintableTimeLocal(JD))); // local date and time
-				treeItem->setData(TransitDate, Qt::UserRole, JD);
-				treeItem->setText(TransitAltitude, altStr);
-				treeItem->setTextAlignment(TransitAltitude, Qt::AlignRight);
-				treeItem->setText(TransitMagnitude, magStr);
-				treeItem->setTextAlignment(TransitMagnitude, Qt::AlignRight);
-				treeItem->setText(TransitElongation, elongSStr);
-				treeItem->setTextAlignment(TransitElongation, Qt::AlignRight);
-				treeItem->setText(TransitAngularDistance, elongLStr);
-				treeItem->setTextAlignment(TransitAngularDistance, Qt::AlignRight);
+				if (rts[3]==0.)
+				{
+					riseStr = QString("%1 %2").arg(localeMgr->getPrintableDateLocal(rts[0]), StelUtils::hoursToHmsStr(StelUtils::getHoursFromJulianDay(rts[0] + utcShift), true));
+					setStr = QString("%1 %2").arg(localeMgr->getPrintableDateLocal(rts[2]), StelUtils::hoursToHmsStr(StelUtils::getHoursFromJulianDay(rts[2] + utcShift), true));
+				}
+				else
+					riseStr = setStr = dash;
+
+				ACRTSTreeWidgetItem* treeItem = new ACRTSTreeWidgetItem(ui->rtsTreeWidget);
+				treeItem->setText(RTSCOName, name);
+				treeItem->setData(RTSCOName, Qt::UserRole, englishName);
+				treeItem->setText(RTSRiseDate, riseStr); // local date and time
+				treeItem->setData(RTSRiseDate, Qt::UserRole, rts[0]);
+				treeItem->setTextAlignment(RTSRiseDate, Qt::AlignRight);
+				treeItem->setText(RTSTransitDate, QString("%1 %2").arg(localeMgr->getPrintableDateLocal(JD), StelUtils::hoursToHmsStr(StelUtils::getHoursFromJulianDay(JD + utcShift), true))); // local date and time
+				treeItem->setData(RTSTransitDate, Qt::UserRole, JD);
+				treeItem->setTextAlignment(RTSTransitDate, Qt::AlignRight);
+				treeItem->setText(RTSSetDate, setStr); // local date and time
+				treeItem->setData(RTSSetDate, Qt::UserRole, rts[2]);
+				treeItem->setTextAlignment(RTSSetDate, Qt::AlignRight);
+				treeItem->setText(RTSTransitAltitude, altStr);
+				treeItem->setToolTip(RTSTransitAltitude, q_("Altitude of celestial object at transit"));
+				treeItem->setTextAlignment(RTSTransitAltitude, Qt::AlignRight);
+				treeItem->setText(RTSMagnitude, magStr);
+				treeItem->setTextAlignment(RTSMagnitude, Qt::AlignRight);
+				treeItem->setToolTip(RTSMagnitude, q_("Magnitude of celestial object at transit"));
+				treeItem->setText(RTSElongation, elongSStr);
+				treeItem->setTextAlignment(RTSElongation, Qt::AlignRight);
+				treeItem->setToolTip(RTSElongation, q_("Celestial object's angular distance from the Sun at transit"));
+				treeItem->setText(RTSAngularDistance, elongLStr);
+				treeItem->setTextAlignment(RTSAngularDistance, Qt::AlignRight);
+				treeItem->setToolTip(RTSAngularDistance, q_("Celestial object's angular distance from the Moon at transit"));
 			}
 			core->setJD(currentJD);
 
 			// adjust the column width
-			for (int i = 0; i < TransitCount; ++i)
+			for (int i = 0; i < RTSCount; ++i)
 			{
-				ui->transitTreeWidget->resizeColumnToContents(i);
+				ui->rtsTreeWidget->resizeColumnToContents(i);
 			}
 
 			// sort-by-date
-			ui->transitTreeWidget->sortItems(TransitDate, Qt::AscendingOrder);
+			ui->rtsTreeWidget->sortItems(RTSTransitDate, Qt::AscendingOrder);
 		}
 		else
-			cleanupTransits();
+			cleanupRTS();
 	}
 }
 
-void AstroCalcDialog::cleanupTransits()
+void AstroCalcDialog::cleanupRTS()
 {
-	ui->transitTreeWidget->clear();
+	ui->rtsTreeWidget->clear();
 }
 
-void AstroCalcDialog::selectCurrentTransit(const QModelIndex& modelIndex)
+void AstroCalcDialog::selectCurrentRTS(const QModelIndex& modelIndex)
 {
 	// Find the object
-	QString name = modelIndex.sibling(modelIndex.row(), TransitCOName).data(Qt::UserRole).toString();
-	double JD = modelIndex.sibling(modelIndex.row(), TransitDate).data(Qt::UserRole).toDouble();
+	QString name = modelIndex.sibling(modelIndex.row(), RTSCOName).data(Qt::UserRole).toString();
+	double JD = modelIndex.sibling(modelIndex.row(), RTSTransitDate).data(Qt::UserRole).toDouble();
 
 	if (objectMgr->findAndSelectI18n(name) || objectMgr->findAndSelect(name))
 	{
@@ -2390,7 +2411,7 @@ void AstroCalcDialog::selectCurrentTransit(const QModelIndex& modelIndex)
 	}
 }
 
-void AstroCalcDialog::setTransitCelestialBodyName()
+void AstroCalcDialog::setRTSCelestialBodyName()
 {
 	QList<StelObjectP> selectedObjects = objectMgr->getSelectedObject();
 	QString name;
@@ -2413,10 +2434,10 @@ void AstroCalcDialog::setTransitCelestialBodyName()
 		if (selectedObject->getType()=="Satellite")
 			name = QString();
 	}
-	ui->transitCelestialBodyNameLabel->setText(name);
+	ui->rtsCelestialBodyNameLabel->setText(name);
 }
 
-void AstroCalcDialog::saveTransits()
+void AstroCalcDialog::saveRTS()
 {
 	QString filter = q_("Microsoft Excel Open XML Spreadsheet");
 	filter.append(" (*.xlsx);;");
@@ -2424,24 +2445,24 @@ void AstroCalcDialog::saveTransits()
 	filter.append(" (*.csv)");
 	QString defaultFilter("(*.xlsx)");
 	QString filePath = QFileDialog::getSaveFileName(Q_NULLPTR,
-							q_("Save calculated transits as..."),
-							QDir::homePath() + "/transits.xlsx",
+							q_("Save calculated data as..."),
+							QDir::homePath() + "/RTS.xlsx",
 							filter,
 							&defaultFilter);
 
 	if (defaultFilter.contains(".csv", Qt::CaseInsensitive))
-		saveTableAsCSV(filePath, ui->transitTreeWidget, ephemerisHeader);
+		saveTableAsCSV(filePath, ui->rtsTreeWidget, ephemerisHeader);
 	else
 	{
-		int count = ui->transitTreeWidget->topLevelItemCount();
-		int columns = transitHeader.size();
+		int count = ui->rtsTreeWidget->topLevelItemCount();
+		int columns = rtsHeader.size();
 		int *width = new int[static_cast<unsigned int>(columns)];
 		QString sData;
 
 		QXlsx::Document xlsx;
 		xlsx.setDocumentProperty("title", q_("Transits"));
 		xlsx.setDocumentProperty("creator", StelUtils::getApplicationName());
-		xlsx.addSheet(ui->transitCelestialBodyNameLabel->text(), AbstractSheet::ST_WorkSheet);
+		xlsx.addSheet(ui->rtsCelestialBodyNameLabel->text(), AbstractSheet::ST_WorkSheet);
 
 		QXlsx::Format header;
 		header.setHorizontalAlignment(QXlsx::Format::AlignHCenter);
@@ -2452,7 +2473,7 @@ void AstroCalcDialog::saveTransits()
 		for (int i = 0; i < columns; i++)
 		{
 			// Row 1: Names of columns
-			sData = transitHeader.at(i).trimmed();
+			sData = rtsHeader.at(i).trimmed();
 			xlsx.write(1, i + 1, sData, header);
 			width[i] = sData.size();
 		}
@@ -2464,7 +2485,7 @@ void AstroCalcDialog::saveTransits()
 			for (int j = 0; j < columns; j++)
 			{
 				// Row 2 and next: the data
-				sData = ui->transitTreeWidget->topLevelItem(i)->text(j).trimmed();
+				sData = ui->rtsTreeWidget->topLevelItem(i)->text(j).trimmed();
 				xlsx.write(i + 2, j + 1, sData, data);
 				int w = sData.size();
 				if (w > width[j])
@@ -6687,9 +6708,9 @@ void AstroCalcDialog::changePage(QListWidgetItem* current, QListWidgetItem* prev
 		ui->dateToDateTimeEdit->setDateTime(currentDT.addMonths(1));
 	}
 
-	// special case - transits
+	// special case - RTS
 	if (ui->stackListWidget->row(current) == 2)
-		setTransitCelestialBodyName();
+		setRTSCelestialBodyName();
 
 	// special case - graphs
 	if (ui->stackListWidget->row(current) == 4)

--- a/src/gui/AstroCalcDialog.cpp
+++ b/src/gui/AstroCalcDialog.cpp
@@ -2300,16 +2300,15 @@ void AstroCalcDialog::generateRTS()
 #endif
 			startJD = startJD - core->getUTCOffset(startJD) / 24.;
 			stopJD = stopJD - core->getUTCOffset(stopJD) / 24.;
-			int elements = 1 + static_cast<int>((stopJD - startJD) / currentStep);
+			int elements = static_cast<int>((stopJD - startJD) / currentStep);
 			double JD, az, alt, utcShift;
 			float magnitude;
 			QString riseStr, setStr, altStr, magStr, elongSStr = dash, elongLStr = dash;
-			for (int i = 1; i <= elements; i++)
+			for (int i = 0; i <= elements; i++)
 			{
-				JD = startJD + i * currentStep;
+				JD = startJD + i * currentStep + 1;
 				core->setJD(JD);
 				core->update(0); // force update to get new coordinates
-				utcShift = core->getUTCOffset(JD) / 24.; // Fix DST shift...
 				Vec4d rts = selectedObject->getRTSTime(core);
 				JD = rts[1]; // static_cast<int>(JD) + 0.5 + rts[1]/24. - UTCshift;
 				core->setJD(JD);
@@ -2333,8 +2332,8 @@ void AstroCalcDialog::generateRTS()
 
 				if (rts[3]==0.)
 				{
-					riseStr = QString("%1 %2").arg(localeMgr->getPrintableDateLocal(rts[0]), StelUtils::hoursToHmsStr(StelUtils::getHoursFromJulianDay(rts[0] + utcShift), true));
-					setStr = QString("%1 %2").arg(localeMgr->getPrintableDateLocal(rts[2]), StelUtils::hoursToHmsStr(StelUtils::getHoursFromJulianDay(rts[2] + utcShift), true));
+					riseStr = QString("%1 %2").arg(localeMgr->getPrintableDateLocal(rts[0]), localeMgr->getPrintableTimeLocal(rts[0]));
+					setStr = QString("%1 %2").arg(localeMgr->getPrintableDateLocal(rts[2]), localeMgr->getPrintableTimeLocal(rts[2]));
 				}
 				else
 					riseStr = setStr = dash;
@@ -2345,7 +2344,7 @@ void AstroCalcDialog::generateRTS()
 				treeItem->setText(RTSRiseDate, riseStr); // local date and time
 				treeItem->setData(RTSRiseDate, Qt::UserRole, rts[0]);
 				treeItem->setTextAlignment(RTSRiseDate, Qt::AlignRight);
-				treeItem->setText(RTSTransitDate, QString("%1 %2").arg(localeMgr->getPrintableDateLocal(JD), StelUtils::hoursToHmsStr(StelUtils::getHoursFromJulianDay(JD + utcShift), true))); // local date and time
+				treeItem->setText(RTSTransitDate, QString("%1 %2").arg(localeMgr->getPrintableDateLocal(JD), localeMgr->getPrintableTimeLocal(JD))); // local date and time
 				treeItem->setData(RTSTransitDate, Qt::UserRole, JD);
 				treeItem->setTextAlignment(RTSTransitDate, Qt::AlignRight);
 				treeItem->setText(RTSSetDate, setStr); // local date and time

--- a/src/gui/AstroCalcDialog.cpp
+++ b/src/gui/AstroCalcDialog.cpp
@@ -2301,7 +2301,7 @@ void AstroCalcDialog::generateRTS()
 			startJD = startJD - core->getUTCOffset(startJD) / 24.;
 			stopJD = stopJD - core->getUTCOffset(stopJD) / 24.;
 			int elements = static_cast<int>((stopJD - startJD) / currentStep);
-			double JD, az, alt, utcShift;
+			double JD, az, alt;
 			float magnitude;
 			QString riseStr, setStr, altStr, magStr, elongSStr = dash, elongLStr = dash;
 			for (int i = 0; i <= elements; i++)
@@ -2310,7 +2310,7 @@ void AstroCalcDialog::generateRTS()
 				core->setJD(JD);
 				core->update(0); // force update to get new coordinates
 				Vec4d rts = selectedObject->getRTSTime(core);
-				JD = rts[1]; // static_cast<int>(JD) + 0.5 + rts[1]/24. - UTCshift;
+				JD = rts[1];
 				core->setJD(JD);
 				core->update(0); // force update to get new coordinates
 

--- a/src/gui/AstroCalcDialog.hpp
+++ b/src/gui/AstroCalcDialog.hpp
@@ -104,16 +104,18 @@ public:
 		EphemerisCount          //! total number of columns
 	};
 
-	//! Defines the number and the order of the columns in the transit table
-	//! @enum TransitColumns
-	enum TransitColumns {
-		TransitCOName,          //! name of celestial object
-		TransitDate,            //! date and time of transit
-		TransitAltitude,        //! altitude
-		TransitMagnitude,       //! magnitude
-		TransitElongation,      //! elongation (from the Sun)
-		TransitAngularDistance, //! angular distance (from the Moon)
-		TransitCount            //! total number of columns
+	//! Defines the number and the order of the columns in the rises, transits and sets table
+	//! @enum RTSColumns
+	enum RTSColumns {
+		RTSCOName,		//! name of celestial object
+		RTSRiseDate,            //! date and time of rise
+		RTSTransitDate,         //! date and time of transit
+		RTSSetDate,		//! date and time of set
+		RTSTransitAltitude,     //! altitude at transit
+		RTSMagnitude,		//! magnitude at transit
+		RTSElongation,		//! elongation at transit (from the Sun)
+		RTSAngularDistance,	//! angular distance at transit (from the Moon)
+		RTSCount		//! total number of columns
 	};
 
 	//! Defines the number and the order of the columns in the phenomena table
@@ -255,15 +257,15 @@ private slots:
 	void onChangedEphemerisPosition();
 	void reGenerateEphemeris();
 
-	//! Calculating the transits for selected celestial body and fill the list.
-	void generateTransits();
-	void cleanupTransits();
-	void selectCurrentTransit(const QModelIndex &modelIndex);
-	void saveTransits();
-	void setTransitCelestialBodyName();
+	//! Calculating the rises, transits and sets for selected celestial body and fill the list.
+	void generateRTS();
+	void cleanupRTS();
+	void selectCurrentRTS(const QModelIndex &modelIndex);
+	void saveRTS();
+	void setRTSCelestialBodyName();
 
 	//! Calculating lunar eclipses to fill the list.
-	//! Algorithm taken from calculating the transits.
+	//! Algorithm taken from calculating the rises, transits and sets.
 	void generateLunarEclipses();
 	void cleanupLunarEclipses();
 	void selectCurrentLunarEclipse(const QModelIndex &modelIndex);
@@ -408,8 +410,8 @@ private:
 	void setHECPositionsHeaderNames();
 	//! Update header names for ephemeris table
 	void setEphemerisHeaderNames();
-	//! update header names for transit table
-	void setTransitHeaderNames();
+	//! update header names for rises, transists and sets table
+	void setRTSHeaderNames();
 	//! Update header names for phenomena table
 	void setPhenomenaHeaderNames();
 	//! Update header names for WUT table
@@ -427,8 +429,8 @@ private:
 	void initListHECPositions();
 	//! Init header and list of ephemeris
 	void initListEphemeris();
-	//! Init header and list of transits
-	void initListTransit();
+	//! Init header and list of rises, transists and sets
+	void initListRTS();
 	//! Init header and list of phenomena
 	void initListPhenomena();
 	//! Init header and list of WUT
@@ -521,7 +523,7 @@ private:
 
 	bool plotAltVsTime, plotAltVsTimeSun, plotAltVsTimeMoon, plotAltVsTimePositive, plotMonthlyElevation, plotMonthlyElevationPositive, plotDistanceGraph, plotAngularDistanceGraph, plotAziVsTime;
 	int altVsTimePositiveLimit, monthlyElevationPositiveLimit, graphsDuration;
-	QStringList ephemerisHeader, phenomenaHeader, positionsHeader, hecPositionsHeader, wutHeader, transitHeader, lunareclipseHeader, solareclipseHeader, solareclipselocalHeader;
+	QStringList ephemerisHeader, phenomenaHeader, positionsHeader, hecPositionsHeader, wutHeader, rtsHeader, lunareclipseHeader, solareclipseHeader, solareclipselocalHeader;
 	static double brightLimit;
 	static double minY, maxY, minYme, maxYme, minYsun, maxYsun, minYmoon, maxYmoon, transitX, minY1, maxY1, minY2, maxY2,
 			     minYld, maxYld, minYad, maxYad, minYadm, maxYadm, minYaz, maxYaz;
@@ -741,10 +743,10 @@ private:
 };
 
 // Reimplements the QTreeWidgetItem class to fix the sorting bug
-class ACTransitTreeWidgetItem : public QTreeWidgetItem
+class ACRTSTreeWidgetItem : public QTreeWidgetItem
 {
 public:
-	ACTransitTreeWidgetItem(QTreeWidget* parent)
+	ACRTSTreeWidgetItem(QTreeWidget* parent)
 		: QTreeWidgetItem(parent)
 	{
 	}
@@ -754,15 +756,15 @@ private:
 	{
 		int column = treeWidget()->sortColumn();
 
-		if (column == AstroCalcDialog::TransitDate)
+		if (column == AstroCalcDialog::RTSRiseDate || column == AstroCalcDialog::RTSTransitDate || column == AstroCalcDialog::RTSSetDate)
 		{
 			return data(column, Qt::UserRole).toFloat() < other.data(column, Qt::UserRole).toFloat();
 		}
-		else if (column == AstroCalcDialog::TransitMagnitude)
+		else if (column == AstroCalcDialog::RTSMagnitude)
 		{
 			return text(column).toFloat() < other.text(column).toFloat();
 		}
-		else if (column == AstroCalcDialog::TransitAltitude || column == AstroCalcDialog::TransitElongation || column == AstroCalcDialog::TransitAngularDistance)
+		else if (column == AstroCalcDialog::RTSTransitAltitude || column == AstroCalcDialog::RTSElongation || column == AstroCalcDialog::RTSAngularDistance)
 		{
 			return StelUtils::getDecAngle(text(column)) < StelUtils::getDecAngle(other.text(column));
 		}

--- a/src/gui/AstroCalcDialog.hpp
+++ b/src/gui/AstroCalcDialog.hpp
@@ -107,15 +107,15 @@ public:
 	//! Defines the number and the order of the columns in the rises, transits and sets table
 	//! @enum RTSColumns
 	enum RTSColumns {
-		RTSCOName,		//! name of celestial object
+		RTSCOName,              //! name of celestial object
 		RTSRiseDate,            //! date and time of rise
 		RTSTransitDate,         //! date and time of transit
-		RTSSetDate,		//! date and time of set
+		RTSSetDate,             //! date and time of set
 		RTSTransitAltitude,     //! altitude at transit
-		RTSMagnitude,		//! magnitude at transit
-		RTSElongation,		//! elongation at transit (from the Sun)
-		RTSAngularDistance,	//! angular distance at transit (from the Moon)
-		RTSCount		//! total number of columns
+		RTSMagnitude,           //! magnitude at transit
+		RTSElongation,          //! elongation at transit (from the Sun)
+		RTSAngularDistance,     //! angular distance at transit (from the Moon)
+		RTSCount                //! total number of columns
 	};
 
 	//! Defines the number and the order of the columns in the phenomena table
@@ -546,81 +546,81 @@ private:
 	bool graphPlotNeedsRefresh;
 
 	enum PhenomenaCategory {
-		PHCLatestSelectedObject			= -1,
-		PHCSolarSystem					= 0,
-		PHCPlanets						= 1,
-		PHCAsteroids						= 2,
-		PHCPlutinos						= 3,
-		PHCComets						= 4,
-		PHCDwarfPlanets					= 5,
-		PHCCubewanos					= 6,
-		PHCScatteredDiscObjects			= 7,
-		PHCOortCloudObjects				= 8,
-		PHCSednoids						= 9,
-		PHCBrightStars					= 10,
-		PHCBrightDoubleStars				= 11,
-		PHCBrightVariableStars				= 12,
-		PHCBrightStarClusters				= 13,
-		PHCPlanetaryNebulae				= 14,
-		PHCBrightNebulae					= 15,
-		PHCDarkNebulae					= 16,
-		PHCBrightGalaxies					= 17,
-		PHCSymbioticStars					= 18,
-		PHCEmissionLineStars				= 19,
-		PHCInterstellarObjects				= 20,
-		PHCPlanetsSun					= 21,
-		PHCSunPlanetsMoons				= 22,
-		PHCBrightSolarSystemObjects		= 23,
-		PHCSolarSystemMinorBodies		= 24,
-		PHCMoonsFirstBody				= 25,
-		PHCBrightCarbonStars				= 26,
-		PHCBrightBariumStars				= 27,
+		PHCLatestSelectedObject     = -1,
+		PHCSolarSystem              =  0,
+		PHCPlanets                  =  1,
+		PHCAsteroids                =  2,
+		PHCPlutinos                 =  3,
+		PHCComets                   =  4,
+		PHCDwarfPlanets             =  5,
+		PHCCubewanos                =  6,
+		PHCScatteredDiscObjects     =  7,
+		PHCOortCloudObjects         =  8,
+		PHCSednoids                 =  9,
+		PHCBrightStars              = 10,
+		PHCBrightDoubleStars        = 11,
+		PHCBrightVariableStars      = 12,
+		PHCBrightStarClusters       = 13,
+		PHCPlanetaryNebulae         = 14,
+		PHCBrightNebulae            = 15,
+		PHCDarkNebulae              = 16,
+		PHCBrightGalaxies           = 17,
+		PHCSymbioticStars           = 18,
+		PHCEmissionLineStars        = 19,
+		PHCInterstellarObjects      = 20,
+		PHCPlanetsSun               = 21,
+		PHCSunPlanetsMoons          = 22,
+		PHCBrightSolarSystemObjects = 23,
+		PHCSolarSystemMinorBodies   = 24,
+		PHCMoonsFirstBody           = 25,
+		PHCBrightCarbonStars        = 26,
+		PHCBrightBariumStars        = 27,
 		PHCNone	// stop gapper for syntax reasons
 	};
 
 	enum WUTCategory {
-		EWPlanets						= 0,
-		EWBrightStars					= 1,
-		EWBrightNebulae					= 2,
-		EWDarkNebulae					= 3,
-		EWGalaxies						= 4,
-		EWOpenStarClusters				= 5,
-		EWAsteroids						= 6,
-		EWComets						= 7,
-		EWPlutinos						= 8,
-		EWDwarfPlanets					= 9,
-		EWCubewanos					= 10,
-		EWScatteredDiscObjects			= 11,
-		EWOortCloudObjects				= 12,
-		EWSednoids						= 13,
-		EWPlanetaryNebulae				= 14,
-		EWBrightDoubleStars				= 15,
-		EWBrightVariableStars				= 16,
-		EWBrightStarsWithHighProperMotion	= 17,
-		EWSymbioticStars					= 18,
-		EWEmissionLineStars				= 19,
-		EWSupernovaeCandidates			= 20,
-		EWSupernovaeRemnantCandidates	= 21,
-		EWSupernovaeRemnants			= 22,
-		EWClustersOfGalaxies				= 23,
-		EWInterstellarObjects				= 24,
-		EWGlobularStarClusters			= 25,
-		EWRegionsOfTheSky				= 26,
-		EWActiveGalaxies					= 27,
-		EWPulsars						= 28,
-		EWExoplanetarySystems			= 29,
-		EWBrightNovaStars				= 30,
-		EWBrightSupernovaStars			= 31,
-		EWInteractingGalaxies				= 32,
-		EWDeepSkyObjects				= 33,
-		EWMessierObjects					= 34,
-		EWNGCICObjects					= 35,
-		EWCaldwellObjects				= 36,
-		EWHerschel400Objects				= 37,
-		EWAlgolTypeVariableStars			= 38,	// http://www.sai.msu.su/gcvs/gcvs/vartype.htm
-		EWClassicalCepheidsTypeVariableStars	= 39,	// http://www.sai.msu.su/gcvs/gcvs/vartype.htm
-		EWCarbonStars					= 40,
-		EWBariumStars					= 41,
+		EWPlanets                            =  0,
+		EWBrightStars                        =  1,
+		EWBrightNebulae                      =  2,
+		EWDarkNebulae                        =  3,
+		EWGalaxies                           =  4,
+		EWOpenStarClusters                   =  5,
+		EWAsteroids                          =  6,
+		EWComets                             =  7,
+		EWPlutinos                           =  8,
+		EWDwarfPlanets                       =  9,
+		EWCubewanos                          = 10,
+		EWScatteredDiscObjects               = 11,
+		EWOortCloudObjects                   = 12,
+		EWSednoids                           = 13,
+		EWPlanetaryNebulae                   = 14,
+		EWBrightDoubleStars                  = 15,
+		EWBrightVariableStars                = 16,
+		EWBrightStarsWithHighProperMotion    = 17,
+		EWSymbioticStars                     = 18,
+		EWEmissionLineStars                  = 19,
+		EWSupernovaeCandidates               = 20,
+		EWSupernovaeRemnantCandidates        = 21,
+		EWSupernovaeRemnants                 = 22,
+		EWClustersOfGalaxies                 = 23,
+		EWInterstellarObjects                = 24,
+		EWGlobularStarClusters               = 25,
+		EWRegionsOfTheSky                    = 26,
+		EWActiveGalaxies                     = 27,
+		EWPulsars                            = 28,
+		EWExoplanetarySystems                = 29,
+		EWBrightNovaStars                    = 30,
+		EWBrightSupernovaStars               = 31,
+		EWInteractingGalaxies                = 32,
+		EWDeepSkyObjects                     = 33,
+		EWMessierObjects                     = 34,
+		EWNGCICObjects                       = 35,
+		EWCaldwellObjects                    = 36,
+		EWHerschel400Objects                 = 37,
+		EWAlgolTypeVariableStars             = 38, // http://www.sai.msu.su/gcvs/gcvs/vartype.htm
+		EWClassicalCepheidsTypeVariableStars = 39, // http://www.sai.msu.su/gcvs/gcvs/vartype.htm
+		EWCarbonStars                        = 40,
+		EWBariumStars                        = 41,
 		EWNone	// stop gapper for syntax reasons
 	};
 };

--- a/src/gui/astroCalcDialog.ui
+++ b/src/gui/astroCalcDialog.ui
@@ -282,7 +282,10 @@
         </item>
         <item>
          <property name="text">
-          <string>Transits</string>
+          <string comment="rise, transit, set">RTS</string>
+         </property>
+         <property name="toolTip">
+          <string>Rises, transits and sets</string>
          </property>
          <property name="icon">
           <iconset>
@@ -1009,30 +1012,30 @@
           <item row="4" column="0">
            <layout class="QHBoxLayout" name="horizontalLayout_30">
             <item>
-             <widget class="QPushButton" name="transitsCleanupButton">
+             <widget class="QPushButton" name="rtsCleanupButton">
               <property name="text">
-               <string>Cleanup transits</string>
+               <string>Cleanup data</string>
               </property>
              </widget>
             </item>
             <item>
-             <widget class="QPushButton" name="transitsSaveButton">
+             <widget class="QPushButton" name="rtsSaveButton">
               <property name="text">
-               <string>Export transits...</string>
+               <string>Export data...</string>
               </property>
              </widget>
             </item>
             <item>
-             <widget class="QPushButton" name="transitsCalculateButton">
+             <widget class="QPushButton" name="rtsCalculateButton">
               <property name="text">
-               <string>Calculate transits</string>
+               <string>Calculate</string>
               </property>
              </widget>
             </item>
            </layout>
           </item>
           <item row="2" column="0">
-           <widget class="QTreeWidget" name="transitTreeWidget">
+           <widget class="QTreeWidget" name="rtsTreeWidget">
             <property name="rootIsDecorated">
              <bool>false</bool>
             </property>
@@ -1061,14 +1064,14 @@
             <item>
              <layout class="QHBoxLayout" name="horizontalLayout_34">
               <item>
-               <widget class="QLabel" name="transitCelestialBodyLabel">
+               <widget class="QLabel" name="rtsCelestialBodyLabel">
                 <property name="text">
                  <string>Celestial object:</string>
                 </property>
                </widget>
               </item>
               <item>
-               <widget class="QLabel" name="transitCelestialBodyNameLabel">
+               <widget class="QLabel" name="rtsCelestialBodyNameLabel">
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
                   <horstretch>0</horstretch>
@@ -1090,14 +1093,14 @@
             <item>
              <layout class="QHBoxLayout" name="horizontalLayout_35">
               <item>
-               <widget class="QLabel" name="transitFromLabel">
+               <widget class="QLabel" name="rtsFromLabel">
                 <property name="text">
                  <string>From:</string>
                 </property>
                </widget>
               </item>
               <item>
-               <widget class="QDateEdit" name="transitFromDateEdit">
+               <widget class="QDateEdit" name="rtsFromDateEdit">
                 <property name="wrapping">
                  <bool>true</bool>
                 </property>
@@ -1114,14 +1117,14 @@
             <item>
              <layout class="QHBoxLayout" name="horizontalLayout_32">
               <item>
-               <widget class="QLabel" name="transitToLabel">
+               <widget class="QLabel" name="rtsToLabel">
                 <property name="text">
                  <string>To:</string>
                 </property>
                </widget>
               </item>
               <item>
-               <widget class="QDateEdit" name="transitToDateEdit">
+               <widget class="QDateEdit" name="rtsToDateEdit">
                 <property name="wrapping">
                  <bool>true</bool>
                 </property>
@@ -1138,14 +1141,14 @@
            </layout>
           </item>
           <item row="0" column="0">
-           <widget class="QLabel" name="transitHeaderLabel">
+           <widget class="QLabel" name="rtsHeaderLabel">
             <property name="font">
              <font>
               <bold>true</bold>
              </font>
             </property>
             <property name="text">
-             <string>Table of approximate transits for selected celestial object</string>
+             <string>Table of approximate rises, transits and sets for selected celestial object</string>
             </property>
             <property name="alignment">
              <set>Qt::AlignCenter</set>
@@ -1153,7 +1156,7 @@
            </widget>
           </item>
           <item row="3" column="0">
-           <widget class="QLabel" name="transitNotificationLabel">
+           <widget class="QLabel" name="rtsNotificationLabel">
             <property name="text">
              <string>Note: artificial satellites and unnamed stars are excluded from calculation</string>
             </property>


### PR DESCRIPTION
### Description
The AstroCalc/Transits tool has been converted to AstroCalc/RTS tool, where RTS is meaning "rises, transits and sets". 

I got the feature request by email:
> I would also appreciate in the Astronomical Calculation section tables with Sun and Moon rise, transit, transit elevation and set times, maybe accompanied by other bits of information for a time span to be defined.

Of course these changes requires the changes in the Stellarium User Guide, but I think the Guide should be updated after merge all planned for version 0.22 modifications in AstroCalc tools. 

### Screenshots (if appropriate):
![stellarium-005](https://user-images.githubusercontent.com/88731/154692426-d862faef-57ea-4dcc-8735-14824db04a8d.jpg)

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] This change requires a documentation update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
