### PR TITLE
Add contact times for lunar eclipses in AstroCal

### DIFF
--- a/src/gui/AstroCalcDialog.cpp
+++ b/src/gui/AstroCalcDialog.cpp
@@ -2901,6 +2901,7 @@ void AstroCalcDialog::selectCurrentLunarEclipse(const QModelIndex& modelIndex)
 	const bool useSouthAzimuth = StelApp::getInstance().getFlagSouthAzimuthUsage();
 	const bool withDecimalDegree = StelApp::getInstance().getFlagShowDecimalDegrees();
 	QPair<QString, QString> coordStrings;
+	QString altitudeStr, azimuthStr, positionAngleStr, distanceStr, latitudeStr, longitudeStr;
 	double JDMid = modelIndex.sibling(modelIndex.row(), LunarEclipseDate).data(Qt::UserRole).toDouble();
 	double uMag = modelIndex.sibling(modelIndex.row(), LunarEclipseUMag).data(Qt::UserRole).toDouble();
 	double JD = JDMid;
@@ -2989,7 +2990,6 @@ void AstroCalcDialog::selectCurrentLunarEclipse(const QModelIndex& modelIndex)
 					treeItem->setText(LunarEclipseContact, QString(q_("Moon leaves penumbra")));
 					break;
 			}
-			QString altitudeStr, azimuthStr, positionAngleStr, distanceStr, latitudeStr, longitudeStr;
 			treeItem->setText(LunarEclipseContactDate, QString("%1 %2").arg(localeMgr->getPrintableDateLocal(JD), localeMgr->getPrintableTimeLocal(JD)));
 			treeItem->setData(LunarEclipseContactDate, Qt::UserRole, JD);
 			core->setJD(JD);

--- a/src/gui/AstroCalcDialog.hpp
+++ b/src/gui/AstroCalcDialog.hpp
@@ -187,6 +187,20 @@ public:
 		LunarEclipseCount		//! total number of columns
 	};
 
+	//! Defines the number and the order of the columns in the lunar eclipse contact table
+	//! @enum LunarEclipseContactColumns
+	enum LunarEclipseContactColumns {
+		LunarEclipseContact,		//! circumstance of lunar eclipse
+		LunarEclipseContactDate,	//! date and time
+		LunarEclipseContactAltitude,	//! altitude of the Moon
+		LunarEclipseContactAzimuth,	//! azimuth of the Moon
+		LunarEclipseContactLatitude,	//! latitude where the Moon appears in the zenith
+		LunarEclipseContactLongitude,	//! longitude where the Moon appears in the zenith
+		LunarEclipseContactPA,		//! position angle of shadow
+		LunarEclipseContactDistance,	//! angular distance between the Moon and shadow
+		LunarEclipseContactCount	//! total number of columns
+	};
+
 	//! Defines the number and the order of the columns in the global solar eclipse table
 	//! @enum SolarEclipseColumns
 	enum SolarEclipseColumns {
@@ -290,6 +304,7 @@ private slots:
 	void generateLunarEclipses();
 	void cleanupLunarEclipses();
 	void selectCurrentLunarEclipse(const QModelIndex &modelIndex);
+	void selectCurrentLunarEclipseContact(const QModelIndex &modelIndex);
 	void saveLunarEclipses();
 
 	//! Calculating solar eclipses to fill the list.
@@ -431,7 +446,6 @@ private:
 	QSettings* conf;
 	QTimer *currentTimeLine;
 	QHash<QString,int> wutCategories;
-	QPair<double, double> getLunarEclipseXY() const;
 	QList<HECPosition> hecObjects;
 
 	void saveTableAsCSV(const QString& fileName, QTreeWidget* tWidget, QStringList& headers);
@@ -455,6 +469,8 @@ private:
 	void setWUTHeaderNames(const bool magnitude = true, const bool separation = false);
 	//! update header names for lunar eclipse table
 	void setLunarEclipseHeaderNames();
+	//! update header names for lunar eclipse contact table
+	void setLunarEclipseContactsHeaderNames();
 	//! update header names for solar eclipse table
 	void setSolarEclipseHeaderNames();
 	//! update header names for local solar eclipse table
@@ -476,6 +492,8 @@ private:
 	void initListWUT(const bool magnitude = true, const bool separation = false);
 	//! Init header and list of lunar eclipse
 	void initListLunarEclipse();
+	//! Init header and list of lunar eclipse contact
+	void initListLunarEclipseContact();
 	//! Init header and list of solar eclipse
 	void initListSolarEclipse();
 	//! Init header and list of local solar eclipse
@@ -564,7 +582,7 @@ private:
 	// Signal that a plot has to be redone
 	bool plotAltVsTime, plotAltVsTimeSun, plotAltVsTimeMoon, plotAltVsTimePositive, plotMonthlyElevation, plotMonthlyElevationPositive, plotDistanceGraph, plotLunarElongationGraph, plotAziVsTime;
 	int altVsTimePositiveLimit, monthlyElevationPositiveLimit, graphsDuration, graphsStep;
-	QStringList ephemerisHeader, phenomenaHeader, positionsHeader, hecPositionsHeader, wutHeader, rtsHeader, lunareclipseHeader, solareclipseHeader, solareclipselocalHeader, transitHeader;
+	QStringList ephemerisHeader, phenomenaHeader, positionsHeader, hecPositionsHeader, wutHeader, rtsHeader, lunareclipseHeader, lunareclipsecontactsHeader, solareclipseHeader, solareclipselocalHeader, transitHeader;
 	static double brightLimit;
 	static const QString dash, delimiter;
 
@@ -836,6 +854,30 @@ private:
 		{
 			return text(column).toLower() < other.text(column).toLower();
 		}
+	}
+};
+
+//! Besselian elements for lunar eclipse
+class LunarEclipseBessel
+{
+public:
+	LunarEclipseBessel(double &besX, double &besY, double &besL1, double &besL2, double &besL3, double &latDeg, double &lngDeg);
+};
+
+//! Iteration to compute contact times of lunar eclipse
+class LunarEclipseIteration
+{
+public:
+	LunarEclipseIteration(double &JD, double &positionAngle, double &axisDistance, bool beforeMaximum, int eclipseType);
+};
+
+// Reimplements the QTreeWidgetItem class to fix the sorting bug
+class ACLunarEclipseContactsTreeWidgetItem : public QTreeWidgetItem
+{
+public:
+	ACLunarEclipseContactsTreeWidgetItem(QTreeWidget* parent)
+		: QTreeWidgetItem(parent)
+	{
 	}
 };
 

--- a/src/gui/AstroCalcDialog.hpp
+++ b/src/gui/AstroCalcDialog.hpp
@@ -306,6 +306,7 @@ private slots:
 	void selectCurrentLunarEclipse(const QModelIndex &modelIndex);
 	void selectCurrentLunarEclipseContact(const QModelIndex &modelIndex);
 	void saveLunarEclipses();
+	void saveLunarEclipseCircumstances();
 
 	//! Calculating solar eclipses to fill the list.
 	//! Algorithm taken from calculating the rises, transits and sets.

--- a/src/gui/astroCalcDialog.ui
+++ b/src/gui/astroCalcDialog.ui
@@ -2785,6 +2785,13 @@
                  </widget>
                 </item>
                 <item>
+                 <widget class="QPushButton" name="lunareclipsescontactsSaveButton">
+                  <property name="text">
+                   <string>Export circumstances of eclipse...</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
                  <widget class="QPushButton" name="lunareclipsesCalculateButton">
                   <property name="text">
                    <string>Calculate lunar eclipses</string>

--- a/src/gui/astroCalcDialog.ui
+++ b/src/gui/astroCalcDialog.ui
@@ -2733,7 +2733,32 @@
                 </attribute>
                </widget>
               </item>
-              <item row="2" column="0">
+              <item row="2" column="0" alignment="Qt::AlignBottom">
+                <widget class="QTreeWidget" name="lunareclipsecontactsTreeWidget">
+                <property name="rootIsDecorated">
+                 <bool>false</bool>
+                </property>
+                <property name="uniformRowHeights">
+                 <bool>true</bool>
+                </property>
+                <property name="itemsExpandable">
+                 <bool>false</bool>
+                </property>
+                <property name="sortingEnabled">
+                 <bool>false</bool>
+                </property>
+                <property name="expandsOnDoubleClick">
+                 <bool>false</bool>
+                </property>
+                <property name="columnCount">
+                 <number>0</number>
+                </property>
+                <attribute name="headerShowSortIndicator" stdset="0">
+                 <bool>true</bool>
+                </attribute>
+               </widget>
+              </item>
+              <item row="3" column="0">
                <widget class="QLabel" name="gammaNoteLabel">
                 <property name="text">
                  <string>Notes: The quantity gamma is the minimum distance from the center of the Moon to the axis of Earth’s umbral shadow cone, in units of Earth’s equatorial radius. This distance is positive or negative, depending on whether the Moon passes north or south of the shadow cone axis. Local circumstances for eclipses during thousands of years in the past and future are not reliable due to uncertainty in ΔT which is caused by fluctuations in Earth's rotation.</string>
@@ -2743,7 +2768,7 @@
                 </property>
                </widget>
               </item>
-              <item row="3" column="0">
+              <item row="4" column="0">
                <layout class="QHBoxLayout" name="horizontalLayout_39">
                 <item>
                  <widget class="QPushButton" name="lunareclipsesCleanupButton">


### PR DESCRIPTION
### Description
Double click an item will also display predicted contact times and additional data for each contact of the eclipse on selected date.

1. Horizontal coordinates of the Moon
2. Zenith latitude/longitude or Sublunar point - useful to draw visiblity map (in the future?)
3. Position angle of contact point
4. Axis distance (distance between the Moon and shadow axis)

### Screenshots (if appropriate):
![lunareclipse-circumstances](https://user-images.githubusercontent.com/41257965/184599289-2ec63e29-1272-4e33-81e9-207905c6d7d9.png)

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system: Linux Mint 21

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
