### PR TITLE
AstroCalc:Graphs - Fix upper limit of phase, unit of magnitude and angular size in tooltip

### DIFF
--- a/src/gui/AstroCalcChart.cpp
+++ b/src/gui/AstroCalcChart.cpp
@@ -264,7 +264,9 @@ void AstroCalcChart::showToolTip(const QPointF &point, bool show)
 						  AstroCalcChart::Distance1, AstroCalcChart::Distance2,
 						  AstroCalcChart::HeliocentricDistance1, AstroCalcChart::HeliocentricDistance2,
 						  AstroCalcChart::RightAscension1, AstroCalcChart::RightAscension2,
-						  AstroCalcChart::Phase1, AstroCalcChart::Phase2, AstroCalcChart::pcDistanceAU}).contains(seriesCode))
+						  AstroCalcChart::Phase1, AstroCalcChart::Phase2, AstroCalcChart::pcDistanceAU,
+						  AstroCalcChart::Magnitude1, AstroCalcChart::Magnitude2,
+						  AstroCalcChart::AngularSize1, AstroCalcChart::AngularSize2}).contains(seriesCode))
 		{
 			units="";
 		}
@@ -640,9 +642,12 @@ void AstroCalcChart::bufferYrange(Series series, double *min, double *max, bool 
 			*max=*max+0.05*range;
 			break;
 		case Phase1:
+			*min=qMax(0., *min-0.05*range);
+			*max=qMin(100., *max+0.05*range);
+			break;
 		case Phase2:
 			*min=qMax(0., *min-0.05*range);
-			*max=qMin(1., *max+0.05*range);
+			*max=qMin(100., *max+0.05*range);
 			break;
 		default: // 8 other series which should not influence chart scaling
 			break;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
Two issues here.
1. Upper limit of phase is at 1% (look at the Moon and Mercury), this will change to 100%
2. In tool tip, magnitude and angular size of object have wrong unit (°). This will remove them.

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system: Linux Mint 21

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
