### PR TITLE
Replace object type booleans with methods. This removes the need for …

### DIFF
--- a/plugins/Observability/src/Observability.hpp
+++ b/plugins/Observability/src/Observability.hpp
@@ -156,6 +156,21 @@ private:
 	//! Configuration window.
 	ObservabilityDialog* configDialog;
 
+	//! Returns whether the first object in the selection is the moon.
+	//! @param List of selected objects.
+	//! @returns true if the moon, false otherwise
+    bool isMoon(QList<StelObjectP> & objectSelection);
+
+	//! Returns whether the first object in the selection is the sun.
+	//! @param List of selected objects.
+	//! @returns true if the sun, false otherwise
+    bool isSun(QList<StelObjectP> & objectSelection);
+
+	//! Returns whether the first object in the selection is not in the solar system. If no object is selected, returns true. SSO stands for "solar system object."
+	//! @param List of selected objects.
+	//! @returns true if in solar system, false otherwise
+    bool isNotSSO(QList<StelObjectP> & objectSelection);
+
 	void setDateFormat(bool b) { dmyFormat=b; }
 	bool getDateFormat(void) { return dmyFormat; }
 
@@ -369,8 +384,8 @@ private:
 	//! Equatorial and local coordinates of currently-selected source.
 	Vec3d EquPos, LocPos;
 
-	//! Some booleans to check the kind of source selected and the kind of output to produce.
-	bool isStar, isMoon, isSun, isScreen;
+	//! Boolean representing if the screen is selected, i.e., no object is selected.
+	bool isScreen;
 
 	//! This really shouldn't be handled like this...
 	bool hasRisen;

--- a/plugins/Observability/src/test/report-generator-for-regression-testing.ssc
+++ b/plugins/Observability/src/test/report-generator-for-regression-testing.ssc
@@ -43,7 +43,6 @@ for (i=0; i < observerLocations.length; i++) {
         var objectName = objectNames[j]
         core.selectObjectByName(objectName, false)
         // Need to wait a sufficient amount of time to allow the object selection to take place.
-        // Could use core.getSelectedObjectInfo to verify the selection was successful, but using that method after selected Achernar crashes Stellarium.
         core.wait(1)
 
         var reportJson = Observability.getReportAsJson()


### PR DESCRIPTION
…managing object type state and delegates it to the StelObjectMgr.

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Please include a summary of the change and which issue is fixed. -->
<!--- Please also include relevant motivation and context. -->
<!--- List any dependencies that are required for this change. -->
The Observability plugin manages object type state within the draw method. This is an error prone manual process that must be tracked by the developer when refactoring. This PR removes the need to manage the state and delegates it back to the StelObjectMgr by using methods that consume the object selection and return whether or not the object is the specified type.

Fixes # (issue)

### Screenshots (if appropriate):

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The changes in this PR are essentially a one-to-one conversion from the previous logic, with the exception of the introduction of `isSystemPlanet`.

These changes were tested by running a pre-change and post-change stellarium instance, selecting the moon, sun, a planet, and an interstellar star, and comparing the output from each instance.

**Test Configuration**:
* Operating system: macOS Catalina v10.15.7
* Graphics Card:  Intel Iris 1536 MB

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
  - I refrained from doing this since I ran the formatter in https://github.com/Stellarium/stellarium/pull/2535.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
