### PR TITLE
Make CMakeLists WSL compatible

### DIFF
--- a/plugins/RemoteControl/CMakeLists.txt
+++ b/plugins/RemoteControl/CMakeLists.txt
@@ -8,11 +8,11 @@ ADD_DEFINITIONS(-DREMOTECONTROL_WEBROOT_PATH="${REMOTECONTROL_WEBROOT_PATH}")
 ADD_SUBDIRECTORY( src )
 
 # Custom target for updating the translationdata.js
-FIND_PACKAGE(PythonInterp)
+find_package(Python3 COMPONENTS Interpreter)
 
-IF(PYTHON_EXECUTABLE)
+IF(Python3_Interpreter_FOUND)
      ADD_CUSTOM_TARGET(RemoteControl-update-translationdata
-         COMMAND ${PYTHON_EXECUTABLE} util/update_translationdata.py 
+         COMMAND ${Python3_EXECUTABLE} util/update_translationdata.py 
          ${PROJECT_SOURCE_DIR}/po/stellarium-remotecontrol/stellarium-remotecontrol.jst ${REMOTECONTROL_WEBROOT_PATH}/js/translationdata.js
          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
          COMMENT "Updating RemoteControl translation data"


### PR DESCRIPTION
When anaconda is installed on windows, building on WSL fails with the current system for looking up the python interpreter.

### Description
Changed python interpreter lookup to use a more modern method, and in so doing fixed building through WSL on windows.

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### How Has This Been Tested?
This change allows me to successfully build stellarium on my windows machine (windows 10 + WSL 2), and I also ensured it still builds on my linux desktop (Ubuntu 20.04).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

The boxes which I have not checked above I don't think are applicable to this pull request.
