### PR TITLE
Stabilize up vector at end of scripted zenith move.

### DIFF
--- a/scripts/tests/test-upvector.ssc
+++ b/scripts/tests/test-upvector.ssc
@@ -1,0 +1,13 @@
+// Name: Up vector test
+// Author: Georg Zotti
+// License: Public Domain
+// Description: This script tests a move by the script command 
+// core.moveToAltAzi(90,180,1), i.e., a move within 1 second 
+// towards 90 degrees altitude (zenith), with south at the screen bottom.
+// This move is dangerous as the view UP vector would usually fall parallel 
+// to the view direction vector, causing either black screen or orientation disorder.
+// The mitigation is storing the final UP vector when the move is set up and setting it 
+// explicitly at the end of the move.
+
+core.moveToAltAzi(90, 180, 1);
+

--- a/src/core/StelMovementMgr.cpp
+++ b/src/core/StelMovementMgr.cpp
@@ -972,11 +972,64 @@ void StelMovementMgr::lookNadir(void)
 
 void StelMovementMgr::lookTowardsNCP(void)
 {
+	if (mountMode==StelMovementMgr::MountEquinoxEquatorial)
+	{
+		Vec3d viewVector=core->j2000ToEquinoxEqu(getViewDirectionJ2000(), StelCore::RefractionOff);
+		if (qFuzzyCompare(viewVector[2], 1.))
+		{
+			//qDebug() << "Already looking to north pole. Doing nothing.";
+			return;
+		}
+
+		if (qFuzzyCompare(viewVector[2], -1.)) // Stress test! We are looing to the south pole and just want to flip over.
+		{
+			//qDebug() << "Looking to south pole. Invert view and up vectors.";
+			viewDirectionMountFrame[2]*=-1;
+			upVectorMountFrame *= -1;
+			return;
+		}
+
+		//qDebug() << "ViewVector" << viewVector << ", viewDirectionMountFrame" << viewDirectionMountFrame;
+		//qDebug() << "viewUpVectorJ2000" << getViewUpVectorJ2000();
+
+		double RA, dec;
+		StelUtils::rectToSphe(&RA, &dec, viewVector);
+		//qDebug() << "Detected RA" << StelUtils::fmodpos(RA*M_180_PI/15., 24.) << "dec" << dec*M_180_PI;
+		Vec3d safeUp(-viewVector[0], -viewVector[1],0.);
+		safeUp.normalize();
+		setViewUpVector(safeUp);
+	}
 	setViewDirectionJ2000(core->equinoxEquToJ2000(Vec3d(0,0,1), StelCore::RefractionOff));
 }
 
 void StelMovementMgr::lookTowardsSCP(void)
 {
+	if (mountMode==StelMovementMgr::MountEquinoxEquatorial)
+	{
+		Vec3d viewVector=core->j2000ToEquinoxEqu(getViewDirectionJ2000(), StelCore::RefractionOff);
+		if (qFuzzyCompare(viewVector[2], -1.))
+		{
+			//qDebug() << "Already looking to south pole. Doing nothing.";
+			return;
+		}
+		if (qFuzzyCompare(viewVector[2], 1.)) // Stress test! We are looing to the north pole and just want to flip over.
+		{
+			//qDebug() << "Looking to north pole. Invert view and up vectors.";
+			viewDirectionMountFrame[2]*=-1;
+			upVectorMountFrame *= -1;
+			return;
+		}
+
+		//qDebug() << "ViewVector" << viewVector << ", viewDirectionMountFrame" << viewDirectionMountFrame;
+		//qDebug() << "viewUpVectorJ2000" << getViewUpVectorJ2000();
+
+		double RA, dec;
+		StelUtils::rectToSphe(&RA, &dec, viewVector);
+		//qDebug() << "Detected RA" << StelUtils::fmodpos(RA*M_180_PI/15., 24.) << "dec" << dec*M_180_PI;
+		Vec3d safeUp(viewVector[0], viewVector[1],0.);
+		safeUp.normalize();
+		setViewUpVector(safeUp);
+	}
 	setViewDirectionJ2000(core->equinoxEquToJ2000(Vec3d(0,0,-1), StelCore::RefractionOff));
 }
 

--- a/src/core/StelMovementMgr.hpp
+++ b/src/core/StelMovementMgr.hpp
@@ -532,6 +532,8 @@ private:
 		Vec3d aim;
 		Vec3d startUp; // The Up vector at start time
 		Vec3d aimUp;   // The Up vector at end time of move
+		Vec3d aimUpCopy;   // The Up vector at end time of move. This gets initialized when the move is configured, never touched during move,
+				   // and ONLY read again when the move is finished and ends in the pole of the view frame.
 		float speed;   // set to 1/duration[ms] during automove setup.
 		float coef;    // Set to 0 at begin of an automove, runs up to 1.
 		// If not null, move to the object instead of the aim.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Please include a summary of the change and which issue is fixed. -->
<!--- Please also include relevant motivation and context. -->
<!--- List any dependencies that are required for this change. -->

Moving to the pole of the current mount frame is notoriously dangerous. With a script command we can still cause a visible bug by setting the up vector parallel to the view vector. This PR introduces yet another complication to the StelMovementMgr: We store the final up vector, and, in a dangerous situation of near-zenith view, set it at the end of the automove.  

When already looking into the zenith at the start of re-moving there, the intermediate up vectors are botched. The remedy is to move slightly out of zenith at the start of the move. 

Also looking into the poles of the equatorial system is equally dangerous when in equatorial view mode. Similar measures in the polar view commands circumvent the problems. 

I have added a 1-line test script that can be assigned to a hotkey.


Fixes #754 

### Screenshots (if appropriate):

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system: Win10
* Graphics Card: Geforce 960M

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
