### PR TITLE
Add and adjust DSO nicknames

### DIFF
--- a/nebulae/default/names.dat
+++ b/nebulae/default/names.dat
@@ -101,6 +101,7 @@
 #   TLO: Guy Consolmagno, Dan M. Davis, Turn Left at Orion, Cambridge University Press, 2019. ISBN 9781108558464; https://doi.org/10.1017/9781108558464
 #   JH: Sir John Herschel's note
 #      - NGC3199/h3239: Falcated Nebula; Results of astronomical observations made during the years 1834, 5, 6, 7, 8, at the Cape of Good Hope... P38, 20, 94; https://ngcicproject.observers.org/Historical_Record/Corwin/1847AO-1_JHerschelCapeObs.pdf
+#      - NGC2070: Great Looped Nebula; Results of astronomical observations made during the years 1834, 5, 6, 7, 8, at the Cape of Good Hope...
 #   ???: Source very much needed. Marked especially for objects which have a well-known name, where a new/alternative name does not help anybody.
 #   TBD:  ADD OTHERS HERE!
 NGC  40              _("Bow-Tie Nebula") # ESKY, B500
@@ -274,7 +275,7 @@ NGC  2035            _("Dragon’s Head Nebula") # ESKY, ADI
 NGC  2060            _("30 Dor B") # SIMBAD
 NGC  2068            _("Casper the Friendly Ghost Nebula") # B500
 NGC  2070            _("Tarantula Nebula") # WK, SIMBAD, BCH, WSO, PSA, DN, PAS, TLO
-NGC  2070            _("Great Looped Nebula") # BCH, SOG
+NGC  2070            _("Great Looped Nebula") # BCH, SOG, JH
 NGC  2070            _("True Lovers' Knot") # ???
 NGC  2070            _("30 Dor Cluster") # SIMBAD, BCH
 NGC  2070            _("30 Dor Nebula") # PSA

--- a/nebulae/default/names.dat
+++ b/nebulae/default/names.dat
@@ -117,8 +117,7 @@
 #   TBD:  ADD OTHERS HERE!
 #      - The Kite Cluster (NGC 1664); https://observing.skyhound.com/archives/dec/NGC_1664.html
 #      - NGC3310 - Bow and Arrow Galaxy; http://astroa.physics.metu.edu.tr/~umk/ccd_wshop_adelman/Astronom/GALAXY/NGC3310.HTM
-#      - NGC6559 - Chinese Dragon Nebula; https://noirlab.edu/public/images/gemini0509b/
-#      - NGC6559 - Chinese Dragon Nebula; https://skyandtelescope.org/astronomy-news/astro-image-in-the-newsdragon-in-the-sky/
+#      - NGC6559 - Chinese Dragon Nebula; https://noirlab.edu/public/images/gemini0509b/ https://skyandtelescope.org/astronomy-news/astro-image-in-the-newsdragon-in-the-sky/
 #      - Ced19D - Electra Nebula; http://www.irida-observatory.org/CCD/VdB20_23/VdB20_23.html
 #      - IC423 - Teardrop Nebula; Sky and Telescope February 2017 (2017S&T...133b..75A)
 #      - IC2087 - Little Flame Nebula; https://delsaert.com/2018/12/02/barnard-22-and-the-little-flame-ic-2087/

--- a/nebulae/default/names.dat
+++ b/nebulae/default/names.dat
@@ -27,6 +27,7 @@
 #      - IC 4592: A Blue Horsehead; https://apod.nasa.gov/apod/ap090521.html
 #      - IC 4592: The Blue Horsehead Reflection Nebula; https://apod.nasa.gov/apod/ap130402.html
 #      - NGC 6979: Fleming's Triangular Wisp; https://apod.nasa.gov/apod/ap150917.html
+#      - NGC 6979: Pickering's Triangle; https://apod.nasa.gov/apod/ap150917.html
 #      - RCW 114: A Dragon's Heart in Ara; https://apod.nasa.gov/apod/ap180111.html
 #      - Barnard 228: The Dark Wolf Nebula in Lupus; https://apod.nasa.gov/apod/ap180726.html
 #      - NGC 1360: The Robin's Egg Nebula; https://apod.nasa.gov/apod/ap180511.html
@@ -123,6 +124,7 @@
 #      - IC2087 - Little Flame Nebula; https://delsaert.com/2018/12/02/barnard-22-and-the-little-flame-ic-2087/
 #      - Arp316 - Gamma Leonis Group; https://astronomy.com/observing/observing-podcasts/2016/04/the-eta-carinae-nebula-m95-and-the-gamma-leonis-group
 #      - B86 - Herschel's Hole in the Heavens; http://www.klima-luft.de/steinicke/Artikel/Herschel's%20Hole.pdf
+#      - CR89: 9-12 Geminorum Cluster; 1,001 Celestial Wonders to See Before You Die. P460.
 NGC  40              _("Bow-Tie Nebula") # ESKY, B500
 NGC  40              _("Scarab Nebula") # B500
 NGC  55              _("String of Pearls") # SG
@@ -227,7 +229,7 @@ NGC  1501            _("Oyster Nebula") # B500, DWH, HT, WP
 NGC  1501            _("Camel's Eye Nebula") # B500
 NGC  1501            _("Blue Oyster Nebula") # HT
 NGC  1502            _("Jolly Roger Cluster") # HT, B500
-NGC  1502            _("Golden Harp Cluster") # B500
+NGC  1502            _("Golden Harp Cluster") # B500, CSOG-BCH
 NGC  1514            _("Crystal Ball Nebula") # DSW, SD, B500
 NGC  1514            _("Pansy Nebula") # B500
 NGC  1528            _("m & m Double Cluster") # HT
@@ -772,7 +774,9 @@ NGC  6960            _("West Veil Nebula") # DSW, BCH, DWH, PAS
 NGC  6960            _("Cirrus Nebula") # SIMBAD
 NGC  6960            _("Witch's Broom Nebula") # WP, APOD
 NGC  6960            _("Veil Nebula") # PSA, CC, DN, B500
+# Fleming's Triangular Wisp/Pickering's Triangle lies 35' SW of NGC6979
 NGC  6979            _("Fleming's Triangular Wisp") # APOD
+NGC  6979            _("Pickering's Triangle") # APOD
 NGC  6979            _("Veil Nebula") # DN, B500
 NGC  6992            _("East Veil Nebula") # DSW, BCH, DWH, PAS
 NGC  6992            _("Veil Nebula") # WSO, PSA, DN, B500
@@ -877,6 +881,7 @@ IC   1805            _("Valentine Nebula") # B500
 IC   1805            _("AFGL 333 Cloud") # SIMBAD
 IC   2087            _("Little Flame Nebula") # TBD, CSOG-BCH
 IC   2118            _("Witch Head Nebula") # WK, DSW, TSS, PSA
+IC   2169            _("Dreyer's Nebula") # WP
 IC   2199            _("IC 2199 group") # WSG
 IC   2220            _("Toby Jug Nebula") # SIMBAD, TSS
 IC   2220            _("Butterfly Nebula")
@@ -972,6 +977,7 @@ CR   69              _("λ Ori Cluster") # HT
 CR   69              _("Aunt Margaret's Mirror") # HT
 CR   70              _("Orion Belt Cluster") # SD
 CR   70              _("Serpentine Column") # SD
+CR   89              _("9-12 Geminorum Cluster") # TBD
 CR   135             _("π Pup Cluster") # OGSC
 CR   140             _("Tuft in the Tail of the Dog Cluster")
 CR   205             _("Markarian 18 Cluster")
@@ -1230,6 +1236,7 @@ PK   331-01.1        _("Ant Nebula") # SIMBAD, DSNI
 PK   331-01.1        _("The Chamber of Horrors") # WP
 PK   331-12.1        _("Stingray Nebula") # WP, SIMBAD
 PK   340-03.1        _("Water Lily Nebula") # SIMBAD
+PNG  004.2+02.1      _("Silkworm Nebula") # SIMBAD
 PNG  010.4+04.4      _("Sakurai's Object") # SIMBAD
 PNG  054.2-03.4      _("Necklace Nebula") # HST
 PNG  126.6+01.3      _("Principes de Asturias Nebula") # SIMBAD

--- a/nebulae/default/names.dat
+++ b/nebulae/default/names.dat
@@ -99,6 +99,8 @@
 #   ADI: https://astrodonimaging.com/
 #      - NGC2029, NGC2032, NGC2035 - Southern Seagull Nebula; https://astrodonimaging.com/gallery/southern-seagull-nebula/
 #   TLO: Guy Consolmagno, Dan M. Davis, Turn Left at Orion, Cambridge University Press, 2019. ISBN 9781108558464; https://doi.org/10.1017/9781108558464
+#   JH: Sir John Herschel's note
+#      - NGC3199/h3239: Falcated Nebula; Results of astronomical observations made during the years 1834, 5, 6, 7, 8, at the Cape of Good Hope... P38, 20, 94; https://ngcicproject.observers.org/Historical_Record/Corwin/1847AO-1_JHerschelCapeObs.pdf
 #   ???: Source very much needed. Marked especially for objects which have a well-known name, where a new/alternative name does not help anybody.
 #   TBD:  ADD OTHERS HERE!
 NGC  40              _("Bow-Tie Nebula") # ESKY, B500
@@ -403,6 +405,7 @@ NGC  3187            _("Leo Quartet") # WSG
 NGC  3189            _("NGC 3190 Group") # BCH, SIMBAD
 NGC  3189            _("Leo Quartet") # WSG
 NGC  3193            _("Leo Quartet") # WSG
+NGC  3199            _("Falcated Nebula") # JH
 NGC  3228            _("Queen's Cache Cluster") # HT
 NGC  3242            _("Ghost of Jupiter Nebula") # WK, SIMBAD, DSW, BCH, DWH, WSO, PSA, CC, DN, B500, PAS, TLO
 NGC  3242            _("Eye Nebula") # DN
@@ -537,7 +540,7 @@ NGC  4826            _("Evil Eye Galaxy") # SIMBAD
 NGC  4826            _("Sleeping Beauty Galaxy") # B500
 NGC  4833            _("The Southern Butterfly") # SG
 NGC  4889            _("Coma B") # ESKY
-NGC  4898            _("Z Coma Coma") # SIMBAD
+# NGC  4898            _("Z Coma Coma") # SIMBAD
 NGC  4945            _("The Tweezers Galaxy") # SG
 # NGC  4990            _("Cocoon Galaxy") # SIMBAD
 NGC  5033            _("Waterbug Galaxy") # SD

--- a/nebulae/default/names.dat
+++ b/nebulae/default/names.dat
@@ -47,6 +47,9 @@
 #      - The Medulla Nebula Supernova Remnant; https://apod.nasa.gov/apod/ap210118.html
 #      - NGC 6188: The Dragons of Ara; https://apod.nasa.gov/apod/ap200728.html
 #      - NGC 2170: Angel Nebula; https://apod.nasa.gov/apod/ap160428.html
+#      - NGC 247: Needle's Eye Galaxy; https://apod.nasa.gov/apod/ap200116.html
+#      - NGC 602: Flying Lizard Nebula; https://apod.nasa.gov/apod/ap150307.html
+#      - NGC 2327: Parrot Nebula; https://apod.nasa.gov/apod/ap120308.html
 #   HST:
 #      - Hubble offers a dazzling necklace; https://spacetelescope.org/images/potw1133a/
 #   ABIN: 
@@ -68,6 +71,8 @@
 #      - Caldwell 22; https://www.nasa.gov/feature/goddard/caldwell-22
 #      - NASA Missions Explore a ‘TIE Fighter’ Active Galaxy; https://www.nasa.gov/feature/goddard/2020/nasa-missions-explore-a-tie-fighter-active-galaxy
 #      - NGC 4151: The 'Eye of Sauron'; https://www.nasa.gov/mission_pages/chandra/multimedia/11-029.html
+#      - NGC1566 - Spanish Dancer Galaxy; https://science.nasa.gov/ngc-1566-spanish-dancer-spiral-galaxy
+#      - NGC7479 - Propeller Galaxy; https://www.nasa.gov/feature/goddard/caldwell-44
 #   DSW: Deep-Sky Wonders: A Tour of the Universe with Sky and Telescope's Sue French, Firefly Books, 2011
 #   TSS: Treasures of the Southern Sky by Robert Gendler, Lars Lindberg Christensen and David Malin, Springer-Verlag New York, 2011; DOI: 10.1007/978-1-4614-0628-0
 #   BCH: Robert Burnham Jr., Burnham's Celestial Handbook: An Observer's Guide to the Universe Beyond the Solar System, Vol. 1-3, Dover Publications, 1978-1979
@@ -90,6 +95,7 @@
 #   CCG: Josef Klepesta, Antonin Rukl (1977). Constellations: A concise guide in colour. ISBN 0600008932.
 #   SBSX: Asterisms in Camelopardalis. https://www.bisque.com/tom/asterisms/camela.asp
 #   CSOG-MSC: Clear Skies Observing Guides: Melotte Star Clusters. http://www.clearskies.eu/csog/download/index/starclusters/Melotte%20-%20index.pdf
+#   CSOG-BCH: Clear Skies Observing Guides: Index of Burnham's Celestial Handbook. https://clearskies.eu/csog/downloads/other/#burnhams
 #   SN: Burçin's galaxy: https://sciencenode.org/feature/burcins-galaxy.php
 #   PAS: Patrick Moore, Paul Doherty, H. J. P. Arnold, The Photographic Atlas of the Stars, CRC Press LLC, 1999. ISBN 0750306548; https://books.google.com/books?id=YjcvJUfnWBAC&pg=PA97#v=onepage&q&f=false
 #   ABALL: R.S. Ball, Astronomy (1878)
@@ -109,6 +115,14 @@
 #   ???: Source very much needed. Marked especially for objects which have a well-known name, where a new/alternative name does not help anybody.
 #   TBD:  ADD OTHERS HERE!
 #      - The Kite Cluster (NGC 1664); https://observing.skyhound.com/archives/dec/NGC_1664.html
+#      - NGC3310 - Bow and Arrow Galaxy; http://astroa.physics.metu.edu.tr/~umk/ccd_wshop_adelman/Astronom/GALAXY/NGC3310.HTM
+#      - NGC6559 - Chinese Dragon Nebula; https://noirlab.edu/public/images/gemini0509b/
+#      - NGC6559 - Chinese Dragon Nebula; https://skyandtelescope.org/astronomy-news/astro-image-in-the-newsdragon-in-the-sky/
+#      - Ced19D - Electra Nebula; http://www.irida-observatory.org/CCD/VdB20_23/VdB20_23.html
+#      - IC423 - Teardrop Nebula; Sky and Telescope February 2017 (2017S&T...133b..75A)
+#      - IC2087 - Little Flame Nebula; https://delsaert.com/2018/12/02/barnard-22-and-the-little-flame-ic-2087/
+#      - Arp316 - Gamma Leonis Group; https://astronomy.com/observing/observing-podcasts/2016/04/the-eta-carinae-nebula-m95-and-the-gamma-leonis-group
+#      - B86 - Herschel's Hole in the Heavens; http://www.klima-luft.de/steinicke/Artikel/Herschel's%20Hole.pdf
 NGC  40              _("Bow-Tie Nebula") # ESKY, B500
 NGC  40              _("Scarab Nebula") # B500
 NGC  55              _("String of Pearls") # SG
@@ -130,7 +144,8 @@ NGC  225             _("Broken Heart Cluster") # HT
 NGC  246             _("Skull Nebula") # ESKY, B500
 NGC  246             _("Soap Bubble Nebula") # B500
 NGC  246             _("Voodoo Mask Nebula") # B500
-NGC  247             _("Burbidge Chain") # NED
+# NGC  247             _("Burbidge Chain") # NED
+NGC  247             _("Needle's Eye Galaxy") # APOD, CSOG-BCH
 NGC  253             _("Sculptor Galaxy") # WK, B500, PAS
 NGC  253             _("Silver Coin Galaxy") # SIMBAD, DSW, B500
 NGC  253             _("Silver Dollar Galaxy") # WSO, WSG
@@ -157,6 +172,7 @@ NGC  598             _("Triangulum Galaxy") # NED, DWH, B500, TLO
 NGC  598             _("Triangulum Pinwheel") # SIMBAD
 NGC  598             _("Pinwheel Galaxy") # DSW, BCH, CC, DN
 NGC  598             _("Triangulum Nebula") # WSG
+NGC  602             _("Flying Lizard Nebula") # APOD, CSOG-BCH
 NGC  628             _("Phantom Galaxy") # MO, B500
 NGC  650             _("Little Dumbbell Nebula") # SIMBAD, DSW, BCH, DWH, PSA, CC, DN, B500, PAS
 NGC  650             _("Cork Nebula") # SIMBAD, DSW, BCH, B500
@@ -228,6 +244,7 @@ NGC  1554            _("Hind's Variable Nebula") # PSA, B500
 NGC  1555            _("Hind's Variable Nebula") # SIMBAD, BCH, DWH, WSO, PSA, B500
 NGC  1555            _("Hind's Nebula") # SIMBAD
 NGC  1566            _("Doradus Cluster") # SIMBAD
+NGC  1566            _("Spanish Dancer Galaxy") # NASA, CSOG-BCH
 NGC  1566            _("NGC 1566 Group") # SIMBAD
 NGC  1579            _("Northern Trifid Nebula") # DSW, SD, B500
 NGC  1595            _("Carafe Group")
@@ -321,6 +338,7 @@ NGC  2301            _("Hagrid's Dragon Cluster") # B500, HT
 NGC  2301            _("Copeland's Golden Worm") # DSW
 NGC  2323            _("Heart-Shaped Cluster") # CSOG-MSC, B500
 NGC  2323            _("Coil Cluster") # DSW
+NGC  2327            _("Parrot Nebula") # APOD, CSOG-BCH
 NGC  2343            _("Doublemint Cluster") # SD
 NGC  2346            _("Butterfly Nebula")
 NGC  2346            _("Hourglass Planetary Nebula")
@@ -421,6 +439,7 @@ NGC  3242            _("Diamond Nebula") # B500
 NGC  3293            _("Gem Cluster") # OGSC, CSOG-MSC, TLO
 NGC  3293            _("Spider Spit Cluster") # SG, HT
 NGC  3293            _("Little Jewel Box") # SG, HT
+NGC  3310            _("Bow and Arrow Galaxy") # TBD, CSOG-BCH
 NGC  3324            _("The Gabriela Mistral Nebula") # WP
 NGC  3344            _("Sliced Onion Galaxy") # B500, HT
 NGC  3372            _("η Car Nebula") # WK, SIMBAD, TSS, BCH, SG, WSO, PSA, PAS
@@ -600,6 +619,7 @@ NGC  6027            _("Seyfert's Sextet") # NED, WSG, SIMBAD
 NGC  6027            _("Seyfert's Quintet") # SIMBAD
 NGC  6027            _("Serpens Sextet")
 NGC  6087            _("S Nor Cluster") # SIMBAD, SG, CSOG-MSC
+NGC  6118            _("Blinking Galaxy") # WP, CSOG-BCH
 NGC  6121            _("Crab Globular Cluster") # B500
 NGC  6121            _("Spider Globular Cluster") # B500
 NGC  6134            _("Little Pincushion") # SG
@@ -657,6 +677,7 @@ NGC  6543            _("Cat's Eye Nebula") # SIMBAD, DSW, DWH, WSO, CC, DN, B500
 NGC  6543            _("Sunflower Nebula") # SIMBAD
 NGC  6543            _("Snail Nebula") # SIMBAD
 NGC  6544            _("Starfish Cluster") # B500, HT
+NGC  6559            _("Chinese Dragon Nebula") # TBD, CSOG-BCH
 NGC  6563            _("Southern Ring Nebula") # B500, SG, SD
 NGC  6572            _("Blue Racquetball Nebula") # DSW, B500
 NGC  6572            _("Emerald Nebula") # DSW, DN, B500
@@ -796,6 +817,7 @@ NGC  7380            _("The Wizard Nebula")
 NGC  7380            _("Harry Potter and the Golden Snitch") # HT
 NGC  7385            _("NGC 7385 group") # WSG
 NGC  7424            _("Grand Design Galaxy")
+NGC  7479            _("Propeller Galaxy") # NASA, CSOG-BCH
 NGC  7479            _("Superman Galaxy") # B500
 NGC  7510            _("The Dormouse Cluster") # B500, SD
 NGC  7510            _("The Arrowhead Cluster") # B500
@@ -840,6 +862,7 @@ IC   417             _("Spider Nebula") # SD
 IC   418             _("Spirograph Nebula") # HT, DN, B500
 IC   418             _("Raspberry Nebula") # B500, HT
 IC   418             _("Colored Contacts Nebula") # HT
+IC   423             _("Teardrop Nebula") # TBD, CSOG-BCH
 IC   443             _("Jellyfish Nebula") # APOD
 IC   443             _("Gemini A") # SIMBAD
 IC   708             _("Papillon")
@@ -852,6 +875,7 @@ IC   1805            _("Heart Nebula") # CSOG-MSC, B500
 IC   1805            _("The Running Dog Nebula") # B500
 IC   1805            _("Valentine Nebula") # B500
 IC   1805            _("AFGL 333 Cloud") # SIMBAD
+IC   2087            _("Little Flame Nebula") # TBD, CSOG-BCH
 IC   2118            _("Witch Head Nebula") # WK, DSW, TSS, PSA
 IC   2199            _("IC 2199 group") # WSG
 IC   2220            _("Toby Jug Nebula") # SIMBAD, TSS
@@ -927,6 +951,7 @@ B    72              _("The S Nebula") # WK, BCH
 B    78              _("Pipe (bowl)") # WK
 B    78              _("Pipe Nebula") # BCH, DN
 B    86              _("Ink Spot Nebula") # WK, DSW, CC, DN, B500
+B    86              _("Herschel's Hole in the Heavens") # CSOG-BCH, TBD
 B    87              _("Parrot's Head Nebula") # DSW
 B    92              _("Black Hole Nebula") # DSNI
 B    142             _("E Nebula") # WK, DSW
@@ -952,6 +977,7 @@ CR   140             _("Tuft in the Tail of the Dog Cluster")
 CR   205             _("Markarian 18 Cluster")
 CR   233             _("η Car Cluster")
 CR   285             _("Ursa Major Cluster")
+CR   285             _("Ursa Major Moving Group") # WP, CSOG-BCH
 CR   302             _("Antares Cluster")
 CR   399             _("Coathanger") # OGSC, DSW, HT, BH, TLO
 CR   399             _("Al Sufi's Cluster")
@@ -960,6 +986,7 @@ CR   399             _("Al-Sufi's Nebula") # HT
 CR   399             _("The Snail") # HT
 CR   463             _("Loch Ness Moster Cluster") # SD
 CR   463             _("The Queen's Reflection") # SD
+CED  19D             _("Electra Nebula") # TBD, CSOG-BCH
 CED  19O             _("Atlas Nebula") # DSNI
 CED  32C             _("Burnham's Nebula") # SIMBAD
 CED  32C             _("T Tauri Nebula")
@@ -1186,6 +1213,7 @@ UGC  11668           _("Egg Nebula") # SIMBAD, PSA, ST5
 UGC  11668           _("Cygnus Egg") # SIMBAD
 UGC  12613           _("Pegasus Dwarf Irregular Galaxy")
 ARP  133             _("Minkowski's Object") # WSG
+ARP  316             _("Gamma Leonis Group") # CSOG-BCH, TBD
 VV   786             _("Lemon Galaxy") # SIMBAD
 PK   010+18.2        _("Minkowski's Butterfly") # DSW
 PK   010+18.2        _("Twin Jet Nebula")

--- a/nebulae/default/names.dat
+++ b/nebulae/default/names.dat
@@ -46,6 +46,7 @@
 #      - Sharpless-308: The Dolphin Nebula; https://apod.nasa.gov/apod/ap200302.html
 #      - The Medulla Nebula Supernova Remnant; https://apod.nasa.gov/apod/ap210118.html
 #      - NGC 6188: The Dragons of Ara; https://apod.nasa.gov/apod/ap200728.html
+#      - NGC 2170: Angel Nebula; https://apod.nasa.gov/apod/ap160428.html
 #   HST:
 #      - Hubble offers a dazzling necklace; https://spacetelescope.org/images/potw1133a/
 #   ABIN: 
@@ -61,9 +62,12 @@
 #   AM:
 #      - Messier 55 "The Summer Rose Star"; http://cs.astronomy.com/asy/m/starclusters/489919.aspx
 #      - Open cluster Stock 2; https://cs.astronomy.com/asy/m/starclusters/491502.aspx
+#      - NGC 1664 - The Kite Cluster; https://cs.astronomy.com/asy/m/starclusters/491916.aspx
+#      - The Little Scorpion Cluster (NGC 1342); https://cs.astronomy.com/asy/m/starclusters/491498.aspx
 #   NASA:
 #      - Caldwell 22; https://www.nasa.gov/feature/goddard/caldwell-22
 #      - NASA Missions Explore a ‘TIE Fighter’ Active Galaxy; https://www.nasa.gov/feature/goddard/2020/nasa-missions-explore-a-tie-fighter-active-galaxy
+#      - NGC 4151: The 'Eye of Sauron'; https://www.nasa.gov/mission_pages/chandra/multimedia/11-029.html
 #   DSW: Deep-Sky Wonders: A Tour of the Universe with Sky and Telescope's Sue French, Firefly Books, 2011
 #   TSS: Treasures of the Southern Sky by Robert Gendler, Lars Lindberg Christensen and David Malin, Springer-Verlag New York, 2011; DOI: 10.1007/978-1-4614-0628-0
 #   BCH: Robert Burnham Jr., Burnham's Celestial Handbook: An Observer's Guide to the Universe Beyond the Solar System, Vol. 1-3, Dover Publications, 1978-1979
@@ -104,6 +108,7 @@
 #      - NGC2070: Great Looped Nebula; Results of astronomical observations made during the years 1834, 5, 6, 7, 8, at the Cape of Good Hope...
 #   ???: Source very much needed. Marked especially for objects which have a well-known name, where a new/alternative name does not help anybody.
 #   TBD:  ADD OTHERS HERE!
+#      - The Kite Cluster (NGC 1664); https://observing.skyhound.com/archives/dec/NGC_1664.html
 NGC  40              _("Bow-Tie Nebula") # ESKY, B500
 NGC  40              _("Scarab Nebula") # B500
 NGC  55              _("String of Pearls") # SG
@@ -188,13 +193,13 @@ NGC  1316            _("Fornax A") # NED, SIMBAD, TSS, SG, HT, WSG, PSA, B500
 NGC  1317            _("Fornax B") # SIMBAD
 NGC  1333            _("Embryo Nebula") # B500, HT
 NGC  1333            _("Phantom Tiara") # HT
-NGC  1342            _("Little Scorpion Cluster")
+NGC  1342            _("Little Scorpion Cluster") # AM
 NGC  1342            _("Stingray Cluster") # B500, SD
 NGC  1342            _("Sea Robin Cluster") # SD
 NGC  1350            _("The Colossal Cosmic Eye") # SG
 NGC  1360            _("Robin's Egg Nebula") # APOD
 NGC  1360            _("Comet Planetary Nebula") # B500, HT
-NGC  1365            _("Great Barred Spiral Galaxy") # TSS
+NGC  1365            _("Great Barred Spiral Galaxy") # TSS, WP
 NGC  1407            _("Eridanus A Group") # DSW
 NGC  1432            _("Maia Nebula") # SIMBAD, DSW, WSO, PSA
 NGC  1435            _("Merope Nebula") # SIMBAD, DSW, DWH, WSO, PSA, B500
@@ -228,6 +233,7 @@ NGC  1579            _("Northern Trifid Nebula") # DSW, SD, B500
 NGC  1595            _("Carafe Group")
 NGC  1598            _("Carafe Group")
 NGC  1647            _("Pirate Moon Cluster") # B500, HT
+NGC  1664            _("Kite Cluster") # AM, TBD
 NGC  1664            _("4-H cluster") # DWH
 NGC  1788            _("Cosmic Bat Nebula") # SD
 NGC  1788            _("Foxface Nebula") # SD
@@ -288,6 +294,7 @@ NGC  2169            _("The 37 Cluster") # HT, B500
 NGC  2169            _("The 'LE' Cluster")
 NGC  2169            _("Shopping Cart Cluster") # B500, HT
 NGC  2169            _("Little Pleiades") # HT
+NGC  2170            _("Angel Nebula") # APOD
 NGC  2170            _("Mon R2 IRS3") # SIMBAD
 NGC  2174            _("Monkey Head Nebula") # SIMBAD
 NGC  2232            _("Double Wedge Cluster") # DSW
@@ -309,8 +316,8 @@ NGC  2269            _("Head Hunter Cluster") # B500
 NGC  2269            _("Starfighter Cluster") # B500
 NGC  2281            _("Broken Heart Cluster") # B500, SD
 NGC  2287            _("Little Beehive Cluster") # MO, B500, CSOG-MSC
-NGC  2301            _("Hagrid's Dragon Cluster") # B500, HT
 NGC  2301            _("Great Bird Cluster") # SIMBAD, CSOG-MSC
+NGC  2301            _("Hagrid's Dragon Cluster") # B500, HT
 NGC  2301            _("Copeland's Golden Worm") # DSW
 NGC  2323            _("Heart-Shaped Cluster") # CSOG-MSC, B500
 NGC  2323            _("Coil Cluster") # DSW
@@ -463,6 +470,7 @@ NGC  4039            _("Snorter") # DSNI
 NGC  4039            _("Mosquito larvae") # B500
 NGC  4103            _("The Longtail") # SG
 NGC  4147            _("Kick the Can Cluster") # SD
+NGC  4151            _("Eye of Sauron") # NASA
 NGC  4169            _("The Box") # DSW, WSO, WSG
 NGC  4170            _("The Box") # DSW, WSO, WSG
 NGC  4174            _("The Box") # DSW, WSO, WSG
@@ -814,7 +822,7 @@ NGC  7789            _("Star Mist Cluster") # B500
 NGC  7789            _("Herschel's Spiral Cluster") # HT
 NGC  7789            _("Crab Cluster") # HT
 NGC  7789            _("Screaming Skull Cluster") # HT
-NGC  7790            _("The Widow's Web Cluster") # B500, SD                  	
+NGC  7790            _("The Widow's Web Cluster") # B500, SD
 NGC  7793            _("Bond's Galaxy") # HT, B500
 NGC  7814            _("The Little Sombrero Galaxy") # ESKY, B500
 NGC  7814            _("Electric Arc Galaxy") # B500


### PR DESCRIPTION
### Add and adjust some general names and source.

### Delete:

NGC247: Burbidge Chain only refer to four small galaxies, already in list.


### Advise:

Add 'Flying Ghost Nebula' (simbad, near IC418).

https://observing.skyhound.com/archives/dec/NGC_1664.html
4-H is an organization, maybe not suitable for name using.

--

note:

Although a lot of names could be found in CSOG-BCH, but I already tried to pick up the reliable and suitable ones of them with different source.