### PR TITLE
Save log file in UTF-8 encoding

### DIFF
--- a/src/StelLogger.cpp
+++ b/src/StelLogger.cpp
@@ -299,7 +299,8 @@ void StelLogger::writeLog(QString msg)
 		msg.append(QLatin1Char('\n'));
 
 	fileMutex.lock();
-	logFile.write(qPrintable(msg), msg.size());
+	const auto utf8 = msg.toUtf8();
+	logFile.write(utf8.constData(), utf8.size());
 	log += msg;
 	fileMutex.unlock();
 }


### PR DESCRIPTION
### Description

qPrintable() converts given string to a local 8-bit encoding, which in 2022 is not really sensible. This patch makes log file saved in UTF-8, which lets us see, in particular, filenames regardless of the machine.

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system: Windows 11 Pro 21H2; GNU/Linux

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules