### PR TITLE
Fix LTO build

### DIFF
--- a/plugins/TextUserInterface/src/DummyDialog.cpp
+++ b/plugins/TextUserInterface/src/DummyDialog.cpp
@@ -28,10 +28,10 @@
 #include <QLineEdit>
 
 // this is adapted from DummyDialog.cpp
-class CustomProxy : public QGraphicsProxyWidget
+class DummyCustomProxy : public QGraphicsProxyWidget
 {
 	public:
-		CustomProxy(QGraphicsItem *parent = Q_NULLPTR, Qt::WindowFlags wFlags = Qt::WindowFlags()) : QGraphicsProxyWidget(parent, wFlags)
+		DummyCustomProxy(QGraphicsItem *parent = Q_NULLPTR, Qt::WindowFlags wFlags = Qt::WindowFlags()) : QGraphicsProxyWidget(parent, wFlags)
 		{
 			setFocusPolicy(Qt::StrongFocus);
 		}
@@ -99,7 +99,7 @@ void DummyDialog::setVisible(bool v)
 		connect(dialog, SIGNAL(rejected()), this, SLOT(close()));
 		createDialogContent();
 		
-		proxy = new CustomProxy(Q_NULLPTR, Qt::Tool);
+		proxy = new DummyCustomProxy(Q_NULLPTR, Qt::Tool);
 		proxy->setWidget(dialog);
 		StelMainView::getInstance().scene()->addItem(proxy);
 		// Invisible frame around the window to make resizing easier

--- a/plugins/TextUserInterface/src/DummyDialog.hpp
+++ b/plugins/TextUserInterface/src/DummyDialog.hpp
@@ -48,7 +48,7 @@ signals:
 protected:
 	bool eventFilter(QObject *obj, QEvent *event) Q_DECL_OVERRIDE;
 	void createDialogContent();
-	class CustomProxy* proxy;
+	class DummyCustomProxy* proxy;
 	QWidget* dialog;
 	StelModule* evtHandler;
 };


### PR DESCRIPTION
CustomProxy class in DummyDialog.cpp conflicts with CustomProxy class in
src/gui/StelDialog.hpp

Ref https://bugs.gentoo.org/862249

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Please include a summary of the change and which issue is fixed. -->
<!--- Please also include relevant motivation and context. -->
<!--- List any dependencies that are required for this change. -->

Fixes this:

```
/mnt/portagetmp/portage/sci-astronomy/stellarium-0.22.2/work/stellarium-0.22.2_build/src/stelMain_autogen/DMHXEJ42XS/../../../../stellarium-0.22.2/src/gui/StelDialog.hpp:230:7: error: virtual table of type ‘struct CustomProxy’ violates one definition rule [-Werror=odr]
  230 | class CustomProxy : public QGraphicsProxyWidget
      |       ^
/mnt/portagetmp/portage/sci-astronomy/stellarium-0.22.2/work/stellarium-0.22.2_build/src/stelMain_autogen/DMHXEJ42XS/../../../../stellarium-0.22.2/src/gui/StelDialog.hpp:230:7: note: the conflicting type defined in another translation unit
/mnt/portagetmp/portage/sci-astronomy/stellarium-0.22.2/work/stellarium-0.22.2_build/src/stelMain_autogen/DMHXEJ42XS/moc_StelDialog.cpp:304:20: note: virtual method ‘metaObject’
  304 | const QMetaObject *CustomProxy::metaObject() const
      |                    ^
/usr/include/qt5/QtWidgets/qgraphicsproxywidget.h:54: note: ought to match virtual method ‘metaObject’ but does not
   54 |     Q_OBJECT
      | 
lto1: some warnings being treated as errors
lto-wrapper: fatal error: /usr/bin/x86_64-pc-linux-gnu-g++ returned 1 exit status
compilation terminated.
```

### Screenshots (if appropriate):

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Add `-flto -Werror=odr -Werror=lto-type-mismatch -Werror=strict-aliasing` to CFLAGS and CXXFLAGS, then build

**Test Configuration**:
* Operating system: Gentoo Linux
* Graphics Card: irrelevant

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
