### PR TITLE
Fix bug in AstroCalc/Eclipses for local solar eclipses

### DIFF
--- a/src/gui/AstroCalcDialog.cpp
+++ b/src/gui/AstroCalcDialog.cpp
@@ -3499,7 +3499,7 @@ void AstroCalcDialog::generateSolarEclipsesLocal()
 							}
 							double C3altitude = eclipseData.altitude;
 
-							if (eclipseData.ce > 0. && ((C2altitude > 0.) || (C3altitude > 0.))) // Central eclipse occurs
+							if (eclipseData.ce > 0. && ((C2altitude > -.3) || (C3altitude > -.3))) // Central eclipse occurs
 							{
 								centraleclipse = true;
 								if (eclipseData.L2 < 0.)
@@ -3539,6 +3539,9 @@ void AstroCalcDialog::generateSolarEclipsesLocal()
 							treeItem->setData(SolarEclipseLocalDate, Qt::UserRole, JDmax);
 							treeItem->setText(SolarEclipseLocalType, eclipseTypeStr);
 							treeItem->setText(SolarEclipseLocalFirstContact, QString("%1").arg(localeMgr->getPrintableTimeLocal(JD1)));
+							if (centraleclipse)
+								if (JD2<JD1) // central eclipse at Sunrise
+									treeItem->setText(SolarEclipseLocalFirstContact, dash);
 							treeItem->setToolTip(SolarEclipseLocalFirstContact, q_("The time of first contact"));
 							
 							if (centraleclipse)
@@ -3555,6 +3558,9 @@ void AstroCalcDialog::generateSolarEclipsesLocal()
 								treeItem->setText(SolarEclipseLocal3rdContact, dash);
 							treeItem->setToolTip(SolarEclipseLocal3rdContact, q_("The time of third contact"));
 							treeItem->setText(SolarEclipseLocalLastContact, QString("%1").arg(localeMgr->getPrintableTimeLocal(JD4)));
+							if (centraleclipse)
+								if (JD3>JD4) // central eclipse at Sunset
+									treeItem->setText(SolarEclipseLocalLastContact, dash);
 							treeItem->setToolTip(SolarEclipseLocalLastContact, q_("The time of fourth contact"));
 							if (centraleclipse)
 								treeItem->setText(SolarEclipseLocalDuration, durationStr);

--- a/src/gui/AstroCalcDialog.cpp
+++ b/src/gui/AstroCalcDialog.cpp
@@ -3539,9 +3539,8 @@ void AstroCalcDialog::generateSolarEclipsesLocal()
 							treeItem->setData(SolarEclipseLocalDate, Qt::UserRole, JDmax);
 							treeItem->setText(SolarEclipseLocalType, eclipseTypeStr);
 							treeItem->setText(SolarEclipseLocalFirstContact, QString("%1").arg(localeMgr->getPrintableTimeLocal(JD1)));
-							if (centraleclipse)
-								if (JD2<JD1) // central eclipse at Sunrise
-									treeItem->setText(SolarEclipseLocalFirstContact, dash);
+							if (centraleclipse && JD2<JD1) // central eclipse  in progress at Sunrise
+								treeItem->setText(SolarEclipseLocalFirstContact, dash);
 							treeItem->setToolTip(SolarEclipseLocalFirstContact, q_("The time of first contact"));
 							
 							if (centraleclipse)
@@ -3558,9 +3557,8 @@ void AstroCalcDialog::generateSolarEclipsesLocal()
 								treeItem->setText(SolarEclipseLocal3rdContact, dash);
 							treeItem->setToolTip(SolarEclipseLocal3rdContact, q_("The time of third contact"));
 							treeItem->setText(SolarEclipseLocalLastContact, QString("%1").arg(localeMgr->getPrintableTimeLocal(JD4)));
-							if (centraleclipse)
-								if (JD3>JD4) // central eclipse at Sunset
-									treeItem->setText(SolarEclipseLocalLastContact, dash);
+							if (centraleclipse && JD3>JD4) // central eclipse in progress at Sunset
+								treeItem->setText(SolarEclipseLocalLastContact, dash);
 							treeItem->setToolTip(SolarEclipseLocalLastContact, q_("The time of fourth contact"));
 							if (centraleclipse)
 								treeItem->setText(SolarEclipseLocalDuration, durationStr);


### PR DESCRIPTION
### Description
This bug in AstroCalc/Eclipses is found when total/annular eclipses take place very close to the horizon.

**To reproduce**
- Set the location to North Pole
- Open 'AstroCalc/Local Solar Eclipses' tab
- Set 2015 as the starting year

The calculation shows that 2015 Mar 20 was a partial eclipse, contradicting to the magnitude at greatest eclipse of 1.013 (total eclipse). The bug happens because the total eclipse took place very close to the horizon. The same situation can be found on other dates when your location is at the start or end point of any central eclipses.

This patch will also avoid to show time of 1st contact or last contact when total or annular eclipses are in progress at Sunrise/Sunset.

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Test cases:
Lat. 26.0
Long. 47.5
Date: 2019-12-26 (annular eclipse at Sunrise)

Lat. 47.4
Long. -19.6
Date: 2024-04-08 (total eclipse at Sunset)

**Test Configuration**:
* Operating system: Windows 10

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
