### PR TITLE
Set default atmosphere model path in the Atmosphere Details dialog

### DIFF
--- a/src/core/modules/LandscapeMgr.cpp
+++ b/src/core/modules/LandscapeMgr.cpp
@@ -699,6 +699,10 @@ void LandscapeMgr::init()
 	setFlagLandscapeUseMinimalBrightness(conf->value("landscape/flag_minimal_brightness", false).toBool());
 	setFlagLandscapeSetsMinimalBrightness(conf->value("landscape/flag_landscape_sets_minimal_brightness",false).toBool());
 
+	const auto var = conf->value(ATMOSPHERE_MODEL_PATH_CONFIG_KEY);
+	if(!var.isValid())
+		conf->setValue(ATMOSPHERE_MODEL_PATH_CONFIG_KEY, getDefaultAtmosphereModelPath());
+
 	createAtmosphere();
 	// Put the atmosphere's Skylight under the StelProperty system (simpler and more consistent GUI)
 	StelApp::getInstance().getStelPropertyManager()->registerObject(&skylight);
@@ -1419,7 +1423,16 @@ QString LandscapeMgr::getAtmosphereModel() const
 QString LandscapeMgr::getAtmosphereModelPath() const
 {
 	const auto conf=StelApp::getInstance().getSettings();
-	return conf->value(ATMOSPHERE_MODEL_PATH_CONFIG_KEY, "").toString();
+
+	const auto var = conf->value(ATMOSPHERE_MODEL_PATH_CONFIG_KEY);
+	if(var.isValid()) return var.toString();
+
+	return getDefaultAtmosphereModelPath();
+}
+
+QString LandscapeMgr::getDefaultAtmosphereModelPath() const
+{
+	return QDir::toNativeSeparators(QString("%1/atmosphere/default").arg(StelFileMgr::getInstallationDir()));
 }
 
 bool LandscapeMgr::getAtmosphereShowMySkyStoppedWithError() const

--- a/src/core/modules/LandscapeMgr.hpp
+++ b/src/core/modules/LandscapeMgr.hpp
@@ -127,6 +127,8 @@ class LandscapeMgr : public StelModule
 		   READ getAtmosphereModelPath
 		   WRITE setAtmosphereModelPath
 		   NOTIFY atmosphereModelPathChanged)
+	Q_PROPERTY(QString defaultAtmosphereModelPath
+		   READ getDefaultAtmosphereModelPath)
 	Q_PROPERTY(bool atmosphereShowMySkyStoppedWithError
 		   READ getAtmosphereShowMySkyStoppedWithError
 		   WRITE setAtmosphereShowMySkyStoppedWithError
@@ -471,6 +473,8 @@ public slots:
 
 	QString getAtmosphereModelPath() const;
 	void setAtmosphereModelPath(const QString& path);
+
+	QString getDefaultAtmosphereModelPath() const;
 
 	bool getAtmosphereShowMySkyStoppedWithError() const;
 	void setAtmosphereShowMySkyStoppedWithError(bool error);

--- a/src/gui/AtmosphereDialog.cpp
+++ b/src/gui/AtmosphereDialog.cpp
@@ -33,6 +33,7 @@ namespace
 {
 constexpr char MODEL_PROPERTY[]      = "LandscapeMgr.atmosphereModel";
 constexpr char MODEL_PATH_PROPERTY[] = "LandscapeMgr.atmosphereModelPath";
+constexpr char DEFAULT_MODEL_PATH_PROPERTY[] = "LandscapeMgr.defaultAtmosphereModelPath";
 constexpr char ERROR_PROPERTY[]       = "LandscapeMgr.atmosphereShowMySkyStoppedWithError";
 constexpr char STATUS_TEXT_PROPERTY[] = "LandscapeMgr.atmosphereShowMySkyStatusText";
 constexpr char ECLIPSE_SIM_QUALITY_PROPERTY[] = "LandscapeMgr.atmosphereEclipseSimulationQuality";
@@ -163,11 +164,11 @@ void AtmosphereDialog::onModelChoiceChanged(const QString& model)
 
 void AtmosphereDialog::browsePathToModel()
 {
-	const QString dataDir = QDir::toNativeSeparators(QString("%1/atmosphere").arg(StelFileMgr::getInstallationDir()));
+	const auto mgr = StelApp::getInstance().getStelPropertyManager();
+	const auto dataDir = mgr->getProperty(DEFAULT_MODEL_PATH_PROPERTY)->getValue().toString() + "/..";
 	const auto path=QFileDialog::getExistingDirectory(nullptr, q_("Open ShowMySky model"), dataDir);
 	if(path.isNull()) return;
 
-	const auto mgr = StelApp::getInstance().getStelPropertyManager();
 	const auto currentModel = mgr->getProperty(MODEL_PROPERTY)->getValue().toString();
 
 	clearStatus();
@@ -241,7 +242,15 @@ void AtmosphereDialog::setCurrentValues()
 	onModelChoiceChanged(ui->atmosphereModel->currentText());
 
 	const auto currentModelPath = mgr->getProperty(MODEL_PATH_PROPERTY)->getValue().toString();
-	ui->showMySky_pathToModelEdit->setText(currentModelPath);
+	if(currentModelPath.isEmpty())
+	{
+		const auto modelPath = mgr->getProperty(DEFAULT_MODEL_PATH_PROPERTY)->getValue().toString();
+		ui->showMySky_pathToModelEdit->setText(modelPath);
+	}
+	else
+	{
+		ui->showMySky_pathToModelEdit->setText(currentModelPath);
+	}
 	const auto currentStatusText = mgr->getProperty(STATUS_TEXT_PROPERTY)->getValue().toString();
 	ui->showMySky_statusLabel->setText(currentStatusText);
 	const bool currentErrorStatus = mgr->getProperty(ERROR_PROPERTY)->getValue().toBool();


### PR DESCRIPTION
### Description
This patch makes the default atmosphere model path point to the `atmosphere/default` supplied with Stellarium.

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### How Has This Been Tested?
**Test Configuration**:
* Operating system: GNU/Linux
* Graphics Card: NVIDIA GeForce 750Ti, binary driver 390.116

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
