### PR TITLE
Fixed rendering 3D models

### DIFF
--- a/data/shaders/planet.frag
+++ b/data/shaders/planet.frag
@@ -26,7 +26,7 @@ varying highp vec3 P; //original vertex pos in model space
 
 uniform sampler2D tex;
 uniform mediump vec2 poleLat; //latitudes of pole caps, in terms of texture coordinate. x>0...north, y<1...south. 
-uniform bool hasNoModel;
+uniform bool renderPolarCaps;
 uniform mediump vec3 ambientLight;
 uniform mediump vec3 diffuseLight;
 uniform highp vec4 sunInfo;
@@ -302,7 +302,7 @@ void main()
     lowp vec4 texColor = texture2D(tex, texc);
 
     mediump vec4 finalColor = texColor;
-    if (hasNoModel)
+    if (renderPolarCaps)
     {
         // apply (currently only Martian) pole caps. texc.t=0 at south pole, 1 at north pole.
         if (texc.t>poleLat.x-0.01+0.001*sin(texc.s*18.*M_PI))

--- a/data/shaders/planet.frag
+++ b/data/shaders/planet.frag
@@ -26,6 +26,7 @@ varying highp vec3 P; //original vertex pos in model space
 
 uniform sampler2D tex;
 uniform mediump vec2 poleLat; //latitudes of pole caps, in terms of texture coordinate. x>0...north, y<1...south. 
+uniform bool hasNoModel;
 uniform mediump vec3 ambientLight;
 uniform mediump vec3 diffuseLight;
 uniform highp vec4 sunInfo;
@@ -301,21 +302,28 @@ void main()
     lowp vec4 texColor = texture2D(tex, texc);
 
     mediump vec4 finalColor = texColor;
-	// apply (currently only Martian) pole caps. texc.t=0 at south pole, 1 at north pole. 
-	if (texc.t>poleLat.x-0.01+0.001*sin(texc.s*18.*M_PI)) {	// North pole near t=1
-		mediump float mixfactor=1.;
-		if (texc.t<poleLat.x+0.01+0.001*sin(texc.s*18.*M_PI))
-			mixfactor=(texc.t-poleLat.x+0.01-0.001*sin(texc.s*18.*M_PI))/0.02;
-		//finalColor.xyz=mix(vec3(1., 1., 1.), finalColor.xyz, 1.-mixfactor); 
-		finalColor.xyz=mix(vec3(1., 1., 1.), finalColor.xyz, smoothstep(0., 1., 1.-mixfactor)); 
-	}
-	if (texc.t<poleLat.y+0.01+0.001*sin(texc.s*18.*M_PI)) {	// South pole near texc.t~0
-		mediump float mixfactor=1.;
-		if (texc.t>poleLat.y-0.01+0.001*sin(texc.s*18.*M_PI))
-			mixfactor=(poleLat.y+0.01-texc.t-0.001*sin(texc.s*18.*M_PI))/0.02;
-		//finalColor.xyz=mix(vec3(1., 1., 1.), finalColor.xyz, 1.-mixfactor); 
-		finalColor.xyz=mix(vec3(1., 1., 1.), finalColor.xyz, smoothstep(0., 1., 1.-mixfactor)); 
-	}
+    if (hasNoModel)
+    {
+        // apply (currently only Martian) pole caps. texc.t=0 at south pole, 1 at north pole.
+        if (texc.t>poleLat.x-0.01+0.001*sin(texc.s*18.*M_PI))
+        {
+            // North pole near t=1
+            mediump float mixfactor=1.;
+            if (texc.t<poleLat.x+0.01+0.001*sin(texc.s*18.*M_PI))
+                mixfactor=(texc.t-poleLat.x+0.01-0.001*sin(texc.s*18.*M_PI))/0.02;
+            //finalColor.xyz=mix(vec3(1., 1., 1.), finalColor.xyz, 1.-mixfactor);
+            finalColor.xyz=mix(vec3(1., 1., 1.), finalColor.xyz, smoothstep(0., 1., 1.-mixfactor));
+        }
+        if (texc.t<poleLat.y+0.01+0.001*sin(texc.s*18.*M_PI))
+        {
+            // South pole near texc.t~0
+            mediump float mixfactor=1.;
+            if (texc.t>poleLat.y-0.01+0.001*sin(texc.s*18.*M_PI))
+                mixfactor=(poleLat.y+0.01-texc.t-0.001*sin(texc.s*18.*M_PI))/0.02;
+            //finalColor.xyz=mix(vec3(1., 1., 1.), finalColor.xyz, 1.-mixfactor);
+            finalColor.xyz=mix(vec3(1., 1., 1.), finalColor.xyz, smoothstep(0., 1., 1.-mixfactor));
+        }
+    }
 #ifdef IS_MOON
     if(final_illumination < 0.9999)
     {

--- a/src/core/modules/Planet.cpp
+++ b/src/core/modules/Planet.cpp
@@ -305,6 +305,8 @@ Planet::Planet(const QString& englishName,
 			qWarning()<<"Cannot resolve path to model file"<<aobjModelName<<"of object"<<englishName;
 		}
 	}
+	else
+		objModelPath = QString();
 	if ((pType <= isDwarfPlanet) && (englishName!="Pluto")) // concentrate on "inner" objects, KBO etc. stay at 1/s recomputation.
 	{
 		deltaJDE = 0.001*StelCore::JD_SECOND;
@@ -2902,6 +2904,7 @@ void Planet::PlanetShaderVars::initLocations(QOpenGLShaderProgram* p)
 	GL(projectionMatrix = p->uniformLocation("projectionMatrix"));
 	GL(tex = p->uniformLocation("tex"));
 	GL(poleLat = p->uniformLocation("poleLat"));
+	GL(hasNoModel = p->uniformLocation("hasNoModel"));
 	GL(lightDirection = p->uniformLocation("lightDirection"));
 	GL(eyeDirection = p->uniformLocation("eyeDirection"));
 	GL(diffuseLight = p->uniformLocation("diffuseLight"));
@@ -3789,6 +3792,9 @@ Planet::RenderData Planet::setCommonShaderUniforms(const StelPainter& painter, Q
 
 	float outgas_intensity_distanceScaled=static_cast<float>(static_cast<double>(outgas_intensity)/getHeliocentricEclipticPos().lengthSquared()); // ad-hoc function: assume square falloff by distance.
 	GL(shader->setUniformValue(shaderVars.outgasParameters, QVector2D(outgas_intensity_distanceScaled, outgas_falloff)));
+
+	// Do not render polar caps effect for celestial bodies, who have 3D models
+	GL(shader->setUniformValue(shaderVars.hasNoModel, objModelPath.isEmpty()));
 
 	return data;
 }

--- a/src/core/modules/Planet.cpp
+++ b/src/core/modules/Planet.cpp
@@ -2904,7 +2904,7 @@ void Planet::PlanetShaderVars::initLocations(QOpenGLShaderProgram* p)
 	GL(projectionMatrix = p->uniformLocation("projectionMatrix"));
 	GL(tex = p->uniformLocation("tex"));
 	GL(poleLat = p->uniformLocation("poleLat"));
-	GL(hasNoModel = p->uniformLocation("hasNoModel"));
+	GL(renderPolarCaps = p->uniformLocation("renderPolarCaps"));
 	GL(lightDirection = p->uniformLocation("lightDirection"));
 	GL(eyeDirection = p->uniformLocation("eyeDirection"));
 	GL(diffuseLight = p->uniformLocation("diffuseLight"));
@@ -3794,7 +3794,7 @@ Planet::RenderData Planet::setCommonShaderUniforms(const StelPainter& painter, Q
 	GL(shader->setUniformValue(shaderVars.outgasParameters, QVector2D(outgas_intensity_distanceScaled, outgas_falloff)));
 
 	// Do not render polar caps effect for celestial bodies, who have 3D models
-	GL(shader->setUniformValue(shaderVars.hasNoModel, objModelPath.isEmpty()));
+	GL(shader->setUniformValue(shaderVars.renderPolarCaps, objModelPath.isEmpty()));
 
 	return data;
 }

--- a/src/core/modules/Planet.hpp
+++ b/src/core/modules/Planet.hpp
@@ -803,7 +803,7 @@ private:
 
 		// For Mars poles
 		int poleLat; // latitudes of edges of northern (x) and southern (y) polar cap [texture y, moving from 0 (S) to 1 (N)]. Only used for Mars, use [1, 0] for other objects.
-		int hasNoModel; // flag "has no 3D model" for celestial body
+		int renderPolarCaps;
 
 		// Moon-specific variables
 		int earthShadow;

--- a/src/core/modules/Planet.hpp
+++ b/src/core/modules/Planet.hpp
@@ -803,6 +803,7 @@ private:
 
 		// For Mars poles
 		int poleLat; // latitudes of edges of northern (x) and southern (y) polar cap [texture y, moving from 0 (S) to 1 (N)]. Only used for Mars, use [1, 0] for other objects.
+		int hasNoModel; // flag "has no 3D model" for celestial body
 
 		// Moon-specific variables
 		int earthShadow;


### PR DESCRIPTION
This patch disables rendering the polar caps effect for celestial bodies, who have 3D models. 

Fixes #2367 (issue)

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
