### PR TITLE
Quick way to jump to the solstice/equinox

### DIFF
--- a/src/core/modules/SolarSystem.hpp
+++ b/src/core/modules/SolarSystem.hpp
@@ -886,7 +886,41 @@ public:
 	//! Get the list of all minor bodies names.
 	const QStringList getMinorBodiesList() const { return minorBodies; }
 
+	//! Compute the time of equinoxes and solstices for specific year
+	//! @param year (valid range: -1000..+3000)
+	//! @return Vec4d
+	//! [0] - March equinox
+	//! [1] - June solstice
+	//! [2] - September equinox
+	//! [3] - December solstice
+	Vec4d getEquinoxesSolstices(int year);
+
 private slots:
+	//! Set simulation time to the time of march equinox at current year
+	void currentMarchEquinox();
+	//! Set simulation time to the time of march equinox at next year
+	void nextMarchEquinox();
+	//! Set simulation time to the time of march equinox at previous year
+	void previousMarchEquinox();
+	//! Set simulation time to the time of june solstice at current year
+	void currentJuneSolstice();
+	//! Set simulation time to the time of june solstice at next year
+	void nextJuneSolstice();
+	//! Set simulation time to the time of june solstice at previous year
+	void previousJuneSolstice();
+	//! Set simulation time to the time of september equinox at current year
+	void currentSeptemberEquinox();
+	//! Set simulation time to the time of september equinox at next year
+	void nextSeptemberEquinox();
+	//! Set simulation time to the time of september equinox at previous year
+	void previousSeptemberEquinox();
+	//! Set simulation time to the time of december solstice at current year
+	void currentDecemberSolstice();
+	//! Set simulation time to the time of december solstice at next year
+	void nextDecemberSolstice();
+	//! Set simulation time to the time of december solstice at previous year
+	void previousDecemberSolstice();
+
 	//! Called when a new object is selected.
 	void selectedObjectChange(StelModule::StelModuleSelectAction action);
 


### PR DESCRIPTION
### Description
This pull request contain the code for compute the time of equinoxes and solstices and set of actions to jump to the solstice/equinox at current, next or previous year. The default hotkeys for actions are not defined.

Fixes #1394 (issue)

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
