### PR TITLE
Added quick selection buttons for DSO (see #2425)

### DIFF
--- a/src/core/modules/Nebula.cpp
+++ b/src/core/modules/Nebula.cpp
@@ -68,7 +68,7 @@ Vec3f Nebula::labelColor = Vec3f(0.4f,0.3f,0.5f);
 QMap<Nebula::NebulaType, Vec3f>Nebula::hintColorMap;
 QMap<Nebula::NebulaType, QString> Nebula::typeStringMap;
 bool Nebula::flagUseTypeFilters = false;
-Nebula::CatalogGroup Nebula::catalogFilters = Nebula::CatalogGroup(Q_NULLPTR);
+Nebula::CatalogGroup Nebula::catalogFilters = Nebula::CatalogGroup(Nebula::CatNone);
 Nebula::TypeGroup Nebula::typeFilters = Nebula::TypeGroup(Nebula::AllTypes);
 bool Nebula::flagUseArcsecSurfaceBrightness = false;
 bool Nebula::flagUseShortNotationSurfaceBrightness = true;

--- a/src/core/modules/Nebula.hpp
+++ b/src/core/modules/Nebula.hpp
@@ -98,7 +98,7 @@ public:
 	Q_FLAG(TypeGroup)
 
 	//! A pre-defined set of specifiers for the catalogs filter
-	static constexpr CatalogGroup AllCatalogs = static_cast<CatalogGroup>(CatNGC|CatIC|CatM|CatC|CatB|CatSh2|CatLBN|CatLDN|CatRCW|CatVdB|CatCr|CatMel|CatPGC|CatUGC|CatCed|CatArp|CatVV|CatPK|CatPNG|CatSNRG|CatACO|CatHCG|CatESO|CatVdBH|CatDWB|CatTr|CatSt|CatRu|CatOther);
+	static constexpr CatalogGroup AllCatalogs = static_cast<CatalogGroup>(CatNGC|CatIC|CatM|CatC|CatB|CatSh2|CatLBN|CatLDN|CatRCW|CatVdB|CatCr|CatMel|CatPGC|CatUGC|CatCed|CatArp|CatVV|CatPK|CatPNG|CatSNRG|CatACO|CatHCG|CatESO|CatVdBH|CatDWB|CatTr|CatSt|CatRu|CatVdBHa|CatOther);
 	static constexpr TypeGroup    AllTypes    = static_cast<TypeGroup>(TypeGalaxies|TypeActiveGalaxies|TypeInteractingGalaxies|TypeOpenStarClusters|TypeGlobularStarClusters|TypeHydrogenRegions|TypeBrightNebulae|TypeDarkNebulae|TypePlanetaryNebulae|TypeSupernovaRemnants|TypeGalaxyClusters|TypeOther);
 
 	//! @enum NebulaType Nebula types

--- a/src/gui/ViewDialog.cpp
+++ b/src/gui/ViewDialog.cpp
@@ -295,6 +295,8 @@ void ViewDialog::createDialogContent()
 	NebulaMgr* nmgr = GETSTELMODULE(NebulaMgr);
 	updateSelectedCatalogsCheckBoxes();
 	connect(nmgr, SIGNAL(catalogFiltersChanged(Nebula::CatalogGroup)), this, SLOT(updateSelectedCatalogsCheckBoxes()));
+	connect(ui->selectAllCatalogs, SIGNAL(clicked()), this, SLOT(selectAllCatalogs()));
+	connect(ui->selectNoneCatalogs, SIGNAL(clicked()), this, SLOT(selectNoneCatalogs()));
 	connect(ui->buttonGroupDisplayedDSOCatalogs, SIGNAL(buttonClicked(int)), this, SLOT(setSelectedCatalogsFromCheckBoxes()));
 	updateSelectedTypesCheckBoxes();
 	connect(nmgr, SIGNAL(typeFiltersChanged(Nebula::TypeGroup)), this, SLOT(updateSelectedTypesCheckBoxes()));
@@ -851,6 +853,16 @@ void ViewDialog::updateSelectedCatalogsCheckBoxes()
 	ui->checkBoxRu->setChecked(flags & Nebula::CatRu);
 	ui->checkBoxVdBHa->setChecked(flags & Nebula::CatVdBHa);
 	ui->checkBoxOther->setChecked(flags & Nebula::CatOther);	
+}
+
+void ViewDialog::selectAllCatalogs()
+{
+	GETSTELMODULE(NebulaMgr)->setCatalogFilters(Nebula::AllCatalogs);
+}
+
+void ViewDialog::selectNoneCatalogs()
+{
+	GETSTELMODULE(NebulaMgr)->setCatalogFilters(Nebula::CatNone);
 }
 
 void ViewDialog::updateSelectedTypesCheckBoxes()

--- a/src/gui/ViewDialog.hpp
+++ b/src/gui/ViewDialog.hpp
@@ -89,6 +89,8 @@ private slots:
 	void changePage(QListWidgetItem *current, QListWidgetItem *previous);
 
 	void updateSelectedCatalogsCheckBoxes();
+	void selectAllCatalogs();
+	void selectNoneCatalogs();
 	void updateSelectedTypesCheckBoxes();
 
 	void updateHips();

--- a/src/gui/viewDialog.ui
+++ b/src/gui/viewDialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>782</width>
-    <height>530</height>
+    <width>919</width>
+    <height>592</height>
    </rect>
   </property>
   <property name="font">
@@ -2000,84 +2000,6 @@
              <property name="spacing">
               <number>6</number>
              </property>
-             <item row="0" column="0">
-              <widget class="QCheckBox" name="checkBoxM">
-               <property name="toolTip">
-                <string>Messier Catalogue</string>
-               </property>
-               <property name="text">
-                <string notr="true">M</string>
-               </property>
-               <attribute name="buttonGroup">
-                <string notr="true">buttonGroupDisplayedDSOCatalogs</string>
-               </attribute>
-              </widget>
-             </item>
-             <item row="1" column="2">
-              <widget class="QCheckBox" name="checkBoxRCW">
-               <property name="toolTip">
-                <string>A catalogue of Hα-emission regions in the southern Milky Way (Rodgers+, 1960)</string>
-               </property>
-               <property name="text">
-                <string notr="true">RCW</string>
-               </property>
-               <attribute name="buttonGroup">
-                <string notr="true">buttonGroupDisplayedDSOCatalogs</string>
-               </attribute>
-              </widget>
-             </item>
-             <item row="1" column="6">
-              <widget class="QCheckBox" name="checkBoxSNRG">
-               <property name="toolTip">
-                <string>A catalogue of Galactic supernova remnants (Green, 2014)</string>
-               </property>
-               <property name="text">
-                <string notr="true">SNR G</string>
-               </property>
-               <attribute name="buttonGroup">
-                <string notr="true">buttonGroupDisplayedDSOCatalogs</string>
-               </attribute>
-              </widget>
-             </item>
-             <item row="1" column="5">
-              <widget class="QCheckBox" name="checkBoxVV">
-               <property name="toolTip">
-                <string>The Catalogue of Interacting Galaxies (Vorontsov-Velyaminov+, 2001)</string>
-               </property>
-               <property name="text">
-                <string notr="true">VV</string>
-               </property>
-               <attribute name="buttonGroup">
-                <string notr="true">buttonGroupDisplayedDSOCatalogs</string>
-               </attribute>
-              </widget>
-             </item>
-             <item row="1" column="8">
-              <widget class="QCheckBox" name="checkBoxTr">
-               <property name="toolTip">
-                <string>Trumpler Catalogue</string>
-               </property>
-               <property name="text">
-                <string notr="true">Tr</string>
-               </property>
-               <attribute name="buttonGroup">
-                <string notr="true">buttonGroupDisplayedDSOCatalogs</string>
-               </attribute>
-              </widget>
-             </item>
-             <item row="1" column="1">
-              <widget class="QCheckBox" name="checkBoxB">
-               <property name="toolTip">
-                <string>Barnard's Catalogue of 349 Dark Objects in the Sky (Barnard, 1927)</string>
-               </property>
-               <property name="text">
-                <string notr="true">B</string>
-               </property>
-               <attribute name="buttonGroup">
-                <string notr="true">buttonGroupDisplayedDSOCatalogs</string>
-               </attribute>
-              </widget>
-             </item>
              <item row="1" column="0">
               <widget class="QCheckBox" name="checkBoxC">
                <property name="toolTip">
@@ -2091,13 +2013,52 @@
                </attribute>
               </widget>
              </item>
-             <item row="1" column="4">
-              <widget class="QCheckBox" name="checkBoxUGC">
+             <item row="1" column="3">
+              <widget class="QCheckBox" name="checkBoxCr">
                <property name="toolTip">
-                <string>The Uppsala General Catalogue of Galaxies</string>
+                <string>Catalog of Open Galactic Clusters (Collinder, 1931)</string>
                </property>
                <property name="text">
-                <string notr="true">UGC</string>
+                <string notr="true">Cr</string>
+               </property>
+               <attribute name="buttonGroup">
+                <string notr="true">buttonGroupDisplayedDSOCatalogs</string>
+               </attribute>
+              </widget>
+             </item>
+             <item row="2" column="1">
+              <widget class="QCheckBox" name="checkBoxSh2">
+               <property name="toolTip">
+                <string>Catalogue of HII Regions (Sharpless, 1959)</string>
+               </property>
+               <property name="text">
+                <string notr="true">SH 2</string>
+               </property>
+               <attribute name="buttonGroup">
+                <string notr="true">buttonGroupDisplayedDSOCatalogs</string>
+               </attribute>
+              </widget>
+             </item>
+             <item row="1" column="7">
+              <widget class="QCheckBox" name="checkBoxVdBH">
+               <property name="toolTip">
+                <string>Catalogue of southern stars embedded in nebulosity (van den Bergh and Herbst, 1975)</string>
+               </property>
+               <property name="text">
+                <string notr="true">vdBH</string>
+               </property>
+               <attribute name="buttonGroup">
+                <string notr="true">buttonGroupDisplayedDSOCatalogs</string>
+               </attribute>
+              </widget>
+             </item>
+             <item row="0" column="1">
+              <widget class="QCheckBox" name="checkBoxIC">
+               <property name="toolTip">
+                <string>Index Catalogue of Nebulae and Clusters of Stars</string>
+               </property>
+               <property name="text">
+                <string notr="true">IC</string>
                </property>
                <attribute name="buttonGroup">
                 <string notr="true">buttonGroupDisplayedDSOCatalogs</string>
@@ -2117,39 +2078,26 @@
                </attribute>
               </widget>
              </item>
-             <item row="0" column="2">
-              <widget class="QCheckBox" name="checkBoxVdB">
+             <item row="0" column="6">
+              <widget class="QCheckBox" name="checkBoxPNG">
                <property name="toolTip">
-                <string>Catalogue of Reflection Nebulae (van den Bergh, 1966)</string>
+                <string>The Strasbourg-ESO Catalogue of Galactic Planetary Nebulae (Acker+, 1992)</string>
                </property>
                <property name="text">
-                <string notr="true">vdB</string>
+                <string notr="true">PN G</string>
                </property>
                <attribute name="buttonGroup">
                 <string notr="true">buttonGroupDisplayedDSOCatalogs</string>
                </attribute>
               </widget>
              </item>
-             <item row="2" column="3">
-              <widget class="QCheckBox" name="checkBoxMel">
+             <item row="0" column="3">
+              <widget class="QCheckBox" name="checkBoxLDN">
                <property name="toolTip">
-                <string>A Catalogue of Star Clusters shown on Franklin-Adams Chart Plates (Melotte, 1915)</string>
+                <string>Lynds' Catalogue of Dark Nebulae (Lynds, 1962)</string>
                </property>
                <property name="text">
-                <string notr="true">Mel</string>
-               </property>
-               <attribute name="buttonGroup">
-                <string notr="true">buttonGroupDisplayedDSOCatalogs</string>
-               </attribute>
-              </widget>
-             </item>
-             <item row="0" column="1">
-              <widget class="QCheckBox" name="checkBoxIC">
-               <property name="toolTip">
-                <string>Index Catalogue of Nebulae and Clusters of Stars</string>
-               </property>
-               <property name="text">
-                <string notr="true">IC</string>
+                <string notr="true">LDN</string>
                </property>
                <attribute name="buttonGroup">
                 <string notr="true">buttonGroupDisplayedDSOCatalogs</string>
@@ -2182,78 +2130,26 @@
                </attribute>
               </widget>
              </item>
-             <item row="0" column="6">
-              <widget class="QCheckBox" name="checkBoxPNG">
+             <item row="1" column="8">
+              <widget class="QCheckBox" name="checkBoxTr">
                <property name="toolTip">
-                <string>The Strasbourg-ESO Catalogue of Galactic Planetary Nebulae (Acker+, 1992)</string>
+                <string>Trumpler Catalogue</string>
                </property>
                <property name="text">
-                <string notr="true">PN G</string>
+                <string notr="true">Tr</string>
                </property>
                <attribute name="buttonGroup">
                 <string notr="true">buttonGroupDisplayedDSOCatalogs</string>
                </attribute>
               </widget>
              </item>
-             <item row="2" column="1">
-              <widget class="QCheckBox" name="checkBoxSh2">
+             <item row="1" column="5">
+              <widget class="QCheckBox" name="checkBoxVV">
                <property name="toolTip">
-                <string>Catalogue of HII Regions (Sharpless, 1959)</string>
+                <string>The Catalogue of Interacting Galaxies (Vorontsov-Velyaminov+, 2001)</string>
                </property>
                <property name="text">
-                <string notr="true">SH 2</string>
-               </property>
-               <attribute name="buttonGroup">
-                <string notr="true">buttonGroupDisplayedDSOCatalogs</string>
-               </attribute>
-              </widget>
-             </item>
-             <item row="2" column="4">
-              <widget class="QCheckBox" name="checkBoxCed">
-               <property name="toolTip">
-                <string>Catalog of bright diffuse Galactic nebulae (Cederblad, 1946)</string>
-               </property>
-               <property name="text">
-                <string notr="true">Ced</string>
-               </property>
-               <attribute name="buttonGroup">
-                <string notr="true">buttonGroupDisplayedDSOCatalogs</string>
-               </attribute>
-              </widget>
-             </item>
-             <item row="0" column="4">
-              <widget class="QCheckBox" name="checkBoxPGC">
-               <property name="toolTip">
-                <string>Principal Galaxy Catalog</string>
-               </property>
-               <property name="text">
-                <string notr="true">PGC</string>
-               </property>
-               <attribute name="buttonGroup">
-                <string notr="true">buttonGroupDisplayedDSOCatalogs</string>
-               </attribute>
-              </widget>
-             </item>
-             <item row="2" column="6">
-              <widget class="QCheckBox" name="checkBoxACO">
-               <property name="toolTip">
-                <string>A Catalog of Rich Clusters of Galaxies (Abell+, 1989)</string>
-               </property>
-               <property name="text">
-                <string notr="true">Abell (ACO)</string>
-               </property>
-               <attribute name="buttonGroup">
-                <string notr="true">buttonGroupDisplayedDSOCatalogs</string>
-               </attribute>
-              </widget>
-             </item>
-             <item row="1" column="3">
-              <widget class="QCheckBox" name="checkBoxCr">
-               <property name="toolTip">
-                <string>Catalog of Open Galactic Clusters (Collinder, 1931)</string>
-               </property>
-               <property name="text">
-                <string notr="true">Cr</string>
+                <string notr="true">VV</string>
                </property>
                <attribute name="buttonGroup">
                 <string notr="true">buttonGroupDisplayedDSOCatalogs</string>
@@ -2273,26 +2169,13 @@
                </attribute>
               </widget>
              </item>
-             <item row="0" column="3">
-              <widget class="QCheckBox" name="checkBoxLDN">
+             <item row="2" column="6">
+              <widget class="QCheckBox" name="checkBoxACO">
                <property name="toolTip">
-                <string>Lynds' Catalogue of Dark Nebulae (Lynds, 1962)</string>
+                <string>A Catalog of Rich Clusters of Galaxies (Abell+, 1989)</string>
                </property>
                <property name="text">
-                <string notr="true">LDN</string>
-               </property>
-               <attribute name="buttonGroup">
-                <string notr="true">buttonGroupDisplayedDSOCatalogs</string>
-               </attribute>
-              </widget>
-             </item>
-             <item row="1" column="7">
-              <widget class="QCheckBox" name="checkBoxVdBH">
-               <property name="toolTip">
-                <string>Catalogue of southern stars embedded in nebulosity (van den Bergh and Herbst, 1975)</string>
-               </property>
-               <property name="text">
-                <string notr="true">vdBH</string>
+                <string notr="true">Abell (ACO)</string>
                </property>
                <attribute name="buttonGroup">
                 <string notr="true">buttonGroupDisplayedDSOCatalogs</string>
@@ -2312,26 +2195,49 @@
                </attribute>
               </widget>
              </item>
-             <item row="2" column="5">
-              <widget class="QCheckBox" name="checkBoxPK">
+             <item row="1" column="9">
+              <widget class="QCheckBox" name="checkBoxVdBHa">
                <property name="toolTip">
-                <string>The Catalogue of Galactic Planetary Nebulae (Kohoutek, 2001)</string>
+                <string>van den Bergh-Hagen Catalogue (Uniform survey of clusters in the Southern Milky Way; van den Bergh and Hagen, 1975)</string>
                </property>
                <property name="text">
-                <string notr="true">PK</string>
+                <string notr="true">vdB-Ha</string>
                </property>
                <attribute name="buttonGroup">
                 <string notr="true">buttonGroupDisplayedDSOCatalogs</string>
                </attribute>
               </widget>
              </item>
-             <item row="2" column="0">
-              <widget class="QCheckBox" name="checkBoxNGC">
+             <item row="2" column="3">
+              <widget class="QCheckBox" name="checkBoxMel">
                <property name="toolTip">
-                <string>New General Catalogue of Nebulae and Clusters of Stars</string>
+                <string>A Catalogue of Star Clusters shown on Franklin-Adams Chart Plates (Melotte, 1915)</string>
                </property>
                <property name="text">
-                <string notr="true">NGC</string>
+                <string notr="true">Mel</string>
+               </property>
+               <attribute name="buttonGroup">
+                <string notr="true">buttonGroupDisplayedDSOCatalogs</string>
+               </attribute>
+              </widget>
+             </item>
+             <item row="1" column="1">
+              <widget class="QCheckBox" name="checkBoxB">
+               <property name="toolTip">
+                <string>Barnard's Catalogue of 349 Dark Objects in the Sky (Barnard, 1927)</string>
+               </property>
+               <property name="text">
+                <string notr="true">B</string>
+               </property>
+               <attribute name="buttonGroup">
+                <string notr="true">buttonGroupDisplayedDSOCatalogs</string>
+               </attribute>
+              </widget>
+             </item>
+             <item row="2" column="9">
+              <widget class="QCheckBox" name="checkBoxOther">
+               <property name="text">
+                <string comment="other catalogs">Other</string>
                </property>
                <attribute name="buttonGroup">
                 <string notr="true">buttonGroupDisplayedDSOCatalogs</string>
@@ -2351,10 +2257,137 @@
                </attribute>
               </widget>
              </item>
-             <item row="2" column="9">
-              <widget class="QCheckBox" name="checkBoxOther">
+             <item row="1" column="6">
+              <widget class="QCheckBox" name="checkBoxSNRG">
+               <property name="toolTip">
+                <string>A catalogue of Galactic supernova remnants (Green, 2014)</string>
+               </property>
                <property name="text">
-                <string comment="other catalogs">Other</string>
+                <string notr="true">SNR G</string>
+               </property>
+               <attribute name="buttonGroup">
+                <string notr="true">buttonGroupDisplayedDSOCatalogs</string>
+               </attribute>
+              </widget>
+             </item>
+             <item row="1" column="4">
+              <widget class="QCheckBox" name="checkBoxUGC">
+               <property name="toolTip">
+                <string>The Uppsala General Catalogue of Galaxies</string>
+               </property>
+               <property name="text">
+                <string notr="true">UGC</string>
+               </property>
+               <attribute name="buttonGroup">
+                <string notr="true">buttonGroupDisplayedDSOCatalogs</string>
+               </attribute>
+              </widget>
+             </item>
+             <item row="0" column="4">
+              <widget class="QCheckBox" name="checkBoxPGC">
+               <property name="toolTip">
+                <string>Principal Galaxy Catalog</string>
+               </property>
+               <property name="text">
+                <string notr="true">PGC</string>
+               </property>
+               <attribute name="buttonGroup">
+                <string notr="true">buttonGroupDisplayedDSOCatalogs</string>
+               </attribute>
+              </widget>
+             </item>
+             <item row="4" column="0" colspan="10">
+              <layout class="QHBoxLayout" name="horizontalLayout">
+               <item>
+                <widget class="QLabel" name="label">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="text">
+                  <string>Quick selection:</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QPushButton" name="selectAllCatalogs">
+                 <property name="minimumSize">
+                  <size>
+                   <width>150</width>
+                   <height>0</height>
+                  </size>
+                 </property>
+                 <property name="text">
+                  <string>select all</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QPushButton" name="selectNoneCatalogs">
+                 <property name="minimumSize">
+                  <size>
+                   <width>150</width>
+                   <height>0</height>
+                  </size>
+                 </property>
+                 <property name="text">
+                  <string>select none</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+             <item row="0" column="2">
+              <widget class="QCheckBox" name="checkBoxVdB">
+               <property name="toolTip">
+                <string>Catalogue of Reflection Nebulae (van den Bergh, 1966)</string>
+               </property>
+               <property name="text">
+                <string notr="true">vdB</string>
+               </property>
+               <attribute name="buttonGroup">
+                <string notr="true">buttonGroupDisplayedDSOCatalogs</string>
+               </attribute>
+              </widget>
+             </item>
+             <item row="2" column="4">
+              <widget class="QCheckBox" name="checkBoxCed">
+               <property name="toolTip">
+                <string>Catalog of bright diffuse Galactic nebulae (Cederblad, 1946)</string>
+               </property>
+               <property name="text">
+                <string notr="true">Ced</string>
+               </property>
+               <attribute name="buttonGroup">
+                <string notr="true">buttonGroupDisplayedDSOCatalogs</string>
+               </attribute>
+              </widget>
+             </item>
+             <item row="2" column="0">
+              <widget class="QCheckBox" name="checkBoxNGC">
+               <property name="toolTip">
+                <string>New General Catalogue of Nebulae and Clusters of Stars</string>
+               </property>
+               <property name="text">
+                <string notr="true">NGC</string>
+               </property>
+               <attribute name="buttonGroup">
+                <string notr="true">buttonGroupDisplayedDSOCatalogs</string>
+               </attribute>
+              </widget>
+             </item>
+             <item row="2" column="5">
+              <widget class="QCheckBox" name="checkBoxPK">
+               <property name="toolTip">
+                <string>The Catalogue of Galactic Planetary Nebulae (Kohoutek, 2001)</string>
+               </property>
+               <property name="text">
+                <string notr="true">PK</string>
                </property>
                <attribute name="buttonGroup">
                 <string notr="true">buttonGroupDisplayedDSOCatalogs</string>
@@ -2374,13 +2407,26 @@
                </attribute>
               </widget>
              </item>
-             <item row="1" column="9">
-              <widget class="QCheckBox" name="checkBoxVdBHa">
+             <item row="0" column="0">
+              <widget class="QCheckBox" name="checkBoxM">
                <property name="toolTip">
-                <string>van den Bergh-Hagen Catalogue (Uniform survey of clusters in the Southern Milky Way; van den Bergh and Hagen, 1975)</string>
+                <string>Messier Catalogue</string>
                </property>
                <property name="text">
-                <string notr="true">vdB-Ha</string>
+                <string notr="true">M</string>
+               </property>
+               <attribute name="buttonGroup">
+                <string notr="true">buttonGroupDisplayedDSOCatalogs</string>
+               </attribute>
+              </widget>
+             </item>
+             <item row="1" column="2">
+              <widget class="QCheckBox" name="checkBoxRCW">
+               <property name="toolTip">
+                <string>A catalogue of Hα-emission regions in the southern Milky Way (Rodgers+, 1960)</string>
+               </property>
+               <property name="text">
+                <string notr="true">RCW</string>
                </property>
                <attribute name="buttonGroup">
                 <string notr="true">buttonGroupDisplayedDSOCatalogs</string>
@@ -5173,12 +5219,12 @@
  </resources>
  <connections/>
  <buttongroups>
-  <buttongroup name="buttonGroupDisplayedDSOTypes">
+  <buttongroup name="buttonGroupDisplayedDSOCatalogs">
    <property name="exclusive">
     <bool>false</bool>
    </property>
   </buttongroup>
-  <buttongroup name="buttonGroupDisplayedDSOCatalogs">
+  <buttongroup name="buttonGroupDisplayedDSOTypes">
    <property name="exclusive">
     <bool>false</bool>
    </property>


### PR DESCRIPTION
### Description

Added 2 buttons for quick selection of DSO catalogs: “select all” and “select none”

Fixes #2425 

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
