### PR TITLE
Screen Blanking - GPS - Angle Measure Snap - Oculars Format Label

### DIFF
--- a/.project
+++ b/.project
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>stellarium</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+	</natures>
+</projectDescription>

--- a/plugins/AngleMeasure/src/AngleMeasure.cpp
+++ b/plugins/AngleMeasure/src/AngleMeasure.cpp
@@ -17,6 +17,9 @@
  * Foundation, Inc., 51 Franklin Street, Suite 500, Boston, MA  02110-1335, USA.
  */
 
+#define PAN_AND_ZOOM // This keeps the left mouse button for panning and selecting objects - only the right mouse button is used for angle measurement
+
+#include "StelObjectMgr.hpp"
 #include "StelTranslator.hpp"
 #include "StelUtils.hpp"
 #include "StelProjector.hpp"
@@ -257,8 +260,10 @@ void AngleMeasure::drawOne(StelCore *core, const StelCore::FrameType frameType, 
 		int y  = static_cast<int>(120*ppx);
 		int ls = static_cast<int>(ppx*painter.getFontMetrics().lineSpacing());
 		painter.drawText(x, y, messageEnabled);
+#ifndef PAN_AND_ZOOM
 		y -= ls;
 		painter.drawText(x, y, messageLeftButton);
+#endif
 		y -= ls;
 		painter.drawText(x, y, messageRightButton);
 	}
@@ -324,6 +329,7 @@ void AngleMeasure::handleMouseClicks(class QMouseEvent* event)
 		return;
 	}
 
+#ifndef PAN_AND_ZOOM
 	if (event->type()==QEvent::MouseButtonPress && event->button()==Qt::LeftButton)
 	{
 		const StelProjectorP prj = StelApp::getInstance().getCore()->getProjection(StelCore::FrameEquinoxEqu);
@@ -351,7 +357,6 @@ void AngleMeasure::handleMouseClicks(class QMouseEvent* event)
 #else
 		prjHor->unProject(event->x(),event->y(),startPointHor);
 #endif
-
 		// first click reset the line... only draw it after we've dragged a little.
 		if (!dragging)
 		{
@@ -405,6 +410,81 @@ void AngleMeasure::handleMouseClicks(class QMouseEvent* event)
 		event->setAccepted(true);
 		return;
 	}
+#else
+	if (event->button() == Qt::RightButton)
+	{
+		bool release = event->type() == QEvent::MouseButtonRelease;
+		bool dblclick = event->type() == QEvent::MouseButtonDblClick;
+		bool press = event->type() == QEvent::MouseButtonPress;
+		bool erase = olddblclick && dblclick;
+		if (erase || release && !picked)
+		{
+			if (dragging)
+				QApplication::restoreOverrideCursor();
+			dragging = false;
+			if (erase)
+			{
+				startPoint = Vec3d(0,0,0);
+				endPoint = Vec3d(0,0,0);
+				startPointHor = Vec3d(0,0,0);
+				endPointHor = Vec3d(0,0,0);
+				lineVisible = false;
+			}
+		}
+		else if (press || dblclick)
+		{
+			olddblclick = picked;
+			picked = dblclick;
+			if (!dragging)
+				QApplication::setOverrideCursor(QCursor(Qt::CrossCursor));
+			dragging = true;
+			lineVisible = true;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+			qreal x = event->position().x(), y = event->position().y();
+#else
+			qreal x = event->x(), y = event->y();
+#endif
+			const StelProjectorP prj = StelApp::getInstance().getCore()->getProjection(StelCore::FrameEquinoxEqu);
+			Vec3d c1, e1, s1;
+			c1.v[0] = x;
+			c1.v[1] = y;
+			prj->project(endPoint, e1);
+			prj->project(startPoint, s1);
+			// Move the point closest to the mouse
+			if ((c1-e1).length() > (c1-s1).length())
+			{
+				startPoint = endPoint;
+				startPointHor = endPointHor;
+			}
+			if (StelApp::getInstance().getStelObjectMgr().getWasSelected())
+			{ // snap to selected object
+				StelCore *core = StelApp::getInstance().getCore();
+				StelObjectP selectedObject = StelApp::getInstance().getStelObjectMgr().getSelectedObject()[0];
+				endPoint = selectedObject->getEquinoxEquatorialPos(core);
+				endPointHor = selectedObject->getAltAzPosAuto(core);
+			}
+			else
+			{
+				if (prj->unProject(x,y,endPoint))
+				{ // Nick Fedoseev patch: improve click match
+					Vec3d win;
+					prj->project(endPoint,win);
+					double dx = x - win.v[0];
+					double dy = y - win.v[1];
+					prj->unProject(x+dx, y+dy, endPoint);
+				}
+				const StelProjectorP prjHor = StelApp::getInstance().getCore()->getProjection(StelCore::FrameAltAz, StelCore::RefractionOff);
+				prjHor->unProject(x,y,endPointHor);
+			}
+			if (!startPoint.length())
+			{
+				startPoint = endPoint;
+				startPointHor = endPointHor;
+			}
+		}
+		calculateEnds();
+	}
+#endif
 	event->setAccepted(false);
 }
 
@@ -425,10 +505,15 @@ bool AngleMeasure::handleMouseMoves(int x, int y, Qt::MouseButtons)
 		prjHor->unProject(x,y,endPointHor);
 		calculateEnds();
 		lineVisible = true;
+#ifndef PAN_AND_ZOOM
 		return true;
 	}
 	else
 		return false;
+#else
+	}
+	return false;
+#endif
 }
 
 void AngleMeasure::calculateEnds(void)
@@ -442,13 +527,13 @@ void AngleMeasure::calculateEnds(void)
 void AngleMeasure::calculateEndsOneLine(const Vec3d &start, const Vec3d &end, Vec3d &perp1Start, Vec3d &perp1End, Vec3d &perp2Start, Vec3d &perp2End, double &angle)
 {
 	Vec3d v0 = end - start;
-	Vec3d v1 = Vec3d(0,0,0) - start;
+	Vec3d v1 = start / end.length();
 	Vec3d p = v0 ^ v1;
 	p *= 0.08;  // end width
 	perp1Start.set(start[0]-p[0],start[1]-p[1],start[2]-p[2]);
 	perp1End.set(start[0]+p[0],start[1]+p[1],start[2]+p[2]);
 
-	v1 = Vec3d(0,0,0) - end;
+	v1 = end / start.length();
 	p = v0 ^ v1;
 	p *= 0.08;  // end width
 	perp2Start.set(end[0]-p[0],end[1]-p[1],end[2]-p[2]);
@@ -492,7 +577,9 @@ void AngleMeasure::enableAngleMeasure(bool b)
 		{
 			//qDebug() << "AngleMeasure::enableAngleMeasure starting timer";
 			messageTimer->start();
+#ifndef PAN_AND_ZOOM
 			QApplication::setOverrideCursor(QCursor(Qt::CrossCursor));
+#endif
 		}
 		else 
 		{
@@ -506,6 +593,7 @@ void AngleMeasure::enableAngleMeasure(bool b)
 
 			// finally, pop the cross cursor
 			QApplication::restoreOverrideCursor();
+			dragging = false;
 		}
 
 		emit flagAngleMeasureChanged(b);

--- a/plugins/AngleMeasure/src/AngleMeasure.hpp
+++ b/plugins/AngleMeasure/src/AngleMeasure.hpp
@@ -172,6 +172,8 @@ private:
 	QString messageRightButton;
 	QString messagePA;
 	bool dragging;
+	bool picked;
+	bool olddblclick;
 	Vec3d startPoint;
 	Vec3d endPoint;
 	Vec3d perp1StartPoint;

--- a/plugins/Oculars/src/Oculars.cpp
+++ b/plugins/Oculars/src/Oculars.cpp
@@ -1974,13 +1974,14 @@ void Oculars::paintText(const StelCore* core)
 
 	// Get the X & Y positions, and the line height
 	painter.setFont(font);
-	QString widthString = "MMMMMMMMMMMMMMMMMMMMM";
+	QString widthString = "MMMMMMMMMMMMMMMMMMMMMM";
 	const double insetFromRHS = painter.getFontMetrics().boundingRect(widthString).width();
 	StelProjector::StelProjectorParams projectorParams = core->getCurrentStelProjectorParams();
 	int yPositionOffset = qRound(projectorParams.viewportXywh[3]*projectorParams.viewportCenterOffset[1]);
-	int xPosition = qRound(projectorParams.devicePixelsPerPixel*projectorParams.viewportXywh[2] - insetFromRHS);
-	int yPosition = qRound(projectorParams.devicePixelsPerPixel*projectorParams.viewportXywh[3] - yPositionOffset - 20);
-	const int lineHeight = painter.getFontMetrics().height();
+	const double ppx = core->getCurrentStelProjectorParams().devicePixelsPerPixel;
+	int xPosition = qRound(projectorParams.devicePixelsPerPixel*projectorParams.viewportXywh[2] - insetFromRHS*ppx);
+	int yPosition = qRound(projectorParams.devicePixelsPerPixel*projectorParams.viewportXywh[3] - yPositionOffset - 20*ppx);
+	const int lineHeight = painter.getFontMetrics().height()*ppx;
 
 	// The Ocular
 	if (flagShowOculars && ocular!=Q_NULLPTR)

--- a/src/StelMainView.cpp
+++ b/src/StelMainView.cpp
@@ -17,6 +17,8 @@
  * Foundation, Inc., 51 Franklin Street, Suite 500, Boston, MA  02110-1335, USA.
  */
 
+#define MOUSE_TRACKING
+
 #include "StelMainView.hpp"
 #include "StelApp.hpp"
 #include "StelCore.hpp"
@@ -387,6 +389,7 @@ protected:
 			mainView->thereWasAnEvent();
 	}
 
+#ifndef MOUSE_TRACKING
 	void mouseMoveEvent(QGraphicsSceneMouseEvent *event) Q_DECL_OVERRIDE
 	{
 		QMouseEvent ev = convertMouseEvent(event);
@@ -395,6 +398,7 @@ protected:
 		if(event->isAccepted())
 			mainView->thereWasAnEvent();
 	}
+#endif
 
 	void wheelEvent(QGraphicsSceneWheelEvent *event) Q_DECL_OVERRIDE
 	{
@@ -700,6 +704,16 @@ void StelMainView::mouseMoveEvent(QMouseEvent *event)
 		cursorTimeoutTimer->start();
 	}
 	
+#ifdef MOUSE_TRACKING
+	QPointF pos = event->pos();
+	//Y needs to be inverted
+	int height1 = StelApp::getInstance().mainWin->height();
+	pos.setY(height1 - 1 - pos.y());
+	event->setAccepted(StelApp::getInstance().handleMove(pos.x(), pos.y(), event->buttons()));
+	if(event->isAccepted())
+		thereWasAnEvent();
+#endif
+
 	QGraphicsView::mouseMoveEvent(event);
 }
 

--- a/src/core/StelApp.hpp
+++ b/src/core/StelApp.hpp
@@ -87,6 +87,7 @@ class StelApp : public QObject
 
 public:
 	friend class StelAppGraphicsWidget;
+	friend class StelMainView;
 	friend class StelRootItem;
 
 	//! Create and initialize the main Stellarium application.

--- a/src/core/StelLocationMgr.hpp
+++ b/src/core/StelLocationMgr.hpp
@@ -19,6 +19,7 @@
 #ifndef STELLOCATIONMGR_HPP
 #define STELLOCATIONMGR_HPP
 
+#include <QtPositioning/QGeoPositionInfoSource>
 #include "StelLocation.hpp"
 #include <QString>
 #include <QObject>
@@ -150,6 +151,7 @@ private slots:
 #ifdef ENABLE_GPS
 	void changeLocationFromGPSQuery(const StelLocation& loc);
 	void gpsQueryError(const QString& err);
+	void positionUpdated(QGeoPositionInfo gpsPos);
 #endif
 private:
 	void loadRegions();
@@ -180,6 +182,7 @@ private:
 	StelLocation lastResortLocation;
 
 	GPSLookupHelper *nmeaHelper,*libGpsHelper;
+	QGeoPositionInfoSource *positionSource=Q_NULLPTR;
 };
 
 #endif // STELLOCATIONMGR_HPP

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -232,6 +232,10 @@ int main(int argc, char **argv)
 	//vsync needs to be set on the default format for it to work
 	//fmt.setSwapInterval(0);
 
+	// avoid screen blanking on Intel UHD
+	//if (confSettings->value("video/SwapBehaviorSingleBuffer", false).toBool())
+	fmt.setSwapBehavior(QSurfaceFormat::SingleBuffer);
+
 	QSurfaceFormat::setDefaultFormat(fmt);
 
 	/////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
### Description

1) Avoid screen blanking on Intel UHD (#2166 #2472 #2484)
Screen flickering on Intel UHD Graphics is a long-known issue. The backlight turns off and on multiple times! The current workaround is to switch to Angle mode. But in Qt6 there is no more angle mode...
Perhaps the user should make their choice based on a configuration setting value like:
... if (confSettings->value("video/SwapBehaviorSingleBuffer", false).toBool()) ...

2) GPS location managed by Windows
On Windows systems, built-in GPS sensors are managed by the operating system. There is no serial port or NMEA protocol. But Qt can handle it.

3) AngleMeasure ~> Align to selected object
You can pan the screen and left-click to select an object as usual, and a right-click will snap the end of the protractor line (closest to the mouse pointer) to the selected object. Double-click with the right mouse button to pick up the end of the line. Another double click with the right mouse button removes the angle measuring line.

4) Oculars ~> format label on HDPI monitors
Makes the label readable on HDPI screens.

Fixes #2166
Fixes #2472
Fixes #2484

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [?] This change requires a documentation update

### How Has This Been Tested?

**Test Configuration**:
* Operating system: Windows 11
* Graphics Card: Intel UHD 620

## Checklist:
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
