### PR TITLE
Show negative radiant drift in RA for meteor showers

### DIFF
--- a/plugins/MeteorShowers/src/MeteorShower.cpp
+++ b/plugins/MeteorShowers/src/MeteorShower.cpp
@@ -546,7 +546,7 @@ QString MeteorShower::getInfoString(const StelCore* core, const InfoStringGroup&
 	if (flags&Extra)
 	{
 		QString sDriftRA;
-		if (m_driftAlpha > 0.)
+		if (m_driftAlpha >= 0.)
 			sDriftRA = StelUtils::radToHmsStr(static_cast<double>(m_driftAlpha));
 		else
 			sDriftRA = '-'+StelUtils::radToHmsStr(static_cast<double>(abs(m_driftAlpha)));

--- a/plugins/MeteorShowers/src/MeteorShower.cpp
+++ b/plugins/MeteorShowers/src/MeteorShower.cpp
@@ -545,7 +545,11 @@ QString MeteorShower::getInfoString(const StelCore* core, const InfoStringGroup&
 
 	if (flags&Extra)
 	{
-		QString sDriftRA = StelUtils::radToHmsStr(static_cast<double>(m_driftAlpha));
+		QString sDriftRA;
+		if (m_driftAlpha > 0.)
+			sDriftRA = StelUtils::radToHmsStr(static_cast<double>(m_driftAlpha));
+		else
+			sDriftRA = '-'+StelUtils::radToHmsStr(static_cast<double>(abs(m_driftAlpha)));
 		QString sDriftDE = StelUtils::radToDmsStr(static_cast<double>(m_driftDelta));
 		if (withDecimalDegree)
 		{


### PR DESCRIPTION
Very small number of meteor showers have negative value of radiant drift in RA (τ-Herculids & October Camelopardalids in latest version of the catalog). It's weird to see the value like 23h 59m 36s for them. This will fix it.

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system: Manjaro Linux 21.3.1

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
