### PR TITLE
Fix lunar halo flickering

### DIFF
--- a/data/shaders/atmosphere.vert
+++ b/data/shaders/atmosphere.vert
@@ -46,15 +46,23 @@ void main()
 	// + the Y (luminance) component of the color in the alpha channel
 	highp vec3 unprojectedVertex = skyColor.xyz;
 	highp float Y = skyColor.w;
+	highp float x,y;
+	if (Y>0.01)
+	{
+		highp float cosDistSunq = dot(sunPos,unprojectedVertex);
+		highp float distSun=acos(cosDistSunq);
+		highp float oneOverCosZenithAngle = (unprojectedVertex.z==0.) ? 9999999999999. : 1. / unprojectedVertex.z;
 
-	highp float cosDistSunq = dot(sunPos,unprojectedVertex);
-	highp float distSun=acos(cosDistSunq);
-	highp float oneOverCosZenithAngle = (unprojectedVertex.z==0.) ? 9999999999999. : 1. / unprojectedVertex.z;
-
-	cosDistSunq*=cosDistSunq;
-	highp float x = term_x * (1. + Ax * exp(Bx*oneOverCosZenithAngle))* (1. + Cx * exp(Dx*distSun) + Ex * cosDistSunq);
-	highp float y = term_y * (1. + Ay * exp(By*oneOverCosZenithAngle))* (1. + Cy * exp(Dy*distSun) + Ey * cosDistSunq);
-	if (x < 0. || y < 0.)
+		cosDistSunq*=cosDistSunq;
+		x = term_x * (1. + Ax * exp(Bx*oneOverCosZenithAngle))* (1. + Cx * exp(Dx*distSun) + Ex * cosDistSunq);
+		y = term_y * (1. + Ay * exp(By*oneOverCosZenithAngle))* (1. + Cy * exp(Dy*distSun) + Ey * cosDistSunq);
+		if (x < 0. || y < 0.)
+		{
+			x = 0.25;
+			y = 0.25;
+		}
+	}
+	else
 	{
 		x = 0.25;
 		y = 0.25;


### PR DESCRIPTION
### Description
This patch fixes Lunar halo flickering when panning or zooming (see #2240) and, probably, unstable rendering the atmosphere on Windows (see #2484 and #2166). The issue was introduced in the PR #2085 (see commit c08b684ba40e24b01b20ee780f47030d28676ded) and this fix may introduce the issues for skylight.

Fixes #2240, #2484, #2166 (issues)

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
