### PR TITLE
Fix #1283: properly detect largest screenshot number

### DIFF
--- a/src/StelMainView.cpp
+++ b/src/StelMainView.cpp
@@ -1717,24 +1717,34 @@ void StelMainView::doScreenshot(void)
 		// get highest-numbered file in screenshot directory
 		QDir dir(shotDir.filePath());
 		QStringList existingFiles = dir.entryList(fileNameFilters);
-		QString lastFileName = existingFiles[existingFiles.size() - 1];
 
-		// extract number from highest-numbered file name
-		QString lastShotNumString = lastFileName.replace(screenShotPrefix, "").replace("." + screenShotFormat, "");
-		// new screenshot number = start at highest number
-		int shotNum = lastShotNumString.toInt() + 1;
+		if (existingFiles.empty())
+		{
+			// empty screenshot dir, just name screenshot prefix-001.format
+			shotPath = QFileInfo(shotDir.filePath() + "/" + screenShotPrefix + "001." + screenShotFormat);
+		}
+		else
+		{
+			// already have screenshots, find largest number
+			QString lastFileName = existingFiles[existingFiles.size() - 1];
 
-		// build new screenshot path: "path/prefix-num.format"
-		// num is at least 3 characters
-		QString shotNumString = QString::number(shotNum).rightJustified(3, '0');
-		QString shotPathString = QString("%1/%2%3.%4").arg(shotDir.filePath(), screenShotPrefix, shotNumString, screenShotFormat);
-		shotPath = QFileInfo(shotPathString);
-		// validate if new screenshot number is valid (non-existent)
-		while (shotPath.exists()) {
-			shotNum++;
-			shotNumString = QString::number(shotNum).rightJustified(3, '0');
-			shotPathString = QString("%1/%2%3.%4").arg(shotDir.filePath(), screenShotPrefix, shotNumString, screenShotFormat);
+			// extract number from highest-numbered file name
+			QString lastShotNumString = lastFileName.replace(screenShotPrefix, "").replace("." + screenShotFormat, "");
+			// new screenshot number = start at highest number
+			int shotNum = lastShotNumString.toInt() + 1;
+
+			// build new screenshot path: "path/prefix-num.format"
+			// num is at least 3 characters
+			QString shotNumString = QString::number(shotNum).rightJustified(3, '0');
+			QString shotPathString = QString("%1/%2%3.%4").arg(shotDir.filePath(), screenShotPrefix, shotNumString, screenShotFormat);
 			shotPath = QFileInfo(shotPathString);
+			// validate if new screenshot number is valid (non-existent)
+			while (shotPath.exists()) {
+				shotNum++;
+				shotNumString = QString::number(shotNum).rightJustified(3, '0');
+				shotPathString = QString("%1/%2%3.%4").arg(shotDir.filePath(), screenShotPrefix, shotNumString, screenShotFormat);
+				shotPath = QFileInfo(shotPathString);
+			}
 		}
 	}
 

--- a/src/StelMainView.cpp
+++ b/src/StelMainView.cpp
@@ -1711,10 +1711,14 @@ void StelMainView::doScreenshot(void)
 	}
 	else
 	{
+		// build filter for file list, so we only select Stellarium screenshot files (prefix*.format)
+		QString shotFilePattern = QString("%1*.%2").arg(screenShotPrefix, screenShotFormat);
+		QStringList fileNameFilters(shotFilePattern);
 		// get highest-numbered file in screenshot directory
 		QDir dir(shotDir.filePath());
-		QStringList existingFiles = dir.entryList();
+		QStringList existingFiles = dir.entryList(fileNameFilters);
 		QString lastFileName = existingFiles[existingFiles.size() - 1];
+
 		// extract number from highest-numbered file name
 		QString lastShotNumString = lastFileName.replace(screenShotPrefix, "").replace("." + screenShotFormat, "");
 		// new screenshot number = start at highest number
@@ -1728,6 +1732,7 @@ void StelMainView::doScreenshot(void)
 		// validate if new screenshot number is valid (non-existent)
 		while (shotPath.exists()) {
 			shotNum++;
+			shotNumString = QString::number(shotNum).rightJustified(3, '0');
 			shotPathString = QString("%1/%2%3.%4").arg(shotDir.filePath(), screenShotPrefix, shotNumString, screenShotFormat);
 			shotPath = QFileInfo(shotPathString);
 		}

--- a/src/StelMainView.cpp
+++ b/src/StelMainView.cpp
@@ -1727,7 +1727,7 @@ void StelMainView::doScreenshot(void)
 		shotPath = QFileInfo(shotPathString);
 		// validate if new screenshot number is valid (non-existent)
 		while (shotPath.exists()) {
-			newShotNum++;
+			shotNum++;
 			shotPathString = QString("%1/%2%3.%4").arg(shotDir.filePath(), screenShotPrefix, shotNumString, screenShotFormat);
 			shotPath = QFileInfo(shotPathString);
 		}

--- a/src/StelMainView.cpp
+++ b/src/StelMainView.cpp
@@ -1711,11 +1711,25 @@ void StelMainView::doScreenshot(void)
 	}
 	else
 	{
-		for (int j=0; j<100000; ++j)
-		{
-			shotPath = QFileInfo(shotDir.filePath() + "/" + screenShotPrefix + QString("%1").arg(j, 3, 10, QLatin1Char('0')) + "." + screenShotFormat);
-			if (!shotPath.exists())
-				break;
+		// get highest-numbered file in screenshot directory
+		QDir dir(shotDir.filePath());
+		QStringList existingFiles = dir.entryList();
+		QString lastFileName = existingFiles[existingFiles.size() - 1];
+		// extract number from highest-numbered file name
+		QString lastShotNumString = lastFileName.replace(screenShotPrefix, "").replace("." + screenShotFormat, "");
+		// new screenshot number = start at highest number
+		int shotNum = lastShotNumString.toInt() + 1;
+
+		// build new screenshot path: "path/prefix-num.format"
+		// num is at least 3 characters
+		QString shotNumString = QString::number(shotNum).rightJustified(3, '0');
+		QString shotPathString = QString("%1/%2%3.%4").arg(shotDir.filePath(), screenShotPrefix, shotNumString, screenShotFormat);
+		shotPath = QFileInfo(shotPathString);
+		// validate if new screenshot number is valid (non-existent)
+		while (shotPath.exists()) {
+			newShotNum++;
+			shotPathString = QString("%1/%2%3.%4").arg(shotDir.filePath(), screenShotPrefix, shotNumString, screenShotFormat);
+			shotPath = QFileInfo(shotPathString);
 		}
 	}
 

--- a/src/StelMainView.cpp
+++ b/src/StelMainView.cpp
@@ -1718,12 +1718,9 @@ void StelMainView::doScreenshot(void)
 		QDir dir(shotDir.filePath());
 		QStringList existingFiles = dir.entryList(fileNameFilters);
 
-		if (existingFiles.empty())
-		{
-			// empty screenshot dir, just name screenshot prefix-001.format
-			shotPath = QFileInfo(shotDir.filePath() + "/" + screenShotPrefix + "001." + screenShotFormat);
-		}
-		else
+		// screenshot number - default to 1 for empty directory
+		int shotNum = 1;
+		if (!existingFiles.empty())
 		{
 			// already have screenshots, find largest number
 			QString lastFileName = existingFiles[existingFiles.size() - 1];
@@ -1731,20 +1728,20 @@ void StelMainView::doScreenshot(void)
 			// extract number from highest-numbered file name
 			QString lastShotNumString = lastFileName.replace(screenShotPrefix, "").replace("." + screenShotFormat, "");
 			// new screenshot number = start at highest number
-			int shotNum = lastShotNumString.toInt() + 1;
+			shotNum = lastShotNumString.toInt() + 1;
+		}
 
-			// build new screenshot path: "path/prefix-num.format"
-			// num is at least 3 characters
-			QString shotNumString = QString::number(shotNum).rightJustified(3, '0');
-			QString shotPathString = QString("%1/%2%3.%4").arg(shotDir.filePath(), screenShotPrefix, shotNumString, screenShotFormat);
+		// build new screenshot path: "path/prefix-num.format"
+		// num is at least 3 characters
+		QString shotNumString = QString::number(shotNum).rightJustified(3, '0');
+		QString shotPathString = QString("%1/%2%3.%4").arg(shotDir.filePath(), screenShotPrefix, shotNumString, screenShotFormat);
+		shotPath = QFileInfo(shotPathString);
+		// validate if new screenshot number is valid (non-existent)
+		while (shotPath.exists()) {
+			shotNum++;
+			shotNumString = QString::number(shotNum).rightJustified(3, '0');
+			shotPathString = QString("%1/%2%3.%4").arg(shotDir.filePath(), screenShotPrefix, shotNumString, screenShotFormat);
 			shotPath = QFileInfo(shotPathString);
-			// validate if new screenshot number is valid (non-existent)
-			while (shotPath.exists()) {
-				shotNum++;
-				shotNumString = QString::number(shotNum).rightJustified(3, '0');
-				shotPathString = QString("%1/%2%3.%4").arg(shotDir.filePath(), screenShotPrefix, shotNumString, screenShotFormat);
-				shotPath = QFileInfo(shotPathString);
-			}
 		}
 	}
 


### PR DESCRIPTION
This implements a proper mechanism to detect the largest screenshot number. Fixes #1283.

### Description
- Detect the largest screenshot number in screenshot directory, using the following logic:
  - Get a list of filenames in screenshot directory
  - Find the last filename (which should contain the largest number), and extract the number from it
  - Number + 1 should be the number for the new screenshot. A failsafe is provided (in case `stellarium-number.format` already exists for some reason).
- This replaces the current (poor) implementation for detecting next available screenshot number. See https://github.com/Stellarium/stellarium/issues/1283#issuecomment-1071992445 for details.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### How Has This Been Tested?

I tried generating screenshots in the following conditions:
- Blank screenshot directory
- Screenshot directory has screenshots with sequential numbers
- Screenshot directory has screenshots with non-sequential numbers
- Screenshot directory has screenshots with large numbers (more than 3 digits)
- Screenshot directory has random (non Stellarium screenshot) files

In all cases listed above, new screenshots are named properly (highest number + 1).

**Test Configuration**:
* Operating system: Fedora 36 (arm64 VM on M1 MacBook)
* Graphics Card: QEMU virtual GPU
* *Note: GPU info is likely irrelevant here, because this change only involves screenshot file naming.* 

## Checklist:
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
