### PR TITLE
Enhancement for the AstroCalc/Positions tool

### DIFF
--- a/src/gui/AstroCalcDialog.hpp
+++ b/src/gui/AstroCalcDialog.hpp
@@ -264,6 +264,7 @@ private slots:
 	void saveHECPositions();
 	void selectCurrentHECPosition(const QModelIndex &modelIndex);
 	void markCurrentHECPosition(const QModelIndex &modelIndex);
+	void saveHECFlagMinorPlanets(bool b);
 
 	void saveCelestialPositionsMagnitudeLimit(double mag);
 	void saveCelestialPositionsHorizontalCoordinatesFlag(bool b);

--- a/src/gui/astroCalcDialog.ui
+++ b/src/gui/astroCalcDialog.ui
@@ -473,13 +473,6 @@
               <string>Major planets</string>
              </attribute>
              <layout class="QGridLayout" name="gridLayout_23">
-              <item row="2" column="1">
-               <widget class="QChartView" name="hecPositionsChartView">
-                <property name="renderHints">
-                 <set>QPainter::Antialiasing|QPainter::TextAntialiasing</set>
-                </property>
-               </widget>
-              </item>
               <item row="0" column="0" colspan="2">
                <widget class="QLabel" name="hecPositionsHeaderLabel">
                 <property name="font">
@@ -523,28 +516,46 @@
                 </item>
                </layout>
               </item>
-              <item row="2" column="0">
-               <widget class="QTreeWidget" name="hecPositionsTreeWidget">
-                <property name="editTriggers">
-                 <set>QAbstractItemView::NoEditTriggers</set>
-                </property>
-                <property name="rootIsDecorated">
-                 <bool>false</bool>
-                </property>
-                <property name="uniformRowHeights">
-                 <bool>true</bool>
-                </property>
-                <property name="itemsExpandable">
-                 <bool>false</bool>
-                </property>
-                <property name="sortingEnabled">
-                 <bool>true</bool>
-                </property>
-                <property name="expandsOnDoubleClick">
-                 <bool>false</bool>
-                </property>
-                <property name="columnCount">
-                 <number>0</number>
+              <item row="1" column="0">
+               <layout class="QVBoxLayout" name="verticalLayout_4">
+                <item>
+                 <widget class="QTreeWidget" name="hecPositionsTreeWidget">
+                  <property name="editTriggers">
+                   <set>QAbstractItemView::NoEditTriggers</set>
+                  </property>
+                  <property name="rootIsDecorated">
+                   <bool>false</bool>
+                  </property>
+                  <property name="uniformRowHeights">
+                   <bool>true</bool>
+                  </property>
+                  <property name="itemsExpandable">
+                   <bool>false</bool>
+                  </property>
+                  <property name="sortingEnabled">
+                   <bool>true</bool>
+                  </property>
+                  <property name="expandsOnDoubleClick">
+                   <bool>false</bool>
+                  </property>
+                  <property name="columnCount">
+                   <number>0</number>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QCheckBox" name="hecSelectedMinorPlanetsCheckBox">
+                  <property name="text">
+                   <string>Include selected minor planets</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </item>
+              <item row="1" column="1">
+               <widget class="QChartView" name="hecPositionsChartView">
+                <property name="renderHints">
+                 <set>QPainter::Antialiasing|QPainter::TextAntialiasing</set>
                 </property>
                </widget>
               </item>


### PR DESCRIPTION
### Description
A small didactic enhancement for AstroCalc/Positions/HEC tool. The HEC chart & table can show 5 selected minor bodies (Pluto, Ceres, Juno, Pallas, Vesta) in additional to the major planets of Solar system. The list of selected minor planets followes the AstroCalc/Phenomena tool and Astronomical Almanacs.

The enhancement was added just for fun by the didactic purpose.

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
