### PR TITLE
Update CI and default atmosphere model to CalcMySky-v0.0.6

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -59,7 +59,7 @@ before_build:
   - ps: if($env:qtver.contains('5.')) { $env:QT_VER_MAJOR=5 }
   - ps: if($env:suffix.contains('32')) { $env:BITS=32 }
   - ps: if($env:suffix.contains('64')) { $env:BITS=64 }
-  - appveyor DownloadFile https://github.com/10110111/CalcMySky/releases/download/v0.0.5/CalcMySky-v0.0.5-win%BITS%-qt%QT_VER_MAJOR%.zip -FileName c:\CalcMySky.zip
+  - appveyor DownloadFile https://github.com/10110111/CalcMySky/releases/download/v0.0.6/CalcMySky-v0.0.6-win%BITS%-qt%QT_VER_MAJOR%.zip -FileName c:\CalcMySky.zip
   - cd c:\
   - 7z x CalcMySky.zip
   - bash -c 'mv CalcMySky{-*,}'

--- a/.github/workflows/ci-beta.yml
+++ b/.github/workflows/ci-beta.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Configure CMake
       shell: bash
       run: |
-        wget https://github.com/10110111/CalcMySky/releases/download/v0.0.5/CalcMySky-v0.0.5-linux-amd64-qt6.tar.xz -O "${{ github.workspace }}/../CalcMySky.tar.xz"
+        wget https://github.com/10110111/CalcMySky/releases/download/v0.0.6/CalcMySky-v0.0.6-linux-amd64-qt6.tar.xz -O "${{ github.workspace }}/../CalcMySky.tar.xz"
         tar xf "${{ github.workspace }}/../CalcMySky.tar.xz" -C "${{ github.workspace }}/.."
         mv "${{ github.workspace }}/../CalcMySky"{-*,}
         mkdir -p build
@@ -67,7 +67,7 @@ jobs:
       shell: bash
       run: |
         export PATH="/usr/local/opt/qt@6/bin:$PATH"
-        wget https://github.com/10110111/CalcMySky/releases/download/v0.0.5/CalcMySky-v0.0.5-macos-amd64-qt6.tar.xz -O "${{ github.workspace }}/../CalcMySky.tar.xz"
+        wget https://github.com/10110111/CalcMySky/releases/download/v0.0.6/CalcMySky-v0.0.6-macos-amd64-qt6.tar.xz -O "${{ github.workspace }}/../CalcMySky.tar.xz"
         tar xf "${{ github.workspace }}/../CalcMySky.tar.xz" -C "${{ github.workspace }}/.."
         mv "${{ github.workspace }}/../CalcMySky"{-*,}
         mkdir -p build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Configure CMake
       shell: bash
       run: |
-        wget https://github.com/10110111/CalcMySky/releases/download/v0.0.5/CalcMySky-v0.0.5-linux-amd64-qt5.tar.xz -O "${{ github.workspace }}/../CalcMySky.tar.xz"
+        wget https://github.com/10110111/CalcMySky/releases/download/v0.0.6/CalcMySky-v0.0.6-linux-amd64-qt5.tar.xz -O "${{ github.workspace }}/../CalcMySky.tar.xz"
         tar xf "${{ github.workspace }}/../CalcMySky.tar.xz" -C "${{ github.workspace }}/.."
         mv "${{ github.workspace }}/../CalcMySky"{-*,}
         mkdir -p build
@@ -67,7 +67,7 @@ jobs:
       shell: bash
       run: |
         export PATH="/usr/local/opt/qt@5/bin:$PATH"
-        wget https://github.com/10110111/CalcMySky/releases/download/v0.0.5/CalcMySky-v0.0.5-macos-amd64-qt5.tar.xz -O "${{ github.workspace }}/../CalcMySky.tar.xz"
+        wget https://github.com/10110111/CalcMySky/releases/download/v0.0.6/CalcMySky-v0.0.6-macos-amd64-qt5.tar.xz -O "${{ github.workspace }}/../CalcMySky.tar.xz"
         tar xf "${{ github.workspace }}/../CalcMySky.tar.xz" -C "${{ github.workspace }}/.."
         mv "${{ github.workspace }}/../CalcMySky"{-*,}
         mkdir -p build

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -52,7 +52,7 @@ jobs:
       shell: bash
       run: |
         mkdir -p ../../../.stellarium/ephem
-        wget https://github.com/10110111/CalcMySky/releases/download/v0.0.5/CalcMySky-v0.0.5-linux-amd64-qt5.tar.xz -O "${{ github.workspace }}/../CalcMySky.tar.xz"
+        wget https://github.com/10110111/CalcMySky/releases/download/v0.0.6/CalcMySky-v0.0.6-linux-amd64-qt5.tar.xz -O "${{ github.workspace }}/../CalcMySky.tar.xz"
         tar xf "${{ github.workspace }}/../CalcMySky.tar.xz" -C "${{ github.workspace }}/.."
         mv "${{ github.workspace }}/../CalcMySky"-* "${{ github.workspace }}/../CalcMySky"
         mkdir -p build

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -59,7 +59,7 @@ jobs:
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Build
       run: |
-        wget https://github.com/10110111/CalcMySky/releases/download/v0.0.5/CalcMySky-v0.0.5-linux-amd64-qt5.tar.xz -O "${{ github.workspace }}/../CalcMySky.tar.xz"
+        wget https://github.com/10110111/CalcMySky/releases/download/v0.0.6/CalcMySky-v0.0.6-linux-amd64-qt5.tar.xz -O "${{ github.workspace }}/../CalcMySky.tar.xz"
         tar xf "${{ github.workspace }}/../CalcMySky.tar.xz" -C "${{ github.workspace }}/.."
         mv "${{ github.workspace }}/../CalcMySky"{-*,}
         mkdir -p build

--- a/atmosphere/default/params.atmo
+++ b/atmosphere/default/params.atmo
@@ -1,11 +1,11 @@
-version: 5
+version: 6
 # These spectra override the spectra further down the document. This is to make sure
 # we have all the required spectra inlined, rather than just references to files.
 wavelengths: min=360nm,max=830nm,count=16
 solar irradiance at toa: 1.03699994,1.24899995,1.68400002,1.97500002,1.96800005,1.87699997,1.85399997,1.81799996,1.72300005,1.60399997,1.51600003,1.40799999,1.30900002,1.23000002,1.14199996,1.06200004
 
 #Copy of original atmosphere description
-version: 5
+version: 6
 
 transmittance texture size for VZA: 256
 transmittance texture size for altitude: 64
@@ -59,7 +59,7 @@ Scatterer "molecules": # Rayleigh scattering
 {
     number density: # in m^-3
     ```
-        const float rayleighScaleHeight=8*km;
+        CONST float rayleighScaleHeight=8*km;
         return 3.08458e25*exp(-1/rayleighScaleHeight * altitude);
     ```
     phase function:
@@ -75,14 +75,14 @@ Scatterer "aerosols": # Mie scattering
 {
     number density: # in m^-3
     ```
-        const float mieScaleHeight=1.2*km;
+        CONST float mieScaleHeight=1.2*km;
         return 1.03333e8*exp(-1/mieScaleHeight*altitude);
     ```
     phase function:
     ```
-        const float g=0.76;
-        const float g2=g*g;
-        const float k = 3/(8*PI)*(1-g2)/(2+g2);
+        CONST float g=0.76;
+        CONST float g2=g*g;
+        CONST float k = 3/(8*PI)*(1-g2)/(2+g2);
         return vec4(k * (1+sqr(dotViewSun)) / pow(1+g2 - 2*g*dotViewSun, 1.5) + 1/((1-dotViewSun)*600+0.05))*0.904;
     ```
     cross section at 1 um: 0.042968 um^2
@@ -93,7 +93,7 @@ Absorber "ozone":
 {
     number density:
     ```
-        const float totalOzoneAmount=370*dobsonUnit;
+        CONST float totalOzoneAmount=370*dobsonUnit;
 
         float density;
 

--- a/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/0/common-functions.frag
+++ b/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/0/common-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // common-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // common-functions.frag
+#line 4 0 // common-functions.frag
 
 bool dbgDataPresent=false;
 bool debugDataPresent()
@@ -69,7 +80,7 @@ void setDebugData(float a,float b, float c, float d)
 
 void swap(inout float x, inout float y)
 {
-    const float t = x;
+    CONST float t = x;
     x = y;
     y = t;
 }
@@ -83,7 +94,7 @@ float safeSqrt(const float x)
 
 float safeAtan(const float y, const float x)
 {
-    const float a = atan(y,x);
+    CONST float a = atan(y,x);
     return x==0 && y==0 ? 0 : a;
 }
 
@@ -116,23 +127,23 @@ float pointAltitude(vec3 point)
 
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float Ratm=earthRadius+atmosphereHeight;
-    const float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float Ratm=earthRadius+atmosphereHeight;
+    CONST float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float distanceToGround(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(-safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float cosZenithAngleOfHorizon(const float altitude)
 {
-    const float R=earthRadius;
-    const float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
+    CONST float R=earthRadius;
+    CONST float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
     return -sqrt(2*h*R+sqr(h))/(R+h);
 }
 
@@ -151,8 +162,8 @@ float distanceToNearestAtmosphereBoundary(const float cosZenithAngle, const floa
 float sunVisibility(const float cosSunZenithAngle, float altitude)
 {
     if(altitude<0) altitude=0;
-    const float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
-    const float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
+    CONST float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
+    CONST float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
     /* Approximating visible fraction of solar disk by smoothstep between the position of the Sun
      * touching the horizon by its upper part and the position with lower part touching the horizon.
      * The calculation assumes that solar angular radius is small and thus approximately equals its sine.
@@ -182,13 +193,13 @@ float circlesIntersectionArea(float R1, float R2, float d)
 
 float angleBetween(const vec3 a, const vec3 b)
 {
-    const float d=dot(a,b);
-    const float c=length(cross(a,b));
+    CONST float d=dot(a,b);
+    CONST float c=length(cross(a,b));
     // To avoid loss of precision, don't use dot product near the singularity
     // of acos, and cross product near the singularity of asin
     if(abs(d) < abs(c))
         return acos(d/(length(a)*length(b)));
-    const float smallerAngle = asin(c/(length(a)*length(b)));
+    CONST float smallerAngle = asin(c/(length(a)*length(b)));
     if(d<0) return PI-smallerAngle;
     return smallerAngle;
 }
@@ -205,11 +216,11 @@ float moonAngularRadius(const vec3 cameraPosition, const vec3 moonPosition)
 
 float visibleSolidAngleOfSun(const vec3 camera, const vec3 sunDir, const vec3 moonPos)
 {
-    const float Rs=sunAngularRadius;
-    const float Rm=moonAngularRadius(camera,moonPos);
+    CONST float Rs=sunAngularRadius;
+    CONST float Rm=moonAngularRadius(camera,moonPos);
     float visibleSolidAngle=PI*sqr(Rs);
 
-    const float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
+    CONST float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
     if(dSM<Rs+Rm)
     {
         visibleSolidAngle -= circlesIntersectionArea(Rm,Rs,dSM);
@@ -229,12 +240,12 @@ float sphereIntegrationSolidAngleDifferential(const int pointCountOnSphere)
 }
 vec3 sphereIntegrationSampleDir(const int index, const int pointCountOnSphere)
 {
-    const float goldenRatio=1.6180339887499;
+    CONST float goldenRatio=1.6180339887499;
     // The range of n is 0.5, 1.5, ..., pointCountOnSphere-0.5
-    const float n=index+0.5;
+    CONST float n=index+0.5;
     // Explanation of the Fibonacci grid generation can be seen at https://stackoverflow.com/a/44164075/673852
-    const float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
-    const float azimuth=n*(2*PI*goldenRatio);
+    CONST float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
+    CONST float azimuth=n*(2*PI*goldenRatio);
     return vec3(cos(azimuth)*sin(zenithAngle),
                 sin(azimuth)*sin(zenithAngle),
                 cos(zenithAngle));

--- a/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/0/compute-eclipsed-double-scattering.frag
+++ b/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/0/compute-eclipsed-double-scattering.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // compute-eclipsed-double-scattering.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,13 +45,13 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // compute-eclipsed-double-scattering.frag
-#line 1 2 // phase-functions.h.glsl
+#line 4 0 // compute-eclipsed-double-scattering.frag
+#line 1 3 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 6 0 // compute-eclipsed-double-scattering.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // compute-eclipsed-double-scattering.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -72,8 +83,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // compute-eclipsed-double-scattering.frag
-#line 1 4 // texture-coordinates.h.glsl
+#line 6 0 // compute-eclipsed-double-scattering.frag
+#line 1 5 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -142,19 +153,19 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 8 0 // compute-eclipsed-double-scattering.frag
-#line 1 5 // radiance-to-luminance.h.glsl
+#line 7 0 // compute-eclipsed-double-scattering.frag
+#line 1 6 // radiance-to-luminance.h.glsl
 const mat4 radianceToLuminance=mat4(1.38997746,0.0419133306,6.48549128,0,  105.968163,3.00652099,500.960266,142.641495,  3776.24023,119.971481,18207.7598,6412.0166,  6910.01318,981.06665,37504.0586,26741.9102);
-#line 9 0 // compute-eclipsed-double-scattering.frag
-#line 1 6 // eclipsed-direct-irradiance.h.glsl
+#line 8 0 // compute-eclipsed-double-scattering.frag
+#line 1 7 // eclipsed-direct-irradiance.h.glsl
 #ifndef INCLUDE_ONCE_8E9C53B3_83A0_4DD7_9106_32A13BD8935D
 #define INCLUDE_ONCE_8E9C53B3_83A0_4DD7_9106_32A13BD8935D
 
 vec4 calcEclipsedDirectGroundIrradiance(const vec3 pointOnGround, const vec3 sunDir, const vec3 moonPos);
 
 #endif
-#line 10 0 // compute-eclipsed-double-scattering.frag
-#line 1 7 // texture-sampling-functions.h.glsl
+#line 9 0 // compute-eclipsed-double-scattering.frag
+#line 1 8 // texture-sampling-functions.h.glsl
 #ifndef INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 #define INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float altitude);
@@ -166,8 +177,8 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                 const int scatteringOrder);
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 #endif
-#line 11 0 // compute-eclipsed-double-scattering.frag
-#line 1 8 // single-scattering-eclipsed.h.glsl
+#line 10 0 // compute-eclipsed-double-scattering.frag
+#line 1 9 // single-scattering-eclipsed.h.glsl
 #ifndef INCLUDE_ONCE_050024D2_BD56_434E_8D40_2055DA0B78EC
 #define INCLUDE_ONCE_050024D2_BD56_434E_8D40_2055DA0B78EC
 
@@ -175,10 +186,10 @@ vec4 computeSingleScatteringEclipsed(const vec3 camera, const vec3 viewDir, cons
                                      const bool viewRayIntersectsGround);
 
 #endif
-#line 12 0 // compute-eclipsed-double-scattering.frag
-#line 1 9 // total-scattering-coefficient.h.glsl
+#line 11 0 // compute-eclipsed-double-scattering.frag
+#line 1 10 // total-scattering-coefficient.h.glsl
 vec4 totalScatteringCoefficient(float altitude, float dotViewInc);
-#line 13 0 // compute-eclipsed-double-scattering.frag
+#line 12 0 // compute-eclipsed-double-scattering.frag
 
 in vec3 position;
 out vec4 partialRadiance;
@@ -186,8 +197,8 @@ out vec4 partialRadiance;
 vec4 computeDoubleScatteringEclipsedDensitySample(const int directionIndex, const vec3 cameraViewDir, const vec3 scatterer,
                                                   const vec3 sunDir, const vec3 moonPos)
 {
-    const vec3 zenith=vec3(0,0,1);
-    const float altitude=pointAltitude(scatterer);
+    CONST vec3 zenith=vec3(0,0,1);
+    CONST float altitude=pointAltitude(scatterer);
     // XXX: Might be a good idea to increase sampling density near horizon and decrease near zenith&nadir.
     // XXX: Also sampling should be more dense near the light source, since there often is a strong forward
     //       scattering peak like that of Mie phase functions.
@@ -197,16 +208,16 @@ vec4 computeDoubleScatteringEclipsedDensitySample(const int directionIndex, cons
     // Instead of iterating over all directions, we compute only one sample, for only one direction, to
     // facilitate parallelization. The summation will be done after this parallel computation of the samples.
 
-    const float dSolidAngle = sphereIntegrationSolidAngleDifferential(eclipseAngularIntegrationPoints);
+    CONST float dSolidAngle = sphereIntegrationSolidAngleDifferential(eclipseAngularIntegrationPoints);
     // Direction to the source of incident ray
-    const vec3 incDir = sphereIntegrationSampleDir(directionIndex, eclipseAngularIntegrationPoints);
+    CONST vec3 incDir = sphereIntegrationSampleDir(directionIndex, eclipseAngularIntegrationPoints);
 
     // NOTE: we don't recalculate sunDir as we do in computeScatteringDensity(), because it would also require
     // at least recalculating the position of the Moon. Instead we take into account scatterer's position to
     // calculate zenith direction and the direction to the incident ray.
-    const vec3 zenithAtScattererPos=normalize(scatterer-earthCenter);
-    const float cosIncZenithAngle=dot(incDir, zenithAtScattererPos);
-    const bool incRayIntersectsGround=rayIntersectsGround(cosIncZenithAngle, altitude);
+    CONST vec3 zenithAtScattererPos=normalize(scatterer-earthCenter);
+    CONST float cosIncZenithAngle=dot(incDir, zenithAtScattererPos);
+    CONST bool incRayIntersectsGround=rayIntersectsGround(cosIncZenithAngle, altitude);
 
     float distToGround=0;
     vec4 transmittanceToGround=vec4(0);
@@ -220,16 +231,16 @@ vec4 computeDoubleScatteringEclipsedDensitySample(const int directionIndex, cons
     // XXX: keep this ground-scattered radiation logic in sync with that in computeScatteringDensity().
     {
         // The point where incident light originates on the ground, with current incDir
-        const vec3 pointOnGround = scatterer+incDir*distToGround;
-        const vec4 groundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDir, moonPos);
+        CONST vec3 pointOnGround = scatterer+incDir*distToGround;
+        CONST vec4 groundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDir, moonPos);
         // Radiation scattered by the ground
-        const float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
+        CONST float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
         incidentRadiance += transmittanceToGround*groundAlbedo*groundIrradiance*groundBRDF;
     }
     // Radiation scattered by the atmosphere
     incidentRadiance+=computeSingleScatteringEclipsed(scatterer,incDir,sunDir,moonPos,incRayIntersectsGround);
 
-    const float dotViewInc = dot(cameraViewDir, incDir);
+    CONST float dotViewInc = dot(cameraViewDir, incDir);
     return dSolidAngle * incidentRadiance * totalScatteringCoefficient(altitude, dotViewInc);
 }
 
@@ -240,22 +251,22 @@ uniform vec3 moonPositionRelativeToSunAzimuth;
 
 void main()
 {
-    const vec3 sunDir=vec3(sin(sunZenithAngle), 0, cos(sunZenithAngle));
-    const vec3 cameraPos=vec3(0,0,cameraAltitude);
-    const bool viewRayIntersectsGround=rayIntersectsGround(cameraViewDir.z, cameraAltitude);
+    CONST vec3 sunDir=vec3(sin(sunZenithAngle), 0, cos(sunZenithAngle));
+    CONST vec3 cameraPos=vec3(0,0,cameraAltitude);
+    CONST bool viewRayIntersectsGround=rayIntersectsGround(cameraViewDir.z, cameraAltitude);
 
-    const float radialIntegrInterval=distanceToNearestAtmosphereBoundary(cameraViewDir.z, cameraAltitude,
+    CONST float radialIntegrInterval=distanceToNearestAtmosphereBoundary(cameraViewDir.z, cameraAltitude,
                                                                          viewRayIntersectsGround);
 
-    const int directionIndex=int(gl_FragCoord.x);
-    const float radialDistIndex=gl_FragCoord.y;
+    CONST int directionIndex=int(gl_FragCoord.x);
+    CONST float radialDistIndex=gl_FragCoord.y;
 
     // Using midpoint rule for quadrature
-    const float dl=radialIntegrInterval/radialIntegrationPoints;
-    const float dist=(radialDistIndex+0.5)*dl;
-    const vec4 scDensity=computeDoubleScatteringEclipsedDensitySample(directionIndex, cameraViewDir, cameraPos+cameraViewDir*dist,
+    CONST float dl=radialIntegrInterval/radialIntegrationPoints;
+    CONST float dist=(radialDistIndex+0.5)*dl;
+    CONST vec4 scDensity=computeDoubleScatteringEclipsedDensitySample(directionIndex, cameraViewDir, cameraPos+cameraViewDir*dist,
                                                                       sunDir, moonPositionRelativeToSunAzimuth);
-    const vec4 xmittance=transmittance(cameraViewDir.z, cameraAltitude, dist, viewRayIntersectsGround);
+    CONST vec4 xmittance=transmittance(cameraViewDir.z, cameraAltitude, dist, viewRayIntersectsGround);
     partialRadiance = scDensity*xmittance*dl;
 
 }

--- a/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/0/densities.frag
+++ b/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/0/densities.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // densities.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,20 +45,20 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // densities.frag
+#line 4 0 // densities.frag
 float scattererNumberDensity_molecules(float altitude)
 {
-        const float rayleighScaleHeight=8*km;
+        CONST float rayleighScaleHeight=8*km;
         return 3.08458e25*exp(-1/rayleighScaleHeight * altitude);
 }
 float scattererNumberDensity_aerosols(float altitude)
 {
-        const float mieScaleHeight=1.2*km;
+        CONST float mieScaleHeight=1.2*km;
         return 1.03333e8*exp(-1/mieScaleHeight*altitude);
 }
 float absorberNumberDensity_ozone(float altitude)
 {
-        const float totalOzoneAmount=370*dobsonUnit;
+        CONST float totalOzoneAmount=370*dobsonUnit;
 
         float density;
 

--- a/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/0/direct-irradiance.frag
+++ b/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/0/direct-irradiance.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // direct-irradiance.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,8 +45,8 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // direct-irradiance.frag
-#line 1 2 // texture-sampling-functions.h.glsl
+#line 4 0 // direct-irradiance.frag
+#line 1 3 // texture-sampling-functions.h.glsl
 #ifndef INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 #define INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float altitude);
@@ -47,7 +58,7 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                 const int scatteringOrder);
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 #endif
-#line 6 0 // direct-irradiance.frag
+#line 5 0 // direct-irradiance.frag
 
 vec4 computeDirectGroundIrradiance(const float cosSunZenithAngle, const float altitude)
 {
@@ -58,7 +69,7 @@ vec4 computeDirectGroundIrradiance(const float cosSunZenithAngle, const float al
     //   value in the center of the solar disk, assuming it to be a kind of "average".
     // * When the Sun is partially behind the astronomical horizon, we approximate the radiative view factor (i.e.
     //   cosine factor integrated over the solar disk) with a simple quadratic spline.
-    const float averageCosFactor = cosSunZenithAngle < -sunAngularRadius ? 0
+    CONST float averageCosFactor = cosSunZenithAngle < -sunAngularRadius ? 0
                                       : cosSunZenithAngle > sunAngularRadius ? cosSunZenithAngle
                                       : sqr(cosSunZenithAngle+sunAngularRadius)/(4*sunAngularRadius);
     return solarIrradianceAtTOA * transmittanceToAtmosphereBorder(cosSunZenithAngle, altitude) * averageCosFactor;

--- a/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/0/eclipsed-direct-irradiance.frag
+++ b/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/0/eclipsed-direct-irradiance.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // eclipsed-direct-irradiance.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,8 +45,8 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // eclipsed-direct-irradiance.frag
-#line 1 2 // common-functions.h.glsl
+#line 4 0 // eclipsed-direct-irradiance.frag
+#line 1 3 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -67,16 +78,16 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 6 0 // eclipsed-direct-irradiance.frag
-#line 1 3 // direct-irradiance.h.glsl
+#line 5 0 // eclipsed-direct-irradiance.frag
+#line 1 4 // direct-irradiance.h.glsl
 #ifndef INCLUDE_ONCE_58AEF899_1A84_4A2F_AD71_4E7680B83E29
 #define INCLUDE_ONCE_58AEF899_1A84_4A2F_AD71_4E7680B83E29
 
 vec4 computeDirectGroundIrradiance(const float cosSunZenithAngle, const float altitude);
 
 #endif
-#line 7 0 // eclipsed-direct-irradiance.frag
-#line 1 4 // texture-sampling-functions.h.glsl
+#line 6 0 // eclipsed-direct-irradiance.frag
+#line 1 5 // texture-sampling-functions.h.glsl
 #ifndef INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 #define INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float altitude);
@@ -88,15 +99,15 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                 const int scatteringOrder);
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 #endif
-#line 8 0 // eclipsed-direct-irradiance.frag
+#line 7 0 // eclipsed-direct-irradiance.frag
 
 vec4 calcEclipsedDirectGroundIrradiance(const vec3 pointOnGround, const vec3 sunDir, const vec3 moonPos)
 {
-    const float altitude=0; // we are on the ground, after all
-    const vec3 zenith=normalize(pointOnGround-earthCenter);
-    const float cosSunZenithAngle=dot(sunDir,zenith);
+    CONST float altitude=0; // we are on the ground, after all
+    CONST vec3 zenith=normalize(pointOnGround-earthCenter);
+    CONST float cosSunZenithAngle=dot(sunDir,zenith);
 
-    const float visibility=sunVisibilityDueToMoon(pointOnGround, sunDir, moonPos)
+    CONST float visibility=sunVisibilityDueToMoon(pointOnGround, sunDir, moonPos)
                                                     *
                       // FIXME: this ignores orientation of the crescent of eclipsed Sun WRT horizon
                                     sunVisibility(cosSunZenithAngle, altitude);

--- a/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/0/phase-functions.frag
+++ b/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/0/phase-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // phase-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // phase-functions.frag
+#line 4 0 // phase-functions.frag
 
 vec4 phaseFunction_molecules(float dotViewSun)
 {
@@ -42,9 +53,9 @@ vec4 phaseFunction_molecules(float dotViewSun)
 }
 vec4 phaseFunction_aerosols(float dotViewSun)
 {
-        const float g=0.76;
-        const float g2=g*g;
-        const float k = 3/(8*PI)*(1-g2)/(2+g2);
+        CONST float g=0.76;
+        CONST float g2=g*g;
+        CONST float k = 3/(8*PI)*(1-g2)/(2+g2);
         return vec4(k * (1+sqr(dotViewSun)) / pow(1+g2 - 2*g*dotViewSun, 1.5) + 1/((1-dotViewSun)*600+0.05))*0.904;
 }
 vec4 currentPhaseFunction(float dotViewSun) { return phaseFunction_aerosols(dotViewSun); }

--- a/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/0/single-scattering-eclipsed.frag
+++ b/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/0/single-scattering-eclipsed.frag
@@ -1,7 +1,21 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
 
-#line 1 1 // const.h.glsl
+
+
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 6 0 // single-scattering-eclipsed.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,15 +48,15 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // single-scattering-eclipsed.frag
-#line 1 2 // densities.h.glsl
+#line 7 0 // single-scattering-eclipsed.frag
+#line 1 3 // densities.h.glsl
 float scattererNumberDensity_molecules(float altitude);
 float scattererNumberDensity_aerosols(float altitude);
 float absorberNumberDensity_ozone(float altitude);
 vec4 scatteringCrossSection();
 float scattererDensity(float altitude);
-#line 6 0 // single-scattering-eclipsed.frag
-#line 1 3 // common-functions.h.glsl
+#line 8 0 // single-scattering-eclipsed.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -74,8 +88,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // single-scattering-eclipsed.frag
-#line 1 4 // texture-sampling-functions.h.glsl
+#line 9 0 // single-scattering-eclipsed.frag
+#line 1 5 // texture-sampling-functions.h.glsl
 #ifndef INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 #define INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float altitude);
@@ -87,12 +101,12 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                 const int scatteringOrder);
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 #endif
-#line 8 0 // single-scattering-eclipsed.frag
-#line 1 5 // phase-functions.h.glsl
+#line 10 0 // single-scattering-eclipsed.frag
+#line 1 6 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 9 0 // single-scattering-eclipsed.frag
+#line 11 0 // single-scattering-eclipsed.frag
 
 float cosZenithAngle(vec3 origin, vec3 direction)
 {
@@ -105,13 +119,13 @@ vec4 computeSingleScatteringIntegrandEclipsed(const float cosSunZenithAngle, con
                                               const float dist, const bool viewRayIntersectsGround,
                                               const vec3 scatterer, const vec3 sunDir, const vec3 moonPos)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle here the case when the
     // endpoint of the view ray intentionally appears in outer space.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosSunZenithAngleAtDist=clampCosine((r*cosSunZenithAngle+dist*dotViewSun)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosSunZenithAngleAtDist=clampCosine((r*cosSunZenithAngle+dist*dotViewSun)/(earthRadius+altAtDist));
 
-    const vec4 xmittance=transmittance(cosViewZenithAngle, altitude, dist, viewRayIntersectsGround)
+    CONST vec4 xmittance=transmittance(cosViewZenithAngle, altitude, dist, viewRayIntersectsGround)
                                                     *
                          transmittanceToAtmosphereBorder(cosSunZenithAngleAtDist, altAtDist)
                                                     *
@@ -133,19 +147,19 @@ vec4 computeSingleScatteringIntegrandEclipsed(const float cosSunZenithAngle, con
 vec4 computeSingleScatteringEclipsed(const vec3 camera, const vec3 viewDir, const vec3 sunDir, const vec3 moonPos,
                                      const bool viewRayIntersectsGround)
 {
-    const float cosViewZenithAngle=cosZenithAngle(camera,viewDir);
-    const float cosSunZenithAngle=cosZenithAngle(camera,sunDir);
-    const float altitude=pointAltitude(camera);
-    const float dotViewSun=dot(viewDir,sunDir);
-    const float integrInterval=distanceToNearestAtmosphereBoundary(cosViewZenithAngle, altitude,
+    CONST float cosViewZenithAngle=cosZenithAngle(camera,viewDir);
+    CONST float cosSunZenithAngle=cosZenithAngle(camera,sunDir);
+    CONST float altitude=pointAltitude(camera);
+    CONST float dotViewSun=dot(viewDir,sunDir);
+    CONST float integrInterval=distanceToNearestAtmosphereBoundary(cosViewZenithAngle, altitude,
                                                                    viewRayIntersectsGround);
 
     // Using the midpoint rule for quadrature
     vec4 spectrum=vec4(0);
-    const float dl=integrInterval/radialIntegrationPoints;
+    CONST float dl=integrInterval/radialIntegrationPoints;
     for(int n=0; n<radialIntegrationPoints; ++n)
     {
-        const float dist=(n+0.5)*dl;
+        CONST float dist=(n+0.5)*dl;
         spectrum += computeSingleScatteringIntegrandEclipsed(cosSunZenithAngle, cosViewZenithAngle, dotViewSun,
                                                              altitude, dist, viewRayIntersectsGround,
                                                              camera+viewDir*dist, sunDir, moonPos);

--- a/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/0/texture-coordinates.frag
+++ b/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/0/texture-coordinates.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-coordinates.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,8 +45,8 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // texture-coordinates.frag
-#line 1 2 // texture-coordinates.h.glsl
+#line 4 0 // texture-coordinates.frag
+#line 1 3 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -104,8 +115,8 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 6 0 // texture-coordinates.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-coordinates.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -137,7 +148,7 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-coordinates.frag
+#line 6 0 // texture-coordinates.frag
 
 const float LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA=sqrt(atmosphereHeight*(atmosphereHeight+2*earthRadius));
 
@@ -205,18 +216,18 @@ vec3 indicesToTexCoords(const vec3 indices, const vec3 texSizes)
 
 TransmittanceTexVars transmittanceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
+    CONST float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
                                 texCoordToUnitRange(texCoord.t,transmittanceTextureSize.t);
     // Distance from Earth center to camera
-    const float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
-    const float altitude=r-earthRadius;
+    CONST float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
+    CONST float altitude=r-earthRadius;
 
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
     // distance to border of visible atmosphere from the view point
-    const float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
+    CONST float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
     // d==0 can happen when altitude==atmosphereHeight
-    const float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
+    CONST float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
     return TransmittanceTexVars(cosVZA,altitude);
 }
 
@@ -235,53 +246,53 @@ vec2 transmittanceTexVarsToTexCoord(const float cosVZA, float altitude)
     if(altitude<0)
         altitude=0;
 
-    const float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
+    CONST float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
                                       transmittanceTextureSize.t);
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
-    const float d=distanceToAtmosphereBorder(cosVZA,altitude);
-    const float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float d=distanceToAtmosphereBorder(cosVZA,altitude);
+    CONST float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
     return vec2(s,t);
 }
 
 // Output: vec2(cos(sunZenithAngle), altitude)
 IrradianceTexVars irradianceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
-    const float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
+    CONST float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
+    CONST float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
     return IrradianceTexVars(cosSZA,alt);
 }
 
 vec2 irradianceTexVarsToTexCoord(const float cosSunZenithAngle, const float altitude)
 {
-    const float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
-    const float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
+    CONST float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
+    CONST float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
     return vec2(s,t);
 }
 
 float cosSZAToUnitRangeTexCoord(const float cosSunZenithAngle)
 {
     // Distance to top atmosphere border along the ray groundUnderCamera-sun: (altitude, cosSunZenithAngle)
-    const float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name
-    const float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
+    CONST float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
     // TODO: choose a more descriptive name
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     return max(0.,1-a/A)/(a+1);
 }
 
 float unitRangeTexCoordToCosSZA(const float texCoord)
 {
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float a=(A-A*texCoord)/(1+A*texCoord);
-    const float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
+    CONST float a=(A-A*texCoord)/(1+A*texCoord);
+    CONST float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
     return distFromGroundToTopAtmoBorder==0 ? 1 :
         clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distFromGroundToTopAtmoBorder)) /
                     (2*earthRadius*distFromGroundToTopAtmoBorder));
@@ -292,24 +303,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
                                                const float dotViewSun, const float altitude,
                                                const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -317,24 +328,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float dotVSCoord=(dotViewSun+1)/2;
+    CONST float dotVSCoord=(dotViewSun+1)/2;
 
     // ------------------------------------
-    const float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
+    CONST float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
 
     return Scattering4DCoords(cosSZACoord, cosVZACoord, dotVSCoord, altCoord, viewRayIntersectsGround);
 }
 
 TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
@@ -342,16 +353,16 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture coordinates we combine into a single sampler3D coordinate.
-    const float texW = scatteringTextureSize[1];
-    const float texH = scatteringTextureSize[2];
-    const float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
-    const vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
+    CONST float texW = scatteringTextureSize[1];
+    CONST float texH = scatteringTextureSize[2];
+    CONST float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
+    CONST vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
                                         ceil (cosSZAIndex)*texW+coords.dotViewSun*(texW-1)) / (texW*texH-1);
-    const vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
+    CONST vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
 
-    const float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
+    CONST float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
 
-    const float alphaUpper=fract(cosSZAIndex);
+    CONST float alphaUpper=fract(cosSZAIndex);
     return TexCoordPair(vec3(cosVZAtc, combinedCoord.x, altitude), float(1-alphaUpper),
                         vec3(cosVZAtc, combinedCoord.y, altitude), float(alphaUpper));
 }
@@ -359,9 +370,9 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
+    CONST TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
     return texture(tex, texCoords.lower) * texCoords.alphaLower +
            texture(tex, texCoords.upper) * texCoords.alphaUpper;
 }
@@ -369,17 +380,17 @@ vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const f
 // 3D texture is the 3D single-altitude slice of a 4D texture
 vec3 scattering4DCoordsToTex3DCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2);
 
-    const float dvsSize = scatteringTextureSize[1];
-    const float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
+    CONST float dvsSize = scatteringTextureSize[1];
+    CONST float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
 
-    const float cszaSize = scatteringTextureSize[2];
-    const float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
+    CONST float cszaSize = scatteringTextureSize[2];
+    CONST float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
 
     return vec3(cosVZAtc, dotVStc, cosSZAtc);
 }
@@ -394,39 +405,39 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along dotViewSun coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[1];
-    const float posOfRow = indices[1];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[1];
+    CONST float posOfRow = indices[1];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         indexToTexCoord(currRow, numRows-1),
                                                         texCoordVerbatim));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               indexToTexCoord(currRow, numRows-1),
                                                               texCoordVerbatim));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          indexToTexCoord(currRow, numRows-1),
                                          texCoordVerbatim));
@@ -434,14 +445,14 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
 vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolationGuides01Tex,
                                  const vec3 indices)
 {
-    const float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
+    CONST float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
 
-    const float cosVZAIndex = indices[0];
-    const float dotVSIndex = indices[1];
-    const float currRow = floor(dotVSIndex);
-    const float posBetweenRows = dotVSIndex - currRow;
-    const float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cosVZAIndex = indices[0];
+    CONST float dotVSIndex = indices[1];
+    CONST float currRow = floor(dotVSIndex);
+    CONST float posBetweenRows = dotVSIndex - currRow;
+    CONST float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -449,14 +460,14 @@ vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolat
     indicesCurrRow[1] =     currRow;
     indicesNextRow[1] = min(currRow+1, scatteringTextureSize[1]-1.);
 
-    const vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
-    const vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
+    CONST vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
+    CONST vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
 
-    const vec4 valueCurrRow = texture(tex, coordsCurrRow);
-    const vec4 valueNextRow = texture(tex, coordsNextRow);
-    const float epsilon = 1e-37; // Prevents passing zero to log
-    const vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
-    const vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
+    CONST vec4 valueCurrRow = texture(tex, coordsCurrRow);
+    CONST vec4 valueNextRow = texture(tex, coordsNextRow);
+    CONST float epsilon = 1e-37; // Prevents passing zero to log
+    CONST vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
+    CONST vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
     return (logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow;
 }
 
@@ -465,37 +476,37 @@ float findGuide02Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along SZA coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[2];
-    const float posOfRow = indices[2];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[2];
+    CONST float posOfRow = indices[2];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
 }
@@ -505,19 +516,19 @@ vec4 sample3DTextureGuided(const sampler3D tex,
                            const float cosSunZenithAngle, const float cosViewZenithAngle,
                            const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
                                                                     dotViewSun, altitude, viewRayIntersectsGround);
     // Handle the external interpolation guides: the guides between a pair of VZA-dotViewSun 2D "pictures".
-    const vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
-    const vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
-    const float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
+    CONST vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
+    CONST float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
 
-    const float cvzaIndex = indices[0];
-    const float cszaIndex = indices[2];
-    const float currRow = floor(cszaIndex);
-    const float posBetweenRows = cszaIndex - currRow;
-    const float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cvzaIndex = indices[0];
+    CONST float cszaIndex = indices[2];
+    CONST float currRow = floor(cszaIndex);
+    CONST float posBetweenRows = cszaIndex - currRow;
+    CONST float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -526,58 +537,58 @@ vec4 sample3DTextureGuided(const sampler3D tex,
     indicesNextRow[2] = min(currRow+1, scatteringTextureSize[2]-1);
 
     // The caller will handle the internal interpolation guides: the ones between rows in each 2D "picture".
-    const vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
-    const vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
+    CONST vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
+    CONST vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
     return exp((logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow);
 }
 
 vec4 sample3DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
     return texture(tex, texCoords);
 }
 
 ScatteringTexVars scatteringTex4DCoordsToTexVars(const Scattering4DCoords coords)
 {
-    const float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
     // ------------------------------------
     float cosViewZenithAngle;
     if(coords.viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
     // ------------------------------------
-    const float dotViewSun=coords.dotViewSun*2-1;
+    CONST float dotViewSun=coords.dotViewSun*2-1;
 
     // ------------------------------------
-    const float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
+    CONST float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
 
     return ScatteringTexVars(cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, coords.viewRayIntersectsGround);
 }
 
 Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 {
-    const vec4 indexMax=scatteringTextureSize-vec4(1);
+    CONST vec4 indexMax=scatteringTextureSize-vec4(1);
     Scattering4DCoords coords4d;
     coords4d.viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
     // The following formulas assume that scatteringTextureSize[0] is even. For odd sizes they would change.
@@ -593,8 +604,8 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture indices we combine into a single sampler3D coordinate.
-    const float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
-    const float combinedIndex=texIndices[1];
+    CONST float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
+    CONST float combinedIndex=texIndices[1];
     coords4d.dotViewSun=mod(combinedIndex,texW)/(texW-1);
     coords4d.cosSunZenithAngle=floor(combinedIndex/texW)/(texH-1);
 
@@ -608,11 +619,11 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
 ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 {
-    const Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
+    CONST Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
     ScatteringTexVars vars=scatteringTex4DCoordsToTexVars(coords4d);
     // Clamp dotViewSun to its valid range of values, given cosViewZenithAngle and cosSunZenithAngle. This is
     // needed to prevent NaNs when computing the scattering texture.
-    const float cosVZA=vars.cosViewZenithAngle,
+    CONST float cosVZA=vars.cosViewZenithAngle,
                 cosSZA=vars.cosSunZenithAngle;
     vars.dotViewSun=clamp(vars.dotViewSun,
                           cosVZA*cosSZA-safeSqrt((1-sqr(cosVZA))*(1-sqr(cosSZA))),
@@ -622,54 +633,54 @@ ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 
 EclipseScatteringTexVars eclipseTexCoordsToTexVars(const vec2 texCoords, const float altitude)
 {
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
-    const bool viewRayIntersectsGround = texCoords.t<0.5;
+    CONST bool viewRayIntersectsGround = texCoords.t<0.5;
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
-    const float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
+    CONST float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
     return EclipseScatteringTexVars(azimuthRelativeToSun, cosViewZenithAngle, viewRayIntersectsGround);
 }
 
 EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                                    const float altitude, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -677,13 +688,13 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
-    const float azimuthCoord = azimuthRelativeToSun/(2*PI);
+    CONST float azimuthCoord = azimuthRelativeToSun/(2*PI);
 
     return EclipseScattering2DCoords(azimuthCoord, cosVZACoord);
 }
@@ -691,14 +702,14 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
 vec2 eclipseTexVarsToTexCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                const float altitude, const bool viewRayIntersectsGround, const vec2 texSize)
 {
-    const EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+    CONST EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                                     viewRayIntersectsGround);
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2);
-    const float azimuthTC = coords.azimuth + 1/(2*texSize.s);
+    CONST float azimuthTC = coords.azimuth + 1/(2*texSize.s);
 
     return vec2(azimuthTC, cosVZAtc);
 }
@@ -707,42 +718,42 @@ vec4 sampleEclipseDoubleScattering3DTexture(const sampler3D tex, const float cos
                                             const float cosViewZenithAngle, const float azimuthRelativeToSun,
                                             const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
+    CONST vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
                                                   eclipsedDoubleScatteringTextureSize.st);
-    const float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
-    const vec3 texCoords=vec3(coords2d, cosSZACoord);
+    CONST float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
+    CONST vec3 texCoords=vec3(coords2d, cosSZACoord);
 
     return texture(tex, texCoords);
 }
 
 LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 texIndices)
 {
-    const vec2 indexMax=lightPollutionTextureSize-vec2(1);
+    CONST vec2 indexMax=lightPollutionTextureSize-vec2(1);
 
-    const float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
-    const float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
+    CONST float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
-    const bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
-    const float cosViewZenithAngleCoord = viewRayIntersectsGround ?
+    CONST bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
+    CONST float cosViewZenithAngleCoord = viewRayIntersectsGround ?
                                    1-2*texIndices[0]/(indexMax[0]-1) :
                                    2*(texIndices[0]-1)/(indexMax[0]-1)-1;
     // ------------------------------------
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
@@ -753,23 +764,23 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 
 LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -777,27 +788,27 @@ LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, con
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     return LightPollution2DCoords(cosVZACoord, altCoord);
 }
 
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
-    const vec2 texSize = lightPollutionTextureSize;
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 texSize = lightPollutionTextureSize;
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2);
-    const float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
+    CONST float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
     return vec2(cosVZAtc, altitudeTC);
 }

--- a/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/0/texture-sampling-functions.frag
+++ b/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/0/texture-sampling-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-sampling-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,13 +45,13 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // texture-sampling-functions.frag
-#line 1 2 // phase-functions.h.glsl
+#line 4 0 // texture-sampling-functions.frag
+#line 1 3 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 6 0 // texture-sampling-functions.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-sampling-functions.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -72,8 +83,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-sampling-functions.frag
-#line 1 4 // texture-coordinates.h.glsl
+#line 6 0 // texture-sampling-functions.frag
+#line 1 5 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -142,7 +153,7 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 8 0 // texture-sampling-functions.frag
+#line 7 0 // texture-sampling-functions.frag
 
 uniform sampler2D transmittanceTexture;
 uniform sampler2D irradianceTexture;
@@ -154,13 +165,13 @@ uniform sampler2D lightPollutionScatteringTexture;
 
 vec4 irradiance(const float cosSunZenithAngle, const float altitude)
 {
-    const vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
+    CONST vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
     return texture(irradianceTexture, texCoords);
 }
 
 vec4 opticalDepthToAtmosphereBorder(const float cosViewZenithAngle, const float altitude)
 {
-    const vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
+    CONST vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact when looking into nadir from TOA at some values of texture sizes (in particular, size of
     // transmittance texture for altitude being 4096). This happens when I simply call texture(eclipsedScatteringTexture,
@@ -178,11 +189,11 @@ vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float
 vec4 transmittance(const float cosViewZenithAngle, const float altitude, const float dist,
                    const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle view ray endpoint
     // in space here.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
 
     vec4 depth;
     if(viewRayIntersectsGround)
@@ -201,7 +212,7 @@ vec4 transmittance(const float cosViewZenithAngle, const float altitude, const f
 vec4 calcFirstScattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                          const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
+    CONST vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
                                           dotViewSun, altitude, viewRayIntersectsGround);
     return scattering*currentPhaseFunction(dotViewSun);
 }
@@ -220,6 +231,6 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
 
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     return texture(lightPollutionScatteringTexture, coords);
 }

--- a/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/0/total-scattering-coefficient.frag
+++ b/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/0/total-scattering-coefficient.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // total-scattering-coefficient.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,19 +45,19 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // total-scattering-coefficient.frag
-#line 1 2 // densities.h.glsl
+#line 4 0 // total-scattering-coefficient.frag
+#line 1 3 // densities.h.glsl
 float scattererNumberDensity_molecules(float altitude);
 float scattererNumberDensity_aerosols(float altitude);
 float absorberNumberDensity_ozone(float altitude);
 vec4 scatteringCrossSection();
 float scattererDensity(float altitude);
-#line 6 0 // total-scattering-coefficient.frag
-#line 1 3 // phase-functions.h.glsl
+#line 5 0 // total-scattering-coefficient.frag
+#line 1 4 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 7 0 // total-scattering-coefficient.frag
+#line 6 0 // total-scattering-coefficient.frag
 
 vec4 totalScatteringCoefficient(float altitude, float dotViewInc)
 {

--- a/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/1/common-functions.frag
+++ b/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/1/common-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // common-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(2.15e-06,1.11400004e-06,3.8580001
 const vec4 wavelengths=vec4(485.333344,516.666687,548,579.333313);
 const int wlSetIndex=1;
 #endif
-#line 5 0 // common-functions.frag
+#line 4 0 // common-functions.frag
 
 bool dbgDataPresent=false;
 bool debugDataPresent()
@@ -69,7 +80,7 @@ void setDebugData(float a,float b, float c, float d)
 
 void swap(inout float x, inout float y)
 {
-    const float t = x;
+    CONST float t = x;
     x = y;
     y = t;
 }
@@ -83,7 +94,7 @@ float safeSqrt(const float x)
 
 float safeAtan(const float y, const float x)
 {
-    const float a = atan(y,x);
+    CONST float a = atan(y,x);
     return x==0 && y==0 ? 0 : a;
 }
 
@@ -116,23 +127,23 @@ float pointAltitude(vec3 point)
 
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float Ratm=earthRadius+atmosphereHeight;
-    const float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float Ratm=earthRadius+atmosphereHeight;
+    CONST float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float distanceToGround(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(-safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float cosZenithAngleOfHorizon(const float altitude)
 {
-    const float R=earthRadius;
-    const float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
+    CONST float R=earthRadius;
+    CONST float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
     return -sqrt(2*h*R+sqr(h))/(R+h);
 }
 
@@ -151,8 +162,8 @@ float distanceToNearestAtmosphereBoundary(const float cosZenithAngle, const floa
 float sunVisibility(const float cosSunZenithAngle, float altitude)
 {
     if(altitude<0) altitude=0;
-    const float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
-    const float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
+    CONST float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
+    CONST float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
     /* Approximating visible fraction of solar disk by smoothstep between the position of the Sun
      * touching the horizon by its upper part and the position with lower part touching the horizon.
      * The calculation assumes that solar angular radius is small and thus approximately equals its sine.
@@ -182,13 +193,13 @@ float circlesIntersectionArea(float R1, float R2, float d)
 
 float angleBetween(const vec3 a, const vec3 b)
 {
-    const float d=dot(a,b);
-    const float c=length(cross(a,b));
+    CONST float d=dot(a,b);
+    CONST float c=length(cross(a,b));
     // To avoid loss of precision, don't use dot product near the singularity
     // of acos, and cross product near the singularity of asin
     if(abs(d) < abs(c))
         return acos(d/(length(a)*length(b)));
-    const float smallerAngle = asin(c/(length(a)*length(b)));
+    CONST float smallerAngle = asin(c/(length(a)*length(b)));
     if(d<0) return PI-smallerAngle;
     return smallerAngle;
 }
@@ -205,11 +216,11 @@ float moonAngularRadius(const vec3 cameraPosition, const vec3 moonPosition)
 
 float visibleSolidAngleOfSun(const vec3 camera, const vec3 sunDir, const vec3 moonPos)
 {
-    const float Rs=sunAngularRadius;
-    const float Rm=moonAngularRadius(camera,moonPos);
+    CONST float Rs=sunAngularRadius;
+    CONST float Rm=moonAngularRadius(camera,moonPos);
     float visibleSolidAngle=PI*sqr(Rs);
 
-    const float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
+    CONST float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
     if(dSM<Rs+Rm)
     {
         visibleSolidAngle -= circlesIntersectionArea(Rm,Rs,dSM);
@@ -229,12 +240,12 @@ float sphereIntegrationSolidAngleDifferential(const int pointCountOnSphere)
 }
 vec3 sphereIntegrationSampleDir(const int index, const int pointCountOnSphere)
 {
-    const float goldenRatio=1.6180339887499;
+    CONST float goldenRatio=1.6180339887499;
     // The range of n is 0.5, 1.5, ..., pointCountOnSphere-0.5
-    const float n=index+0.5;
+    CONST float n=index+0.5;
     // Explanation of the Fibonacci grid generation can be seen at https://stackoverflow.com/a/44164075/673852
-    const float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
-    const float azimuth=n*(2*PI*goldenRatio);
+    CONST float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
+    CONST float azimuth=n*(2*PI*goldenRatio);
     return vec3(cos(azimuth)*sin(zenithAngle),
                 sin(azimuth)*sin(zenithAngle),
                 cos(zenithAngle));

--- a/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/1/compute-eclipsed-double-scattering.frag
+++ b/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/1/compute-eclipsed-double-scattering.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // compute-eclipsed-double-scattering.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,13 +45,13 @@ const vec4 lightPollutionRelativeRadiance=vec4(2.15e-06,1.11400004e-06,3.8580001
 const vec4 wavelengths=vec4(485.333344,516.666687,548,579.333313);
 const int wlSetIndex=1;
 #endif
-#line 5 0 // compute-eclipsed-double-scattering.frag
-#line 1 2 // phase-functions.h.glsl
+#line 4 0 // compute-eclipsed-double-scattering.frag
+#line 1 3 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 6 0 // compute-eclipsed-double-scattering.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // compute-eclipsed-double-scattering.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -72,8 +83,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // compute-eclipsed-double-scattering.frag
-#line 1 4 // texture-coordinates.h.glsl
+#line 6 0 // compute-eclipsed-double-scattering.frag
+#line 1 5 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -142,19 +153,19 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 8 0 // compute-eclipsed-double-scattering.frag
-#line 1 5 // radiance-to-luminance.h.glsl
+#line 7 0 // compute-eclipsed-double-scattering.frag
+#line 1 6 // radiance-to-luminance.h.glsl
 const mat4 radianceToLuminance=mat4(1196.74268,3672.67432,12945.498,45528.7344,  835.02478,13767.5205,2120.37939,51317.4727,  8632.59277,21193.416,222.095078,27381.1602,  19410,18758.1973,35.7829971,6712.12158);
-#line 9 0 // compute-eclipsed-double-scattering.frag
-#line 1 6 // eclipsed-direct-irradiance.h.glsl
+#line 8 0 // compute-eclipsed-double-scattering.frag
+#line 1 7 // eclipsed-direct-irradiance.h.glsl
 #ifndef INCLUDE_ONCE_8E9C53B3_83A0_4DD7_9106_32A13BD8935D
 #define INCLUDE_ONCE_8E9C53B3_83A0_4DD7_9106_32A13BD8935D
 
 vec4 calcEclipsedDirectGroundIrradiance(const vec3 pointOnGround, const vec3 sunDir, const vec3 moonPos);
 
 #endif
-#line 10 0 // compute-eclipsed-double-scattering.frag
-#line 1 7 // texture-sampling-functions.h.glsl
+#line 9 0 // compute-eclipsed-double-scattering.frag
+#line 1 8 // texture-sampling-functions.h.glsl
 #ifndef INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 #define INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float altitude);
@@ -166,8 +177,8 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                 const int scatteringOrder);
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 #endif
-#line 11 0 // compute-eclipsed-double-scattering.frag
-#line 1 8 // single-scattering-eclipsed.h.glsl
+#line 10 0 // compute-eclipsed-double-scattering.frag
+#line 1 9 // single-scattering-eclipsed.h.glsl
 #ifndef INCLUDE_ONCE_050024D2_BD56_434E_8D40_2055DA0B78EC
 #define INCLUDE_ONCE_050024D2_BD56_434E_8D40_2055DA0B78EC
 
@@ -175,10 +186,10 @@ vec4 computeSingleScatteringEclipsed(const vec3 camera, const vec3 viewDir, cons
                                      const bool viewRayIntersectsGround);
 
 #endif
-#line 12 0 // compute-eclipsed-double-scattering.frag
-#line 1 9 // total-scattering-coefficient.h.glsl
+#line 11 0 // compute-eclipsed-double-scattering.frag
+#line 1 10 // total-scattering-coefficient.h.glsl
 vec4 totalScatteringCoefficient(float altitude, float dotViewInc);
-#line 13 0 // compute-eclipsed-double-scattering.frag
+#line 12 0 // compute-eclipsed-double-scattering.frag
 
 in vec3 position;
 out vec4 partialRadiance;
@@ -186,8 +197,8 @@ out vec4 partialRadiance;
 vec4 computeDoubleScatteringEclipsedDensitySample(const int directionIndex, const vec3 cameraViewDir, const vec3 scatterer,
                                                   const vec3 sunDir, const vec3 moonPos)
 {
-    const vec3 zenith=vec3(0,0,1);
-    const float altitude=pointAltitude(scatterer);
+    CONST vec3 zenith=vec3(0,0,1);
+    CONST float altitude=pointAltitude(scatterer);
     // XXX: Might be a good idea to increase sampling density near horizon and decrease near zenith&nadir.
     // XXX: Also sampling should be more dense near the light source, since there often is a strong forward
     //       scattering peak like that of Mie phase functions.
@@ -197,16 +208,16 @@ vec4 computeDoubleScatteringEclipsedDensitySample(const int directionIndex, cons
     // Instead of iterating over all directions, we compute only one sample, for only one direction, to
     // facilitate parallelization. The summation will be done after this parallel computation of the samples.
 
-    const float dSolidAngle = sphereIntegrationSolidAngleDifferential(eclipseAngularIntegrationPoints);
+    CONST float dSolidAngle = sphereIntegrationSolidAngleDifferential(eclipseAngularIntegrationPoints);
     // Direction to the source of incident ray
-    const vec3 incDir = sphereIntegrationSampleDir(directionIndex, eclipseAngularIntegrationPoints);
+    CONST vec3 incDir = sphereIntegrationSampleDir(directionIndex, eclipseAngularIntegrationPoints);
 
     // NOTE: we don't recalculate sunDir as we do in computeScatteringDensity(), because it would also require
     // at least recalculating the position of the Moon. Instead we take into account scatterer's position to
     // calculate zenith direction and the direction to the incident ray.
-    const vec3 zenithAtScattererPos=normalize(scatterer-earthCenter);
-    const float cosIncZenithAngle=dot(incDir, zenithAtScattererPos);
-    const bool incRayIntersectsGround=rayIntersectsGround(cosIncZenithAngle, altitude);
+    CONST vec3 zenithAtScattererPos=normalize(scatterer-earthCenter);
+    CONST float cosIncZenithAngle=dot(incDir, zenithAtScattererPos);
+    CONST bool incRayIntersectsGround=rayIntersectsGround(cosIncZenithAngle, altitude);
 
     float distToGround=0;
     vec4 transmittanceToGround=vec4(0);
@@ -220,16 +231,16 @@ vec4 computeDoubleScatteringEclipsedDensitySample(const int directionIndex, cons
     // XXX: keep this ground-scattered radiation logic in sync with that in computeScatteringDensity().
     {
         // The point where incident light originates on the ground, with current incDir
-        const vec3 pointOnGround = scatterer+incDir*distToGround;
-        const vec4 groundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDir, moonPos);
+        CONST vec3 pointOnGround = scatterer+incDir*distToGround;
+        CONST vec4 groundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDir, moonPos);
         // Radiation scattered by the ground
-        const float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
+        CONST float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
         incidentRadiance += transmittanceToGround*groundAlbedo*groundIrradiance*groundBRDF;
     }
     // Radiation scattered by the atmosphere
     incidentRadiance+=computeSingleScatteringEclipsed(scatterer,incDir,sunDir,moonPos,incRayIntersectsGround);
 
-    const float dotViewInc = dot(cameraViewDir, incDir);
+    CONST float dotViewInc = dot(cameraViewDir, incDir);
     return dSolidAngle * incidentRadiance * totalScatteringCoefficient(altitude, dotViewInc);
 }
 
@@ -240,22 +251,22 @@ uniform vec3 moonPositionRelativeToSunAzimuth;
 
 void main()
 {
-    const vec3 sunDir=vec3(sin(sunZenithAngle), 0, cos(sunZenithAngle));
-    const vec3 cameraPos=vec3(0,0,cameraAltitude);
-    const bool viewRayIntersectsGround=rayIntersectsGround(cameraViewDir.z, cameraAltitude);
+    CONST vec3 sunDir=vec3(sin(sunZenithAngle), 0, cos(sunZenithAngle));
+    CONST vec3 cameraPos=vec3(0,0,cameraAltitude);
+    CONST bool viewRayIntersectsGround=rayIntersectsGround(cameraViewDir.z, cameraAltitude);
 
-    const float radialIntegrInterval=distanceToNearestAtmosphereBoundary(cameraViewDir.z, cameraAltitude,
+    CONST float radialIntegrInterval=distanceToNearestAtmosphereBoundary(cameraViewDir.z, cameraAltitude,
                                                                          viewRayIntersectsGround);
 
-    const int directionIndex=int(gl_FragCoord.x);
-    const float radialDistIndex=gl_FragCoord.y;
+    CONST int directionIndex=int(gl_FragCoord.x);
+    CONST float radialDistIndex=gl_FragCoord.y;
 
     // Using midpoint rule for quadrature
-    const float dl=radialIntegrInterval/radialIntegrationPoints;
-    const float dist=(radialDistIndex+0.5)*dl;
-    const vec4 scDensity=computeDoubleScatteringEclipsedDensitySample(directionIndex, cameraViewDir, cameraPos+cameraViewDir*dist,
+    CONST float dl=radialIntegrInterval/radialIntegrationPoints;
+    CONST float dist=(radialDistIndex+0.5)*dl;
+    CONST vec4 scDensity=computeDoubleScatteringEclipsedDensitySample(directionIndex, cameraViewDir, cameraPos+cameraViewDir*dist,
                                                                       sunDir, moonPositionRelativeToSunAzimuth);
-    const vec4 xmittance=transmittance(cameraViewDir.z, cameraAltitude, dist, viewRayIntersectsGround);
+    CONST vec4 xmittance=transmittance(cameraViewDir.z, cameraAltitude, dist, viewRayIntersectsGround);
     partialRadiance = scDensity*xmittance*dl;
 
 }

--- a/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/1/densities.frag
+++ b/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/1/densities.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // densities.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,20 +45,20 @@ const vec4 lightPollutionRelativeRadiance=vec4(2.15e-06,1.11400004e-06,3.8580001
 const vec4 wavelengths=vec4(485.333344,516.666687,548,579.333313);
 const int wlSetIndex=1;
 #endif
-#line 5 0 // densities.frag
+#line 4 0 // densities.frag
 float scattererNumberDensity_molecules(float altitude)
 {
-        const float rayleighScaleHeight=8*km;
+        CONST float rayleighScaleHeight=8*km;
         return 3.08458e25*exp(-1/rayleighScaleHeight * altitude);
 }
 float scattererNumberDensity_aerosols(float altitude)
 {
-        const float mieScaleHeight=1.2*km;
+        CONST float mieScaleHeight=1.2*km;
         return 1.03333e8*exp(-1/mieScaleHeight*altitude);
 }
 float absorberNumberDensity_ozone(float altitude)
 {
-        const float totalOzoneAmount=370*dobsonUnit;
+        CONST float totalOzoneAmount=370*dobsonUnit;
 
         float density;
 

--- a/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/1/direct-irradiance.frag
+++ b/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/1/direct-irradiance.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // direct-irradiance.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,8 +45,8 @@ const vec4 lightPollutionRelativeRadiance=vec4(2.15e-06,1.11400004e-06,3.8580001
 const vec4 wavelengths=vec4(485.333344,516.666687,548,579.333313);
 const int wlSetIndex=1;
 #endif
-#line 5 0 // direct-irradiance.frag
-#line 1 2 // texture-sampling-functions.h.glsl
+#line 4 0 // direct-irradiance.frag
+#line 1 3 // texture-sampling-functions.h.glsl
 #ifndef INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 #define INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float altitude);
@@ -47,7 +58,7 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                 const int scatteringOrder);
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 #endif
-#line 6 0 // direct-irradiance.frag
+#line 5 0 // direct-irradiance.frag
 
 vec4 computeDirectGroundIrradiance(const float cosSunZenithAngle, const float altitude)
 {
@@ -58,7 +69,7 @@ vec4 computeDirectGroundIrradiance(const float cosSunZenithAngle, const float al
     //   value in the center of the solar disk, assuming it to be a kind of "average".
     // * When the Sun is partially behind the astronomical horizon, we approximate the radiative view factor (i.e.
     //   cosine factor integrated over the solar disk) with a simple quadratic spline.
-    const float averageCosFactor = cosSunZenithAngle < -sunAngularRadius ? 0
+    CONST float averageCosFactor = cosSunZenithAngle < -sunAngularRadius ? 0
                                       : cosSunZenithAngle > sunAngularRadius ? cosSunZenithAngle
                                       : sqr(cosSunZenithAngle+sunAngularRadius)/(4*sunAngularRadius);
     return solarIrradianceAtTOA * transmittanceToAtmosphereBorder(cosSunZenithAngle, altitude) * averageCosFactor;

--- a/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/1/eclipsed-direct-irradiance.frag
+++ b/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/1/eclipsed-direct-irradiance.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // eclipsed-direct-irradiance.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,8 +45,8 @@ const vec4 lightPollutionRelativeRadiance=vec4(2.15e-06,1.11400004e-06,3.8580001
 const vec4 wavelengths=vec4(485.333344,516.666687,548,579.333313);
 const int wlSetIndex=1;
 #endif
-#line 5 0 // eclipsed-direct-irradiance.frag
-#line 1 2 // common-functions.h.glsl
+#line 4 0 // eclipsed-direct-irradiance.frag
+#line 1 3 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -67,16 +78,16 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 6 0 // eclipsed-direct-irradiance.frag
-#line 1 3 // direct-irradiance.h.glsl
+#line 5 0 // eclipsed-direct-irradiance.frag
+#line 1 4 // direct-irradiance.h.glsl
 #ifndef INCLUDE_ONCE_58AEF899_1A84_4A2F_AD71_4E7680B83E29
 #define INCLUDE_ONCE_58AEF899_1A84_4A2F_AD71_4E7680B83E29
 
 vec4 computeDirectGroundIrradiance(const float cosSunZenithAngle, const float altitude);
 
 #endif
-#line 7 0 // eclipsed-direct-irradiance.frag
-#line 1 4 // texture-sampling-functions.h.glsl
+#line 6 0 // eclipsed-direct-irradiance.frag
+#line 1 5 // texture-sampling-functions.h.glsl
 #ifndef INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 #define INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float altitude);
@@ -88,15 +99,15 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                 const int scatteringOrder);
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 #endif
-#line 8 0 // eclipsed-direct-irradiance.frag
+#line 7 0 // eclipsed-direct-irradiance.frag
 
 vec4 calcEclipsedDirectGroundIrradiance(const vec3 pointOnGround, const vec3 sunDir, const vec3 moonPos)
 {
-    const float altitude=0; // we are on the ground, after all
-    const vec3 zenith=normalize(pointOnGround-earthCenter);
-    const float cosSunZenithAngle=dot(sunDir,zenith);
+    CONST float altitude=0; // we are on the ground, after all
+    CONST vec3 zenith=normalize(pointOnGround-earthCenter);
+    CONST float cosSunZenithAngle=dot(sunDir,zenith);
 
-    const float visibility=sunVisibilityDueToMoon(pointOnGround, sunDir, moonPos)
+    CONST float visibility=sunVisibilityDueToMoon(pointOnGround, sunDir, moonPos)
                                                     *
                       // FIXME: this ignores orientation of the crescent of eclipsed Sun WRT horizon
                                     sunVisibility(cosSunZenithAngle, altitude);

--- a/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/1/phase-functions.frag
+++ b/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/1/phase-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // phase-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(2.15e-06,1.11400004e-06,3.8580001
 const vec4 wavelengths=vec4(485.333344,516.666687,548,579.333313);
 const int wlSetIndex=1;
 #endif
-#line 5 0 // phase-functions.frag
+#line 4 0 // phase-functions.frag
 
 vec4 phaseFunction_molecules(float dotViewSun)
 {
@@ -42,9 +53,9 @@ vec4 phaseFunction_molecules(float dotViewSun)
 }
 vec4 phaseFunction_aerosols(float dotViewSun)
 {
-        const float g=0.76;
-        const float g2=g*g;
-        const float k = 3/(8*PI)*(1-g2)/(2+g2);
+        CONST float g=0.76;
+        CONST float g2=g*g;
+        CONST float k = 3/(8*PI)*(1-g2)/(2+g2);
         return vec4(k * (1+sqr(dotViewSun)) / pow(1+g2 - 2*g*dotViewSun, 1.5) + 1/((1-dotViewSun)*600+0.05))*0.904;
 }
 vec4 currentPhaseFunction(float dotViewSun) { return phaseFunction_aerosols(dotViewSun); }

--- a/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/1/single-scattering-eclipsed.frag
+++ b/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/1/single-scattering-eclipsed.frag
@@ -1,7 +1,21 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
 
-#line 1 1 // const.h.glsl
+
+
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 6 0 // single-scattering-eclipsed.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,15 +48,15 @@ const vec4 lightPollutionRelativeRadiance=vec4(2.15e-06,1.11400004e-06,3.8580001
 const vec4 wavelengths=vec4(485.333344,516.666687,548,579.333313);
 const int wlSetIndex=1;
 #endif
-#line 5 0 // single-scattering-eclipsed.frag
-#line 1 2 // densities.h.glsl
+#line 7 0 // single-scattering-eclipsed.frag
+#line 1 3 // densities.h.glsl
 float scattererNumberDensity_molecules(float altitude);
 float scattererNumberDensity_aerosols(float altitude);
 float absorberNumberDensity_ozone(float altitude);
 vec4 scatteringCrossSection();
 float scattererDensity(float altitude);
-#line 6 0 // single-scattering-eclipsed.frag
-#line 1 3 // common-functions.h.glsl
+#line 8 0 // single-scattering-eclipsed.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -74,8 +88,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // single-scattering-eclipsed.frag
-#line 1 4 // texture-sampling-functions.h.glsl
+#line 9 0 // single-scattering-eclipsed.frag
+#line 1 5 // texture-sampling-functions.h.glsl
 #ifndef INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 #define INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float altitude);
@@ -87,12 +101,12 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                 const int scatteringOrder);
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 #endif
-#line 8 0 // single-scattering-eclipsed.frag
-#line 1 5 // phase-functions.h.glsl
+#line 10 0 // single-scattering-eclipsed.frag
+#line 1 6 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 9 0 // single-scattering-eclipsed.frag
+#line 11 0 // single-scattering-eclipsed.frag
 
 float cosZenithAngle(vec3 origin, vec3 direction)
 {
@@ -105,13 +119,13 @@ vec4 computeSingleScatteringIntegrandEclipsed(const float cosSunZenithAngle, con
                                               const float dist, const bool viewRayIntersectsGround,
                                               const vec3 scatterer, const vec3 sunDir, const vec3 moonPos)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle here the case when the
     // endpoint of the view ray intentionally appears in outer space.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosSunZenithAngleAtDist=clampCosine((r*cosSunZenithAngle+dist*dotViewSun)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosSunZenithAngleAtDist=clampCosine((r*cosSunZenithAngle+dist*dotViewSun)/(earthRadius+altAtDist));
 
-    const vec4 xmittance=transmittance(cosViewZenithAngle, altitude, dist, viewRayIntersectsGround)
+    CONST vec4 xmittance=transmittance(cosViewZenithAngle, altitude, dist, viewRayIntersectsGround)
                                                     *
                          transmittanceToAtmosphereBorder(cosSunZenithAngleAtDist, altAtDist)
                                                     *
@@ -133,19 +147,19 @@ vec4 computeSingleScatteringIntegrandEclipsed(const float cosSunZenithAngle, con
 vec4 computeSingleScatteringEclipsed(const vec3 camera, const vec3 viewDir, const vec3 sunDir, const vec3 moonPos,
                                      const bool viewRayIntersectsGround)
 {
-    const float cosViewZenithAngle=cosZenithAngle(camera,viewDir);
-    const float cosSunZenithAngle=cosZenithAngle(camera,sunDir);
-    const float altitude=pointAltitude(camera);
-    const float dotViewSun=dot(viewDir,sunDir);
-    const float integrInterval=distanceToNearestAtmosphereBoundary(cosViewZenithAngle, altitude,
+    CONST float cosViewZenithAngle=cosZenithAngle(camera,viewDir);
+    CONST float cosSunZenithAngle=cosZenithAngle(camera,sunDir);
+    CONST float altitude=pointAltitude(camera);
+    CONST float dotViewSun=dot(viewDir,sunDir);
+    CONST float integrInterval=distanceToNearestAtmosphereBoundary(cosViewZenithAngle, altitude,
                                                                    viewRayIntersectsGround);
 
     // Using the midpoint rule for quadrature
     vec4 spectrum=vec4(0);
-    const float dl=integrInterval/radialIntegrationPoints;
+    CONST float dl=integrInterval/radialIntegrationPoints;
     for(int n=0; n<radialIntegrationPoints; ++n)
     {
-        const float dist=(n+0.5)*dl;
+        CONST float dist=(n+0.5)*dl;
         spectrum += computeSingleScatteringIntegrandEclipsed(cosSunZenithAngle, cosViewZenithAngle, dotViewSun,
                                                              altitude, dist, viewRayIntersectsGround,
                                                              camera+viewDir*dist, sunDir, moonPos);

--- a/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/1/texture-coordinates.frag
+++ b/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/1/texture-coordinates.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-coordinates.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,8 +45,8 @@ const vec4 lightPollutionRelativeRadiance=vec4(2.15e-06,1.11400004e-06,3.8580001
 const vec4 wavelengths=vec4(485.333344,516.666687,548,579.333313);
 const int wlSetIndex=1;
 #endif
-#line 5 0 // texture-coordinates.frag
-#line 1 2 // texture-coordinates.h.glsl
+#line 4 0 // texture-coordinates.frag
+#line 1 3 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -104,8 +115,8 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 6 0 // texture-coordinates.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-coordinates.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -137,7 +148,7 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-coordinates.frag
+#line 6 0 // texture-coordinates.frag
 
 const float LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA=sqrt(atmosphereHeight*(atmosphereHeight+2*earthRadius));
 
@@ -205,18 +216,18 @@ vec3 indicesToTexCoords(const vec3 indices, const vec3 texSizes)
 
 TransmittanceTexVars transmittanceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
+    CONST float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
                                 texCoordToUnitRange(texCoord.t,transmittanceTextureSize.t);
     // Distance from Earth center to camera
-    const float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
-    const float altitude=r-earthRadius;
+    CONST float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
+    CONST float altitude=r-earthRadius;
 
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
     // distance to border of visible atmosphere from the view point
-    const float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
+    CONST float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
     // d==0 can happen when altitude==atmosphereHeight
-    const float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
+    CONST float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
     return TransmittanceTexVars(cosVZA,altitude);
 }
 
@@ -235,53 +246,53 @@ vec2 transmittanceTexVarsToTexCoord(const float cosVZA, float altitude)
     if(altitude<0)
         altitude=0;
 
-    const float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
+    CONST float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
                                       transmittanceTextureSize.t);
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
-    const float d=distanceToAtmosphereBorder(cosVZA,altitude);
-    const float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float d=distanceToAtmosphereBorder(cosVZA,altitude);
+    CONST float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
     return vec2(s,t);
 }
 
 // Output: vec2(cos(sunZenithAngle), altitude)
 IrradianceTexVars irradianceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
-    const float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
+    CONST float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
+    CONST float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
     return IrradianceTexVars(cosSZA,alt);
 }
 
 vec2 irradianceTexVarsToTexCoord(const float cosSunZenithAngle, const float altitude)
 {
-    const float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
-    const float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
+    CONST float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
+    CONST float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
     return vec2(s,t);
 }
 
 float cosSZAToUnitRangeTexCoord(const float cosSunZenithAngle)
 {
     // Distance to top atmosphere border along the ray groundUnderCamera-sun: (altitude, cosSunZenithAngle)
-    const float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name
-    const float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
+    CONST float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
     // TODO: choose a more descriptive name
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     return max(0.,1-a/A)/(a+1);
 }
 
 float unitRangeTexCoordToCosSZA(const float texCoord)
 {
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float a=(A-A*texCoord)/(1+A*texCoord);
-    const float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
+    CONST float a=(A-A*texCoord)/(1+A*texCoord);
+    CONST float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
     return distFromGroundToTopAtmoBorder==0 ? 1 :
         clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distFromGroundToTopAtmoBorder)) /
                     (2*earthRadius*distFromGroundToTopAtmoBorder));
@@ -292,24 +303,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
                                                const float dotViewSun, const float altitude,
                                                const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -317,24 +328,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float dotVSCoord=(dotViewSun+1)/2;
+    CONST float dotVSCoord=(dotViewSun+1)/2;
 
     // ------------------------------------
-    const float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
+    CONST float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
 
     return Scattering4DCoords(cosSZACoord, cosVZACoord, dotVSCoord, altCoord, viewRayIntersectsGround);
 }
 
 TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
@@ -342,16 +353,16 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture coordinates we combine into a single sampler3D coordinate.
-    const float texW = scatteringTextureSize[1];
-    const float texH = scatteringTextureSize[2];
-    const float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
-    const vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
+    CONST float texW = scatteringTextureSize[1];
+    CONST float texH = scatteringTextureSize[2];
+    CONST float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
+    CONST vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
                                         ceil (cosSZAIndex)*texW+coords.dotViewSun*(texW-1)) / (texW*texH-1);
-    const vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
+    CONST vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
 
-    const float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
+    CONST float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
 
-    const float alphaUpper=fract(cosSZAIndex);
+    CONST float alphaUpper=fract(cosSZAIndex);
     return TexCoordPair(vec3(cosVZAtc, combinedCoord.x, altitude), float(1-alphaUpper),
                         vec3(cosVZAtc, combinedCoord.y, altitude), float(alphaUpper));
 }
@@ -359,9 +370,9 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
+    CONST TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
     return texture(tex, texCoords.lower) * texCoords.alphaLower +
            texture(tex, texCoords.upper) * texCoords.alphaUpper;
 }
@@ -369,17 +380,17 @@ vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const f
 // 3D texture is the 3D single-altitude slice of a 4D texture
 vec3 scattering4DCoordsToTex3DCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2);
 
-    const float dvsSize = scatteringTextureSize[1];
-    const float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
+    CONST float dvsSize = scatteringTextureSize[1];
+    CONST float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
 
-    const float cszaSize = scatteringTextureSize[2];
-    const float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
+    CONST float cszaSize = scatteringTextureSize[2];
+    CONST float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
 
     return vec3(cosVZAtc, dotVStc, cosSZAtc);
 }
@@ -394,39 +405,39 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along dotViewSun coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[1];
-    const float posOfRow = indices[1];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[1];
+    CONST float posOfRow = indices[1];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         indexToTexCoord(currRow, numRows-1),
                                                         texCoordVerbatim));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               indexToTexCoord(currRow, numRows-1),
                                                               texCoordVerbatim));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          indexToTexCoord(currRow, numRows-1),
                                          texCoordVerbatim));
@@ -434,14 +445,14 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
 vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolationGuides01Tex,
                                  const vec3 indices)
 {
-    const float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
+    CONST float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
 
-    const float cosVZAIndex = indices[0];
-    const float dotVSIndex = indices[1];
-    const float currRow = floor(dotVSIndex);
-    const float posBetweenRows = dotVSIndex - currRow;
-    const float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cosVZAIndex = indices[0];
+    CONST float dotVSIndex = indices[1];
+    CONST float currRow = floor(dotVSIndex);
+    CONST float posBetweenRows = dotVSIndex - currRow;
+    CONST float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -449,14 +460,14 @@ vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolat
     indicesCurrRow[1] =     currRow;
     indicesNextRow[1] = min(currRow+1, scatteringTextureSize[1]-1.);
 
-    const vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
-    const vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
+    CONST vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
+    CONST vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
 
-    const vec4 valueCurrRow = texture(tex, coordsCurrRow);
-    const vec4 valueNextRow = texture(tex, coordsNextRow);
-    const float epsilon = 1e-37; // Prevents passing zero to log
-    const vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
-    const vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
+    CONST vec4 valueCurrRow = texture(tex, coordsCurrRow);
+    CONST vec4 valueNextRow = texture(tex, coordsNextRow);
+    CONST float epsilon = 1e-37; // Prevents passing zero to log
+    CONST vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
+    CONST vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
     return (logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow;
 }
 
@@ -465,37 +476,37 @@ float findGuide02Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along SZA coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[2];
-    const float posOfRow = indices[2];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[2];
+    CONST float posOfRow = indices[2];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
 }
@@ -505,19 +516,19 @@ vec4 sample3DTextureGuided(const sampler3D tex,
                            const float cosSunZenithAngle, const float cosViewZenithAngle,
                            const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
                                                                     dotViewSun, altitude, viewRayIntersectsGround);
     // Handle the external interpolation guides: the guides between a pair of VZA-dotViewSun 2D "pictures".
-    const vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
-    const vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
-    const float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
+    CONST vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
+    CONST float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
 
-    const float cvzaIndex = indices[0];
-    const float cszaIndex = indices[2];
-    const float currRow = floor(cszaIndex);
-    const float posBetweenRows = cszaIndex - currRow;
-    const float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cvzaIndex = indices[0];
+    CONST float cszaIndex = indices[2];
+    CONST float currRow = floor(cszaIndex);
+    CONST float posBetweenRows = cszaIndex - currRow;
+    CONST float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -526,58 +537,58 @@ vec4 sample3DTextureGuided(const sampler3D tex,
     indicesNextRow[2] = min(currRow+1, scatteringTextureSize[2]-1);
 
     // The caller will handle the internal interpolation guides: the ones between rows in each 2D "picture".
-    const vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
-    const vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
+    CONST vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
+    CONST vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
     return exp((logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow);
 }
 
 vec4 sample3DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
     return texture(tex, texCoords);
 }
 
 ScatteringTexVars scatteringTex4DCoordsToTexVars(const Scattering4DCoords coords)
 {
-    const float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
     // ------------------------------------
     float cosViewZenithAngle;
     if(coords.viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
     // ------------------------------------
-    const float dotViewSun=coords.dotViewSun*2-1;
+    CONST float dotViewSun=coords.dotViewSun*2-1;
 
     // ------------------------------------
-    const float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
+    CONST float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
 
     return ScatteringTexVars(cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, coords.viewRayIntersectsGround);
 }
 
 Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 {
-    const vec4 indexMax=scatteringTextureSize-vec4(1);
+    CONST vec4 indexMax=scatteringTextureSize-vec4(1);
     Scattering4DCoords coords4d;
     coords4d.viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
     // The following formulas assume that scatteringTextureSize[0] is even. For odd sizes they would change.
@@ -593,8 +604,8 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture indices we combine into a single sampler3D coordinate.
-    const float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
-    const float combinedIndex=texIndices[1];
+    CONST float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
+    CONST float combinedIndex=texIndices[1];
     coords4d.dotViewSun=mod(combinedIndex,texW)/(texW-1);
     coords4d.cosSunZenithAngle=floor(combinedIndex/texW)/(texH-1);
 
@@ -608,11 +619,11 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
 ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 {
-    const Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
+    CONST Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
     ScatteringTexVars vars=scatteringTex4DCoordsToTexVars(coords4d);
     // Clamp dotViewSun to its valid range of values, given cosViewZenithAngle and cosSunZenithAngle. This is
     // needed to prevent NaNs when computing the scattering texture.
-    const float cosVZA=vars.cosViewZenithAngle,
+    CONST float cosVZA=vars.cosViewZenithAngle,
                 cosSZA=vars.cosSunZenithAngle;
     vars.dotViewSun=clamp(vars.dotViewSun,
                           cosVZA*cosSZA-safeSqrt((1-sqr(cosVZA))*(1-sqr(cosSZA))),
@@ -622,54 +633,54 @@ ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 
 EclipseScatteringTexVars eclipseTexCoordsToTexVars(const vec2 texCoords, const float altitude)
 {
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
-    const bool viewRayIntersectsGround = texCoords.t<0.5;
+    CONST bool viewRayIntersectsGround = texCoords.t<0.5;
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
-    const float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
+    CONST float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
     return EclipseScatteringTexVars(azimuthRelativeToSun, cosViewZenithAngle, viewRayIntersectsGround);
 }
 
 EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                                    const float altitude, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -677,13 +688,13 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
-    const float azimuthCoord = azimuthRelativeToSun/(2*PI);
+    CONST float azimuthCoord = azimuthRelativeToSun/(2*PI);
 
     return EclipseScattering2DCoords(azimuthCoord, cosVZACoord);
 }
@@ -691,14 +702,14 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
 vec2 eclipseTexVarsToTexCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                const float altitude, const bool viewRayIntersectsGround, const vec2 texSize)
 {
-    const EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+    CONST EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                                     viewRayIntersectsGround);
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2);
-    const float azimuthTC = coords.azimuth + 1/(2*texSize.s);
+    CONST float azimuthTC = coords.azimuth + 1/(2*texSize.s);
 
     return vec2(azimuthTC, cosVZAtc);
 }
@@ -707,42 +718,42 @@ vec4 sampleEclipseDoubleScattering3DTexture(const sampler3D tex, const float cos
                                             const float cosViewZenithAngle, const float azimuthRelativeToSun,
                                             const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
+    CONST vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
                                                   eclipsedDoubleScatteringTextureSize.st);
-    const float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
-    const vec3 texCoords=vec3(coords2d, cosSZACoord);
+    CONST float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
+    CONST vec3 texCoords=vec3(coords2d, cosSZACoord);
 
     return texture(tex, texCoords);
 }
 
 LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 texIndices)
 {
-    const vec2 indexMax=lightPollutionTextureSize-vec2(1);
+    CONST vec2 indexMax=lightPollutionTextureSize-vec2(1);
 
-    const float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
-    const float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
+    CONST float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
-    const bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
-    const float cosViewZenithAngleCoord = viewRayIntersectsGround ?
+    CONST bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
+    CONST float cosViewZenithAngleCoord = viewRayIntersectsGround ?
                                    1-2*texIndices[0]/(indexMax[0]-1) :
                                    2*(texIndices[0]-1)/(indexMax[0]-1)-1;
     // ------------------------------------
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
@@ -753,23 +764,23 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 
 LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -777,27 +788,27 @@ LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, con
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     return LightPollution2DCoords(cosVZACoord, altCoord);
 }
 
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
-    const vec2 texSize = lightPollutionTextureSize;
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 texSize = lightPollutionTextureSize;
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2);
-    const float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
+    CONST float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
     return vec2(cosVZAtc, altitudeTC);
 }

--- a/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/1/texture-sampling-functions.frag
+++ b/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/1/texture-sampling-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-sampling-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,13 +45,13 @@ const vec4 lightPollutionRelativeRadiance=vec4(2.15e-06,1.11400004e-06,3.8580001
 const vec4 wavelengths=vec4(485.333344,516.666687,548,579.333313);
 const int wlSetIndex=1;
 #endif
-#line 5 0 // texture-sampling-functions.frag
-#line 1 2 // phase-functions.h.glsl
+#line 4 0 // texture-sampling-functions.frag
+#line 1 3 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 6 0 // texture-sampling-functions.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-sampling-functions.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -72,8 +83,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-sampling-functions.frag
-#line 1 4 // texture-coordinates.h.glsl
+#line 6 0 // texture-sampling-functions.frag
+#line 1 5 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -142,7 +153,7 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 8 0 // texture-sampling-functions.frag
+#line 7 0 // texture-sampling-functions.frag
 
 uniform sampler2D transmittanceTexture;
 uniform sampler2D irradianceTexture;
@@ -154,13 +165,13 @@ uniform sampler2D lightPollutionScatteringTexture;
 
 vec4 irradiance(const float cosSunZenithAngle, const float altitude)
 {
-    const vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
+    CONST vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
     return texture(irradianceTexture, texCoords);
 }
 
 vec4 opticalDepthToAtmosphereBorder(const float cosViewZenithAngle, const float altitude)
 {
-    const vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
+    CONST vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact when looking into nadir from TOA at some values of texture sizes (in particular, size of
     // transmittance texture for altitude being 4096). This happens when I simply call texture(eclipsedScatteringTexture,
@@ -178,11 +189,11 @@ vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float
 vec4 transmittance(const float cosViewZenithAngle, const float altitude, const float dist,
                    const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle view ray endpoint
     // in space here.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
 
     vec4 depth;
     if(viewRayIntersectsGround)
@@ -201,7 +212,7 @@ vec4 transmittance(const float cosViewZenithAngle, const float altitude, const f
 vec4 calcFirstScattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                          const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
+    CONST vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
                                           dotViewSun, altitude, viewRayIntersectsGround);
     return scattering*currentPhaseFunction(dotViewSun);
 }
@@ -220,6 +231,6 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
 
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     return texture(lightPollutionScatteringTexture, coords);
 }

--- a/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/1/total-scattering-coefficient.frag
+++ b/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/1/total-scattering-coefficient.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // total-scattering-coefficient.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,19 +45,19 @@ const vec4 lightPollutionRelativeRadiance=vec4(2.15e-06,1.11400004e-06,3.8580001
 const vec4 wavelengths=vec4(485.333344,516.666687,548,579.333313);
 const int wlSetIndex=1;
 #endif
-#line 5 0 // total-scattering-coefficient.frag
-#line 1 2 // densities.h.glsl
+#line 4 0 // total-scattering-coefficient.frag
+#line 1 3 // densities.h.glsl
 float scattererNumberDensity_molecules(float altitude);
 float scattererNumberDensity_aerosols(float altitude);
 float absorberNumberDensity_ozone(float altitude);
 vec4 scatteringCrossSection();
 float scattererDensity(float altitude);
-#line 6 0 // total-scattering-coefficient.frag
-#line 1 3 // phase-functions.h.glsl
+#line 5 0 // total-scattering-coefficient.frag
+#line 1 4 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 7 0 // total-scattering-coefficient.frag
+#line 6 0 // total-scattering-coefficient.frag
 
 vec4 totalScatteringCoefficient(float altitude, float dotViewInc)
 {

--- a/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/2/common-functions.frag
+++ b/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/2/common-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // common-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.35000004e-05,1.33100002e-05,9.4
 const vec4 wavelengths=vec4(610.666687,642,673.333313,704.666687);
 const int wlSetIndex=2;
 #endif
-#line 5 0 // common-functions.frag
+#line 4 0 // common-functions.frag
 
 bool dbgDataPresent=false;
 bool debugDataPresent()
@@ -69,7 +80,7 @@ void setDebugData(float a,float b, float c, float d)
 
 void swap(inout float x, inout float y)
 {
-    const float t = x;
+    CONST float t = x;
     x = y;
     y = t;
 }
@@ -83,7 +94,7 @@ float safeSqrt(const float x)
 
 float safeAtan(const float y, const float x)
 {
-    const float a = atan(y,x);
+    CONST float a = atan(y,x);
     return x==0 && y==0 ? 0 : a;
 }
 
@@ -116,23 +127,23 @@ float pointAltitude(vec3 point)
 
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float Ratm=earthRadius+atmosphereHeight;
-    const float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float Ratm=earthRadius+atmosphereHeight;
+    CONST float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float distanceToGround(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(-safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float cosZenithAngleOfHorizon(const float altitude)
 {
-    const float R=earthRadius;
-    const float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
+    CONST float R=earthRadius;
+    CONST float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
     return -sqrt(2*h*R+sqr(h))/(R+h);
 }
 
@@ -151,8 +162,8 @@ float distanceToNearestAtmosphereBoundary(const float cosZenithAngle, const floa
 float sunVisibility(const float cosSunZenithAngle, float altitude)
 {
     if(altitude<0) altitude=0;
-    const float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
-    const float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
+    CONST float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
+    CONST float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
     /* Approximating visible fraction of solar disk by smoothstep between the position of the Sun
      * touching the horizon by its upper part and the position with lower part touching the horizon.
      * The calculation assumes that solar angular radius is small and thus approximately equals its sine.
@@ -182,13 +193,13 @@ float circlesIntersectionArea(float R1, float R2, float d)
 
 float angleBetween(const vec3 a, const vec3 b)
 {
-    const float d=dot(a,b);
-    const float c=length(cross(a,b));
+    CONST float d=dot(a,b);
+    CONST float c=length(cross(a,b));
     // To avoid loss of precision, don't use dot product near the singularity
     // of acos, and cross product near the singularity of asin
     if(abs(d) < abs(c))
         return acos(d/(length(a)*length(b)));
-    const float smallerAngle = asin(c/(length(a)*length(b)));
+    CONST float smallerAngle = asin(c/(length(a)*length(b)));
     if(d<0) return PI-smallerAngle;
     return smallerAngle;
 }
@@ -205,11 +216,11 @@ float moonAngularRadius(const vec3 cameraPosition, const vec3 moonPosition)
 
 float visibleSolidAngleOfSun(const vec3 camera, const vec3 sunDir, const vec3 moonPos)
 {
-    const float Rs=sunAngularRadius;
-    const float Rm=moonAngularRadius(camera,moonPos);
+    CONST float Rs=sunAngularRadius;
+    CONST float Rm=moonAngularRadius(camera,moonPos);
     float visibleSolidAngle=PI*sqr(Rs);
 
-    const float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
+    CONST float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
     if(dSM<Rs+Rm)
     {
         visibleSolidAngle -= circlesIntersectionArea(Rm,Rs,dSM);
@@ -229,12 +240,12 @@ float sphereIntegrationSolidAngleDifferential(const int pointCountOnSphere)
 }
 vec3 sphereIntegrationSampleDir(const int index, const int pointCountOnSphere)
 {
-    const float goldenRatio=1.6180339887499;
+    CONST float goldenRatio=1.6180339887499;
     // The range of n is 0.5, 1.5, ..., pointCountOnSphere-0.5
-    const float n=index+0.5;
+    CONST float n=index+0.5;
     // Explanation of the Fibonacci grid generation can be seen at https://stackoverflow.com/a/44164075/673852
-    const float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
-    const float azimuth=n*(2*PI*goldenRatio);
+    CONST float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
+    CONST float azimuth=n*(2*PI*goldenRatio);
     return vec3(cos(azimuth)*sin(zenithAngle),
                 sin(azimuth)*sin(zenithAngle),
                 cos(zenithAngle));

--- a/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/2/compute-eclipsed-double-scattering.frag
+++ b/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/2/compute-eclipsed-double-scattering.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // compute-eclipsed-double-scattering.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,13 +45,13 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.35000004e-05,1.33100002e-05,9.4
 const vec4 wavelengths=vec4(610.666687,642,673.333313,704.666687);
 const int wlSetIndex=2;
 #endif
-#line 5 0 // compute-eclipsed-double-scattering.frag
-#line 1 2 // phase-functions.h.glsl
+#line 4 0 // compute-eclipsed-double-scattering.frag
+#line 1 3 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 6 0 // compute-eclipsed-double-scattering.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // compute-eclipsed-double-scattering.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -72,8 +83,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // compute-eclipsed-double-scattering.frag
-#line 1 4 // texture-coordinates.h.glsl
+#line 6 0 // compute-eclipsed-double-scattering.frag
+#line 1 5 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -142,19 +153,19 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 8 0 // compute-eclipsed-double-scattering.frag
-#line 1 5 // radiance-to-luminance.h.glsl
+#line 7 0 // compute-eclipsed-double-scattering.frag
+#line 1 6 // radiance-to-luminance.h.glsl
 const mat4 radianceToLuminance=mat4(21296.1113,10585.7773,6.80903196,807.40564,  8819.19727,3416.5498,0.346691847,67.973465,  1511.18506,551.902527,0,6.17586422,  177.630722,64.1456985,0,0.693584085);
-#line 9 0 // compute-eclipsed-double-scattering.frag
-#line 1 6 // eclipsed-direct-irradiance.h.glsl
+#line 8 0 // compute-eclipsed-double-scattering.frag
+#line 1 7 // eclipsed-direct-irradiance.h.glsl
 #ifndef INCLUDE_ONCE_8E9C53B3_83A0_4DD7_9106_32A13BD8935D
 #define INCLUDE_ONCE_8E9C53B3_83A0_4DD7_9106_32A13BD8935D
 
 vec4 calcEclipsedDirectGroundIrradiance(const vec3 pointOnGround, const vec3 sunDir, const vec3 moonPos);
 
 #endif
-#line 10 0 // compute-eclipsed-double-scattering.frag
-#line 1 7 // texture-sampling-functions.h.glsl
+#line 9 0 // compute-eclipsed-double-scattering.frag
+#line 1 8 // texture-sampling-functions.h.glsl
 #ifndef INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 #define INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float altitude);
@@ -166,8 +177,8 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                 const int scatteringOrder);
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 #endif
-#line 11 0 // compute-eclipsed-double-scattering.frag
-#line 1 8 // single-scattering-eclipsed.h.glsl
+#line 10 0 // compute-eclipsed-double-scattering.frag
+#line 1 9 // single-scattering-eclipsed.h.glsl
 #ifndef INCLUDE_ONCE_050024D2_BD56_434E_8D40_2055DA0B78EC
 #define INCLUDE_ONCE_050024D2_BD56_434E_8D40_2055DA0B78EC
 
@@ -175,10 +186,10 @@ vec4 computeSingleScatteringEclipsed(const vec3 camera, const vec3 viewDir, cons
                                      const bool viewRayIntersectsGround);
 
 #endif
-#line 12 0 // compute-eclipsed-double-scattering.frag
-#line 1 9 // total-scattering-coefficient.h.glsl
+#line 11 0 // compute-eclipsed-double-scattering.frag
+#line 1 10 // total-scattering-coefficient.h.glsl
 vec4 totalScatteringCoefficient(float altitude, float dotViewInc);
-#line 13 0 // compute-eclipsed-double-scattering.frag
+#line 12 0 // compute-eclipsed-double-scattering.frag
 
 in vec3 position;
 out vec4 partialRadiance;
@@ -186,8 +197,8 @@ out vec4 partialRadiance;
 vec4 computeDoubleScatteringEclipsedDensitySample(const int directionIndex, const vec3 cameraViewDir, const vec3 scatterer,
                                                   const vec3 sunDir, const vec3 moonPos)
 {
-    const vec3 zenith=vec3(0,0,1);
-    const float altitude=pointAltitude(scatterer);
+    CONST vec3 zenith=vec3(0,0,1);
+    CONST float altitude=pointAltitude(scatterer);
     // XXX: Might be a good idea to increase sampling density near horizon and decrease near zenith&nadir.
     // XXX: Also sampling should be more dense near the light source, since there often is a strong forward
     //       scattering peak like that of Mie phase functions.
@@ -197,16 +208,16 @@ vec4 computeDoubleScatteringEclipsedDensitySample(const int directionIndex, cons
     // Instead of iterating over all directions, we compute only one sample, for only one direction, to
     // facilitate parallelization. The summation will be done after this parallel computation of the samples.
 
-    const float dSolidAngle = sphereIntegrationSolidAngleDifferential(eclipseAngularIntegrationPoints);
+    CONST float dSolidAngle = sphereIntegrationSolidAngleDifferential(eclipseAngularIntegrationPoints);
     // Direction to the source of incident ray
-    const vec3 incDir = sphereIntegrationSampleDir(directionIndex, eclipseAngularIntegrationPoints);
+    CONST vec3 incDir = sphereIntegrationSampleDir(directionIndex, eclipseAngularIntegrationPoints);
 
     // NOTE: we don't recalculate sunDir as we do in computeScatteringDensity(), because it would also require
     // at least recalculating the position of the Moon. Instead we take into account scatterer's position to
     // calculate zenith direction and the direction to the incident ray.
-    const vec3 zenithAtScattererPos=normalize(scatterer-earthCenter);
-    const float cosIncZenithAngle=dot(incDir, zenithAtScattererPos);
-    const bool incRayIntersectsGround=rayIntersectsGround(cosIncZenithAngle, altitude);
+    CONST vec3 zenithAtScattererPos=normalize(scatterer-earthCenter);
+    CONST float cosIncZenithAngle=dot(incDir, zenithAtScattererPos);
+    CONST bool incRayIntersectsGround=rayIntersectsGround(cosIncZenithAngle, altitude);
 
     float distToGround=0;
     vec4 transmittanceToGround=vec4(0);
@@ -220,16 +231,16 @@ vec4 computeDoubleScatteringEclipsedDensitySample(const int directionIndex, cons
     // XXX: keep this ground-scattered radiation logic in sync with that in computeScatteringDensity().
     {
         // The point where incident light originates on the ground, with current incDir
-        const vec3 pointOnGround = scatterer+incDir*distToGround;
-        const vec4 groundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDir, moonPos);
+        CONST vec3 pointOnGround = scatterer+incDir*distToGround;
+        CONST vec4 groundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDir, moonPos);
         // Radiation scattered by the ground
-        const float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
+        CONST float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
         incidentRadiance += transmittanceToGround*groundAlbedo*groundIrradiance*groundBRDF;
     }
     // Radiation scattered by the atmosphere
     incidentRadiance+=computeSingleScatteringEclipsed(scatterer,incDir,sunDir,moonPos,incRayIntersectsGround);
 
-    const float dotViewInc = dot(cameraViewDir, incDir);
+    CONST float dotViewInc = dot(cameraViewDir, incDir);
     return dSolidAngle * incidentRadiance * totalScatteringCoefficient(altitude, dotViewInc);
 }
 
@@ -240,22 +251,22 @@ uniform vec3 moonPositionRelativeToSunAzimuth;
 
 void main()
 {
-    const vec3 sunDir=vec3(sin(sunZenithAngle), 0, cos(sunZenithAngle));
-    const vec3 cameraPos=vec3(0,0,cameraAltitude);
-    const bool viewRayIntersectsGround=rayIntersectsGround(cameraViewDir.z, cameraAltitude);
+    CONST vec3 sunDir=vec3(sin(sunZenithAngle), 0, cos(sunZenithAngle));
+    CONST vec3 cameraPos=vec3(0,0,cameraAltitude);
+    CONST bool viewRayIntersectsGround=rayIntersectsGround(cameraViewDir.z, cameraAltitude);
 
-    const float radialIntegrInterval=distanceToNearestAtmosphereBoundary(cameraViewDir.z, cameraAltitude,
+    CONST float radialIntegrInterval=distanceToNearestAtmosphereBoundary(cameraViewDir.z, cameraAltitude,
                                                                          viewRayIntersectsGround);
 
-    const int directionIndex=int(gl_FragCoord.x);
-    const float radialDistIndex=gl_FragCoord.y;
+    CONST int directionIndex=int(gl_FragCoord.x);
+    CONST float radialDistIndex=gl_FragCoord.y;
 
     // Using midpoint rule for quadrature
-    const float dl=radialIntegrInterval/radialIntegrationPoints;
-    const float dist=(radialDistIndex+0.5)*dl;
-    const vec4 scDensity=computeDoubleScatteringEclipsedDensitySample(directionIndex, cameraViewDir, cameraPos+cameraViewDir*dist,
+    CONST float dl=radialIntegrInterval/radialIntegrationPoints;
+    CONST float dist=(radialDistIndex+0.5)*dl;
+    CONST vec4 scDensity=computeDoubleScatteringEclipsedDensitySample(directionIndex, cameraViewDir, cameraPos+cameraViewDir*dist,
                                                                       sunDir, moonPositionRelativeToSunAzimuth);
-    const vec4 xmittance=transmittance(cameraViewDir.z, cameraAltitude, dist, viewRayIntersectsGround);
+    CONST vec4 xmittance=transmittance(cameraViewDir.z, cameraAltitude, dist, viewRayIntersectsGround);
     partialRadiance = scDensity*xmittance*dl;
 
 }

--- a/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/2/densities.frag
+++ b/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/2/densities.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // densities.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,20 +45,20 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.35000004e-05,1.33100002e-05,9.4
 const vec4 wavelengths=vec4(610.666687,642,673.333313,704.666687);
 const int wlSetIndex=2;
 #endif
-#line 5 0 // densities.frag
+#line 4 0 // densities.frag
 float scattererNumberDensity_molecules(float altitude)
 {
-        const float rayleighScaleHeight=8*km;
+        CONST float rayleighScaleHeight=8*km;
         return 3.08458e25*exp(-1/rayleighScaleHeight * altitude);
 }
 float scattererNumberDensity_aerosols(float altitude)
 {
-        const float mieScaleHeight=1.2*km;
+        CONST float mieScaleHeight=1.2*km;
         return 1.03333e8*exp(-1/mieScaleHeight*altitude);
 }
 float absorberNumberDensity_ozone(float altitude)
 {
-        const float totalOzoneAmount=370*dobsonUnit;
+        CONST float totalOzoneAmount=370*dobsonUnit;
 
         float density;
 

--- a/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/2/direct-irradiance.frag
+++ b/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/2/direct-irradiance.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // direct-irradiance.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,8 +45,8 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.35000004e-05,1.33100002e-05,9.4
 const vec4 wavelengths=vec4(610.666687,642,673.333313,704.666687);
 const int wlSetIndex=2;
 #endif
-#line 5 0 // direct-irradiance.frag
-#line 1 2 // texture-sampling-functions.h.glsl
+#line 4 0 // direct-irradiance.frag
+#line 1 3 // texture-sampling-functions.h.glsl
 #ifndef INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 #define INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float altitude);
@@ -47,7 +58,7 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                 const int scatteringOrder);
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 #endif
-#line 6 0 // direct-irradiance.frag
+#line 5 0 // direct-irradiance.frag
 
 vec4 computeDirectGroundIrradiance(const float cosSunZenithAngle, const float altitude)
 {
@@ -58,7 +69,7 @@ vec4 computeDirectGroundIrradiance(const float cosSunZenithAngle, const float al
     //   value in the center of the solar disk, assuming it to be a kind of "average".
     // * When the Sun is partially behind the astronomical horizon, we approximate the radiative view factor (i.e.
     //   cosine factor integrated over the solar disk) with a simple quadratic spline.
-    const float averageCosFactor = cosSunZenithAngle < -sunAngularRadius ? 0
+    CONST float averageCosFactor = cosSunZenithAngle < -sunAngularRadius ? 0
                                       : cosSunZenithAngle > sunAngularRadius ? cosSunZenithAngle
                                       : sqr(cosSunZenithAngle+sunAngularRadius)/(4*sunAngularRadius);
     return solarIrradianceAtTOA * transmittanceToAtmosphereBorder(cosSunZenithAngle, altitude) * averageCosFactor;

--- a/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/2/eclipsed-direct-irradiance.frag
+++ b/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/2/eclipsed-direct-irradiance.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // eclipsed-direct-irradiance.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,8 +45,8 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.35000004e-05,1.33100002e-05,9.4
 const vec4 wavelengths=vec4(610.666687,642,673.333313,704.666687);
 const int wlSetIndex=2;
 #endif
-#line 5 0 // eclipsed-direct-irradiance.frag
-#line 1 2 // common-functions.h.glsl
+#line 4 0 // eclipsed-direct-irradiance.frag
+#line 1 3 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -67,16 +78,16 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 6 0 // eclipsed-direct-irradiance.frag
-#line 1 3 // direct-irradiance.h.glsl
+#line 5 0 // eclipsed-direct-irradiance.frag
+#line 1 4 // direct-irradiance.h.glsl
 #ifndef INCLUDE_ONCE_58AEF899_1A84_4A2F_AD71_4E7680B83E29
 #define INCLUDE_ONCE_58AEF899_1A84_4A2F_AD71_4E7680B83E29
 
 vec4 computeDirectGroundIrradiance(const float cosSunZenithAngle, const float altitude);
 
 #endif
-#line 7 0 // eclipsed-direct-irradiance.frag
-#line 1 4 // texture-sampling-functions.h.glsl
+#line 6 0 // eclipsed-direct-irradiance.frag
+#line 1 5 // texture-sampling-functions.h.glsl
 #ifndef INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 #define INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float altitude);
@@ -88,15 +99,15 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                 const int scatteringOrder);
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 #endif
-#line 8 0 // eclipsed-direct-irradiance.frag
+#line 7 0 // eclipsed-direct-irradiance.frag
 
 vec4 calcEclipsedDirectGroundIrradiance(const vec3 pointOnGround, const vec3 sunDir, const vec3 moonPos)
 {
-    const float altitude=0; // we are on the ground, after all
-    const vec3 zenith=normalize(pointOnGround-earthCenter);
-    const float cosSunZenithAngle=dot(sunDir,zenith);
+    CONST float altitude=0; // we are on the ground, after all
+    CONST vec3 zenith=normalize(pointOnGround-earthCenter);
+    CONST float cosSunZenithAngle=dot(sunDir,zenith);
 
-    const float visibility=sunVisibilityDueToMoon(pointOnGround, sunDir, moonPos)
+    CONST float visibility=sunVisibilityDueToMoon(pointOnGround, sunDir, moonPos)
                                                     *
                       // FIXME: this ignores orientation of the crescent of eclipsed Sun WRT horizon
                                     sunVisibility(cosSunZenithAngle, altitude);

--- a/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/2/phase-functions.frag
+++ b/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/2/phase-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // phase-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.35000004e-05,1.33100002e-05,9.4
 const vec4 wavelengths=vec4(610.666687,642,673.333313,704.666687);
 const int wlSetIndex=2;
 #endif
-#line 5 0 // phase-functions.frag
+#line 4 0 // phase-functions.frag
 
 vec4 phaseFunction_molecules(float dotViewSun)
 {
@@ -42,9 +53,9 @@ vec4 phaseFunction_molecules(float dotViewSun)
 }
 vec4 phaseFunction_aerosols(float dotViewSun)
 {
-        const float g=0.76;
-        const float g2=g*g;
-        const float k = 3/(8*PI)*(1-g2)/(2+g2);
+        CONST float g=0.76;
+        CONST float g2=g*g;
+        CONST float k = 3/(8*PI)*(1-g2)/(2+g2);
         return vec4(k * (1+sqr(dotViewSun)) / pow(1+g2 - 2*g*dotViewSun, 1.5) + 1/((1-dotViewSun)*600+0.05))*0.904;
 }
 vec4 currentPhaseFunction(float dotViewSun) { return phaseFunction_aerosols(dotViewSun); }

--- a/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/2/single-scattering-eclipsed.frag
+++ b/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/2/single-scattering-eclipsed.frag
@@ -1,7 +1,21 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
 
-#line 1 1 // const.h.glsl
+
+
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 6 0 // single-scattering-eclipsed.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,15 +48,15 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.35000004e-05,1.33100002e-05,9.4
 const vec4 wavelengths=vec4(610.666687,642,673.333313,704.666687);
 const int wlSetIndex=2;
 #endif
-#line 5 0 // single-scattering-eclipsed.frag
-#line 1 2 // densities.h.glsl
+#line 7 0 // single-scattering-eclipsed.frag
+#line 1 3 // densities.h.glsl
 float scattererNumberDensity_molecules(float altitude);
 float scattererNumberDensity_aerosols(float altitude);
 float absorberNumberDensity_ozone(float altitude);
 vec4 scatteringCrossSection();
 float scattererDensity(float altitude);
-#line 6 0 // single-scattering-eclipsed.frag
-#line 1 3 // common-functions.h.glsl
+#line 8 0 // single-scattering-eclipsed.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -74,8 +88,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // single-scattering-eclipsed.frag
-#line 1 4 // texture-sampling-functions.h.glsl
+#line 9 0 // single-scattering-eclipsed.frag
+#line 1 5 // texture-sampling-functions.h.glsl
 #ifndef INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 #define INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float altitude);
@@ -87,12 +101,12 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                 const int scatteringOrder);
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 #endif
-#line 8 0 // single-scattering-eclipsed.frag
-#line 1 5 // phase-functions.h.glsl
+#line 10 0 // single-scattering-eclipsed.frag
+#line 1 6 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 9 0 // single-scattering-eclipsed.frag
+#line 11 0 // single-scattering-eclipsed.frag
 
 float cosZenithAngle(vec3 origin, vec3 direction)
 {
@@ -105,13 +119,13 @@ vec4 computeSingleScatteringIntegrandEclipsed(const float cosSunZenithAngle, con
                                               const float dist, const bool viewRayIntersectsGround,
                                               const vec3 scatterer, const vec3 sunDir, const vec3 moonPos)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle here the case when the
     // endpoint of the view ray intentionally appears in outer space.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosSunZenithAngleAtDist=clampCosine((r*cosSunZenithAngle+dist*dotViewSun)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosSunZenithAngleAtDist=clampCosine((r*cosSunZenithAngle+dist*dotViewSun)/(earthRadius+altAtDist));
 
-    const vec4 xmittance=transmittance(cosViewZenithAngle, altitude, dist, viewRayIntersectsGround)
+    CONST vec4 xmittance=transmittance(cosViewZenithAngle, altitude, dist, viewRayIntersectsGround)
                                                     *
                          transmittanceToAtmosphereBorder(cosSunZenithAngleAtDist, altAtDist)
                                                     *
@@ -133,19 +147,19 @@ vec4 computeSingleScatteringIntegrandEclipsed(const float cosSunZenithAngle, con
 vec4 computeSingleScatteringEclipsed(const vec3 camera, const vec3 viewDir, const vec3 sunDir, const vec3 moonPos,
                                      const bool viewRayIntersectsGround)
 {
-    const float cosViewZenithAngle=cosZenithAngle(camera,viewDir);
-    const float cosSunZenithAngle=cosZenithAngle(camera,sunDir);
-    const float altitude=pointAltitude(camera);
-    const float dotViewSun=dot(viewDir,sunDir);
-    const float integrInterval=distanceToNearestAtmosphereBoundary(cosViewZenithAngle, altitude,
+    CONST float cosViewZenithAngle=cosZenithAngle(camera,viewDir);
+    CONST float cosSunZenithAngle=cosZenithAngle(camera,sunDir);
+    CONST float altitude=pointAltitude(camera);
+    CONST float dotViewSun=dot(viewDir,sunDir);
+    CONST float integrInterval=distanceToNearestAtmosphereBoundary(cosViewZenithAngle, altitude,
                                                                    viewRayIntersectsGround);
 
     // Using the midpoint rule for quadrature
     vec4 spectrum=vec4(0);
-    const float dl=integrInterval/radialIntegrationPoints;
+    CONST float dl=integrInterval/radialIntegrationPoints;
     for(int n=0; n<radialIntegrationPoints; ++n)
     {
-        const float dist=(n+0.5)*dl;
+        CONST float dist=(n+0.5)*dl;
         spectrum += computeSingleScatteringIntegrandEclipsed(cosSunZenithAngle, cosViewZenithAngle, dotViewSun,
                                                              altitude, dist, viewRayIntersectsGround,
                                                              camera+viewDir*dist, sunDir, moonPos);

--- a/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/2/texture-coordinates.frag
+++ b/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/2/texture-coordinates.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-coordinates.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,8 +45,8 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.35000004e-05,1.33100002e-05,9.4
 const vec4 wavelengths=vec4(610.666687,642,673.333313,704.666687);
 const int wlSetIndex=2;
 #endif
-#line 5 0 // texture-coordinates.frag
-#line 1 2 // texture-coordinates.h.glsl
+#line 4 0 // texture-coordinates.frag
+#line 1 3 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -104,8 +115,8 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 6 0 // texture-coordinates.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-coordinates.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -137,7 +148,7 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-coordinates.frag
+#line 6 0 // texture-coordinates.frag
 
 const float LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA=sqrt(atmosphereHeight*(atmosphereHeight+2*earthRadius));
 
@@ -205,18 +216,18 @@ vec3 indicesToTexCoords(const vec3 indices, const vec3 texSizes)
 
 TransmittanceTexVars transmittanceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
+    CONST float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
                                 texCoordToUnitRange(texCoord.t,transmittanceTextureSize.t);
     // Distance from Earth center to camera
-    const float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
-    const float altitude=r-earthRadius;
+    CONST float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
+    CONST float altitude=r-earthRadius;
 
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
     // distance to border of visible atmosphere from the view point
-    const float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
+    CONST float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
     // d==0 can happen when altitude==atmosphereHeight
-    const float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
+    CONST float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
     return TransmittanceTexVars(cosVZA,altitude);
 }
 
@@ -235,53 +246,53 @@ vec2 transmittanceTexVarsToTexCoord(const float cosVZA, float altitude)
     if(altitude<0)
         altitude=0;
 
-    const float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
+    CONST float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
                                       transmittanceTextureSize.t);
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
-    const float d=distanceToAtmosphereBorder(cosVZA,altitude);
-    const float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float d=distanceToAtmosphereBorder(cosVZA,altitude);
+    CONST float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
     return vec2(s,t);
 }
 
 // Output: vec2(cos(sunZenithAngle), altitude)
 IrradianceTexVars irradianceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
-    const float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
+    CONST float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
+    CONST float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
     return IrradianceTexVars(cosSZA,alt);
 }
 
 vec2 irradianceTexVarsToTexCoord(const float cosSunZenithAngle, const float altitude)
 {
-    const float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
-    const float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
+    CONST float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
+    CONST float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
     return vec2(s,t);
 }
 
 float cosSZAToUnitRangeTexCoord(const float cosSunZenithAngle)
 {
     // Distance to top atmosphere border along the ray groundUnderCamera-sun: (altitude, cosSunZenithAngle)
-    const float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name
-    const float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
+    CONST float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
     // TODO: choose a more descriptive name
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     return max(0.,1-a/A)/(a+1);
 }
 
 float unitRangeTexCoordToCosSZA(const float texCoord)
 {
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float a=(A-A*texCoord)/(1+A*texCoord);
-    const float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
+    CONST float a=(A-A*texCoord)/(1+A*texCoord);
+    CONST float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
     return distFromGroundToTopAtmoBorder==0 ? 1 :
         clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distFromGroundToTopAtmoBorder)) /
                     (2*earthRadius*distFromGroundToTopAtmoBorder));
@@ -292,24 +303,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
                                                const float dotViewSun, const float altitude,
                                                const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -317,24 +328,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float dotVSCoord=(dotViewSun+1)/2;
+    CONST float dotVSCoord=(dotViewSun+1)/2;
 
     // ------------------------------------
-    const float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
+    CONST float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
 
     return Scattering4DCoords(cosSZACoord, cosVZACoord, dotVSCoord, altCoord, viewRayIntersectsGround);
 }
 
 TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
@@ -342,16 +353,16 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture coordinates we combine into a single sampler3D coordinate.
-    const float texW = scatteringTextureSize[1];
-    const float texH = scatteringTextureSize[2];
-    const float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
-    const vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
+    CONST float texW = scatteringTextureSize[1];
+    CONST float texH = scatteringTextureSize[2];
+    CONST float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
+    CONST vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
                                         ceil (cosSZAIndex)*texW+coords.dotViewSun*(texW-1)) / (texW*texH-1);
-    const vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
+    CONST vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
 
-    const float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
+    CONST float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
 
-    const float alphaUpper=fract(cosSZAIndex);
+    CONST float alphaUpper=fract(cosSZAIndex);
     return TexCoordPair(vec3(cosVZAtc, combinedCoord.x, altitude), float(1-alphaUpper),
                         vec3(cosVZAtc, combinedCoord.y, altitude), float(alphaUpper));
 }
@@ -359,9 +370,9 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
+    CONST TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
     return texture(tex, texCoords.lower) * texCoords.alphaLower +
            texture(tex, texCoords.upper) * texCoords.alphaUpper;
 }
@@ -369,17 +380,17 @@ vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const f
 // 3D texture is the 3D single-altitude slice of a 4D texture
 vec3 scattering4DCoordsToTex3DCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2);
 
-    const float dvsSize = scatteringTextureSize[1];
-    const float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
+    CONST float dvsSize = scatteringTextureSize[1];
+    CONST float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
 
-    const float cszaSize = scatteringTextureSize[2];
-    const float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
+    CONST float cszaSize = scatteringTextureSize[2];
+    CONST float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
 
     return vec3(cosVZAtc, dotVStc, cosSZAtc);
 }
@@ -394,39 +405,39 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along dotViewSun coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[1];
-    const float posOfRow = indices[1];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[1];
+    CONST float posOfRow = indices[1];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         indexToTexCoord(currRow, numRows-1),
                                                         texCoordVerbatim));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               indexToTexCoord(currRow, numRows-1),
                                                               texCoordVerbatim));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          indexToTexCoord(currRow, numRows-1),
                                          texCoordVerbatim));
@@ -434,14 +445,14 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
 vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolationGuides01Tex,
                                  const vec3 indices)
 {
-    const float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
+    CONST float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
 
-    const float cosVZAIndex = indices[0];
-    const float dotVSIndex = indices[1];
-    const float currRow = floor(dotVSIndex);
-    const float posBetweenRows = dotVSIndex - currRow;
-    const float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cosVZAIndex = indices[0];
+    CONST float dotVSIndex = indices[1];
+    CONST float currRow = floor(dotVSIndex);
+    CONST float posBetweenRows = dotVSIndex - currRow;
+    CONST float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -449,14 +460,14 @@ vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolat
     indicesCurrRow[1] =     currRow;
     indicesNextRow[1] = min(currRow+1, scatteringTextureSize[1]-1.);
 
-    const vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
-    const vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
+    CONST vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
+    CONST vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
 
-    const vec4 valueCurrRow = texture(tex, coordsCurrRow);
-    const vec4 valueNextRow = texture(tex, coordsNextRow);
-    const float epsilon = 1e-37; // Prevents passing zero to log
-    const vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
-    const vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
+    CONST vec4 valueCurrRow = texture(tex, coordsCurrRow);
+    CONST vec4 valueNextRow = texture(tex, coordsNextRow);
+    CONST float epsilon = 1e-37; // Prevents passing zero to log
+    CONST vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
+    CONST vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
     return (logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow;
 }
 
@@ -465,37 +476,37 @@ float findGuide02Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along SZA coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[2];
-    const float posOfRow = indices[2];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[2];
+    CONST float posOfRow = indices[2];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
 }
@@ -505,19 +516,19 @@ vec4 sample3DTextureGuided(const sampler3D tex,
                            const float cosSunZenithAngle, const float cosViewZenithAngle,
                            const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
                                                                     dotViewSun, altitude, viewRayIntersectsGround);
     // Handle the external interpolation guides: the guides between a pair of VZA-dotViewSun 2D "pictures".
-    const vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
-    const vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
-    const float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
+    CONST vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
+    CONST float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
 
-    const float cvzaIndex = indices[0];
-    const float cszaIndex = indices[2];
-    const float currRow = floor(cszaIndex);
-    const float posBetweenRows = cszaIndex - currRow;
-    const float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cvzaIndex = indices[0];
+    CONST float cszaIndex = indices[2];
+    CONST float currRow = floor(cszaIndex);
+    CONST float posBetweenRows = cszaIndex - currRow;
+    CONST float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -526,58 +537,58 @@ vec4 sample3DTextureGuided(const sampler3D tex,
     indicesNextRow[2] = min(currRow+1, scatteringTextureSize[2]-1);
 
     // The caller will handle the internal interpolation guides: the ones between rows in each 2D "picture".
-    const vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
-    const vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
+    CONST vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
+    CONST vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
     return exp((logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow);
 }
 
 vec4 sample3DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
     return texture(tex, texCoords);
 }
 
 ScatteringTexVars scatteringTex4DCoordsToTexVars(const Scattering4DCoords coords)
 {
-    const float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
     // ------------------------------------
     float cosViewZenithAngle;
     if(coords.viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
     // ------------------------------------
-    const float dotViewSun=coords.dotViewSun*2-1;
+    CONST float dotViewSun=coords.dotViewSun*2-1;
 
     // ------------------------------------
-    const float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
+    CONST float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
 
     return ScatteringTexVars(cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, coords.viewRayIntersectsGround);
 }
 
 Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 {
-    const vec4 indexMax=scatteringTextureSize-vec4(1);
+    CONST vec4 indexMax=scatteringTextureSize-vec4(1);
     Scattering4DCoords coords4d;
     coords4d.viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
     // The following formulas assume that scatteringTextureSize[0] is even. For odd sizes they would change.
@@ -593,8 +604,8 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture indices we combine into a single sampler3D coordinate.
-    const float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
-    const float combinedIndex=texIndices[1];
+    CONST float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
+    CONST float combinedIndex=texIndices[1];
     coords4d.dotViewSun=mod(combinedIndex,texW)/(texW-1);
     coords4d.cosSunZenithAngle=floor(combinedIndex/texW)/(texH-1);
 
@@ -608,11 +619,11 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
 ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 {
-    const Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
+    CONST Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
     ScatteringTexVars vars=scatteringTex4DCoordsToTexVars(coords4d);
     // Clamp dotViewSun to its valid range of values, given cosViewZenithAngle and cosSunZenithAngle. This is
     // needed to prevent NaNs when computing the scattering texture.
-    const float cosVZA=vars.cosViewZenithAngle,
+    CONST float cosVZA=vars.cosViewZenithAngle,
                 cosSZA=vars.cosSunZenithAngle;
     vars.dotViewSun=clamp(vars.dotViewSun,
                           cosVZA*cosSZA-safeSqrt((1-sqr(cosVZA))*(1-sqr(cosSZA))),
@@ -622,54 +633,54 @@ ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 
 EclipseScatteringTexVars eclipseTexCoordsToTexVars(const vec2 texCoords, const float altitude)
 {
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
-    const bool viewRayIntersectsGround = texCoords.t<0.5;
+    CONST bool viewRayIntersectsGround = texCoords.t<0.5;
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
-    const float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
+    CONST float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
     return EclipseScatteringTexVars(azimuthRelativeToSun, cosViewZenithAngle, viewRayIntersectsGround);
 }
 
 EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                                    const float altitude, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -677,13 +688,13 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
-    const float azimuthCoord = azimuthRelativeToSun/(2*PI);
+    CONST float azimuthCoord = azimuthRelativeToSun/(2*PI);
 
     return EclipseScattering2DCoords(azimuthCoord, cosVZACoord);
 }
@@ -691,14 +702,14 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
 vec2 eclipseTexVarsToTexCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                const float altitude, const bool viewRayIntersectsGround, const vec2 texSize)
 {
-    const EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+    CONST EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                                     viewRayIntersectsGround);
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2);
-    const float azimuthTC = coords.azimuth + 1/(2*texSize.s);
+    CONST float azimuthTC = coords.azimuth + 1/(2*texSize.s);
 
     return vec2(azimuthTC, cosVZAtc);
 }
@@ -707,42 +718,42 @@ vec4 sampleEclipseDoubleScattering3DTexture(const sampler3D tex, const float cos
                                             const float cosViewZenithAngle, const float azimuthRelativeToSun,
                                             const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
+    CONST vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
                                                   eclipsedDoubleScatteringTextureSize.st);
-    const float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
-    const vec3 texCoords=vec3(coords2d, cosSZACoord);
+    CONST float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
+    CONST vec3 texCoords=vec3(coords2d, cosSZACoord);
 
     return texture(tex, texCoords);
 }
 
 LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 texIndices)
 {
-    const vec2 indexMax=lightPollutionTextureSize-vec2(1);
+    CONST vec2 indexMax=lightPollutionTextureSize-vec2(1);
 
-    const float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
-    const float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
+    CONST float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
-    const bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
-    const float cosViewZenithAngleCoord = viewRayIntersectsGround ?
+    CONST bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
+    CONST float cosViewZenithAngleCoord = viewRayIntersectsGround ?
                                    1-2*texIndices[0]/(indexMax[0]-1) :
                                    2*(texIndices[0]-1)/(indexMax[0]-1)-1;
     // ------------------------------------
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
@@ -753,23 +764,23 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 
 LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -777,27 +788,27 @@ LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, con
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     return LightPollution2DCoords(cosVZACoord, altCoord);
 }
 
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
-    const vec2 texSize = lightPollutionTextureSize;
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 texSize = lightPollutionTextureSize;
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2);
-    const float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
+    CONST float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
     return vec2(cosVZAtc, altitudeTC);
 }

--- a/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/2/texture-sampling-functions.frag
+++ b/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/2/texture-sampling-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-sampling-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,13 +45,13 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.35000004e-05,1.33100002e-05,9.4
 const vec4 wavelengths=vec4(610.666687,642,673.333313,704.666687);
 const int wlSetIndex=2;
 #endif
-#line 5 0 // texture-sampling-functions.frag
-#line 1 2 // phase-functions.h.glsl
+#line 4 0 // texture-sampling-functions.frag
+#line 1 3 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 6 0 // texture-sampling-functions.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-sampling-functions.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -72,8 +83,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-sampling-functions.frag
-#line 1 4 // texture-coordinates.h.glsl
+#line 6 0 // texture-sampling-functions.frag
+#line 1 5 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -142,7 +153,7 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 8 0 // texture-sampling-functions.frag
+#line 7 0 // texture-sampling-functions.frag
 
 uniform sampler2D transmittanceTexture;
 uniform sampler2D irradianceTexture;
@@ -154,13 +165,13 @@ uniform sampler2D lightPollutionScatteringTexture;
 
 vec4 irradiance(const float cosSunZenithAngle, const float altitude)
 {
-    const vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
+    CONST vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
     return texture(irradianceTexture, texCoords);
 }
 
 vec4 opticalDepthToAtmosphereBorder(const float cosViewZenithAngle, const float altitude)
 {
-    const vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
+    CONST vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact when looking into nadir from TOA at some values of texture sizes (in particular, size of
     // transmittance texture for altitude being 4096). This happens when I simply call texture(eclipsedScatteringTexture,
@@ -178,11 +189,11 @@ vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float
 vec4 transmittance(const float cosViewZenithAngle, const float altitude, const float dist,
                    const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle view ray endpoint
     // in space here.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
 
     vec4 depth;
     if(viewRayIntersectsGround)
@@ -201,7 +212,7 @@ vec4 transmittance(const float cosViewZenithAngle, const float altitude, const f
 vec4 calcFirstScattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                          const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
+    CONST vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
                                           dotViewSun, altitude, viewRayIntersectsGround);
     return scattering*currentPhaseFunction(dotViewSun);
 }
@@ -220,6 +231,6 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
 
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     return texture(lightPollutionScatteringTexture, coords);
 }

--- a/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/2/total-scattering-coefficient.frag
+++ b/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/2/total-scattering-coefficient.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // total-scattering-coefficient.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,19 +45,19 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.35000004e-05,1.33100002e-05,9.4
 const vec4 wavelengths=vec4(610.666687,642,673.333313,704.666687);
 const int wlSetIndex=2;
 #endif
-#line 5 0 // total-scattering-coefficient.frag
-#line 1 2 // densities.h.glsl
+#line 4 0 // total-scattering-coefficient.frag
+#line 1 3 // densities.h.glsl
 float scattererNumberDensity_molecules(float altitude);
 float scattererNumberDensity_aerosols(float altitude);
 float absorberNumberDensity_ozone(float altitude);
 vec4 scatteringCrossSection();
 float scattererDensity(float altitude);
-#line 6 0 // total-scattering-coefficient.frag
-#line 1 3 // phase-functions.h.glsl
+#line 5 0 // total-scattering-coefficient.frag
+#line 1 4 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 7 0 // total-scattering-coefficient.frag
+#line 6 0 // total-scattering-coefficient.frag
 
 vec4 totalScatteringCoefficient(float altitude, float dotViewInc)
 {

--- a/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/3/common-functions.frag
+++ b/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/3/common-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // common-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // common-functions.frag
+#line 4 0 // common-functions.frag
 
 bool dbgDataPresent=false;
 bool debugDataPresent()
@@ -69,7 +80,7 @@ void setDebugData(float a,float b, float c, float d)
 
 void swap(inout float x, inout float y)
 {
-    const float t = x;
+    CONST float t = x;
     x = y;
     y = t;
 }
@@ -83,7 +94,7 @@ float safeSqrt(const float x)
 
 float safeAtan(const float y, const float x)
 {
-    const float a = atan(y,x);
+    CONST float a = atan(y,x);
     return x==0 && y==0 ? 0 : a;
 }
 
@@ -116,23 +127,23 @@ float pointAltitude(vec3 point)
 
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float Ratm=earthRadius+atmosphereHeight;
-    const float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float Ratm=earthRadius+atmosphereHeight;
+    CONST float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float distanceToGround(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(-safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float cosZenithAngleOfHorizon(const float altitude)
 {
-    const float R=earthRadius;
-    const float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
+    CONST float R=earthRadius;
+    CONST float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
     return -sqrt(2*h*R+sqr(h))/(R+h);
 }
 
@@ -151,8 +162,8 @@ float distanceToNearestAtmosphereBoundary(const float cosZenithAngle, const floa
 float sunVisibility(const float cosSunZenithAngle, float altitude)
 {
     if(altitude<0) altitude=0;
-    const float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
-    const float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
+    CONST float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
+    CONST float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
     /* Approximating visible fraction of solar disk by smoothstep between the position of the Sun
      * touching the horizon by its upper part and the position with lower part touching the horizon.
      * The calculation assumes that solar angular radius is small and thus approximately equals its sine.
@@ -182,13 +193,13 @@ float circlesIntersectionArea(float R1, float R2, float d)
 
 float angleBetween(const vec3 a, const vec3 b)
 {
-    const float d=dot(a,b);
-    const float c=length(cross(a,b));
+    CONST float d=dot(a,b);
+    CONST float c=length(cross(a,b));
     // To avoid loss of precision, don't use dot product near the singularity
     // of acos, and cross product near the singularity of asin
     if(abs(d) < abs(c))
         return acos(d/(length(a)*length(b)));
-    const float smallerAngle = asin(c/(length(a)*length(b)));
+    CONST float smallerAngle = asin(c/(length(a)*length(b)));
     if(d<0) return PI-smallerAngle;
     return smallerAngle;
 }
@@ -205,11 +216,11 @@ float moonAngularRadius(const vec3 cameraPosition, const vec3 moonPosition)
 
 float visibleSolidAngleOfSun(const vec3 camera, const vec3 sunDir, const vec3 moonPos)
 {
-    const float Rs=sunAngularRadius;
-    const float Rm=moonAngularRadius(camera,moonPos);
+    CONST float Rs=sunAngularRadius;
+    CONST float Rm=moonAngularRadius(camera,moonPos);
     float visibleSolidAngle=PI*sqr(Rs);
 
-    const float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
+    CONST float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
     if(dSM<Rs+Rm)
     {
         visibleSolidAngle -= circlesIntersectionArea(Rm,Rs,dSM);
@@ -229,12 +240,12 @@ float sphereIntegrationSolidAngleDifferential(const int pointCountOnSphere)
 }
 vec3 sphereIntegrationSampleDir(const int index, const int pointCountOnSphere)
 {
-    const float goldenRatio=1.6180339887499;
+    CONST float goldenRatio=1.6180339887499;
     // The range of n is 0.5, 1.5, ..., pointCountOnSphere-0.5
-    const float n=index+0.5;
+    CONST float n=index+0.5;
     // Explanation of the Fibonacci grid generation can be seen at https://stackoverflow.com/a/44164075/673852
-    const float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
-    const float azimuth=n*(2*PI*goldenRatio);
+    CONST float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
+    CONST float azimuth=n*(2*PI*goldenRatio);
     return vec3(cos(azimuth)*sin(zenithAngle),
                 sin(azimuth)*sin(zenithAngle),
                 cos(zenithAngle));

--- a/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/3/compute-eclipsed-double-scattering.frag
+++ b/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/3/compute-eclipsed-double-scattering.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // compute-eclipsed-double-scattering.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,13 +45,13 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // compute-eclipsed-double-scattering.frag
-#line 1 2 // phase-functions.h.glsl
+#line 4 0 // compute-eclipsed-double-scattering.frag
+#line 1 3 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 6 0 // compute-eclipsed-double-scattering.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // compute-eclipsed-double-scattering.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -72,8 +83,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // compute-eclipsed-double-scattering.frag
-#line 1 4 // texture-coordinates.h.glsl
+#line 6 0 // compute-eclipsed-double-scattering.frag
+#line 1 5 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -142,19 +153,19 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 8 0 // compute-eclipsed-double-scattering.frag
-#line 1 5 // radiance-to-luminance.h.glsl
+#line 7 0 // compute-eclipsed-double-scattering.frag
+#line 1 6 // radiance-to-luminance.h.glsl
 const mat4 radianceToLuminance=mat4(19.8756237,7.17745161,0,0.0937032327,  2.13895917,0.772417068,0,0.0149318045,  0.241072536,0.0870557055,0,0,  0.0133876652,0.00483453181,0,0);
-#line 9 0 // compute-eclipsed-double-scattering.frag
-#line 1 6 // eclipsed-direct-irradiance.h.glsl
+#line 8 0 // compute-eclipsed-double-scattering.frag
+#line 1 7 // eclipsed-direct-irradiance.h.glsl
 #ifndef INCLUDE_ONCE_8E9C53B3_83A0_4DD7_9106_32A13BD8935D
 #define INCLUDE_ONCE_8E9C53B3_83A0_4DD7_9106_32A13BD8935D
 
 vec4 calcEclipsedDirectGroundIrradiance(const vec3 pointOnGround, const vec3 sunDir, const vec3 moonPos);
 
 #endif
-#line 10 0 // compute-eclipsed-double-scattering.frag
-#line 1 7 // texture-sampling-functions.h.glsl
+#line 9 0 // compute-eclipsed-double-scattering.frag
+#line 1 8 // texture-sampling-functions.h.glsl
 #ifndef INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 #define INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float altitude);
@@ -166,8 +177,8 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                 const int scatteringOrder);
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 #endif
-#line 11 0 // compute-eclipsed-double-scattering.frag
-#line 1 8 // single-scattering-eclipsed.h.glsl
+#line 10 0 // compute-eclipsed-double-scattering.frag
+#line 1 9 // single-scattering-eclipsed.h.glsl
 #ifndef INCLUDE_ONCE_050024D2_BD56_434E_8D40_2055DA0B78EC
 #define INCLUDE_ONCE_050024D2_BD56_434E_8D40_2055DA0B78EC
 
@@ -175,10 +186,10 @@ vec4 computeSingleScatteringEclipsed(const vec3 camera, const vec3 viewDir, cons
                                      const bool viewRayIntersectsGround);
 
 #endif
-#line 12 0 // compute-eclipsed-double-scattering.frag
-#line 1 9 // total-scattering-coefficient.h.glsl
+#line 11 0 // compute-eclipsed-double-scattering.frag
+#line 1 10 // total-scattering-coefficient.h.glsl
 vec4 totalScatteringCoefficient(float altitude, float dotViewInc);
-#line 13 0 // compute-eclipsed-double-scattering.frag
+#line 12 0 // compute-eclipsed-double-scattering.frag
 
 in vec3 position;
 out vec4 partialRadiance;
@@ -186,8 +197,8 @@ out vec4 partialRadiance;
 vec4 computeDoubleScatteringEclipsedDensitySample(const int directionIndex, const vec3 cameraViewDir, const vec3 scatterer,
                                                   const vec3 sunDir, const vec3 moonPos)
 {
-    const vec3 zenith=vec3(0,0,1);
-    const float altitude=pointAltitude(scatterer);
+    CONST vec3 zenith=vec3(0,0,1);
+    CONST float altitude=pointAltitude(scatterer);
     // XXX: Might be a good idea to increase sampling density near horizon and decrease near zenith&nadir.
     // XXX: Also sampling should be more dense near the light source, since there often is a strong forward
     //       scattering peak like that of Mie phase functions.
@@ -197,16 +208,16 @@ vec4 computeDoubleScatteringEclipsedDensitySample(const int directionIndex, cons
     // Instead of iterating over all directions, we compute only one sample, for only one direction, to
     // facilitate parallelization. The summation will be done after this parallel computation of the samples.
 
-    const float dSolidAngle = sphereIntegrationSolidAngleDifferential(eclipseAngularIntegrationPoints);
+    CONST float dSolidAngle = sphereIntegrationSolidAngleDifferential(eclipseAngularIntegrationPoints);
     // Direction to the source of incident ray
-    const vec3 incDir = sphereIntegrationSampleDir(directionIndex, eclipseAngularIntegrationPoints);
+    CONST vec3 incDir = sphereIntegrationSampleDir(directionIndex, eclipseAngularIntegrationPoints);
 
     // NOTE: we don't recalculate sunDir as we do in computeScatteringDensity(), because it would also require
     // at least recalculating the position of the Moon. Instead we take into account scatterer's position to
     // calculate zenith direction and the direction to the incident ray.
-    const vec3 zenithAtScattererPos=normalize(scatterer-earthCenter);
-    const float cosIncZenithAngle=dot(incDir, zenithAtScattererPos);
-    const bool incRayIntersectsGround=rayIntersectsGround(cosIncZenithAngle, altitude);
+    CONST vec3 zenithAtScattererPos=normalize(scatterer-earthCenter);
+    CONST float cosIncZenithAngle=dot(incDir, zenithAtScattererPos);
+    CONST bool incRayIntersectsGround=rayIntersectsGround(cosIncZenithAngle, altitude);
 
     float distToGround=0;
     vec4 transmittanceToGround=vec4(0);
@@ -220,16 +231,16 @@ vec4 computeDoubleScatteringEclipsedDensitySample(const int directionIndex, cons
     // XXX: keep this ground-scattered radiation logic in sync with that in computeScatteringDensity().
     {
         // The point where incident light originates on the ground, with current incDir
-        const vec3 pointOnGround = scatterer+incDir*distToGround;
-        const vec4 groundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDir, moonPos);
+        CONST vec3 pointOnGround = scatterer+incDir*distToGround;
+        CONST vec4 groundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDir, moonPos);
         // Radiation scattered by the ground
-        const float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
+        CONST float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
         incidentRadiance += transmittanceToGround*groundAlbedo*groundIrradiance*groundBRDF;
     }
     // Radiation scattered by the atmosphere
     incidentRadiance+=computeSingleScatteringEclipsed(scatterer,incDir,sunDir,moonPos,incRayIntersectsGround);
 
-    const float dotViewInc = dot(cameraViewDir, incDir);
+    CONST float dotViewInc = dot(cameraViewDir, incDir);
     return dSolidAngle * incidentRadiance * totalScatteringCoefficient(altitude, dotViewInc);
 }
 
@@ -240,22 +251,22 @@ uniform vec3 moonPositionRelativeToSunAzimuth;
 
 void main()
 {
-    const vec3 sunDir=vec3(sin(sunZenithAngle), 0, cos(sunZenithAngle));
-    const vec3 cameraPos=vec3(0,0,cameraAltitude);
-    const bool viewRayIntersectsGround=rayIntersectsGround(cameraViewDir.z, cameraAltitude);
+    CONST vec3 sunDir=vec3(sin(sunZenithAngle), 0, cos(sunZenithAngle));
+    CONST vec3 cameraPos=vec3(0,0,cameraAltitude);
+    CONST bool viewRayIntersectsGround=rayIntersectsGround(cameraViewDir.z, cameraAltitude);
 
-    const float radialIntegrInterval=distanceToNearestAtmosphereBoundary(cameraViewDir.z, cameraAltitude,
+    CONST float radialIntegrInterval=distanceToNearestAtmosphereBoundary(cameraViewDir.z, cameraAltitude,
                                                                          viewRayIntersectsGround);
 
-    const int directionIndex=int(gl_FragCoord.x);
-    const float radialDistIndex=gl_FragCoord.y;
+    CONST int directionIndex=int(gl_FragCoord.x);
+    CONST float radialDistIndex=gl_FragCoord.y;
 
     // Using midpoint rule for quadrature
-    const float dl=radialIntegrInterval/radialIntegrationPoints;
-    const float dist=(radialDistIndex+0.5)*dl;
-    const vec4 scDensity=computeDoubleScatteringEclipsedDensitySample(directionIndex, cameraViewDir, cameraPos+cameraViewDir*dist,
+    CONST float dl=radialIntegrInterval/radialIntegrationPoints;
+    CONST float dist=(radialDistIndex+0.5)*dl;
+    CONST vec4 scDensity=computeDoubleScatteringEclipsedDensitySample(directionIndex, cameraViewDir, cameraPos+cameraViewDir*dist,
                                                                       sunDir, moonPositionRelativeToSunAzimuth);
-    const vec4 xmittance=transmittance(cameraViewDir.z, cameraAltitude, dist, viewRayIntersectsGround);
+    CONST vec4 xmittance=transmittance(cameraViewDir.z, cameraAltitude, dist, viewRayIntersectsGround);
     partialRadiance = scDensity*xmittance*dl;
 
 }

--- a/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/3/densities.frag
+++ b/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/3/densities.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // densities.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,20 +45,20 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // densities.frag
+#line 4 0 // densities.frag
 float scattererNumberDensity_molecules(float altitude)
 {
-        const float rayleighScaleHeight=8*km;
+        CONST float rayleighScaleHeight=8*km;
         return 3.08458e25*exp(-1/rayleighScaleHeight * altitude);
 }
 float scattererNumberDensity_aerosols(float altitude)
 {
-        const float mieScaleHeight=1.2*km;
+        CONST float mieScaleHeight=1.2*km;
         return 1.03333e8*exp(-1/mieScaleHeight*altitude);
 }
 float absorberNumberDensity_ozone(float altitude)
 {
-        const float totalOzoneAmount=370*dobsonUnit;
+        CONST float totalOzoneAmount=370*dobsonUnit;
 
         float density;
 

--- a/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/3/direct-irradiance.frag
+++ b/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/3/direct-irradiance.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // direct-irradiance.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,8 +45,8 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // direct-irradiance.frag
-#line 1 2 // texture-sampling-functions.h.glsl
+#line 4 0 // direct-irradiance.frag
+#line 1 3 // texture-sampling-functions.h.glsl
 #ifndef INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 #define INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float altitude);
@@ -47,7 +58,7 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                 const int scatteringOrder);
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 #endif
-#line 6 0 // direct-irradiance.frag
+#line 5 0 // direct-irradiance.frag
 
 vec4 computeDirectGroundIrradiance(const float cosSunZenithAngle, const float altitude)
 {
@@ -58,7 +69,7 @@ vec4 computeDirectGroundIrradiance(const float cosSunZenithAngle, const float al
     //   value in the center of the solar disk, assuming it to be a kind of "average".
     // * When the Sun is partially behind the astronomical horizon, we approximate the radiative view factor (i.e.
     //   cosine factor integrated over the solar disk) with a simple quadratic spline.
-    const float averageCosFactor = cosSunZenithAngle < -sunAngularRadius ? 0
+    CONST float averageCosFactor = cosSunZenithAngle < -sunAngularRadius ? 0
                                       : cosSunZenithAngle > sunAngularRadius ? cosSunZenithAngle
                                       : sqr(cosSunZenithAngle+sunAngularRadius)/(4*sunAngularRadius);
     return solarIrradianceAtTOA * transmittanceToAtmosphereBorder(cosSunZenithAngle, altitude) * averageCosFactor;

--- a/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/3/eclipsed-direct-irradiance.frag
+++ b/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/3/eclipsed-direct-irradiance.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // eclipsed-direct-irradiance.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,8 +45,8 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // eclipsed-direct-irradiance.frag
-#line 1 2 // common-functions.h.glsl
+#line 4 0 // eclipsed-direct-irradiance.frag
+#line 1 3 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -67,16 +78,16 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 6 0 // eclipsed-direct-irradiance.frag
-#line 1 3 // direct-irradiance.h.glsl
+#line 5 0 // eclipsed-direct-irradiance.frag
+#line 1 4 // direct-irradiance.h.glsl
 #ifndef INCLUDE_ONCE_58AEF899_1A84_4A2F_AD71_4E7680B83E29
 #define INCLUDE_ONCE_58AEF899_1A84_4A2F_AD71_4E7680B83E29
 
 vec4 computeDirectGroundIrradiance(const float cosSunZenithAngle, const float altitude);
 
 #endif
-#line 7 0 // eclipsed-direct-irradiance.frag
-#line 1 4 // texture-sampling-functions.h.glsl
+#line 6 0 // eclipsed-direct-irradiance.frag
+#line 1 5 // texture-sampling-functions.h.glsl
 #ifndef INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 #define INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float altitude);
@@ -88,15 +99,15 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                 const int scatteringOrder);
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 #endif
-#line 8 0 // eclipsed-direct-irradiance.frag
+#line 7 0 // eclipsed-direct-irradiance.frag
 
 vec4 calcEclipsedDirectGroundIrradiance(const vec3 pointOnGround, const vec3 sunDir, const vec3 moonPos)
 {
-    const float altitude=0; // we are on the ground, after all
-    const vec3 zenith=normalize(pointOnGround-earthCenter);
-    const float cosSunZenithAngle=dot(sunDir,zenith);
+    CONST float altitude=0; // we are on the ground, after all
+    CONST vec3 zenith=normalize(pointOnGround-earthCenter);
+    CONST float cosSunZenithAngle=dot(sunDir,zenith);
 
-    const float visibility=sunVisibilityDueToMoon(pointOnGround, sunDir, moonPos)
+    CONST float visibility=sunVisibilityDueToMoon(pointOnGround, sunDir, moonPos)
                                                     *
                       // FIXME: this ignores orientation of the crescent of eclipsed Sun WRT horizon
                                     sunVisibility(cosSunZenithAngle, altitude);

--- a/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/3/phase-functions.frag
+++ b/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/3/phase-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // phase-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // phase-functions.frag
+#line 4 0 // phase-functions.frag
 
 vec4 phaseFunction_molecules(float dotViewSun)
 {
@@ -42,9 +53,9 @@ vec4 phaseFunction_molecules(float dotViewSun)
 }
 vec4 phaseFunction_aerosols(float dotViewSun)
 {
-        const float g=0.76;
-        const float g2=g*g;
-        const float k = 3/(8*PI)*(1-g2)/(2+g2);
+        CONST float g=0.76;
+        CONST float g2=g*g;
+        CONST float k = 3/(8*PI)*(1-g2)/(2+g2);
         return vec4(k * (1+sqr(dotViewSun)) / pow(1+g2 - 2*g*dotViewSun, 1.5) + 1/((1-dotViewSun)*600+0.05))*0.904;
 }
 vec4 currentPhaseFunction(float dotViewSun) { return phaseFunction_aerosols(dotViewSun); }

--- a/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/3/single-scattering-eclipsed.frag
+++ b/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/3/single-scattering-eclipsed.frag
@@ -1,7 +1,21 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
 
-#line 1 1 // const.h.glsl
+
+
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 6 0 // single-scattering-eclipsed.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,15 +48,15 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // single-scattering-eclipsed.frag
-#line 1 2 // densities.h.glsl
+#line 7 0 // single-scattering-eclipsed.frag
+#line 1 3 // densities.h.glsl
 float scattererNumberDensity_molecules(float altitude);
 float scattererNumberDensity_aerosols(float altitude);
 float absorberNumberDensity_ozone(float altitude);
 vec4 scatteringCrossSection();
 float scattererDensity(float altitude);
-#line 6 0 // single-scattering-eclipsed.frag
-#line 1 3 // common-functions.h.glsl
+#line 8 0 // single-scattering-eclipsed.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -74,8 +88,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // single-scattering-eclipsed.frag
-#line 1 4 // texture-sampling-functions.h.glsl
+#line 9 0 // single-scattering-eclipsed.frag
+#line 1 5 // texture-sampling-functions.h.glsl
 #ifndef INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 #define INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float altitude);
@@ -87,12 +101,12 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                 const int scatteringOrder);
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 #endif
-#line 8 0 // single-scattering-eclipsed.frag
-#line 1 5 // phase-functions.h.glsl
+#line 10 0 // single-scattering-eclipsed.frag
+#line 1 6 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 9 0 // single-scattering-eclipsed.frag
+#line 11 0 // single-scattering-eclipsed.frag
 
 float cosZenithAngle(vec3 origin, vec3 direction)
 {
@@ -105,13 +119,13 @@ vec4 computeSingleScatteringIntegrandEclipsed(const float cosSunZenithAngle, con
                                               const float dist, const bool viewRayIntersectsGround,
                                               const vec3 scatterer, const vec3 sunDir, const vec3 moonPos)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle here the case when the
     // endpoint of the view ray intentionally appears in outer space.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosSunZenithAngleAtDist=clampCosine((r*cosSunZenithAngle+dist*dotViewSun)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosSunZenithAngleAtDist=clampCosine((r*cosSunZenithAngle+dist*dotViewSun)/(earthRadius+altAtDist));
 
-    const vec4 xmittance=transmittance(cosViewZenithAngle, altitude, dist, viewRayIntersectsGround)
+    CONST vec4 xmittance=transmittance(cosViewZenithAngle, altitude, dist, viewRayIntersectsGround)
                                                     *
                          transmittanceToAtmosphereBorder(cosSunZenithAngleAtDist, altAtDist)
                                                     *
@@ -133,19 +147,19 @@ vec4 computeSingleScatteringIntegrandEclipsed(const float cosSunZenithAngle, con
 vec4 computeSingleScatteringEclipsed(const vec3 camera, const vec3 viewDir, const vec3 sunDir, const vec3 moonPos,
                                      const bool viewRayIntersectsGround)
 {
-    const float cosViewZenithAngle=cosZenithAngle(camera,viewDir);
-    const float cosSunZenithAngle=cosZenithAngle(camera,sunDir);
-    const float altitude=pointAltitude(camera);
-    const float dotViewSun=dot(viewDir,sunDir);
-    const float integrInterval=distanceToNearestAtmosphereBoundary(cosViewZenithAngle, altitude,
+    CONST float cosViewZenithAngle=cosZenithAngle(camera,viewDir);
+    CONST float cosSunZenithAngle=cosZenithAngle(camera,sunDir);
+    CONST float altitude=pointAltitude(camera);
+    CONST float dotViewSun=dot(viewDir,sunDir);
+    CONST float integrInterval=distanceToNearestAtmosphereBoundary(cosViewZenithAngle, altitude,
                                                                    viewRayIntersectsGround);
 
     // Using the midpoint rule for quadrature
     vec4 spectrum=vec4(0);
-    const float dl=integrInterval/radialIntegrationPoints;
+    CONST float dl=integrInterval/radialIntegrationPoints;
     for(int n=0; n<radialIntegrationPoints; ++n)
     {
-        const float dist=(n+0.5)*dl;
+        CONST float dist=(n+0.5)*dl;
         spectrum += computeSingleScatteringIntegrandEclipsed(cosSunZenithAngle, cosViewZenithAngle, dotViewSun,
                                                              altitude, dist, viewRayIntersectsGround,
                                                              camera+viewDir*dist, sunDir, moonPos);

--- a/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/3/texture-coordinates.frag
+++ b/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/3/texture-coordinates.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-coordinates.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,8 +45,8 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // texture-coordinates.frag
-#line 1 2 // texture-coordinates.h.glsl
+#line 4 0 // texture-coordinates.frag
+#line 1 3 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -104,8 +115,8 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 6 0 // texture-coordinates.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-coordinates.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -137,7 +148,7 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-coordinates.frag
+#line 6 0 // texture-coordinates.frag
 
 const float LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA=sqrt(atmosphereHeight*(atmosphereHeight+2*earthRadius));
 
@@ -205,18 +216,18 @@ vec3 indicesToTexCoords(const vec3 indices, const vec3 texSizes)
 
 TransmittanceTexVars transmittanceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
+    CONST float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
                                 texCoordToUnitRange(texCoord.t,transmittanceTextureSize.t);
     // Distance from Earth center to camera
-    const float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
-    const float altitude=r-earthRadius;
+    CONST float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
+    CONST float altitude=r-earthRadius;
 
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
     // distance to border of visible atmosphere from the view point
-    const float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
+    CONST float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
     // d==0 can happen when altitude==atmosphereHeight
-    const float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
+    CONST float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
     return TransmittanceTexVars(cosVZA,altitude);
 }
 
@@ -235,53 +246,53 @@ vec2 transmittanceTexVarsToTexCoord(const float cosVZA, float altitude)
     if(altitude<0)
         altitude=0;
 
-    const float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
+    CONST float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
                                       transmittanceTextureSize.t);
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
-    const float d=distanceToAtmosphereBorder(cosVZA,altitude);
-    const float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float d=distanceToAtmosphereBorder(cosVZA,altitude);
+    CONST float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
     return vec2(s,t);
 }
 
 // Output: vec2(cos(sunZenithAngle), altitude)
 IrradianceTexVars irradianceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
-    const float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
+    CONST float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
+    CONST float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
     return IrradianceTexVars(cosSZA,alt);
 }
 
 vec2 irradianceTexVarsToTexCoord(const float cosSunZenithAngle, const float altitude)
 {
-    const float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
-    const float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
+    CONST float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
+    CONST float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
     return vec2(s,t);
 }
 
 float cosSZAToUnitRangeTexCoord(const float cosSunZenithAngle)
 {
     // Distance to top atmosphere border along the ray groundUnderCamera-sun: (altitude, cosSunZenithAngle)
-    const float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name
-    const float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
+    CONST float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
     // TODO: choose a more descriptive name
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     return max(0.,1-a/A)/(a+1);
 }
 
 float unitRangeTexCoordToCosSZA(const float texCoord)
 {
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float a=(A-A*texCoord)/(1+A*texCoord);
-    const float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
+    CONST float a=(A-A*texCoord)/(1+A*texCoord);
+    CONST float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
     return distFromGroundToTopAtmoBorder==0 ? 1 :
         clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distFromGroundToTopAtmoBorder)) /
                     (2*earthRadius*distFromGroundToTopAtmoBorder));
@@ -292,24 +303,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
                                                const float dotViewSun, const float altitude,
                                                const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -317,24 +328,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float dotVSCoord=(dotViewSun+1)/2;
+    CONST float dotVSCoord=(dotViewSun+1)/2;
 
     // ------------------------------------
-    const float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
+    CONST float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
 
     return Scattering4DCoords(cosSZACoord, cosVZACoord, dotVSCoord, altCoord, viewRayIntersectsGround);
 }
 
 TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
@@ -342,16 +353,16 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture coordinates we combine into a single sampler3D coordinate.
-    const float texW = scatteringTextureSize[1];
-    const float texH = scatteringTextureSize[2];
-    const float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
-    const vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
+    CONST float texW = scatteringTextureSize[1];
+    CONST float texH = scatteringTextureSize[2];
+    CONST float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
+    CONST vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
                                         ceil (cosSZAIndex)*texW+coords.dotViewSun*(texW-1)) / (texW*texH-1);
-    const vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
+    CONST vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
 
-    const float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
+    CONST float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
 
-    const float alphaUpper=fract(cosSZAIndex);
+    CONST float alphaUpper=fract(cosSZAIndex);
     return TexCoordPair(vec3(cosVZAtc, combinedCoord.x, altitude), float(1-alphaUpper),
                         vec3(cosVZAtc, combinedCoord.y, altitude), float(alphaUpper));
 }
@@ -359,9 +370,9 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
+    CONST TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
     return texture(tex, texCoords.lower) * texCoords.alphaLower +
            texture(tex, texCoords.upper) * texCoords.alphaUpper;
 }
@@ -369,17 +380,17 @@ vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const f
 // 3D texture is the 3D single-altitude slice of a 4D texture
 vec3 scattering4DCoordsToTex3DCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2);
 
-    const float dvsSize = scatteringTextureSize[1];
-    const float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
+    CONST float dvsSize = scatteringTextureSize[1];
+    CONST float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
 
-    const float cszaSize = scatteringTextureSize[2];
-    const float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
+    CONST float cszaSize = scatteringTextureSize[2];
+    CONST float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
 
     return vec3(cosVZAtc, dotVStc, cosSZAtc);
 }
@@ -394,39 +405,39 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along dotViewSun coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[1];
-    const float posOfRow = indices[1];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[1];
+    CONST float posOfRow = indices[1];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         indexToTexCoord(currRow, numRows-1),
                                                         texCoordVerbatim));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               indexToTexCoord(currRow, numRows-1),
                                                               texCoordVerbatim));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          indexToTexCoord(currRow, numRows-1),
                                          texCoordVerbatim));
@@ -434,14 +445,14 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
 vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolationGuides01Tex,
                                  const vec3 indices)
 {
-    const float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
+    CONST float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
 
-    const float cosVZAIndex = indices[0];
-    const float dotVSIndex = indices[1];
-    const float currRow = floor(dotVSIndex);
-    const float posBetweenRows = dotVSIndex - currRow;
-    const float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cosVZAIndex = indices[0];
+    CONST float dotVSIndex = indices[1];
+    CONST float currRow = floor(dotVSIndex);
+    CONST float posBetweenRows = dotVSIndex - currRow;
+    CONST float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -449,14 +460,14 @@ vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolat
     indicesCurrRow[1] =     currRow;
     indicesNextRow[1] = min(currRow+1, scatteringTextureSize[1]-1.);
 
-    const vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
-    const vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
+    CONST vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
+    CONST vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
 
-    const vec4 valueCurrRow = texture(tex, coordsCurrRow);
-    const vec4 valueNextRow = texture(tex, coordsNextRow);
-    const float epsilon = 1e-37; // Prevents passing zero to log
-    const vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
-    const vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
+    CONST vec4 valueCurrRow = texture(tex, coordsCurrRow);
+    CONST vec4 valueNextRow = texture(tex, coordsNextRow);
+    CONST float epsilon = 1e-37; // Prevents passing zero to log
+    CONST vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
+    CONST vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
     return (logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow;
 }
 
@@ -465,37 +476,37 @@ float findGuide02Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along SZA coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[2];
-    const float posOfRow = indices[2];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[2];
+    CONST float posOfRow = indices[2];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
 }
@@ -505,19 +516,19 @@ vec4 sample3DTextureGuided(const sampler3D tex,
                            const float cosSunZenithAngle, const float cosViewZenithAngle,
                            const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
                                                                     dotViewSun, altitude, viewRayIntersectsGround);
     // Handle the external interpolation guides: the guides between a pair of VZA-dotViewSun 2D "pictures".
-    const vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
-    const vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
-    const float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
+    CONST vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
+    CONST float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
 
-    const float cvzaIndex = indices[0];
-    const float cszaIndex = indices[2];
-    const float currRow = floor(cszaIndex);
-    const float posBetweenRows = cszaIndex - currRow;
-    const float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cvzaIndex = indices[0];
+    CONST float cszaIndex = indices[2];
+    CONST float currRow = floor(cszaIndex);
+    CONST float posBetweenRows = cszaIndex - currRow;
+    CONST float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -526,58 +537,58 @@ vec4 sample3DTextureGuided(const sampler3D tex,
     indicesNextRow[2] = min(currRow+1, scatteringTextureSize[2]-1);
 
     // The caller will handle the internal interpolation guides: the ones between rows in each 2D "picture".
-    const vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
-    const vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
+    CONST vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
+    CONST vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
     return exp((logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow);
 }
 
 vec4 sample3DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
     return texture(tex, texCoords);
 }
 
 ScatteringTexVars scatteringTex4DCoordsToTexVars(const Scattering4DCoords coords)
 {
-    const float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
     // ------------------------------------
     float cosViewZenithAngle;
     if(coords.viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
     // ------------------------------------
-    const float dotViewSun=coords.dotViewSun*2-1;
+    CONST float dotViewSun=coords.dotViewSun*2-1;
 
     // ------------------------------------
-    const float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
+    CONST float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
 
     return ScatteringTexVars(cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, coords.viewRayIntersectsGround);
 }
 
 Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 {
-    const vec4 indexMax=scatteringTextureSize-vec4(1);
+    CONST vec4 indexMax=scatteringTextureSize-vec4(1);
     Scattering4DCoords coords4d;
     coords4d.viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
     // The following formulas assume that scatteringTextureSize[0] is even. For odd sizes they would change.
@@ -593,8 +604,8 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture indices we combine into a single sampler3D coordinate.
-    const float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
-    const float combinedIndex=texIndices[1];
+    CONST float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
+    CONST float combinedIndex=texIndices[1];
     coords4d.dotViewSun=mod(combinedIndex,texW)/(texW-1);
     coords4d.cosSunZenithAngle=floor(combinedIndex/texW)/(texH-1);
 
@@ -608,11 +619,11 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
 ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 {
-    const Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
+    CONST Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
     ScatteringTexVars vars=scatteringTex4DCoordsToTexVars(coords4d);
     // Clamp dotViewSun to its valid range of values, given cosViewZenithAngle and cosSunZenithAngle. This is
     // needed to prevent NaNs when computing the scattering texture.
-    const float cosVZA=vars.cosViewZenithAngle,
+    CONST float cosVZA=vars.cosViewZenithAngle,
                 cosSZA=vars.cosSunZenithAngle;
     vars.dotViewSun=clamp(vars.dotViewSun,
                           cosVZA*cosSZA-safeSqrt((1-sqr(cosVZA))*(1-sqr(cosSZA))),
@@ -622,54 +633,54 @@ ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 
 EclipseScatteringTexVars eclipseTexCoordsToTexVars(const vec2 texCoords, const float altitude)
 {
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
-    const bool viewRayIntersectsGround = texCoords.t<0.5;
+    CONST bool viewRayIntersectsGround = texCoords.t<0.5;
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
-    const float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
+    CONST float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
     return EclipseScatteringTexVars(azimuthRelativeToSun, cosViewZenithAngle, viewRayIntersectsGround);
 }
 
 EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                                    const float altitude, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -677,13 +688,13 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
-    const float azimuthCoord = azimuthRelativeToSun/(2*PI);
+    CONST float azimuthCoord = azimuthRelativeToSun/(2*PI);
 
     return EclipseScattering2DCoords(azimuthCoord, cosVZACoord);
 }
@@ -691,14 +702,14 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
 vec2 eclipseTexVarsToTexCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                const float altitude, const bool viewRayIntersectsGround, const vec2 texSize)
 {
-    const EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+    CONST EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                                     viewRayIntersectsGround);
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2);
-    const float azimuthTC = coords.azimuth + 1/(2*texSize.s);
+    CONST float azimuthTC = coords.azimuth + 1/(2*texSize.s);
 
     return vec2(azimuthTC, cosVZAtc);
 }
@@ -707,42 +718,42 @@ vec4 sampleEclipseDoubleScattering3DTexture(const sampler3D tex, const float cos
                                             const float cosViewZenithAngle, const float azimuthRelativeToSun,
                                             const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
+    CONST vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
                                                   eclipsedDoubleScatteringTextureSize.st);
-    const float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
-    const vec3 texCoords=vec3(coords2d, cosSZACoord);
+    CONST float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
+    CONST vec3 texCoords=vec3(coords2d, cosSZACoord);
 
     return texture(tex, texCoords);
 }
 
 LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 texIndices)
 {
-    const vec2 indexMax=lightPollutionTextureSize-vec2(1);
+    CONST vec2 indexMax=lightPollutionTextureSize-vec2(1);
 
-    const float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
-    const float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
+    CONST float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
-    const bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
-    const float cosViewZenithAngleCoord = viewRayIntersectsGround ?
+    CONST bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
+    CONST float cosViewZenithAngleCoord = viewRayIntersectsGround ?
                                    1-2*texIndices[0]/(indexMax[0]-1) :
                                    2*(texIndices[0]-1)/(indexMax[0]-1)-1;
     // ------------------------------------
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
@@ -753,23 +764,23 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 
 LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -777,27 +788,27 @@ LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, con
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     return LightPollution2DCoords(cosVZACoord, altCoord);
 }
 
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
-    const vec2 texSize = lightPollutionTextureSize;
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 texSize = lightPollutionTextureSize;
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2);
-    const float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
+    CONST float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
     return vec2(cosVZAtc, altitudeTC);
 }

--- a/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/3/texture-sampling-functions.frag
+++ b/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/3/texture-sampling-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-sampling-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,13 +45,13 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // texture-sampling-functions.frag
-#line 1 2 // phase-functions.h.glsl
+#line 4 0 // texture-sampling-functions.frag
+#line 1 3 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 6 0 // texture-sampling-functions.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-sampling-functions.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -72,8 +83,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-sampling-functions.frag
-#line 1 4 // texture-coordinates.h.glsl
+#line 6 0 // texture-sampling-functions.frag
+#line 1 5 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -142,7 +153,7 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 8 0 // texture-sampling-functions.frag
+#line 7 0 // texture-sampling-functions.frag
 
 uniform sampler2D transmittanceTexture;
 uniform sampler2D irradianceTexture;
@@ -154,13 +165,13 @@ uniform sampler2D lightPollutionScatteringTexture;
 
 vec4 irradiance(const float cosSunZenithAngle, const float altitude)
 {
-    const vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
+    CONST vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
     return texture(irradianceTexture, texCoords);
 }
 
 vec4 opticalDepthToAtmosphereBorder(const float cosViewZenithAngle, const float altitude)
 {
-    const vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
+    CONST vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact when looking into nadir from TOA at some values of texture sizes (in particular, size of
     // transmittance texture for altitude being 4096). This happens when I simply call texture(eclipsedScatteringTexture,
@@ -178,11 +189,11 @@ vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float
 vec4 transmittance(const float cosViewZenithAngle, const float altitude, const float dist,
                    const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle view ray endpoint
     // in space here.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
 
     vec4 depth;
     if(viewRayIntersectsGround)
@@ -201,7 +212,7 @@ vec4 transmittance(const float cosViewZenithAngle, const float altitude, const f
 vec4 calcFirstScattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                          const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
+    CONST vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
                                           dotViewSun, altitude, viewRayIntersectsGround);
     return scattering*currentPhaseFunction(dotViewSun);
 }
@@ -220,6 +231,6 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
 
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     return texture(lightPollutionScatteringTexture, coords);
 }

--- a/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/3/total-scattering-coefficient.frag
+++ b/atmosphere/default/shaders/double-scattering-eclipsed/precomputation/3/total-scattering-coefficient.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // total-scattering-coefficient.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,19 +45,19 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // total-scattering-coefficient.frag
-#line 1 2 // densities.h.glsl
+#line 4 0 // total-scattering-coefficient.frag
+#line 1 3 // densities.h.glsl
 float scattererNumberDensity_molecules(float altitude);
 float scattererNumberDensity_aerosols(float altitude);
 float absorberNumberDensity_ozone(float altitude);
 vec4 scatteringCrossSection();
 float scattererDensity(float altitude);
-#line 6 0 // total-scattering-coefficient.frag
-#line 1 3 // phase-functions.h.glsl
+#line 5 0 // total-scattering-coefficient.frag
+#line 1 4 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 7 0 // total-scattering-coefficient.frag
+#line 6 0 // total-scattering-coefficient.frag
 
 vec4 totalScatteringCoefficient(float altitude, float dotViewInc)
 {

--- a/atmosphere/default/shaders/double-scattering-eclipsed/precomputed/common-functions.frag
+++ b/atmosphere/default/shaders/double-scattering-eclipsed/precomputed/common-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // common-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // common-functions.frag
+#line 4 0 // common-functions.frag
 
 bool dbgDataPresent=false;
 bool debugDataPresent()
@@ -69,7 +80,7 @@ void setDebugData(float a,float b, float c, float d)
 
 void swap(inout float x, inout float y)
 {
-    const float t = x;
+    CONST float t = x;
     x = y;
     y = t;
 }
@@ -83,7 +94,7 @@ float safeSqrt(const float x)
 
 float safeAtan(const float y, const float x)
 {
-    const float a = atan(y,x);
+    CONST float a = atan(y,x);
     return x==0 && y==0 ? 0 : a;
 }
 
@@ -116,23 +127,23 @@ float pointAltitude(vec3 point)
 
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float Ratm=earthRadius+atmosphereHeight;
-    const float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float Ratm=earthRadius+atmosphereHeight;
+    CONST float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float distanceToGround(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(-safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float cosZenithAngleOfHorizon(const float altitude)
 {
-    const float R=earthRadius;
-    const float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
+    CONST float R=earthRadius;
+    CONST float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
     return -sqrt(2*h*R+sqr(h))/(R+h);
 }
 
@@ -151,8 +162,8 @@ float distanceToNearestAtmosphereBoundary(const float cosZenithAngle, const floa
 float sunVisibility(const float cosSunZenithAngle, float altitude)
 {
     if(altitude<0) altitude=0;
-    const float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
-    const float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
+    CONST float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
+    CONST float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
     /* Approximating visible fraction of solar disk by smoothstep between the position of the Sun
      * touching the horizon by its upper part and the position with lower part touching the horizon.
      * The calculation assumes that solar angular radius is small and thus approximately equals its sine.
@@ -182,13 +193,13 @@ float circlesIntersectionArea(float R1, float R2, float d)
 
 float angleBetween(const vec3 a, const vec3 b)
 {
-    const float d=dot(a,b);
-    const float c=length(cross(a,b));
+    CONST float d=dot(a,b);
+    CONST float c=length(cross(a,b));
     // To avoid loss of precision, don't use dot product near the singularity
     // of acos, and cross product near the singularity of asin
     if(abs(d) < abs(c))
         return acos(d/(length(a)*length(b)));
-    const float smallerAngle = asin(c/(length(a)*length(b)));
+    CONST float smallerAngle = asin(c/(length(a)*length(b)));
     if(d<0) return PI-smallerAngle;
     return smallerAngle;
 }
@@ -205,11 +216,11 @@ float moonAngularRadius(const vec3 cameraPosition, const vec3 moonPosition)
 
 float visibleSolidAngleOfSun(const vec3 camera, const vec3 sunDir, const vec3 moonPos)
 {
-    const float Rs=sunAngularRadius;
-    const float Rm=moonAngularRadius(camera,moonPos);
+    CONST float Rs=sunAngularRadius;
+    CONST float Rm=moonAngularRadius(camera,moonPos);
     float visibleSolidAngle=PI*sqr(Rs);
 
-    const float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
+    CONST float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
     if(dSM<Rs+Rm)
     {
         visibleSolidAngle -= circlesIntersectionArea(Rm,Rs,dSM);
@@ -229,12 +240,12 @@ float sphereIntegrationSolidAngleDifferential(const int pointCountOnSphere)
 }
 vec3 sphereIntegrationSampleDir(const int index, const int pointCountOnSphere)
 {
-    const float goldenRatio=1.6180339887499;
+    CONST float goldenRatio=1.6180339887499;
     // The range of n is 0.5, 1.5, ..., pointCountOnSphere-0.5
-    const float n=index+0.5;
+    CONST float n=index+0.5;
     // Explanation of the Fibonacci grid generation can be seen at https://stackoverflow.com/a/44164075/673852
-    const float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
-    const float azimuth=n*(2*PI*goldenRatio);
+    CONST float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
+    CONST float azimuth=n*(2*PI*goldenRatio);
     return vec3(cos(azimuth)*sin(zenithAngle),
                 sin(azimuth)*sin(zenithAngle),
                 cos(zenithAngle));

--- a/atmosphere/default/shaders/double-scattering-eclipsed/precomputed/render.frag
+++ b/atmosphere/default/shaders/double-scattering-eclipsed/precomputed/render.frag
@@ -1,7 +1,21 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
 
-#line 1 1 // const.h.glsl
+
+
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 6 0 // render.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,11 +48,11 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // render.frag
-#line 1 2 // calc-view-dir.h.glsl
+#line 7 0 // render.frag
+#line 1 3 // calc-view-dir.h.glsl
 vec3 calcViewDir();
-#line 6 0 // render.frag
-#line 1 3 // common-functions.h.glsl
+#line 8 0 // render.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -70,11 +84,11 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // render.frag
+#line 9 0 // render.frag
 
 
 
-#line 1 4 // texture-coordinates.h.glsl
+#line 1 5 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -143,10 +157,10 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 11 0 // render.frag
-#line 1 5 // radiance-to-luminance.h.glsl
+#line 13 0 // render.frag
+#line 1 6 // radiance-to-luminance.h.glsl
 const mat4 radianceToLuminance=mat4(19.8756237,7.17745161,0,0.0937032327,  2.13895917,0.772417068,0,0.0149318045,  0.241072536,0.0870557055,0,0,  0.0133876652,0.00483453181,0,0);
-#line 12 0 // render.frag
+#line 14 0 // render.frag
 
 
 
@@ -183,18 +197,18 @@ void main()
     // this approximation has the same order of magnitude as the assumption that the Earth and its atmosphere
     // are spherical.
     float altitude = max(cameraPosition.z, 0.);
-    const vec3 oldCamPos=cameraPosition;
+    CONST vec3 oldCamPos=cameraPosition;
     // Hide the uniform with this name, thus effectively modifying it for the following code
     vec3 cameraPosition=vec3(oldCamPos.xy, altitude);
 
     bool lookingIntoAtmosphere=true;
     if(altitude>atmosphereHeight)
     {
-        const vec3 p = cameraPosition - earthCenter;
-        const float p_dot_v = dot(p, viewDir);
-        const float p_dot_p = dot(p, p);
-        const float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
-        const float distanceToTOA = -p_dot_v - sqrt(sqr(earthRadius+atmosphereHeight) - squaredDistBetweenViewRayAndEarthCenter);
+        CONST vec3 p = cameraPosition - earthCenter;
+        CONST float p_dot_v = dot(p, viewDir);
+        CONST float p_dot_p = dot(p, p);
+        CONST float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
+        CONST float distanceToTOA = -p_dot_v - sqrt(sqr(earthRadius+atmosphereHeight) - squaredDistBetweenViewRayAndEarthCenter);
         if(distanceToTOA>=0)
         {
             cameraPosition += viewDir*distanceToTOA;
@@ -202,7 +216,7 @@ void main()
         }
         else
         {
-#if RENDERING_ANY_ZERO_SCATTERING
+#if 0 /*RENDERING_ANY_ZERO_SCATTERING*/
             lookingIntoAtmosphere=false;
 #else
             luminance=vec4(0);
@@ -212,16 +226,16 @@ void main()
         }
     }
 
-    const vec3 zenith=normalize(cameraPosition-earthCenter);
+    CONST vec3 zenith=normalize(cameraPosition-earthCenter);
     float cosViewZenithAngle=dot(zenith,viewDir);
 
     bool viewRayIntersectsGround=false;
     {
-        const vec3 p = cameraPosition - earthCenter;
-        const float p_dot_v = dot(p, viewDir);
-        const float p_dot_p = dot(p, p);
-        const float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
-        const float distanceToIntersection = -p_dot_v - sqrt(sqr(earthRadius) - squaredDistBetweenViewRayAndEarthCenter);
+        CONST vec3 p = cameraPosition - earthCenter;
+        CONST float p_dot_v = dot(p, viewDir);
+        CONST float p_dot_p = dot(p, p);
+        CONST float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
+        CONST float distanceToIntersection = -p_dot_v - sqrt(sqr(earthRadius) - squaredDistBetweenViewRayAndEarthCenter);
         // altitude==0 is a special case where distance to intersection calculation
         // is unreliable (has a lot of noise in its sign), so check it separately
         if(distanceToIntersection>0 || (altitude==0 && cosViewZenithAngle<0))
@@ -232,11 +246,11 @@ void main()
     // Aside from aesthetics, this affects brightness input to Stellarium's tone mapper.
     if(pseudoMirrorSkyBelowHorizon && viewRayIntersectsGround)
     {
-        const float horizonCZA = cosZenithAngleOfHorizon(altitude);
-        const float viewElev  = asin(clampCosine(cosViewZenithAngle));
-        const float horizElev = asin(clampCosine(horizonCZA));
-        const float newViewElev = 2*horizElev - viewElev;
-        const float viewDirXYnorm = length(viewDir-zenith*cosViewZenithAngle);
+        CONST float horizonCZA = cosZenithAngleOfHorizon(altitude);
+        CONST float viewElev  = asin(clampCosine(cosViewZenithAngle));
+        CONST float horizElev = asin(clampCosine(horizonCZA));
+        CONST float newViewElev = 2*horizElev - viewElev;
+        CONST float viewDirXYnorm = length(viewDir-zenith*cosViewZenithAngle);
         if(viewDirXYnorm == 0)
         {
             viewDir = zenith;
@@ -255,27 +269,27 @@ void main()
         viewRayIntersectsGround = false;
     }
 
-    const float cosSunZenithAngle =dot(zenith,sunDirection);
-    const float dotViewSun=dot(viewDir,sunDirection);
+    CONST float cosSunZenithAngle =dot(zenith,sunDirection);
+    CONST float dotViewSun=dot(viewDir,sunDirection);
 
-    const vec3 sunXYunnorm=sunDirection-dot(sunDirection,zenith)*zenith;
-    const vec3 viewXYunnorm=viewDir-dot(viewDir,zenith)*zenith;
-    const vec3 sunXY = sunXYunnorm.x!=0 || sunXYunnorm.y!=0 || sunXYunnorm.z!=0 ? normalize(sunXYunnorm) : vec3(0);
-    const vec3 viewXY = viewXYunnorm.x!=0 || viewXYunnorm.y!=0 || viewXYunnorm.z!=0 ? normalize(viewXYunnorm) : vec3(0);
-    const float azimuthRelativeToSun=safeAtan(dot(cross(sunXY, viewXY), zenith), dot(sunXY, viewXY));
+    CONST vec3 sunXYunnorm=sunDirection-dot(sunDirection,zenith)*zenith;
+    CONST vec3 viewXYunnorm=viewDir-dot(viewDir,zenith)*zenith;
+    CONST vec3 sunXY = sunXYunnorm.x!=0 || sunXYunnorm.y!=0 || sunXYunnorm.z!=0 ? normalize(sunXYunnorm) : vec3(0);
+    CONST vec3 viewXY = viewXYunnorm.x!=0 || viewXYunnorm.y!=0 || viewXYunnorm.z!=0 ? normalize(viewXYunnorm) : vec3(0);
+    CONST float azimuthRelativeToSun=safeAtan(dot(cross(sunXY, viewXY), zenith), dot(sunXY, viewXY));
 
-#if RENDERING_ZERO_SCATTERING
+#if 0 /*RENDERING_ZERO_SCATTERING*/
     vec4 radiance;
     if(viewRayIntersectsGround)
     {
         // XXX: keep in sync with the same code in computeScatteringDensity(), but don't forget about
         //      the difference in the usage of viewDir vs incDir.
-        const float distToGround = distanceToGround(cosViewZenithAngle, altitude);
-        const vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
-        const vec3 groundNormal = normalize(zenith*(earthRadius+altitude)+viewDir*distToGround);
-        const vec4 groundIrradiance = irradiance(dot(groundNormal, sunDirection), 0);
+        CONST float distToGround = distanceToGround(cosViewZenithAngle, altitude);
+        CONST vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
+        CONST vec3 groundNormal = normalize(zenith*(earthRadius+altitude)+viewDir*distToGround);
+        CONST vec4 groundIrradiance = irradiance(dot(groundNormal, sunDirection), 0);
         // Radiation scattered by the ground
-        const float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
+        CONST float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
         radiance = transmittanceToGround*groundAlbedo*groundIrradiance*solarIrradianceFixup*groundBRDF
                  + lightPollutionGroundLuminance*lightPollutionRelativeRadiance;
     }
@@ -292,22 +306,22 @@ void main()
     }
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_ZERO_SCATTERING
+#elif 0 /*RENDERING_ECLIPSED_ZERO_SCATTERING*/
     vec4 radiance;
-    const float dotViewMoon=dot(viewDir,normalize(moonPosition-cameraPosition));
+    CONST float dotViewMoon=dot(viewDir,normalize(moonPosition-cameraPosition));
     if(viewRayIntersectsGround)
     {
         // XXX: keep in sync with the similar code in non-eclipsed zero scattering rendering.
-        const float distToGround = distanceToGround(cosViewZenithAngle, altitude);
-        const vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
-        const vec3 pointOnGround = cameraPosition+viewDir*distToGround;
-        const vec4 directGroundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDirection, moonPosition);
+        CONST float distToGround = distanceToGround(cosViewZenithAngle, altitude);
+        CONST vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
+        CONST vec3 pointOnGround = cameraPosition+viewDir*distToGround;
+        CONST vec4 directGroundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDirection, moonPosition);
         // FIXME: add first-order indirect irradiance too: it's done in non-eclipsed irradiance (in the same
         // conditions: when limited to 2 orders). This should be calculated at the same time when second order
         // is: all the infrastructure is already there.
-        const vec4 groundIrradiance = directGroundIrradiance;
+        CONST vec4 groundIrradiance = directGroundIrradiance;
         // Radiation scattered by the ground
-        const float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
+        CONST float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
         radiance = transmittanceToGround*groundAlbedo*groundIrradiance*solarIrradianceFixup*groundBRDF
                  + lightPollutionGroundLuminance*lightPollutionRelativeRadiance;
     }
@@ -324,35 +338,35 @@ void main()
     }
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_ON_THE_FLY
-    const vec4 scattering=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPosition,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_ON_THE_FLY*/
+    CONST vec4 scattering=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPosition,
                                                           viewRayIntersectsGround);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE
-    const vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE*/
+    CONST vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                      viewRayIntersectsGround, eclipsedSingleScatteringTextureSize);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact at the point where azimuth texture coordinate changes from 1 to 0 (at azimuthRelativeToSun crossing
     // 0). This happens when I simply call texture(eclipsedScatteringTexture, texCoords) without specifying LOD.
     // Apparently, the driver uses the derivative for some reason, even though it shouldn't.
-    const vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
+    CONST vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE
-    const vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
+    CONST vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                      viewRayIntersectsGround, eclipsedSingleScatteringTextureSize);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact at the point where azimuth texture coordinate changes from 1 to 0 (at azimuthRelativeToSun crossing
     // 0). This happens when I simply call texture(eclipsedScatteringTexture, texCoords) without specifying LOD.
     // Apparently, the driver uses the derivative for some reason, even though it shouldn't.
-    const vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
+    CONST vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
     luminance=scattering*currentPhaseFunction(dotViewSun);
-#elif RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_RADIANCE
+#elif 0 /*RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_RADIANCE*/
     vec4 radiance=exp(sampleEclipseDoubleScattering3DTexture(eclipsedDoubleScatteringTexture,
                                                              cosSunZenithAngle, cosViewZenithAngle, azimuthRelativeToSun,
                                                              altitude, viewRayIntersectsGround));
@@ -363,14 +377,14 @@ void main()
     luminance=exp(sampleEclipseDoubleScattering3DTexture(eclipsedDoubleScatteringTexture,
                                                          cosSunZenithAngle, cosViewZenithAngle, azimuthRelativeToSun,
                                                          altitude, viewRayIntersectsGround));
-#elif RENDERING_SINGLE_SCATTERING_ON_THE_FLY
-    const vec4 scattering=computeSingleScattering(cosSunZenithAngle,cosViewZenithAngle,dotViewSun,
+#elif 0 /*RENDERING_SINGLE_SCATTERING_ON_THE_FLY*/
+    CONST vec4 scattering=computeSingleScattering(cosSunZenithAngle,cosViewZenithAngle,dotViewSun,
                                                   altitude,viewRayIntersectsGround);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE
+#elif 0 /*RENDERING_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE*/
     vec4 scattering;
     if(useInterpolationGuides)
     {
@@ -387,7 +401,7 @@ void main()
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE
+#elif 0 /*RENDERING_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
     vec4 scattering;
     if(useInterpolationGuides)
     {
@@ -401,18 +415,18 @@ void main()
                                      dotViewSun, altitude, viewRayIntersectsGround);
     }
     luminance=scattering * (bool(PHASE_FUNCTION_IS_EMBEDDED) ? vec4(1) : currentPhaseFunction(dotViewSun));
-#elif RENDERING_MULTIPLE_SCATTERING_LUMINANCE
+#elif 0 /*RENDERING_MULTIPLE_SCATTERING_LUMINANCE*/
     luminance=sample3DTexture(scatteringTexture, cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, viewRayIntersectsGround);
-#elif RENDERING_MULTIPLE_SCATTERING_RADIANCE
+#elif 0 /*RENDERING_MULTIPLE_SCATTERING_RADIANCE*/
     vec4 radiance=sample3DTexture(scatteringTexture, cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, viewRayIntersectsGround);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_LIGHT_POLLUTION_RADIANCE
+#elif 0 /*RENDERING_LIGHT_POLLUTION_RADIANCE*/
     vec4 radiance=lightPollutionGroundLuminance*lightPollutionScattering(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_LIGHT_POLLUTION_LUMINANCE
+#elif 0 /*RENDERING_LIGHT_POLLUTION_LUMINANCE*/
     luminance=lightPollutionGroundLuminance*lightPollutionScattering(altitude, cosViewZenithAngle, viewRayIntersectsGround);
 #else
 #error What to render?

--- a/atmosphere/default/shaders/double-scattering-eclipsed/precomputed/texture-coordinates.frag
+++ b/atmosphere/default/shaders/double-scattering-eclipsed/precomputed/texture-coordinates.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-coordinates.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,8 +45,8 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // texture-coordinates.frag
-#line 1 2 // texture-coordinates.h.glsl
+#line 4 0 // texture-coordinates.frag
+#line 1 3 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -104,8 +115,8 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 6 0 // texture-coordinates.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-coordinates.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -137,7 +148,7 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-coordinates.frag
+#line 6 0 // texture-coordinates.frag
 
 const float LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA=sqrt(atmosphereHeight*(atmosphereHeight+2*earthRadius));
 
@@ -205,18 +216,18 @@ vec3 indicesToTexCoords(const vec3 indices, const vec3 texSizes)
 
 TransmittanceTexVars transmittanceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
+    CONST float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
                                 texCoordToUnitRange(texCoord.t,transmittanceTextureSize.t);
     // Distance from Earth center to camera
-    const float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
-    const float altitude=r-earthRadius;
+    CONST float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
+    CONST float altitude=r-earthRadius;
 
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
     // distance to border of visible atmosphere from the view point
-    const float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
+    CONST float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
     // d==0 can happen when altitude==atmosphereHeight
-    const float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
+    CONST float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
     return TransmittanceTexVars(cosVZA,altitude);
 }
 
@@ -235,53 +246,53 @@ vec2 transmittanceTexVarsToTexCoord(const float cosVZA, float altitude)
     if(altitude<0)
         altitude=0;
 
-    const float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
+    CONST float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
                                       transmittanceTextureSize.t);
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
-    const float d=distanceToAtmosphereBorder(cosVZA,altitude);
-    const float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float d=distanceToAtmosphereBorder(cosVZA,altitude);
+    CONST float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
     return vec2(s,t);
 }
 
 // Output: vec2(cos(sunZenithAngle), altitude)
 IrradianceTexVars irradianceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
-    const float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
+    CONST float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
+    CONST float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
     return IrradianceTexVars(cosSZA,alt);
 }
 
 vec2 irradianceTexVarsToTexCoord(const float cosSunZenithAngle, const float altitude)
 {
-    const float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
-    const float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
+    CONST float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
+    CONST float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
     return vec2(s,t);
 }
 
 float cosSZAToUnitRangeTexCoord(const float cosSunZenithAngle)
 {
     // Distance to top atmosphere border along the ray groundUnderCamera-sun: (altitude, cosSunZenithAngle)
-    const float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name
-    const float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
+    CONST float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
     // TODO: choose a more descriptive name
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     return max(0.,1-a/A)/(a+1);
 }
 
 float unitRangeTexCoordToCosSZA(const float texCoord)
 {
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float a=(A-A*texCoord)/(1+A*texCoord);
-    const float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
+    CONST float a=(A-A*texCoord)/(1+A*texCoord);
+    CONST float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
     return distFromGroundToTopAtmoBorder==0 ? 1 :
         clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distFromGroundToTopAtmoBorder)) /
                     (2*earthRadius*distFromGroundToTopAtmoBorder));
@@ -292,24 +303,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
                                                const float dotViewSun, const float altitude,
                                                const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -317,24 +328,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float dotVSCoord=(dotViewSun+1)/2;
+    CONST float dotVSCoord=(dotViewSun+1)/2;
 
     // ------------------------------------
-    const float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
+    CONST float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
 
     return Scattering4DCoords(cosSZACoord, cosVZACoord, dotVSCoord, altCoord, viewRayIntersectsGround);
 }
 
 TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
@@ -342,16 +353,16 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture coordinates we combine into a single sampler3D coordinate.
-    const float texW = scatteringTextureSize[1];
-    const float texH = scatteringTextureSize[2];
-    const float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
-    const vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
+    CONST float texW = scatteringTextureSize[1];
+    CONST float texH = scatteringTextureSize[2];
+    CONST float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
+    CONST vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
                                         ceil (cosSZAIndex)*texW+coords.dotViewSun*(texW-1)) / (texW*texH-1);
-    const vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
+    CONST vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
 
-    const float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
+    CONST float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
 
-    const float alphaUpper=fract(cosSZAIndex);
+    CONST float alphaUpper=fract(cosSZAIndex);
     return TexCoordPair(vec3(cosVZAtc, combinedCoord.x, altitude), float(1-alphaUpper),
                         vec3(cosVZAtc, combinedCoord.y, altitude), float(alphaUpper));
 }
@@ -359,9 +370,9 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
+    CONST TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
     return texture(tex, texCoords.lower) * texCoords.alphaLower +
            texture(tex, texCoords.upper) * texCoords.alphaUpper;
 }
@@ -369,17 +380,17 @@ vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const f
 // 3D texture is the 3D single-altitude slice of a 4D texture
 vec3 scattering4DCoordsToTex3DCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2);
 
-    const float dvsSize = scatteringTextureSize[1];
-    const float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
+    CONST float dvsSize = scatteringTextureSize[1];
+    CONST float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
 
-    const float cszaSize = scatteringTextureSize[2];
-    const float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
+    CONST float cszaSize = scatteringTextureSize[2];
+    CONST float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
 
     return vec3(cosVZAtc, dotVStc, cosSZAtc);
 }
@@ -394,39 +405,39 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along dotViewSun coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[1];
-    const float posOfRow = indices[1];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[1];
+    CONST float posOfRow = indices[1];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         indexToTexCoord(currRow, numRows-1),
                                                         texCoordVerbatim));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               indexToTexCoord(currRow, numRows-1),
                                                               texCoordVerbatim));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          indexToTexCoord(currRow, numRows-1),
                                          texCoordVerbatim));
@@ -434,14 +445,14 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
 vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolationGuides01Tex,
                                  const vec3 indices)
 {
-    const float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
+    CONST float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
 
-    const float cosVZAIndex = indices[0];
-    const float dotVSIndex = indices[1];
-    const float currRow = floor(dotVSIndex);
-    const float posBetweenRows = dotVSIndex - currRow;
-    const float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cosVZAIndex = indices[0];
+    CONST float dotVSIndex = indices[1];
+    CONST float currRow = floor(dotVSIndex);
+    CONST float posBetweenRows = dotVSIndex - currRow;
+    CONST float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -449,14 +460,14 @@ vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolat
     indicesCurrRow[1] =     currRow;
     indicesNextRow[1] = min(currRow+1, scatteringTextureSize[1]-1.);
 
-    const vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
-    const vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
+    CONST vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
+    CONST vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
 
-    const vec4 valueCurrRow = texture(tex, coordsCurrRow);
-    const vec4 valueNextRow = texture(tex, coordsNextRow);
-    const float epsilon = 1e-37; // Prevents passing zero to log
-    const vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
-    const vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
+    CONST vec4 valueCurrRow = texture(tex, coordsCurrRow);
+    CONST vec4 valueNextRow = texture(tex, coordsNextRow);
+    CONST float epsilon = 1e-37; // Prevents passing zero to log
+    CONST vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
+    CONST vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
     return (logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow;
 }
 
@@ -465,37 +476,37 @@ float findGuide02Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along SZA coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[2];
-    const float posOfRow = indices[2];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[2];
+    CONST float posOfRow = indices[2];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
 }
@@ -505,19 +516,19 @@ vec4 sample3DTextureGuided(const sampler3D tex,
                            const float cosSunZenithAngle, const float cosViewZenithAngle,
                            const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
                                                                     dotViewSun, altitude, viewRayIntersectsGround);
     // Handle the external interpolation guides: the guides between a pair of VZA-dotViewSun 2D "pictures".
-    const vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
-    const vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
-    const float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
+    CONST vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
+    CONST float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
 
-    const float cvzaIndex = indices[0];
-    const float cszaIndex = indices[2];
-    const float currRow = floor(cszaIndex);
-    const float posBetweenRows = cszaIndex - currRow;
-    const float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cvzaIndex = indices[0];
+    CONST float cszaIndex = indices[2];
+    CONST float currRow = floor(cszaIndex);
+    CONST float posBetweenRows = cszaIndex - currRow;
+    CONST float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -526,58 +537,58 @@ vec4 sample3DTextureGuided(const sampler3D tex,
     indicesNextRow[2] = min(currRow+1, scatteringTextureSize[2]-1);
 
     // The caller will handle the internal interpolation guides: the ones between rows in each 2D "picture".
-    const vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
-    const vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
+    CONST vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
+    CONST vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
     return exp((logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow);
 }
 
 vec4 sample3DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
     return texture(tex, texCoords);
 }
 
 ScatteringTexVars scatteringTex4DCoordsToTexVars(const Scattering4DCoords coords)
 {
-    const float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
     // ------------------------------------
     float cosViewZenithAngle;
     if(coords.viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
     // ------------------------------------
-    const float dotViewSun=coords.dotViewSun*2-1;
+    CONST float dotViewSun=coords.dotViewSun*2-1;
 
     // ------------------------------------
-    const float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
+    CONST float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
 
     return ScatteringTexVars(cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, coords.viewRayIntersectsGround);
 }
 
 Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 {
-    const vec4 indexMax=scatteringTextureSize-vec4(1);
+    CONST vec4 indexMax=scatteringTextureSize-vec4(1);
     Scattering4DCoords coords4d;
     coords4d.viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
     // The following formulas assume that scatteringTextureSize[0] is even. For odd sizes they would change.
@@ -593,8 +604,8 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture indices we combine into a single sampler3D coordinate.
-    const float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
-    const float combinedIndex=texIndices[1];
+    CONST float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
+    CONST float combinedIndex=texIndices[1];
     coords4d.dotViewSun=mod(combinedIndex,texW)/(texW-1);
     coords4d.cosSunZenithAngle=floor(combinedIndex/texW)/(texH-1);
 
@@ -608,11 +619,11 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
 ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 {
-    const Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
+    CONST Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
     ScatteringTexVars vars=scatteringTex4DCoordsToTexVars(coords4d);
     // Clamp dotViewSun to its valid range of values, given cosViewZenithAngle and cosSunZenithAngle. This is
     // needed to prevent NaNs when computing the scattering texture.
-    const float cosVZA=vars.cosViewZenithAngle,
+    CONST float cosVZA=vars.cosViewZenithAngle,
                 cosSZA=vars.cosSunZenithAngle;
     vars.dotViewSun=clamp(vars.dotViewSun,
                           cosVZA*cosSZA-safeSqrt((1-sqr(cosVZA))*(1-sqr(cosSZA))),
@@ -622,54 +633,54 @@ ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 
 EclipseScatteringTexVars eclipseTexCoordsToTexVars(const vec2 texCoords, const float altitude)
 {
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
-    const bool viewRayIntersectsGround = texCoords.t<0.5;
+    CONST bool viewRayIntersectsGround = texCoords.t<0.5;
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
-    const float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
+    CONST float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
     return EclipseScatteringTexVars(azimuthRelativeToSun, cosViewZenithAngle, viewRayIntersectsGround);
 }
 
 EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                                    const float altitude, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -677,13 +688,13 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
-    const float azimuthCoord = azimuthRelativeToSun/(2*PI);
+    CONST float azimuthCoord = azimuthRelativeToSun/(2*PI);
 
     return EclipseScattering2DCoords(azimuthCoord, cosVZACoord);
 }
@@ -691,14 +702,14 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
 vec2 eclipseTexVarsToTexCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                const float altitude, const bool viewRayIntersectsGround, const vec2 texSize)
 {
-    const EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+    CONST EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                                     viewRayIntersectsGround);
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2);
-    const float azimuthTC = coords.azimuth + 1/(2*texSize.s);
+    CONST float azimuthTC = coords.azimuth + 1/(2*texSize.s);
 
     return vec2(azimuthTC, cosVZAtc);
 }
@@ -707,42 +718,42 @@ vec4 sampleEclipseDoubleScattering3DTexture(const sampler3D tex, const float cos
                                             const float cosViewZenithAngle, const float azimuthRelativeToSun,
                                             const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
+    CONST vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
                                                   eclipsedDoubleScatteringTextureSize.st);
-    const float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
-    const vec3 texCoords=vec3(coords2d, cosSZACoord);
+    CONST float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
+    CONST vec3 texCoords=vec3(coords2d, cosSZACoord);
 
     return texture(tex, texCoords);
 }
 
 LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 texIndices)
 {
-    const vec2 indexMax=lightPollutionTextureSize-vec2(1);
+    CONST vec2 indexMax=lightPollutionTextureSize-vec2(1);
 
-    const float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
-    const float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
+    CONST float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
-    const bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
-    const float cosViewZenithAngleCoord = viewRayIntersectsGround ?
+    CONST bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
+    CONST float cosViewZenithAngleCoord = viewRayIntersectsGround ?
                                    1-2*texIndices[0]/(indexMax[0]-1) :
                                    2*(texIndices[0]-1)/(indexMax[0]-1)-1;
     // ------------------------------------
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
@@ -753,23 +764,23 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 
 LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -777,27 +788,27 @@ LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, con
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     return LightPollution2DCoords(cosVZACoord, altCoord);
 }
 
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
-    const vec2 texSize = lightPollutionTextureSize;
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 texSize = lightPollutionTextureSize;
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2);
-    const float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
+    CONST float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
     return vec2(cosVZAtc, altitudeTC);
 }

--- a/atmosphere/default/shaders/eclipsed-zero-order-scattering/0/common-functions.frag
+++ b/atmosphere/default/shaders/eclipsed-zero-order-scattering/0/common-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // common-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // common-functions.frag
+#line 4 0 // common-functions.frag
 
 bool dbgDataPresent=false;
 bool debugDataPresent()
@@ -69,7 +80,7 @@ void setDebugData(float a,float b, float c, float d)
 
 void swap(inout float x, inout float y)
 {
-    const float t = x;
+    CONST float t = x;
     x = y;
     y = t;
 }
@@ -83,7 +94,7 @@ float safeSqrt(const float x)
 
 float safeAtan(const float y, const float x)
 {
-    const float a = atan(y,x);
+    CONST float a = atan(y,x);
     return x==0 && y==0 ? 0 : a;
 }
 
@@ -116,23 +127,23 @@ float pointAltitude(vec3 point)
 
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float Ratm=earthRadius+atmosphereHeight;
-    const float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float Ratm=earthRadius+atmosphereHeight;
+    CONST float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float distanceToGround(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(-safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float cosZenithAngleOfHorizon(const float altitude)
 {
-    const float R=earthRadius;
-    const float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
+    CONST float R=earthRadius;
+    CONST float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
     return -sqrt(2*h*R+sqr(h))/(R+h);
 }
 
@@ -151,8 +162,8 @@ float distanceToNearestAtmosphereBoundary(const float cosZenithAngle, const floa
 float sunVisibility(const float cosSunZenithAngle, float altitude)
 {
     if(altitude<0) altitude=0;
-    const float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
-    const float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
+    CONST float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
+    CONST float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
     /* Approximating visible fraction of solar disk by smoothstep between the position of the Sun
      * touching the horizon by its upper part and the position with lower part touching the horizon.
      * The calculation assumes that solar angular radius is small and thus approximately equals its sine.
@@ -182,13 +193,13 @@ float circlesIntersectionArea(float R1, float R2, float d)
 
 float angleBetween(const vec3 a, const vec3 b)
 {
-    const float d=dot(a,b);
-    const float c=length(cross(a,b));
+    CONST float d=dot(a,b);
+    CONST float c=length(cross(a,b));
     // To avoid loss of precision, don't use dot product near the singularity
     // of acos, and cross product near the singularity of asin
     if(abs(d) < abs(c))
         return acos(d/(length(a)*length(b)));
-    const float smallerAngle = asin(c/(length(a)*length(b)));
+    CONST float smallerAngle = asin(c/(length(a)*length(b)));
     if(d<0) return PI-smallerAngle;
     return smallerAngle;
 }
@@ -205,11 +216,11 @@ float moonAngularRadius(const vec3 cameraPosition, const vec3 moonPosition)
 
 float visibleSolidAngleOfSun(const vec3 camera, const vec3 sunDir, const vec3 moonPos)
 {
-    const float Rs=sunAngularRadius;
-    const float Rm=moonAngularRadius(camera,moonPos);
+    CONST float Rs=sunAngularRadius;
+    CONST float Rm=moonAngularRadius(camera,moonPos);
     float visibleSolidAngle=PI*sqr(Rs);
 
-    const float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
+    CONST float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
     if(dSM<Rs+Rm)
     {
         visibleSolidAngle -= circlesIntersectionArea(Rm,Rs,dSM);
@@ -229,12 +240,12 @@ float sphereIntegrationSolidAngleDifferential(const int pointCountOnSphere)
 }
 vec3 sphereIntegrationSampleDir(const int index, const int pointCountOnSphere)
 {
-    const float goldenRatio=1.6180339887499;
+    CONST float goldenRatio=1.6180339887499;
     // The range of n is 0.5, 1.5, ..., pointCountOnSphere-0.5
-    const float n=index+0.5;
+    CONST float n=index+0.5;
     // Explanation of the Fibonacci grid generation can be seen at https://stackoverflow.com/a/44164075/673852
-    const float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
-    const float azimuth=n*(2*PI*goldenRatio);
+    CONST float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
+    CONST float azimuth=n*(2*PI*goldenRatio);
     return vec3(cos(azimuth)*sin(zenithAngle),
                 sin(azimuth)*sin(zenithAngle),
                 cos(zenithAngle));

--- a/atmosphere/default/shaders/eclipsed-zero-order-scattering/0/direct-irradiance.frag
+++ b/atmosphere/default/shaders/eclipsed-zero-order-scattering/0/direct-irradiance.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // direct-irradiance.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,8 +45,8 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // direct-irradiance.frag
-#line 1 2 // texture-sampling-functions.h.glsl
+#line 4 0 // direct-irradiance.frag
+#line 1 3 // texture-sampling-functions.h.glsl
 #ifndef INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 #define INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float altitude);
@@ -47,7 +58,7 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                 const int scatteringOrder);
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 #endif
-#line 6 0 // direct-irradiance.frag
+#line 5 0 // direct-irradiance.frag
 
 vec4 computeDirectGroundIrradiance(const float cosSunZenithAngle, const float altitude)
 {
@@ -58,7 +69,7 @@ vec4 computeDirectGroundIrradiance(const float cosSunZenithAngle, const float al
     //   value in the center of the solar disk, assuming it to be a kind of "average".
     // * When the Sun is partially behind the astronomical horizon, we approximate the radiative view factor (i.e.
     //   cosine factor integrated over the solar disk) with a simple quadratic spline.
-    const float averageCosFactor = cosSunZenithAngle < -sunAngularRadius ? 0
+    CONST float averageCosFactor = cosSunZenithAngle < -sunAngularRadius ? 0
                                       : cosSunZenithAngle > sunAngularRadius ? cosSunZenithAngle
                                       : sqr(cosSunZenithAngle+sunAngularRadius)/(4*sunAngularRadius);
     return solarIrradianceAtTOA * transmittanceToAtmosphereBorder(cosSunZenithAngle, altitude) * averageCosFactor;

--- a/atmosphere/default/shaders/eclipsed-zero-order-scattering/0/eclipsed-direct-irradiance.frag
+++ b/atmosphere/default/shaders/eclipsed-zero-order-scattering/0/eclipsed-direct-irradiance.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // eclipsed-direct-irradiance.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,8 +45,8 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // eclipsed-direct-irradiance.frag
-#line 1 2 // common-functions.h.glsl
+#line 4 0 // eclipsed-direct-irradiance.frag
+#line 1 3 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -67,16 +78,16 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 6 0 // eclipsed-direct-irradiance.frag
-#line 1 3 // direct-irradiance.h.glsl
+#line 5 0 // eclipsed-direct-irradiance.frag
+#line 1 4 // direct-irradiance.h.glsl
 #ifndef INCLUDE_ONCE_58AEF899_1A84_4A2F_AD71_4E7680B83E29
 #define INCLUDE_ONCE_58AEF899_1A84_4A2F_AD71_4E7680B83E29
 
 vec4 computeDirectGroundIrradiance(const float cosSunZenithAngle, const float altitude);
 
 #endif
-#line 7 0 // eclipsed-direct-irradiance.frag
-#line 1 4 // texture-sampling-functions.h.glsl
+#line 6 0 // eclipsed-direct-irradiance.frag
+#line 1 5 // texture-sampling-functions.h.glsl
 #ifndef INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 #define INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float altitude);
@@ -88,15 +99,15 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                 const int scatteringOrder);
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 #endif
-#line 8 0 // eclipsed-direct-irradiance.frag
+#line 7 0 // eclipsed-direct-irradiance.frag
 
 vec4 calcEclipsedDirectGroundIrradiance(const vec3 pointOnGround, const vec3 sunDir, const vec3 moonPos)
 {
-    const float altitude=0; // we are on the ground, after all
-    const vec3 zenith=normalize(pointOnGround-earthCenter);
-    const float cosSunZenithAngle=dot(sunDir,zenith);
+    CONST float altitude=0; // we are on the ground, after all
+    CONST vec3 zenith=normalize(pointOnGround-earthCenter);
+    CONST float cosSunZenithAngle=dot(sunDir,zenith);
 
-    const float visibility=sunVisibilityDueToMoon(pointOnGround, sunDir, moonPos)
+    CONST float visibility=sunVisibilityDueToMoon(pointOnGround, sunDir, moonPos)
                                                     *
                       // FIXME: this ignores orientation of the crescent of eclipsed Sun WRT horizon
                                     sunVisibility(cosSunZenithAngle, altitude);

--- a/atmosphere/default/shaders/eclipsed-zero-order-scattering/0/phase-functions.frag
+++ b/atmosphere/default/shaders/eclipsed-zero-order-scattering/0/phase-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // phase-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // phase-functions.frag
+#line 4 0 // phase-functions.frag
 
 vec4 phaseFunction_molecules(float dotViewSun)
 {
@@ -42,8 +53,8 @@ vec4 phaseFunction_molecules(float dotViewSun)
 }
 vec4 phaseFunction_aerosols(float dotViewSun)
 {
-        const float g=0.76;
-        const float g2=g*g;
-        const float k = 3/(8*PI)*(1-g2)/(2+g2);
+        CONST float g=0.76;
+        CONST float g2=g*g;
+        CONST float k = 3/(8*PI)*(1-g2)/(2+g2);
         return vec4(k * (1+sqr(dotViewSun)) / pow(1+g2 - 2*g*dotViewSun, 1.5) + 1/((1-dotViewSun)*600+0.05))*0.904;
 }

--- a/atmosphere/default/shaders/eclipsed-zero-order-scattering/0/render.frag
+++ b/atmosphere/default/shaders/eclipsed-zero-order-scattering/0/render.frag
@@ -1,7 +1,21 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
 
-#line 1 1 // const.h.glsl
+
+
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 6 0 // render.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,11 +48,11 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // render.frag
-#line 1 2 // calc-view-dir.h.glsl
+#line 7 0 // render.frag
+#line 1 3 // calc-view-dir.h.glsl
 vec3 calcViewDir();
-#line 6 0 // render.frag
-#line 1 3 // common-functions.h.glsl
+#line 8 0 // render.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -70,11 +84,11 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // render.frag
+#line 9 0 // render.frag
 
 
 
-#line 1 4 // texture-coordinates.h.glsl
+#line 1 5 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -143,11 +157,11 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 11 0 // render.frag
-#line 1 5 // radiance-to-luminance.h.glsl
+#line 13 0 // render.frag
+#line 1 6 // radiance-to-luminance.h.glsl
 const mat4 radianceToLuminance=mat4(1.38997746,0.0419133306,6.48549128,0,  105.968163,3.00652099,500.960266,142.641495,  3776.24023,119.971481,18207.7598,6412.0166,  6910.01318,981.06665,37504.0586,26741.9102);
-#line 12 0 // render.frag
-#line 1 6 // texture-sampling-functions.h.glsl
+#line 14 0 // render.frag
+#line 1 7 // texture-sampling-functions.h.glsl
 #ifndef INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 #define INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float altitude);
@@ -159,15 +173,15 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                 const int scatteringOrder);
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 #endif
-#line 13 0 // render.frag
-#line 1 7 // eclipsed-direct-irradiance.h.glsl
+#line 15 0 // render.frag
+#line 1 8 // eclipsed-direct-irradiance.h.glsl
 #ifndef INCLUDE_ONCE_8E9C53B3_83A0_4DD7_9106_32A13BD8935D
 #define INCLUDE_ONCE_8E9C53B3_83A0_4DD7_9106_32A13BD8935D
 
 vec4 calcEclipsedDirectGroundIrradiance(const vec3 pointOnGround, const vec3 sunDir, const vec3 moonPos);
 
 #endif
-#line 14 0 // render.frag
+#line 16 0 // render.frag
 
 
 uniform sampler3D scatteringTextureInterpolationGuides01;
@@ -202,18 +216,18 @@ void main()
     // this approximation has the same order of magnitude as the assumption that the Earth and its atmosphere
     // are spherical.
     float altitude = max(cameraPosition.z, 0.);
-    const vec3 oldCamPos=cameraPosition;
+    CONST vec3 oldCamPos=cameraPosition;
     // Hide the uniform with this name, thus effectively modifying it for the following code
     vec3 cameraPosition=vec3(oldCamPos.xy, altitude);
 
     bool lookingIntoAtmosphere=true;
     if(altitude>atmosphereHeight)
     {
-        const vec3 p = cameraPosition - earthCenter;
-        const float p_dot_v = dot(p, viewDir);
-        const float p_dot_p = dot(p, p);
-        const float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
-        const float distanceToTOA = -p_dot_v - sqrt(sqr(earthRadius+atmosphereHeight) - squaredDistBetweenViewRayAndEarthCenter);
+        CONST vec3 p = cameraPosition - earthCenter;
+        CONST float p_dot_v = dot(p, viewDir);
+        CONST float p_dot_p = dot(p, p);
+        CONST float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
+        CONST float distanceToTOA = -p_dot_v - sqrt(sqr(earthRadius+atmosphereHeight) - squaredDistBetweenViewRayAndEarthCenter);
         if(distanceToTOA>=0)
         {
             cameraPosition += viewDir*distanceToTOA;
@@ -231,16 +245,16 @@ void main()
         }
     }
 
-    const vec3 zenith=normalize(cameraPosition-earthCenter);
+    CONST vec3 zenith=normalize(cameraPosition-earthCenter);
     float cosViewZenithAngle=dot(zenith,viewDir);
 
     bool viewRayIntersectsGround=false;
     {
-        const vec3 p = cameraPosition - earthCenter;
-        const float p_dot_v = dot(p, viewDir);
-        const float p_dot_p = dot(p, p);
-        const float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
-        const float distanceToIntersection = -p_dot_v - sqrt(sqr(earthRadius) - squaredDistBetweenViewRayAndEarthCenter);
+        CONST vec3 p = cameraPosition - earthCenter;
+        CONST float p_dot_v = dot(p, viewDir);
+        CONST float p_dot_p = dot(p, p);
+        CONST float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
+        CONST float distanceToIntersection = -p_dot_v - sqrt(sqr(earthRadius) - squaredDistBetweenViewRayAndEarthCenter);
         // altitude==0 is a special case where distance to intersection calculation
         // is unreliable (has a lot of noise in its sign), so check it separately
         if(distanceToIntersection>0 || (altitude==0 && cosViewZenithAngle<0))
@@ -251,11 +265,11 @@ void main()
     // Aside from aesthetics, this affects brightness input to Stellarium's tone mapper.
     if(pseudoMirrorSkyBelowHorizon && viewRayIntersectsGround)
     {
-        const float horizonCZA = cosZenithAngleOfHorizon(altitude);
-        const float viewElev  = asin(clampCosine(cosViewZenithAngle));
-        const float horizElev = asin(clampCosine(horizonCZA));
-        const float newViewElev = 2*horizElev - viewElev;
-        const float viewDirXYnorm = length(viewDir-zenith*cosViewZenithAngle);
+        CONST float horizonCZA = cosZenithAngleOfHorizon(altitude);
+        CONST float viewElev  = asin(clampCosine(cosViewZenithAngle));
+        CONST float horizElev = asin(clampCosine(horizonCZA));
+        CONST float newViewElev = 2*horizElev - viewElev;
+        CONST float viewDirXYnorm = length(viewDir-zenith*cosViewZenithAngle);
         if(viewDirXYnorm == 0)
         {
             viewDir = zenith;
@@ -274,27 +288,27 @@ void main()
         viewRayIntersectsGround = false;
     }
 
-    const float cosSunZenithAngle =dot(zenith,sunDirection);
-    const float dotViewSun=dot(viewDir,sunDirection);
+    CONST float cosSunZenithAngle =dot(zenith,sunDirection);
+    CONST float dotViewSun=dot(viewDir,sunDirection);
 
-    const vec3 sunXYunnorm=sunDirection-dot(sunDirection,zenith)*zenith;
-    const vec3 viewXYunnorm=viewDir-dot(viewDir,zenith)*zenith;
-    const vec3 sunXY = sunXYunnorm.x!=0 || sunXYunnorm.y!=0 || sunXYunnorm.z!=0 ? normalize(sunXYunnorm) : vec3(0);
-    const vec3 viewXY = viewXYunnorm.x!=0 || viewXYunnorm.y!=0 || viewXYunnorm.z!=0 ? normalize(viewXYunnorm) : vec3(0);
-    const float azimuthRelativeToSun=safeAtan(dot(cross(sunXY, viewXY), zenith), dot(sunXY, viewXY));
+    CONST vec3 sunXYunnorm=sunDirection-dot(sunDirection,zenith)*zenith;
+    CONST vec3 viewXYunnorm=viewDir-dot(viewDir,zenith)*zenith;
+    CONST vec3 sunXY = sunXYunnorm.x!=0 || sunXYunnorm.y!=0 || sunXYunnorm.z!=0 ? normalize(sunXYunnorm) : vec3(0);
+    CONST vec3 viewXY = viewXYunnorm.x!=0 || viewXYunnorm.y!=0 || viewXYunnorm.z!=0 ? normalize(viewXYunnorm) : vec3(0);
+    CONST float azimuthRelativeToSun=safeAtan(dot(cross(sunXY, viewXY), zenith), dot(sunXY, viewXY));
 
-#if RENDERING_ZERO_SCATTERING
+#if 0 /*RENDERING_ZERO_SCATTERING*/
     vec4 radiance;
     if(viewRayIntersectsGround)
     {
         // XXX: keep in sync with the same code in computeScatteringDensity(), but don't forget about
         //      the difference in the usage of viewDir vs incDir.
-        const float distToGround = distanceToGround(cosViewZenithAngle, altitude);
-        const vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
-        const vec3 groundNormal = normalize(zenith*(earthRadius+altitude)+viewDir*distToGround);
-        const vec4 groundIrradiance = irradiance(dot(groundNormal, sunDirection), 0);
+        CONST float distToGround = distanceToGround(cosViewZenithAngle, altitude);
+        CONST vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
+        CONST vec3 groundNormal = normalize(zenith*(earthRadius+altitude)+viewDir*distToGround);
+        CONST vec4 groundIrradiance = irradiance(dot(groundNormal, sunDirection), 0);
         // Radiation scattered by the ground
-        const float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
+        CONST float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
         radiance = transmittanceToGround*groundAlbedo*groundIrradiance*solarIrradianceFixup*groundBRDF
                  + lightPollutionGroundLuminance*lightPollutionRelativeRadiance;
     }
@@ -313,20 +327,20 @@ void main()
     radianceOutput=radiance;
 #elif 1 /*RENDERING_ECLIPSED_ZERO_SCATTERING*/
     vec4 radiance;
-    const float dotViewMoon=dot(viewDir,normalize(moonPosition-cameraPosition));
+    CONST float dotViewMoon=dot(viewDir,normalize(moonPosition-cameraPosition));
     if(viewRayIntersectsGround)
     {
         // XXX: keep in sync with the similar code in non-eclipsed zero scattering rendering.
-        const float distToGround = distanceToGround(cosViewZenithAngle, altitude);
-        const vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
-        const vec3 pointOnGround = cameraPosition+viewDir*distToGround;
-        const vec4 directGroundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDirection, moonPosition);
+        CONST float distToGround = distanceToGround(cosViewZenithAngle, altitude);
+        CONST vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
+        CONST vec3 pointOnGround = cameraPosition+viewDir*distToGround;
+        CONST vec4 directGroundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDirection, moonPosition);
         // FIXME: add first-order indirect irradiance too: it's done in non-eclipsed irradiance (in the same
         // conditions: when limited to 2 orders). This should be calculated at the same time when second order
         // is: all the infrastructure is already there.
-        const vec4 groundIrradiance = directGroundIrradiance;
+        CONST vec4 groundIrradiance = directGroundIrradiance;
         // Radiation scattered by the ground
-        const float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
+        CONST float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
         radiance = transmittanceToGround*groundAlbedo*groundIrradiance*solarIrradianceFixup*groundBRDF
                  + lightPollutionGroundLuminance*lightPollutionRelativeRadiance;
     }
@@ -343,53 +357,53 @@ void main()
     }
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_ON_THE_FLY
-    const vec4 scattering=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPosition,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_ON_THE_FLY*/
+    CONST vec4 scattering=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPosition,
                                                           viewRayIntersectsGround);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE
-    const vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE*/
+    CONST vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                      viewRayIntersectsGround, eclipsedSingleScatteringTextureSize);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact at the point where azimuth texture coordinate changes from 1 to 0 (at azimuthRelativeToSun crossing
     // 0). This happens when I simply call texture(eclipsedScatteringTexture, texCoords) without specifying LOD.
     // Apparently, the driver uses the derivative for some reason, even though it shouldn't.
-    const vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
+    CONST vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE
-    const vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
+    CONST vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                      viewRayIntersectsGround, eclipsedSingleScatteringTextureSize);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact at the point where azimuth texture coordinate changes from 1 to 0 (at azimuthRelativeToSun crossing
     // 0). This happens when I simply call texture(eclipsedScatteringTexture, texCoords) without specifying LOD.
     // Apparently, the driver uses the derivative for some reason, even though it shouldn't.
-    const vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
+    CONST vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
     luminance=scattering*currentPhaseFunction(dotViewSun);
-#elif RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_RADIANCE
+#elif 0 /*RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_RADIANCE*/
     vec4 radiance=exp(sampleEclipseDoubleScattering3DTexture(eclipsedDoubleScatteringTexture,
                                                              cosSunZenithAngle, cosViewZenithAngle, azimuthRelativeToSun,
                                                              altitude, viewRayIntersectsGround));
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_LUMINANCE
+#elif 0 /*RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
     luminance=exp(sampleEclipseDoubleScattering3DTexture(eclipsedDoubleScatteringTexture,
                                                          cosSunZenithAngle, cosViewZenithAngle, azimuthRelativeToSun,
                                                          altitude, viewRayIntersectsGround));
-#elif RENDERING_SINGLE_SCATTERING_ON_THE_FLY
-    const vec4 scattering=computeSingleScattering(cosSunZenithAngle,cosViewZenithAngle,dotViewSun,
+#elif 0 /*RENDERING_SINGLE_SCATTERING_ON_THE_FLY*/
+    CONST vec4 scattering=computeSingleScattering(cosSunZenithAngle,cosViewZenithAngle,dotViewSun,
                                                   altitude,viewRayIntersectsGround);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE
+#elif 0 /*RENDERING_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE*/
     vec4 scattering;
     if(useInterpolationGuides)
     {
@@ -406,7 +420,7 @@ void main()
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE
+#elif 0 /*RENDERING_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
     vec4 scattering;
     if(useInterpolationGuides)
     {
@@ -420,18 +434,18 @@ void main()
                                      dotViewSun, altitude, viewRayIntersectsGround);
     }
     luminance=scattering * (bool(PHASE_FUNCTION_IS_EMBEDDED) ? vec4(1) : currentPhaseFunction(dotViewSun));
-#elif RENDERING_MULTIPLE_SCATTERING_LUMINANCE
+#elif 0 /*RENDERING_MULTIPLE_SCATTERING_LUMINANCE*/
     luminance=sample3DTexture(scatteringTexture, cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, viewRayIntersectsGround);
-#elif RENDERING_MULTIPLE_SCATTERING_RADIANCE
+#elif 0 /*RENDERING_MULTIPLE_SCATTERING_RADIANCE*/
     vec4 radiance=sample3DTexture(scatteringTexture, cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, viewRayIntersectsGround);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_LIGHT_POLLUTION_RADIANCE
+#elif 0 /*RENDERING_LIGHT_POLLUTION_RADIANCE*/
     vec4 radiance=lightPollutionGroundLuminance*lightPollutionScattering(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_LIGHT_POLLUTION_LUMINANCE
+#elif 0 /*RENDERING_LIGHT_POLLUTION_LUMINANCE*/
     luminance=lightPollutionGroundLuminance*lightPollutionScattering(altitude, cosViewZenithAngle, viewRayIntersectsGround);
 #else
 #error What to render?

--- a/atmosphere/default/shaders/eclipsed-zero-order-scattering/0/texture-coordinates.frag
+++ b/atmosphere/default/shaders/eclipsed-zero-order-scattering/0/texture-coordinates.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-coordinates.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,8 +45,8 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // texture-coordinates.frag
-#line 1 2 // texture-coordinates.h.glsl
+#line 4 0 // texture-coordinates.frag
+#line 1 3 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -104,8 +115,8 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 6 0 // texture-coordinates.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-coordinates.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -137,7 +148,7 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-coordinates.frag
+#line 6 0 // texture-coordinates.frag
 
 const float LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA=sqrt(atmosphereHeight*(atmosphereHeight+2*earthRadius));
 
@@ -205,18 +216,18 @@ vec3 indicesToTexCoords(const vec3 indices, const vec3 texSizes)
 
 TransmittanceTexVars transmittanceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
+    CONST float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
                                 texCoordToUnitRange(texCoord.t,transmittanceTextureSize.t);
     // Distance from Earth center to camera
-    const float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
-    const float altitude=r-earthRadius;
+    CONST float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
+    CONST float altitude=r-earthRadius;
 
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
     // distance to border of visible atmosphere from the view point
-    const float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
+    CONST float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
     // d==0 can happen when altitude==atmosphereHeight
-    const float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
+    CONST float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
     return TransmittanceTexVars(cosVZA,altitude);
 }
 
@@ -235,53 +246,53 @@ vec2 transmittanceTexVarsToTexCoord(const float cosVZA, float altitude)
     if(altitude<0)
         altitude=0;
 
-    const float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
+    CONST float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
                                       transmittanceTextureSize.t);
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
-    const float d=distanceToAtmosphereBorder(cosVZA,altitude);
-    const float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float d=distanceToAtmosphereBorder(cosVZA,altitude);
+    CONST float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
     return vec2(s,t);
 }
 
 // Output: vec2(cos(sunZenithAngle), altitude)
 IrradianceTexVars irradianceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
-    const float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
+    CONST float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
+    CONST float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
     return IrradianceTexVars(cosSZA,alt);
 }
 
 vec2 irradianceTexVarsToTexCoord(const float cosSunZenithAngle, const float altitude)
 {
-    const float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
-    const float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
+    CONST float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
+    CONST float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
     return vec2(s,t);
 }
 
 float cosSZAToUnitRangeTexCoord(const float cosSunZenithAngle)
 {
     // Distance to top atmosphere border along the ray groundUnderCamera-sun: (altitude, cosSunZenithAngle)
-    const float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name
-    const float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
+    CONST float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
     // TODO: choose a more descriptive name
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     return max(0.,1-a/A)/(a+1);
 }
 
 float unitRangeTexCoordToCosSZA(const float texCoord)
 {
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float a=(A-A*texCoord)/(1+A*texCoord);
-    const float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
+    CONST float a=(A-A*texCoord)/(1+A*texCoord);
+    CONST float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
     return distFromGroundToTopAtmoBorder==0 ? 1 :
         clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distFromGroundToTopAtmoBorder)) /
                     (2*earthRadius*distFromGroundToTopAtmoBorder));
@@ -292,24 +303,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
                                                const float dotViewSun, const float altitude,
                                                const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -317,24 +328,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float dotVSCoord=(dotViewSun+1)/2;
+    CONST float dotVSCoord=(dotViewSun+1)/2;
 
     // ------------------------------------
-    const float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
+    CONST float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
 
     return Scattering4DCoords(cosSZACoord, cosVZACoord, dotVSCoord, altCoord, viewRayIntersectsGround);
 }
 
 TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
@@ -342,16 +353,16 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture coordinates we combine into a single sampler3D coordinate.
-    const float texW = scatteringTextureSize[1];
-    const float texH = scatteringTextureSize[2];
-    const float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
-    const vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
+    CONST float texW = scatteringTextureSize[1];
+    CONST float texH = scatteringTextureSize[2];
+    CONST float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
+    CONST vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
                                         ceil (cosSZAIndex)*texW+coords.dotViewSun*(texW-1)) / (texW*texH-1);
-    const vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
+    CONST vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
 
-    const float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
+    CONST float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
 
-    const float alphaUpper=fract(cosSZAIndex);
+    CONST float alphaUpper=fract(cosSZAIndex);
     return TexCoordPair(vec3(cosVZAtc, combinedCoord.x, altitude), float(1-alphaUpper),
                         vec3(cosVZAtc, combinedCoord.y, altitude), float(alphaUpper));
 }
@@ -359,9 +370,9 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
+    CONST TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
     return texture(tex, texCoords.lower) * texCoords.alphaLower +
            texture(tex, texCoords.upper) * texCoords.alphaUpper;
 }
@@ -369,17 +380,17 @@ vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const f
 // 3D texture is the 3D single-altitude slice of a 4D texture
 vec3 scattering4DCoordsToTex3DCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2);
 
-    const float dvsSize = scatteringTextureSize[1];
-    const float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
+    CONST float dvsSize = scatteringTextureSize[1];
+    CONST float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
 
-    const float cszaSize = scatteringTextureSize[2];
-    const float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
+    CONST float cszaSize = scatteringTextureSize[2];
+    CONST float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
 
     return vec3(cosVZAtc, dotVStc, cosSZAtc);
 }
@@ -394,39 +405,39 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along dotViewSun coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[1];
-    const float posOfRow = indices[1];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[1];
+    CONST float posOfRow = indices[1];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         indexToTexCoord(currRow, numRows-1),
                                                         texCoordVerbatim));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               indexToTexCoord(currRow, numRows-1),
                                                               texCoordVerbatim));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          indexToTexCoord(currRow, numRows-1),
                                          texCoordVerbatim));
@@ -434,14 +445,14 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
 vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolationGuides01Tex,
                                  const vec3 indices)
 {
-    const float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
+    CONST float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
 
-    const float cosVZAIndex = indices[0];
-    const float dotVSIndex = indices[1];
-    const float currRow = floor(dotVSIndex);
-    const float posBetweenRows = dotVSIndex - currRow;
-    const float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cosVZAIndex = indices[0];
+    CONST float dotVSIndex = indices[1];
+    CONST float currRow = floor(dotVSIndex);
+    CONST float posBetweenRows = dotVSIndex - currRow;
+    CONST float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -449,14 +460,14 @@ vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolat
     indicesCurrRow[1] =     currRow;
     indicesNextRow[1] = min(currRow+1, scatteringTextureSize[1]-1.);
 
-    const vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
-    const vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
+    CONST vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
+    CONST vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
 
-    const vec4 valueCurrRow = texture(tex, coordsCurrRow);
-    const vec4 valueNextRow = texture(tex, coordsNextRow);
-    const float epsilon = 1e-37; // Prevents passing zero to log
-    const vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
-    const vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
+    CONST vec4 valueCurrRow = texture(tex, coordsCurrRow);
+    CONST vec4 valueNextRow = texture(tex, coordsNextRow);
+    CONST float epsilon = 1e-37; // Prevents passing zero to log
+    CONST vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
+    CONST vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
     return (logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow;
 }
 
@@ -465,37 +476,37 @@ float findGuide02Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along SZA coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[2];
-    const float posOfRow = indices[2];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[2];
+    CONST float posOfRow = indices[2];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
 }
@@ -505,19 +516,19 @@ vec4 sample3DTextureGuided(const sampler3D tex,
                            const float cosSunZenithAngle, const float cosViewZenithAngle,
                            const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
                                                                     dotViewSun, altitude, viewRayIntersectsGround);
     // Handle the external interpolation guides: the guides between a pair of VZA-dotViewSun 2D "pictures".
-    const vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
-    const vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
-    const float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
+    CONST vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
+    CONST float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
 
-    const float cvzaIndex = indices[0];
-    const float cszaIndex = indices[2];
-    const float currRow = floor(cszaIndex);
-    const float posBetweenRows = cszaIndex - currRow;
-    const float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cvzaIndex = indices[0];
+    CONST float cszaIndex = indices[2];
+    CONST float currRow = floor(cszaIndex);
+    CONST float posBetweenRows = cszaIndex - currRow;
+    CONST float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -526,58 +537,58 @@ vec4 sample3DTextureGuided(const sampler3D tex,
     indicesNextRow[2] = min(currRow+1, scatteringTextureSize[2]-1);
 
     // The caller will handle the internal interpolation guides: the ones between rows in each 2D "picture".
-    const vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
-    const vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
+    CONST vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
+    CONST vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
     return exp((logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow);
 }
 
 vec4 sample3DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
     return texture(tex, texCoords);
 }
 
 ScatteringTexVars scatteringTex4DCoordsToTexVars(const Scattering4DCoords coords)
 {
-    const float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
     // ------------------------------------
     float cosViewZenithAngle;
     if(coords.viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
     // ------------------------------------
-    const float dotViewSun=coords.dotViewSun*2-1;
+    CONST float dotViewSun=coords.dotViewSun*2-1;
 
     // ------------------------------------
-    const float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
+    CONST float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
 
     return ScatteringTexVars(cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, coords.viewRayIntersectsGround);
 }
 
 Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 {
-    const vec4 indexMax=scatteringTextureSize-vec4(1);
+    CONST vec4 indexMax=scatteringTextureSize-vec4(1);
     Scattering4DCoords coords4d;
     coords4d.viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
     // The following formulas assume that scatteringTextureSize[0] is even. For odd sizes they would change.
@@ -593,8 +604,8 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture indices we combine into a single sampler3D coordinate.
-    const float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
-    const float combinedIndex=texIndices[1];
+    CONST float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
+    CONST float combinedIndex=texIndices[1];
     coords4d.dotViewSun=mod(combinedIndex,texW)/(texW-1);
     coords4d.cosSunZenithAngle=floor(combinedIndex/texW)/(texH-1);
 
@@ -608,11 +619,11 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
 ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 {
-    const Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
+    CONST Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
     ScatteringTexVars vars=scatteringTex4DCoordsToTexVars(coords4d);
     // Clamp dotViewSun to its valid range of values, given cosViewZenithAngle and cosSunZenithAngle. This is
     // needed to prevent NaNs when computing the scattering texture.
-    const float cosVZA=vars.cosViewZenithAngle,
+    CONST float cosVZA=vars.cosViewZenithAngle,
                 cosSZA=vars.cosSunZenithAngle;
     vars.dotViewSun=clamp(vars.dotViewSun,
                           cosVZA*cosSZA-safeSqrt((1-sqr(cosVZA))*(1-sqr(cosSZA))),
@@ -622,54 +633,54 @@ ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 
 EclipseScatteringTexVars eclipseTexCoordsToTexVars(const vec2 texCoords, const float altitude)
 {
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
-    const bool viewRayIntersectsGround = texCoords.t<0.5;
+    CONST bool viewRayIntersectsGround = texCoords.t<0.5;
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
-    const float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
+    CONST float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
     return EclipseScatteringTexVars(azimuthRelativeToSun, cosViewZenithAngle, viewRayIntersectsGround);
 }
 
 EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                                    const float altitude, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -677,13 +688,13 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
-    const float azimuthCoord = azimuthRelativeToSun/(2*PI);
+    CONST float azimuthCoord = azimuthRelativeToSun/(2*PI);
 
     return EclipseScattering2DCoords(azimuthCoord, cosVZACoord);
 }
@@ -691,14 +702,14 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
 vec2 eclipseTexVarsToTexCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                const float altitude, const bool viewRayIntersectsGround, const vec2 texSize)
 {
-    const EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+    CONST EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                                     viewRayIntersectsGround);
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2);
-    const float azimuthTC = coords.azimuth + 1/(2*texSize.s);
+    CONST float azimuthTC = coords.azimuth + 1/(2*texSize.s);
 
     return vec2(azimuthTC, cosVZAtc);
 }
@@ -707,42 +718,42 @@ vec4 sampleEclipseDoubleScattering3DTexture(const sampler3D tex, const float cos
                                             const float cosViewZenithAngle, const float azimuthRelativeToSun,
                                             const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
+    CONST vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
                                                   eclipsedDoubleScatteringTextureSize.st);
-    const float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
-    const vec3 texCoords=vec3(coords2d, cosSZACoord);
+    CONST float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
+    CONST vec3 texCoords=vec3(coords2d, cosSZACoord);
 
     return texture(tex, texCoords);
 }
 
 LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 texIndices)
 {
-    const vec2 indexMax=lightPollutionTextureSize-vec2(1);
+    CONST vec2 indexMax=lightPollutionTextureSize-vec2(1);
 
-    const float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
-    const float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
+    CONST float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
-    const bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
-    const float cosViewZenithAngleCoord = viewRayIntersectsGround ?
+    CONST bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
+    CONST float cosViewZenithAngleCoord = viewRayIntersectsGround ?
                                    1-2*texIndices[0]/(indexMax[0]-1) :
                                    2*(texIndices[0]-1)/(indexMax[0]-1)-1;
     // ------------------------------------
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
@@ -753,23 +764,23 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 
 LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -777,27 +788,27 @@ LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, con
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     return LightPollution2DCoords(cosVZACoord, altCoord);
 }
 
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
-    const vec2 texSize = lightPollutionTextureSize;
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 texSize = lightPollutionTextureSize;
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2);
-    const float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
+    CONST float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
     return vec2(cosVZAtc, altitudeTC);
 }

--- a/atmosphere/default/shaders/eclipsed-zero-order-scattering/0/texture-sampling-functions.frag
+++ b/atmosphere/default/shaders/eclipsed-zero-order-scattering/0/texture-sampling-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-sampling-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,13 +45,13 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // texture-sampling-functions.frag
-#line 1 2 // phase-functions.h.glsl
+#line 4 0 // texture-sampling-functions.frag
+#line 1 3 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 6 0 // texture-sampling-functions.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-sampling-functions.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -72,8 +83,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-sampling-functions.frag
-#line 1 4 // texture-coordinates.h.glsl
+#line 6 0 // texture-sampling-functions.frag
+#line 1 5 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -142,7 +153,7 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 8 0 // texture-sampling-functions.frag
+#line 7 0 // texture-sampling-functions.frag
 
 uniform sampler2D transmittanceTexture;
 uniform sampler2D irradianceTexture;
@@ -154,13 +165,13 @@ uniform sampler2D lightPollutionScatteringTexture;
 
 vec4 irradiance(const float cosSunZenithAngle, const float altitude)
 {
-    const vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
+    CONST vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
     return texture(irradianceTexture, texCoords);
 }
 
 vec4 opticalDepthToAtmosphereBorder(const float cosViewZenithAngle, const float altitude)
 {
-    const vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
+    CONST vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact when looking into nadir from TOA at some values of texture sizes (in particular, size of
     // transmittance texture for altitude being 4096). This happens when I simply call texture(eclipsedScatteringTexture,
@@ -178,11 +189,11 @@ vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float
 vec4 transmittance(const float cosViewZenithAngle, const float altitude, const float dist,
                    const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle view ray endpoint
     // in space here.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
 
     vec4 depth;
     if(viewRayIntersectsGround)
@@ -201,7 +212,7 @@ vec4 transmittance(const float cosViewZenithAngle, const float altitude, const f
 vec4 calcFirstScattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                          const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
+    CONST vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
                                           dotViewSun, altitude, viewRayIntersectsGround);
     return scattering*currentPhaseFunction(dotViewSun);
 }
@@ -220,6 +231,6 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
 
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     return texture(lightPollutionScatteringTexture, coords);
 }

--- a/atmosphere/default/shaders/eclipsed-zero-order-scattering/1/common-functions.frag
+++ b/atmosphere/default/shaders/eclipsed-zero-order-scattering/1/common-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // common-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(2.15e-06,1.11400004e-06,3.8580001
 const vec4 wavelengths=vec4(485.333344,516.666687,548,579.333313);
 const int wlSetIndex=1;
 #endif
-#line 5 0 // common-functions.frag
+#line 4 0 // common-functions.frag
 
 bool dbgDataPresent=false;
 bool debugDataPresent()
@@ -69,7 +80,7 @@ void setDebugData(float a,float b, float c, float d)
 
 void swap(inout float x, inout float y)
 {
-    const float t = x;
+    CONST float t = x;
     x = y;
     y = t;
 }
@@ -83,7 +94,7 @@ float safeSqrt(const float x)
 
 float safeAtan(const float y, const float x)
 {
-    const float a = atan(y,x);
+    CONST float a = atan(y,x);
     return x==0 && y==0 ? 0 : a;
 }
 
@@ -116,23 +127,23 @@ float pointAltitude(vec3 point)
 
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float Ratm=earthRadius+atmosphereHeight;
-    const float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float Ratm=earthRadius+atmosphereHeight;
+    CONST float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float distanceToGround(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(-safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float cosZenithAngleOfHorizon(const float altitude)
 {
-    const float R=earthRadius;
-    const float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
+    CONST float R=earthRadius;
+    CONST float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
     return -sqrt(2*h*R+sqr(h))/(R+h);
 }
 
@@ -151,8 +162,8 @@ float distanceToNearestAtmosphereBoundary(const float cosZenithAngle, const floa
 float sunVisibility(const float cosSunZenithAngle, float altitude)
 {
     if(altitude<0) altitude=0;
-    const float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
-    const float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
+    CONST float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
+    CONST float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
     /* Approximating visible fraction of solar disk by smoothstep between the position of the Sun
      * touching the horizon by its upper part and the position with lower part touching the horizon.
      * The calculation assumes that solar angular radius is small and thus approximately equals its sine.
@@ -182,13 +193,13 @@ float circlesIntersectionArea(float R1, float R2, float d)
 
 float angleBetween(const vec3 a, const vec3 b)
 {
-    const float d=dot(a,b);
-    const float c=length(cross(a,b));
+    CONST float d=dot(a,b);
+    CONST float c=length(cross(a,b));
     // To avoid loss of precision, don't use dot product near the singularity
     // of acos, and cross product near the singularity of asin
     if(abs(d) < abs(c))
         return acos(d/(length(a)*length(b)));
-    const float smallerAngle = asin(c/(length(a)*length(b)));
+    CONST float smallerAngle = asin(c/(length(a)*length(b)));
     if(d<0) return PI-smallerAngle;
     return smallerAngle;
 }
@@ -205,11 +216,11 @@ float moonAngularRadius(const vec3 cameraPosition, const vec3 moonPosition)
 
 float visibleSolidAngleOfSun(const vec3 camera, const vec3 sunDir, const vec3 moonPos)
 {
-    const float Rs=sunAngularRadius;
-    const float Rm=moonAngularRadius(camera,moonPos);
+    CONST float Rs=sunAngularRadius;
+    CONST float Rm=moonAngularRadius(camera,moonPos);
     float visibleSolidAngle=PI*sqr(Rs);
 
-    const float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
+    CONST float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
     if(dSM<Rs+Rm)
     {
         visibleSolidAngle -= circlesIntersectionArea(Rm,Rs,dSM);
@@ -229,12 +240,12 @@ float sphereIntegrationSolidAngleDifferential(const int pointCountOnSphere)
 }
 vec3 sphereIntegrationSampleDir(const int index, const int pointCountOnSphere)
 {
-    const float goldenRatio=1.6180339887499;
+    CONST float goldenRatio=1.6180339887499;
     // The range of n is 0.5, 1.5, ..., pointCountOnSphere-0.5
-    const float n=index+0.5;
+    CONST float n=index+0.5;
     // Explanation of the Fibonacci grid generation can be seen at https://stackoverflow.com/a/44164075/673852
-    const float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
-    const float azimuth=n*(2*PI*goldenRatio);
+    CONST float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
+    CONST float azimuth=n*(2*PI*goldenRatio);
     return vec3(cos(azimuth)*sin(zenithAngle),
                 sin(azimuth)*sin(zenithAngle),
                 cos(zenithAngle));

--- a/atmosphere/default/shaders/eclipsed-zero-order-scattering/1/direct-irradiance.frag
+++ b/atmosphere/default/shaders/eclipsed-zero-order-scattering/1/direct-irradiance.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // direct-irradiance.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,8 +45,8 @@ const vec4 lightPollutionRelativeRadiance=vec4(2.15e-06,1.11400004e-06,3.8580001
 const vec4 wavelengths=vec4(485.333344,516.666687,548,579.333313);
 const int wlSetIndex=1;
 #endif
-#line 5 0 // direct-irradiance.frag
-#line 1 2 // texture-sampling-functions.h.glsl
+#line 4 0 // direct-irradiance.frag
+#line 1 3 // texture-sampling-functions.h.glsl
 #ifndef INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 #define INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float altitude);
@@ -47,7 +58,7 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                 const int scatteringOrder);
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 #endif
-#line 6 0 // direct-irradiance.frag
+#line 5 0 // direct-irradiance.frag
 
 vec4 computeDirectGroundIrradiance(const float cosSunZenithAngle, const float altitude)
 {
@@ -58,7 +69,7 @@ vec4 computeDirectGroundIrradiance(const float cosSunZenithAngle, const float al
     //   value in the center of the solar disk, assuming it to be a kind of "average".
     // * When the Sun is partially behind the astronomical horizon, we approximate the radiative view factor (i.e.
     //   cosine factor integrated over the solar disk) with a simple quadratic spline.
-    const float averageCosFactor = cosSunZenithAngle < -sunAngularRadius ? 0
+    CONST float averageCosFactor = cosSunZenithAngle < -sunAngularRadius ? 0
                                       : cosSunZenithAngle > sunAngularRadius ? cosSunZenithAngle
                                       : sqr(cosSunZenithAngle+sunAngularRadius)/(4*sunAngularRadius);
     return solarIrradianceAtTOA * transmittanceToAtmosphereBorder(cosSunZenithAngle, altitude) * averageCosFactor;

--- a/atmosphere/default/shaders/eclipsed-zero-order-scattering/1/eclipsed-direct-irradiance.frag
+++ b/atmosphere/default/shaders/eclipsed-zero-order-scattering/1/eclipsed-direct-irradiance.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // eclipsed-direct-irradiance.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,8 +45,8 @@ const vec4 lightPollutionRelativeRadiance=vec4(2.15e-06,1.11400004e-06,3.8580001
 const vec4 wavelengths=vec4(485.333344,516.666687,548,579.333313);
 const int wlSetIndex=1;
 #endif
-#line 5 0 // eclipsed-direct-irradiance.frag
-#line 1 2 // common-functions.h.glsl
+#line 4 0 // eclipsed-direct-irradiance.frag
+#line 1 3 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -67,16 +78,16 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 6 0 // eclipsed-direct-irradiance.frag
-#line 1 3 // direct-irradiance.h.glsl
+#line 5 0 // eclipsed-direct-irradiance.frag
+#line 1 4 // direct-irradiance.h.glsl
 #ifndef INCLUDE_ONCE_58AEF899_1A84_4A2F_AD71_4E7680B83E29
 #define INCLUDE_ONCE_58AEF899_1A84_4A2F_AD71_4E7680B83E29
 
 vec4 computeDirectGroundIrradiance(const float cosSunZenithAngle, const float altitude);
 
 #endif
-#line 7 0 // eclipsed-direct-irradiance.frag
-#line 1 4 // texture-sampling-functions.h.glsl
+#line 6 0 // eclipsed-direct-irradiance.frag
+#line 1 5 // texture-sampling-functions.h.glsl
 #ifndef INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 #define INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float altitude);
@@ -88,15 +99,15 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                 const int scatteringOrder);
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 #endif
-#line 8 0 // eclipsed-direct-irradiance.frag
+#line 7 0 // eclipsed-direct-irradiance.frag
 
 vec4 calcEclipsedDirectGroundIrradiance(const vec3 pointOnGround, const vec3 sunDir, const vec3 moonPos)
 {
-    const float altitude=0; // we are on the ground, after all
-    const vec3 zenith=normalize(pointOnGround-earthCenter);
-    const float cosSunZenithAngle=dot(sunDir,zenith);
+    CONST float altitude=0; // we are on the ground, after all
+    CONST vec3 zenith=normalize(pointOnGround-earthCenter);
+    CONST float cosSunZenithAngle=dot(sunDir,zenith);
 
-    const float visibility=sunVisibilityDueToMoon(pointOnGround, sunDir, moonPos)
+    CONST float visibility=sunVisibilityDueToMoon(pointOnGround, sunDir, moonPos)
                                                     *
                       // FIXME: this ignores orientation of the crescent of eclipsed Sun WRT horizon
                                     sunVisibility(cosSunZenithAngle, altitude);

--- a/atmosphere/default/shaders/eclipsed-zero-order-scattering/1/phase-functions.frag
+++ b/atmosphere/default/shaders/eclipsed-zero-order-scattering/1/phase-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // phase-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(2.15e-06,1.11400004e-06,3.8580001
 const vec4 wavelengths=vec4(485.333344,516.666687,548,579.333313);
 const int wlSetIndex=1;
 #endif
-#line 5 0 // phase-functions.frag
+#line 4 0 // phase-functions.frag
 
 vec4 phaseFunction_molecules(float dotViewSun)
 {
@@ -42,8 +53,8 @@ vec4 phaseFunction_molecules(float dotViewSun)
 }
 vec4 phaseFunction_aerosols(float dotViewSun)
 {
-        const float g=0.76;
-        const float g2=g*g;
-        const float k = 3/(8*PI)*(1-g2)/(2+g2);
+        CONST float g=0.76;
+        CONST float g2=g*g;
+        CONST float k = 3/(8*PI)*(1-g2)/(2+g2);
         return vec4(k * (1+sqr(dotViewSun)) / pow(1+g2 - 2*g*dotViewSun, 1.5) + 1/((1-dotViewSun)*600+0.05))*0.904;
 }

--- a/atmosphere/default/shaders/eclipsed-zero-order-scattering/1/render.frag
+++ b/atmosphere/default/shaders/eclipsed-zero-order-scattering/1/render.frag
@@ -1,7 +1,21 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
 
-#line 1 1 // const.h.glsl
+
+
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 6 0 // render.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,11 +48,11 @@ const vec4 lightPollutionRelativeRadiance=vec4(2.15e-06,1.11400004e-06,3.8580001
 const vec4 wavelengths=vec4(485.333344,516.666687,548,579.333313);
 const int wlSetIndex=1;
 #endif
-#line 5 0 // render.frag
-#line 1 2 // calc-view-dir.h.glsl
+#line 7 0 // render.frag
+#line 1 3 // calc-view-dir.h.glsl
 vec3 calcViewDir();
-#line 6 0 // render.frag
-#line 1 3 // common-functions.h.glsl
+#line 8 0 // render.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -70,11 +84,11 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // render.frag
+#line 9 0 // render.frag
 
 
 
-#line 1 4 // texture-coordinates.h.glsl
+#line 1 5 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -143,11 +157,11 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 11 0 // render.frag
-#line 1 5 // radiance-to-luminance.h.glsl
+#line 13 0 // render.frag
+#line 1 6 // radiance-to-luminance.h.glsl
 const mat4 radianceToLuminance=mat4(1196.74268,3672.67432,12945.498,45528.7344,  835.02478,13767.5205,2120.37939,51317.4727,  8632.59277,21193.416,222.095078,27381.1602,  19410,18758.1973,35.7829971,6712.12158);
-#line 12 0 // render.frag
-#line 1 6 // texture-sampling-functions.h.glsl
+#line 14 0 // render.frag
+#line 1 7 // texture-sampling-functions.h.glsl
 #ifndef INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 #define INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float altitude);
@@ -159,15 +173,15 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                 const int scatteringOrder);
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 #endif
-#line 13 0 // render.frag
-#line 1 7 // eclipsed-direct-irradiance.h.glsl
+#line 15 0 // render.frag
+#line 1 8 // eclipsed-direct-irradiance.h.glsl
 #ifndef INCLUDE_ONCE_8E9C53B3_83A0_4DD7_9106_32A13BD8935D
 #define INCLUDE_ONCE_8E9C53B3_83A0_4DD7_9106_32A13BD8935D
 
 vec4 calcEclipsedDirectGroundIrradiance(const vec3 pointOnGround, const vec3 sunDir, const vec3 moonPos);
 
 #endif
-#line 14 0 // render.frag
+#line 16 0 // render.frag
 
 
 uniform sampler3D scatteringTextureInterpolationGuides01;
@@ -202,18 +216,18 @@ void main()
     // this approximation has the same order of magnitude as the assumption that the Earth and its atmosphere
     // are spherical.
     float altitude = max(cameraPosition.z, 0.);
-    const vec3 oldCamPos=cameraPosition;
+    CONST vec3 oldCamPos=cameraPosition;
     // Hide the uniform with this name, thus effectively modifying it for the following code
     vec3 cameraPosition=vec3(oldCamPos.xy, altitude);
 
     bool lookingIntoAtmosphere=true;
     if(altitude>atmosphereHeight)
     {
-        const vec3 p = cameraPosition - earthCenter;
-        const float p_dot_v = dot(p, viewDir);
-        const float p_dot_p = dot(p, p);
-        const float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
-        const float distanceToTOA = -p_dot_v - sqrt(sqr(earthRadius+atmosphereHeight) - squaredDistBetweenViewRayAndEarthCenter);
+        CONST vec3 p = cameraPosition - earthCenter;
+        CONST float p_dot_v = dot(p, viewDir);
+        CONST float p_dot_p = dot(p, p);
+        CONST float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
+        CONST float distanceToTOA = -p_dot_v - sqrt(sqr(earthRadius+atmosphereHeight) - squaredDistBetweenViewRayAndEarthCenter);
         if(distanceToTOA>=0)
         {
             cameraPosition += viewDir*distanceToTOA;
@@ -231,16 +245,16 @@ void main()
         }
     }
 
-    const vec3 zenith=normalize(cameraPosition-earthCenter);
+    CONST vec3 zenith=normalize(cameraPosition-earthCenter);
     float cosViewZenithAngle=dot(zenith,viewDir);
 
     bool viewRayIntersectsGround=false;
     {
-        const vec3 p = cameraPosition - earthCenter;
-        const float p_dot_v = dot(p, viewDir);
-        const float p_dot_p = dot(p, p);
-        const float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
-        const float distanceToIntersection = -p_dot_v - sqrt(sqr(earthRadius) - squaredDistBetweenViewRayAndEarthCenter);
+        CONST vec3 p = cameraPosition - earthCenter;
+        CONST float p_dot_v = dot(p, viewDir);
+        CONST float p_dot_p = dot(p, p);
+        CONST float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
+        CONST float distanceToIntersection = -p_dot_v - sqrt(sqr(earthRadius) - squaredDistBetweenViewRayAndEarthCenter);
         // altitude==0 is a special case where distance to intersection calculation
         // is unreliable (has a lot of noise in its sign), so check it separately
         if(distanceToIntersection>0 || (altitude==0 && cosViewZenithAngle<0))
@@ -251,11 +265,11 @@ void main()
     // Aside from aesthetics, this affects brightness input to Stellarium's tone mapper.
     if(pseudoMirrorSkyBelowHorizon && viewRayIntersectsGround)
     {
-        const float horizonCZA = cosZenithAngleOfHorizon(altitude);
-        const float viewElev  = asin(clampCosine(cosViewZenithAngle));
-        const float horizElev = asin(clampCosine(horizonCZA));
-        const float newViewElev = 2*horizElev - viewElev;
-        const float viewDirXYnorm = length(viewDir-zenith*cosViewZenithAngle);
+        CONST float horizonCZA = cosZenithAngleOfHorizon(altitude);
+        CONST float viewElev  = asin(clampCosine(cosViewZenithAngle));
+        CONST float horizElev = asin(clampCosine(horizonCZA));
+        CONST float newViewElev = 2*horizElev - viewElev;
+        CONST float viewDirXYnorm = length(viewDir-zenith*cosViewZenithAngle);
         if(viewDirXYnorm == 0)
         {
             viewDir = zenith;
@@ -274,27 +288,27 @@ void main()
         viewRayIntersectsGround = false;
     }
 
-    const float cosSunZenithAngle =dot(zenith,sunDirection);
-    const float dotViewSun=dot(viewDir,sunDirection);
+    CONST float cosSunZenithAngle =dot(zenith,sunDirection);
+    CONST float dotViewSun=dot(viewDir,sunDirection);
 
-    const vec3 sunXYunnorm=sunDirection-dot(sunDirection,zenith)*zenith;
-    const vec3 viewXYunnorm=viewDir-dot(viewDir,zenith)*zenith;
-    const vec3 sunXY = sunXYunnorm.x!=0 || sunXYunnorm.y!=0 || sunXYunnorm.z!=0 ? normalize(sunXYunnorm) : vec3(0);
-    const vec3 viewXY = viewXYunnorm.x!=0 || viewXYunnorm.y!=0 || viewXYunnorm.z!=0 ? normalize(viewXYunnorm) : vec3(0);
-    const float azimuthRelativeToSun=safeAtan(dot(cross(sunXY, viewXY), zenith), dot(sunXY, viewXY));
+    CONST vec3 sunXYunnorm=sunDirection-dot(sunDirection,zenith)*zenith;
+    CONST vec3 viewXYunnorm=viewDir-dot(viewDir,zenith)*zenith;
+    CONST vec3 sunXY = sunXYunnorm.x!=0 || sunXYunnorm.y!=0 || sunXYunnorm.z!=0 ? normalize(sunXYunnorm) : vec3(0);
+    CONST vec3 viewXY = viewXYunnorm.x!=0 || viewXYunnorm.y!=0 || viewXYunnorm.z!=0 ? normalize(viewXYunnorm) : vec3(0);
+    CONST float azimuthRelativeToSun=safeAtan(dot(cross(sunXY, viewXY), zenith), dot(sunXY, viewXY));
 
-#if RENDERING_ZERO_SCATTERING
+#if 0 /*RENDERING_ZERO_SCATTERING*/
     vec4 radiance;
     if(viewRayIntersectsGround)
     {
         // XXX: keep in sync with the same code in computeScatteringDensity(), but don't forget about
         //      the difference in the usage of viewDir vs incDir.
-        const float distToGround = distanceToGround(cosViewZenithAngle, altitude);
-        const vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
-        const vec3 groundNormal = normalize(zenith*(earthRadius+altitude)+viewDir*distToGround);
-        const vec4 groundIrradiance = irradiance(dot(groundNormal, sunDirection), 0);
+        CONST float distToGround = distanceToGround(cosViewZenithAngle, altitude);
+        CONST vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
+        CONST vec3 groundNormal = normalize(zenith*(earthRadius+altitude)+viewDir*distToGround);
+        CONST vec4 groundIrradiance = irradiance(dot(groundNormal, sunDirection), 0);
         // Radiation scattered by the ground
-        const float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
+        CONST float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
         radiance = transmittanceToGround*groundAlbedo*groundIrradiance*solarIrradianceFixup*groundBRDF
                  + lightPollutionGroundLuminance*lightPollutionRelativeRadiance;
     }
@@ -313,20 +327,20 @@ void main()
     radianceOutput=radiance;
 #elif 1 /*RENDERING_ECLIPSED_ZERO_SCATTERING*/
     vec4 radiance;
-    const float dotViewMoon=dot(viewDir,normalize(moonPosition-cameraPosition));
+    CONST float dotViewMoon=dot(viewDir,normalize(moonPosition-cameraPosition));
     if(viewRayIntersectsGround)
     {
         // XXX: keep in sync with the similar code in non-eclipsed zero scattering rendering.
-        const float distToGround = distanceToGround(cosViewZenithAngle, altitude);
-        const vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
-        const vec3 pointOnGround = cameraPosition+viewDir*distToGround;
-        const vec4 directGroundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDirection, moonPosition);
+        CONST float distToGround = distanceToGround(cosViewZenithAngle, altitude);
+        CONST vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
+        CONST vec3 pointOnGround = cameraPosition+viewDir*distToGround;
+        CONST vec4 directGroundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDirection, moonPosition);
         // FIXME: add first-order indirect irradiance too: it's done in non-eclipsed irradiance (in the same
         // conditions: when limited to 2 orders). This should be calculated at the same time when second order
         // is: all the infrastructure is already there.
-        const vec4 groundIrradiance = directGroundIrradiance;
+        CONST vec4 groundIrradiance = directGroundIrradiance;
         // Radiation scattered by the ground
-        const float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
+        CONST float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
         radiance = transmittanceToGround*groundAlbedo*groundIrradiance*solarIrradianceFixup*groundBRDF
                  + lightPollutionGroundLuminance*lightPollutionRelativeRadiance;
     }
@@ -343,53 +357,53 @@ void main()
     }
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_ON_THE_FLY
-    const vec4 scattering=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPosition,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_ON_THE_FLY*/
+    CONST vec4 scattering=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPosition,
                                                           viewRayIntersectsGround);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE
-    const vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE*/
+    CONST vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                      viewRayIntersectsGround, eclipsedSingleScatteringTextureSize);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact at the point where azimuth texture coordinate changes from 1 to 0 (at azimuthRelativeToSun crossing
     // 0). This happens when I simply call texture(eclipsedScatteringTexture, texCoords) without specifying LOD.
     // Apparently, the driver uses the derivative for some reason, even though it shouldn't.
-    const vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
+    CONST vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE
-    const vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
+    CONST vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                      viewRayIntersectsGround, eclipsedSingleScatteringTextureSize);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact at the point where azimuth texture coordinate changes from 1 to 0 (at azimuthRelativeToSun crossing
     // 0). This happens when I simply call texture(eclipsedScatteringTexture, texCoords) without specifying LOD.
     // Apparently, the driver uses the derivative for some reason, even though it shouldn't.
-    const vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
+    CONST vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
     luminance=scattering*currentPhaseFunction(dotViewSun);
-#elif RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_RADIANCE
+#elif 0 /*RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_RADIANCE*/
     vec4 radiance=exp(sampleEclipseDoubleScattering3DTexture(eclipsedDoubleScatteringTexture,
                                                              cosSunZenithAngle, cosViewZenithAngle, azimuthRelativeToSun,
                                                              altitude, viewRayIntersectsGround));
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_LUMINANCE
+#elif 0 /*RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
     luminance=exp(sampleEclipseDoubleScattering3DTexture(eclipsedDoubleScatteringTexture,
                                                          cosSunZenithAngle, cosViewZenithAngle, azimuthRelativeToSun,
                                                          altitude, viewRayIntersectsGround));
-#elif RENDERING_SINGLE_SCATTERING_ON_THE_FLY
-    const vec4 scattering=computeSingleScattering(cosSunZenithAngle,cosViewZenithAngle,dotViewSun,
+#elif 0 /*RENDERING_SINGLE_SCATTERING_ON_THE_FLY*/
+    CONST vec4 scattering=computeSingleScattering(cosSunZenithAngle,cosViewZenithAngle,dotViewSun,
                                                   altitude,viewRayIntersectsGround);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE
+#elif 0 /*RENDERING_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE*/
     vec4 scattering;
     if(useInterpolationGuides)
     {
@@ -406,7 +420,7 @@ void main()
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE
+#elif 0 /*RENDERING_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
     vec4 scattering;
     if(useInterpolationGuides)
     {
@@ -420,18 +434,18 @@ void main()
                                      dotViewSun, altitude, viewRayIntersectsGround);
     }
     luminance=scattering * (bool(PHASE_FUNCTION_IS_EMBEDDED) ? vec4(1) : currentPhaseFunction(dotViewSun));
-#elif RENDERING_MULTIPLE_SCATTERING_LUMINANCE
+#elif 0 /*RENDERING_MULTIPLE_SCATTERING_LUMINANCE*/
     luminance=sample3DTexture(scatteringTexture, cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, viewRayIntersectsGround);
-#elif RENDERING_MULTIPLE_SCATTERING_RADIANCE
+#elif 0 /*RENDERING_MULTIPLE_SCATTERING_RADIANCE*/
     vec4 radiance=sample3DTexture(scatteringTexture, cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, viewRayIntersectsGround);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_LIGHT_POLLUTION_RADIANCE
+#elif 0 /*RENDERING_LIGHT_POLLUTION_RADIANCE*/
     vec4 radiance=lightPollutionGroundLuminance*lightPollutionScattering(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_LIGHT_POLLUTION_LUMINANCE
+#elif 0 /*RENDERING_LIGHT_POLLUTION_LUMINANCE*/
     luminance=lightPollutionGroundLuminance*lightPollutionScattering(altitude, cosViewZenithAngle, viewRayIntersectsGround);
 #else
 #error What to render?

--- a/atmosphere/default/shaders/eclipsed-zero-order-scattering/1/texture-coordinates.frag
+++ b/atmosphere/default/shaders/eclipsed-zero-order-scattering/1/texture-coordinates.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-coordinates.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,8 +45,8 @@ const vec4 lightPollutionRelativeRadiance=vec4(2.15e-06,1.11400004e-06,3.8580001
 const vec4 wavelengths=vec4(485.333344,516.666687,548,579.333313);
 const int wlSetIndex=1;
 #endif
-#line 5 0 // texture-coordinates.frag
-#line 1 2 // texture-coordinates.h.glsl
+#line 4 0 // texture-coordinates.frag
+#line 1 3 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -104,8 +115,8 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 6 0 // texture-coordinates.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-coordinates.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -137,7 +148,7 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-coordinates.frag
+#line 6 0 // texture-coordinates.frag
 
 const float LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA=sqrt(atmosphereHeight*(atmosphereHeight+2*earthRadius));
 
@@ -205,18 +216,18 @@ vec3 indicesToTexCoords(const vec3 indices, const vec3 texSizes)
 
 TransmittanceTexVars transmittanceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
+    CONST float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
                                 texCoordToUnitRange(texCoord.t,transmittanceTextureSize.t);
     // Distance from Earth center to camera
-    const float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
-    const float altitude=r-earthRadius;
+    CONST float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
+    CONST float altitude=r-earthRadius;
 
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
     // distance to border of visible atmosphere from the view point
-    const float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
+    CONST float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
     // d==0 can happen when altitude==atmosphereHeight
-    const float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
+    CONST float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
     return TransmittanceTexVars(cosVZA,altitude);
 }
 
@@ -235,53 +246,53 @@ vec2 transmittanceTexVarsToTexCoord(const float cosVZA, float altitude)
     if(altitude<0)
         altitude=0;
 
-    const float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
+    CONST float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
                                       transmittanceTextureSize.t);
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
-    const float d=distanceToAtmosphereBorder(cosVZA,altitude);
-    const float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float d=distanceToAtmosphereBorder(cosVZA,altitude);
+    CONST float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
     return vec2(s,t);
 }
 
 // Output: vec2(cos(sunZenithAngle), altitude)
 IrradianceTexVars irradianceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
-    const float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
+    CONST float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
+    CONST float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
     return IrradianceTexVars(cosSZA,alt);
 }
 
 vec2 irradianceTexVarsToTexCoord(const float cosSunZenithAngle, const float altitude)
 {
-    const float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
-    const float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
+    CONST float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
+    CONST float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
     return vec2(s,t);
 }
 
 float cosSZAToUnitRangeTexCoord(const float cosSunZenithAngle)
 {
     // Distance to top atmosphere border along the ray groundUnderCamera-sun: (altitude, cosSunZenithAngle)
-    const float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name
-    const float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
+    CONST float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
     // TODO: choose a more descriptive name
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     return max(0.,1-a/A)/(a+1);
 }
 
 float unitRangeTexCoordToCosSZA(const float texCoord)
 {
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float a=(A-A*texCoord)/(1+A*texCoord);
-    const float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
+    CONST float a=(A-A*texCoord)/(1+A*texCoord);
+    CONST float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
     return distFromGroundToTopAtmoBorder==0 ? 1 :
         clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distFromGroundToTopAtmoBorder)) /
                     (2*earthRadius*distFromGroundToTopAtmoBorder));
@@ -292,24 +303,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
                                                const float dotViewSun, const float altitude,
                                                const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -317,24 +328,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float dotVSCoord=(dotViewSun+1)/2;
+    CONST float dotVSCoord=(dotViewSun+1)/2;
 
     // ------------------------------------
-    const float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
+    CONST float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
 
     return Scattering4DCoords(cosSZACoord, cosVZACoord, dotVSCoord, altCoord, viewRayIntersectsGround);
 }
 
 TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
@@ -342,16 +353,16 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture coordinates we combine into a single sampler3D coordinate.
-    const float texW = scatteringTextureSize[1];
-    const float texH = scatteringTextureSize[2];
-    const float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
-    const vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
+    CONST float texW = scatteringTextureSize[1];
+    CONST float texH = scatteringTextureSize[2];
+    CONST float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
+    CONST vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
                                         ceil (cosSZAIndex)*texW+coords.dotViewSun*(texW-1)) / (texW*texH-1);
-    const vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
+    CONST vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
 
-    const float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
+    CONST float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
 
-    const float alphaUpper=fract(cosSZAIndex);
+    CONST float alphaUpper=fract(cosSZAIndex);
     return TexCoordPair(vec3(cosVZAtc, combinedCoord.x, altitude), float(1-alphaUpper),
                         vec3(cosVZAtc, combinedCoord.y, altitude), float(alphaUpper));
 }
@@ -359,9 +370,9 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
+    CONST TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
     return texture(tex, texCoords.lower) * texCoords.alphaLower +
            texture(tex, texCoords.upper) * texCoords.alphaUpper;
 }
@@ -369,17 +380,17 @@ vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const f
 // 3D texture is the 3D single-altitude slice of a 4D texture
 vec3 scattering4DCoordsToTex3DCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2);
 
-    const float dvsSize = scatteringTextureSize[1];
-    const float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
+    CONST float dvsSize = scatteringTextureSize[1];
+    CONST float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
 
-    const float cszaSize = scatteringTextureSize[2];
-    const float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
+    CONST float cszaSize = scatteringTextureSize[2];
+    CONST float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
 
     return vec3(cosVZAtc, dotVStc, cosSZAtc);
 }
@@ -394,39 +405,39 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along dotViewSun coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[1];
-    const float posOfRow = indices[1];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[1];
+    CONST float posOfRow = indices[1];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         indexToTexCoord(currRow, numRows-1),
                                                         texCoordVerbatim));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               indexToTexCoord(currRow, numRows-1),
                                                               texCoordVerbatim));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          indexToTexCoord(currRow, numRows-1),
                                          texCoordVerbatim));
@@ -434,14 +445,14 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
 vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolationGuides01Tex,
                                  const vec3 indices)
 {
-    const float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
+    CONST float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
 
-    const float cosVZAIndex = indices[0];
-    const float dotVSIndex = indices[1];
-    const float currRow = floor(dotVSIndex);
-    const float posBetweenRows = dotVSIndex - currRow;
-    const float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cosVZAIndex = indices[0];
+    CONST float dotVSIndex = indices[1];
+    CONST float currRow = floor(dotVSIndex);
+    CONST float posBetweenRows = dotVSIndex - currRow;
+    CONST float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -449,14 +460,14 @@ vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolat
     indicesCurrRow[1] =     currRow;
     indicesNextRow[1] = min(currRow+1, scatteringTextureSize[1]-1.);
 
-    const vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
-    const vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
+    CONST vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
+    CONST vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
 
-    const vec4 valueCurrRow = texture(tex, coordsCurrRow);
-    const vec4 valueNextRow = texture(tex, coordsNextRow);
-    const float epsilon = 1e-37; // Prevents passing zero to log
-    const vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
-    const vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
+    CONST vec4 valueCurrRow = texture(tex, coordsCurrRow);
+    CONST vec4 valueNextRow = texture(tex, coordsNextRow);
+    CONST float epsilon = 1e-37; // Prevents passing zero to log
+    CONST vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
+    CONST vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
     return (logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow;
 }
 
@@ -465,37 +476,37 @@ float findGuide02Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along SZA coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[2];
-    const float posOfRow = indices[2];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[2];
+    CONST float posOfRow = indices[2];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
 }
@@ -505,19 +516,19 @@ vec4 sample3DTextureGuided(const sampler3D tex,
                            const float cosSunZenithAngle, const float cosViewZenithAngle,
                            const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
                                                                     dotViewSun, altitude, viewRayIntersectsGround);
     // Handle the external interpolation guides: the guides between a pair of VZA-dotViewSun 2D "pictures".
-    const vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
-    const vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
-    const float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
+    CONST vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
+    CONST float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
 
-    const float cvzaIndex = indices[0];
-    const float cszaIndex = indices[2];
-    const float currRow = floor(cszaIndex);
-    const float posBetweenRows = cszaIndex - currRow;
-    const float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cvzaIndex = indices[0];
+    CONST float cszaIndex = indices[2];
+    CONST float currRow = floor(cszaIndex);
+    CONST float posBetweenRows = cszaIndex - currRow;
+    CONST float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -526,58 +537,58 @@ vec4 sample3DTextureGuided(const sampler3D tex,
     indicesNextRow[2] = min(currRow+1, scatteringTextureSize[2]-1);
 
     // The caller will handle the internal interpolation guides: the ones between rows in each 2D "picture".
-    const vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
-    const vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
+    CONST vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
+    CONST vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
     return exp((logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow);
 }
 
 vec4 sample3DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
     return texture(tex, texCoords);
 }
 
 ScatteringTexVars scatteringTex4DCoordsToTexVars(const Scattering4DCoords coords)
 {
-    const float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
     // ------------------------------------
     float cosViewZenithAngle;
     if(coords.viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
     // ------------------------------------
-    const float dotViewSun=coords.dotViewSun*2-1;
+    CONST float dotViewSun=coords.dotViewSun*2-1;
 
     // ------------------------------------
-    const float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
+    CONST float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
 
     return ScatteringTexVars(cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, coords.viewRayIntersectsGround);
 }
 
 Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 {
-    const vec4 indexMax=scatteringTextureSize-vec4(1);
+    CONST vec4 indexMax=scatteringTextureSize-vec4(1);
     Scattering4DCoords coords4d;
     coords4d.viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
     // The following formulas assume that scatteringTextureSize[0] is even. For odd sizes they would change.
@@ -593,8 +604,8 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture indices we combine into a single sampler3D coordinate.
-    const float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
-    const float combinedIndex=texIndices[1];
+    CONST float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
+    CONST float combinedIndex=texIndices[1];
     coords4d.dotViewSun=mod(combinedIndex,texW)/(texW-1);
     coords4d.cosSunZenithAngle=floor(combinedIndex/texW)/(texH-1);
 
@@ -608,11 +619,11 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
 ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 {
-    const Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
+    CONST Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
     ScatteringTexVars vars=scatteringTex4DCoordsToTexVars(coords4d);
     // Clamp dotViewSun to its valid range of values, given cosViewZenithAngle and cosSunZenithAngle. This is
     // needed to prevent NaNs when computing the scattering texture.
-    const float cosVZA=vars.cosViewZenithAngle,
+    CONST float cosVZA=vars.cosViewZenithAngle,
                 cosSZA=vars.cosSunZenithAngle;
     vars.dotViewSun=clamp(vars.dotViewSun,
                           cosVZA*cosSZA-safeSqrt((1-sqr(cosVZA))*(1-sqr(cosSZA))),
@@ -622,54 +633,54 @@ ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 
 EclipseScatteringTexVars eclipseTexCoordsToTexVars(const vec2 texCoords, const float altitude)
 {
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
-    const bool viewRayIntersectsGround = texCoords.t<0.5;
+    CONST bool viewRayIntersectsGround = texCoords.t<0.5;
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
-    const float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
+    CONST float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
     return EclipseScatteringTexVars(azimuthRelativeToSun, cosViewZenithAngle, viewRayIntersectsGround);
 }
 
 EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                                    const float altitude, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -677,13 +688,13 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
-    const float azimuthCoord = azimuthRelativeToSun/(2*PI);
+    CONST float azimuthCoord = azimuthRelativeToSun/(2*PI);
 
     return EclipseScattering2DCoords(azimuthCoord, cosVZACoord);
 }
@@ -691,14 +702,14 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
 vec2 eclipseTexVarsToTexCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                const float altitude, const bool viewRayIntersectsGround, const vec2 texSize)
 {
-    const EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+    CONST EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                                     viewRayIntersectsGround);
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2);
-    const float azimuthTC = coords.azimuth + 1/(2*texSize.s);
+    CONST float azimuthTC = coords.azimuth + 1/(2*texSize.s);
 
     return vec2(azimuthTC, cosVZAtc);
 }
@@ -707,42 +718,42 @@ vec4 sampleEclipseDoubleScattering3DTexture(const sampler3D tex, const float cos
                                             const float cosViewZenithAngle, const float azimuthRelativeToSun,
                                             const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
+    CONST vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
                                                   eclipsedDoubleScatteringTextureSize.st);
-    const float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
-    const vec3 texCoords=vec3(coords2d, cosSZACoord);
+    CONST float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
+    CONST vec3 texCoords=vec3(coords2d, cosSZACoord);
 
     return texture(tex, texCoords);
 }
 
 LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 texIndices)
 {
-    const vec2 indexMax=lightPollutionTextureSize-vec2(1);
+    CONST vec2 indexMax=lightPollutionTextureSize-vec2(1);
 
-    const float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
-    const float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
+    CONST float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
-    const bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
-    const float cosViewZenithAngleCoord = viewRayIntersectsGround ?
+    CONST bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
+    CONST float cosViewZenithAngleCoord = viewRayIntersectsGround ?
                                    1-2*texIndices[0]/(indexMax[0]-1) :
                                    2*(texIndices[0]-1)/(indexMax[0]-1)-1;
     // ------------------------------------
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
@@ -753,23 +764,23 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 
 LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -777,27 +788,27 @@ LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, con
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     return LightPollution2DCoords(cosVZACoord, altCoord);
 }
 
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
-    const vec2 texSize = lightPollutionTextureSize;
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 texSize = lightPollutionTextureSize;
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2);
-    const float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
+    CONST float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
     return vec2(cosVZAtc, altitudeTC);
 }

--- a/atmosphere/default/shaders/eclipsed-zero-order-scattering/1/texture-sampling-functions.frag
+++ b/atmosphere/default/shaders/eclipsed-zero-order-scattering/1/texture-sampling-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-sampling-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,13 +45,13 @@ const vec4 lightPollutionRelativeRadiance=vec4(2.15e-06,1.11400004e-06,3.8580001
 const vec4 wavelengths=vec4(485.333344,516.666687,548,579.333313);
 const int wlSetIndex=1;
 #endif
-#line 5 0 // texture-sampling-functions.frag
-#line 1 2 // phase-functions.h.glsl
+#line 4 0 // texture-sampling-functions.frag
+#line 1 3 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 6 0 // texture-sampling-functions.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-sampling-functions.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -72,8 +83,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-sampling-functions.frag
-#line 1 4 // texture-coordinates.h.glsl
+#line 6 0 // texture-sampling-functions.frag
+#line 1 5 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -142,7 +153,7 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 8 0 // texture-sampling-functions.frag
+#line 7 0 // texture-sampling-functions.frag
 
 uniform sampler2D transmittanceTexture;
 uniform sampler2D irradianceTexture;
@@ -154,13 +165,13 @@ uniform sampler2D lightPollutionScatteringTexture;
 
 vec4 irradiance(const float cosSunZenithAngle, const float altitude)
 {
-    const vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
+    CONST vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
     return texture(irradianceTexture, texCoords);
 }
 
 vec4 opticalDepthToAtmosphereBorder(const float cosViewZenithAngle, const float altitude)
 {
-    const vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
+    CONST vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact when looking into nadir from TOA at some values of texture sizes (in particular, size of
     // transmittance texture for altitude being 4096). This happens when I simply call texture(eclipsedScatteringTexture,
@@ -178,11 +189,11 @@ vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float
 vec4 transmittance(const float cosViewZenithAngle, const float altitude, const float dist,
                    const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle view ray endpoint
     // in space here.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
 
     vec4 depth;
     if(viewRayIntersectsGround)
@@ -201,7 +212,7 @@ vec4 transmittance(const float cosViewZenithAngle, const float altitude, const f
 vec4 calcFirstScattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                          const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
+    CONST vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
                                           dotViewSun, altitude, viewRayIntersectsGround);
     return scattering*currentPhaseFunction(dotViewSun);
 }
@@ -220,6 +231,6 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
 
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     return texture(lightPollutionScatteringTexture, coords);
 }

--- a/atmosphere/default/shaders/eclipsed-zero-order-scattering/2/common-functions.frag
+++ b/atmosphere/default/shaders/eclipsed-zero-order-scattering/2/common-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // common-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.35000004e-05,1.33100002e-05,9.4
 const vec4 wavelengths=vec4(610.666687,642,673.333313,704.666687);
 const int wlSetIndex=2;
 #endif
-#line 5 0 // common-functions.frag
+#line 4 0 // common-functions.frag
 
 bool dbgDataPresent=false;
 bool debugDataPresent()
@@ -69,7 +80,7 @@ void setDebugData(float a,float b, float c, float d)
 
 void swap(inout float x, inout float y)
 {
-    const float t = x;
+    CONST float t = x;
     x = y;
     y = t;
 }
@@ -83,7 +94,7 @@ float safeSqrt(const float x)
 
 float safeAtan(const float y, const float x)
 {
-    const float a = atan(y,x);
+    CONST float a = atan(y,x);
     return x==0 && y==0 ? 0 : a;
 }
 
@@ -116,23 +127,23 @@ float pointAltitude(vec3 point)
 
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float Ratm=earthRadius+atmosphereHeight;
-    const float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float Ratm=earthRadius+atmosphereHeight;
+    CONST float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float distanceToGround(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(-safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float cosZenithAngleOfHorizon(const float altitude)
 {
-    const float R=earthRadius;
-    const float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
+    CONST float R=earthRadius;
+    CONST float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
     return -sqrt(2*h*R+sqr(h))/(R+h);
 }
 
@@ -151,8 +162,8 @@ float distanceToNearestAtmosphereBoundary(const float cosZenithAngle, const floa
 float sunVisibility(const float cosSunZenithAngle, float altitude)
 {
     if(altitude<0) altitude=0;
-    const float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
-    const float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
+    CONST float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
+    CONST float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
     /* Approximating visible fraction of solar disk by smoothstep between the position of the Sun
      * touching the horizon by its upper part and the position with lower part touching the horizon.
      * The calculation assumes that solar angular radius is small and thus approximately equals its sine.
@@ -182,13 +193,13 @@ float circlesIntersectionArea(float R1, float R2, float d)
 
 float angleBetween(const vec3 a, const vec3 b)
 {
-    const float d=dot(a,b);
-    const float c=length(cross(a,b));
+    CONST float d=dot(a,b);
+    CONST float c=length(cross(a,b));
     // To avoid loss of precision, don't use dot product near the singularity
     // of acos, and cross product near the singularity of asin
     if(abs(d) < abs(c))
         return acos(d/(length(a)*length(b)));
-    const float smallerAngle = asin(c/(length(a)*length(b)));
+    CONST float smallerAngle = asin(c/(length(a)*length(b)));
     if(d<0) return PI-smallerAngle;
     return smallerAngle;
 }
@@ -205,11 +216,11 @@ float moonAngularRadius(const vec3 cameraPosition, const vec3 moonPosition)
 
 float visibleSolidAngleOfSun(const vec3 camera, const vec3 sunDir, const vec3 moonPos)
 {
-    const float Rs=sunAngularRadius;
-    const float Rm=moonAngularRadius(camera,moonPos);
+    CONST float Rs=sunAngularRadius;
+    CONST float Rm=moonAngularRadius(camera,moonPos);
     float visibleSolidAngle=PI*sqr(Rs);
 
-    const float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
+    CONST float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
     if(dSM<Rs+Rm)
     {
         visibleSolidAngle -= circlesIntersectionArea(Rm,Rs,dSM);
@@ -229,12 +240,12 @@ float sphereIntegrationSolidAngleDifferential(const int pointCountOnSphere)
 }
 vec3 sphereIntegrationSampleDir(const int index, const int pointCountOnSphere)
 {
-    const float goldenRatio=1.6180339887499;
+    CONST float goldenRatio=1.6180339887499;
     // The range of n is 0.5, 1.5, ..., pointCountOnSphere-0.5
-    const float n=index+0.5;
+    CONST float n=index+0.5;
     // Explanation of the Fibonacci grid generation can be seen at https://stackoverflow.com/a/44164075/673852
-    const float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
-    const float azimuth=n*(2*PI*goldenRatio);
+    CONST float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
+    CONST float azimuth=n*(2*PI*goldenRatio);
     return vec3(cos(azimuth)*sin(zenithAngle),
                 sin(azimuth)*sin(zenithAngle),
                 cos(zenithAngle));

--- a/atmosphere/default/shaders/eclipsed-zero-order-scattering/2/direct-irradiance.frag
+++ b/atmosphere/default/shaders/eclipsed-zero-order-scattering/2/direct-irradiance.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // direct-irradiance.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,8 +45,8 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.35000004e-05,1.33100002e-05,9.4
 const vec4 wavelengths=vec4(610.666687,642,673.333313,704.666687);
 const int wlSetIndex=2;
 #endif
-#line 5 0 // direct-irradiance.frag
-#line 1 2 // texture-sampling-functions.h.glsl
+#line 4 0 // direct-irradiance.frag
+#line 1 3 // texture-sampling-functions.h.glsl
 #ifndef INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 #define INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float altitude);
@@ -47,7 +58,7 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                 const int scatteringOrder);
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 #endif
-#line 6 0 // direct-irradiance.frag
+#line 5 0 // direct-irradiance.frag
 
 vec4 computeDirectGroundIrradiance(const float cosSunZenithAngle, const float altitude)
 {
@@ -58,7 +69,7 @@ vec4 computeDirectGroundIrradiance(const float cosSunZenithAngle, const float al
     //   value in the center of the solar disk, assuming it to be a kind of "average".
     // * When the Sun is partially behind the astronomical horizon, we approximate the radiative view factor (i.e.
     //   cosine factor integrated over the solar disk) with a simple quadratic spline.
-    const float averageCosFactor = cosSunZenithAngle < -sunAngularRadius ? 0
+    CONST float averageCosFactor = cosSunZenithAngle < -sunAngularRadius ? 0
                                       : cosSunZenithAngle > sunAngularRadius ? cosSunZenithAngle
                                       : sqr(cosSunZenithAngle+sunAngularRadius)/(4*sunAngularRadius);
     return solarIrradianceAtTOA * transmittanceToAtmosphereBorder(cosSunZenithAngle, altitude) * averageCosFactor;

--- a/atmosphere/default/shaders/eclipsed-zero-order-scattering/2/eclipsed-direct-irradiance.frag
+++ b/atmosphere/default/shaders/eclipsed-zero-order-scattering/2/eclipsed-direct-irradiance.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // eclipsed-direct-irradiance.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,8 +45,8 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.35000004e-05,1.33100002e-05,9.4
 const vec4 wavelengths=vec4(610.666687,642,673.333313,704.666687);
 const int wlSetIndex=2;
 #endif
-#line 5 0 // eclipsed-direct-irradiance.frag
-#line 1 2 // common-functions.h.glsl
+#line 4 0 // eclipsed-direct-irradiance.frag
+#line 1 3 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -67,16 +78,16 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 6 0 // eclipsed-direct-irradiance.frag
-#line 1 3 // direct-irradiance.h.glsl
+#line 5 0 // eclipsed-direct-irradiance.frag
+#line 1 4 // direct-irradiance.h.glsl
 #ifndef INCLUDE_ONCE_58AEF899_1A84_4A2F_AD71_4E7680B83E29
 #define INCLUDE_ONCE_58AEF899_1A84_4A2F_AD71_4E7680B83E29
 
 vec4 computeDirectGroundIrradiance(const float cosSunZenithAngle, const float altitude);
 
 #endif
-#line 7 0 // eclipsed-direct-irradiance.frag
-#line 1 4 // texture-sampling-functions.h.glsl
+#line 6 0 // eclipsed-direct-irradiance.frag
+#line 1 5 // texture-sampling-functions.h.glsl
 #ifndef INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 #define INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float altitude);
@@ -88,15 +99,15 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                 const int scatteringOrder);
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 #endif
-#line 8 0 // eclipsed-direct-irradiance.frag
+#line 7 0 // eclipsed-direct-irradiance.frag
 
 vec4 calcEclipsedDirectGroundIrradiance(const vec3 pointOnGround, const vec3 sunDir, const vec3 moonPos)
 {
-    const float altitude=0; // we are on the ground, after all
-    const vec3 zenith=normalize(pointOnGround-earthCenter);
-    const float cosSunZenithAngle=dot(sunDir,zenith);
+    CONST float altitude=0; // we are on the ground, after all
+    CONST vec3 zenith=normalize(pointOnGround-earthCenter);
+    CONST float cosSunZenithAngle=dot(sunDir,zenith);
 
-    const float visibility=sunVisibilityDueToMoon(pointOnGround, sunDir, moonPos)
+    CONST float visibility=sunVisibilityDueToMoon(pointOnGround, sunDir, moonPos)
                                                     *
                       // FIXME: this ignores orientation of the crescent of eclipsed Sun WRT horizon
                                     sunVisibility(cosSunZenithAngle, altitude);

--- a/atmosphere/default/shaders/eclipsed-zero-order-scattering/2/phase-functions.frag
+++ b/atmosphere/default/shaders/eclipsed-zero-order-scattering/2/phase-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // phase-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.35000004e-05,1.33100002e-05,9.4
 const vec4 wavelengths=vec4(610.666687,642,673.333313,704.666687);
 const int wlSetIndex=2;
 #endif
-#line 5 0 // phase-functions.frag
+#line 4 0 // phase-functions.frag
 
 vec4 phaseFunction_molecules(float dotViewSun)
 {
@@ -42,8 +53,8 @@ vec4 phaseFunction_molecules(float dotViewSun)
 }
 vec4 phaseFunction_aerosols(float dotViewSun)
 {
-        const float g=0.76;
-        const float g2=g*g;
-        const float k = 3/(8*PI)*(1-g2)/(2+g2);
+        CONST float g=0.76;
+        CONST float g2=g*g;
+        CONST float k = 3/(8*PI)*(1-g2)/(2+g2);
         return vec4(k * (1+sqr(dotViewSun)) / pow(1+g2 - 2*g*dotViewSun, 1.5) + 1/((1-dotViewSun)*600+0.05))*0.904;
 }

--- a/atmosphere/default/shaders/eclipsed-zero-order-scattering/2/render.frag
+++ b/atmosphere/default/shaders/eclipsed-zero-order-scattering/2/render.frag
@@ -1,7 +1,21 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
 
-#line 1 1 // const.h.glsl
+
+
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 6 0 // render.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,11 +48,11 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.35000004e-05,1.33100002e-05,9.4
 const vec4 wavelengths=vec4(610.666687,642,673.333313,704.666687);
 const int wlSetIndex=2;
 #endif
-#line 5 0 // render.frag
-#line 1 2 // calc-view-dir.h.glsl
+#line 7 0 // render.frag
+#line 1 3 // calc-view-dir.h.glsl
 vec3 calcViewDir();
-#line 6 0 // render.frag
-#line 1 3 // common-functions.h.glsl
+#line 8 0 // render.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -70,11 +84,11 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // render.frag
+#line 9 0 // render.frag
 
 
 
-#line 1 4 // texture-coordinates.h.glsl
+#line 1 5 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -143,11 +157,11 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 11 0 // render.frag
-#line 1 5 // radiance-to-luminance.h.glsl
+#line 13 0 // render.frag
+#line 1 6 // radiance-to-luminance.h.glsl
 const mat4 radianceToLuminance=mat4(21296.1113,10585.7773,6.80903196,807.40564,  8819.19727,3416.5498,0.346691847,67.973465,  1511.18506,551.902527,0,6.17586422,  177.630722,64.1456985,0,0.693584085);
-#line 12 0 // render.frag
-#line 1 6 // texture-sampling-functions.h.glsl
+#line 14 0 // render.frag
+#line 1 7 // texture-sampling-functions.h.glsl
 #ifndef INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 #define INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float altitude);
@@ -159,15 +173,15 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                 const int scatteringOrder);
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 #endif
-#line 13 0 // render.frag
-#line 1 7 // eclipsed-direct-irradiance.h.glsl
+#line 15 0 // render.frag
+#line 1 8 // eclipsed-direct-irradiance.h.glsl
 #ifndef INCLUDE_ONCE_8E9C53B3_83A0_4DD7_9106_32A13BD8935D
 #define INCLUDE_ONCE_8E9C53B3_83A0_4DD7_9106_32A13BD8935D
 
 vec4 calcEclipsedDirectGroundIrradiance(const vec3 pointOnGround, const vec3 sunDir, const vec3 moonPos);
 
 #endif
-#line 14 0 // render.frag
+#line 16 0 // render.frag
 
 
 uniform sampler3D scatteringTextureInterpolationGuides01;
@@ -202,18 +216,18 @@ void main()
     // this approximation has the same order of magnitude as the assumption that the Earth and its atmosphere
     // are spherical.
     float altitude = max(cameraPosition.z, 0.);
-    const vec3 oldCamPos=cameraPosition;
+    CONST vec3 oldCamPos=cameraPosition;
     // Hide the uniform with this name, thus effectively modifying it for the following code
     vec3 cameraPosition=vec3(oldCamPos.xy, altitude);
 
     bool lookingIntoAtmosphere=true;
     if(altitude>atmosphereHeight)
     {
-        const vec3 p = cameraPosition - earthCenter;
-        const float p_dot_v = dot(p, viewDir);
-        const float p_dot_p = dot(p, p);
-        const float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
-        const float distanceToTOA = -p_dot_v - sqrt(sqr(earthRadius+atmosphereHeight) - squaredDistBetweenViewRayAndEarthCenter);
+        CONST vec3 p = cameraPosition - earthCenter;
+        CONST float p_dot_v = dot(p, viewDir);
+        CONST float p_dot_p = dot(p, p);
+        CONST float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
+        CONST float distanceToTOA = -p_dot_v - sqrt(sqr(earthRadius+atmosphereHeight) - squaredDistBetweenViewRayAndEarthCenter);
         if(distanceToTOA>=0)
         {
             cameraPosition += viewDir*distanceToTOA;
@@ -231,16 +245,16 @@ void main()
         }
     }
 
-    const vec3 zenith=normalize(cameraPosition-earthCenter);
+    CONST vec3 zenith=normalize(cameraPosition-earthCenter);
     float cosViewZenithAngle=dot(zenith,viewDir);
 
     bool viewRayIntersectsGround=false;
     {
-        const vec3 p = cameraPosition - earthCenter;
-        const float p_dot_v = dot(p, viewDir);
-        const float p_dot_p = dot(p, p);
-        const float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
-        const float distanceToIntersection = -p_dot_v - sqrt(sqr(earthRadius) - squaredDistBetweenViewRayAndEarthCenter);
+        CONST vec3 p = cameraPosition - earthCenter;
+        CONST float p_dot_v = dot(p, viewDir);
+        CONST float p_dot_p = dot(p, p);
+        CONST float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
+        CONST float distanceToIntersection = -p_dot_v - sqrt(sqr(earthRadius) - squaredDistBetweenViewRayAndEarthCenter);
         // altitude==0 is a special case where distance to intersection calculation
         // is unreliable (has a lot of noise in its sign), so check it separately
         if(distanceToIntersection>0 || (altitude==0 && cosViewZenithAngle<0))
@@ -251,11 +265,11 @@ void main()
     // Aside from aesthetics, this affects brightness input to Stellarium's tone mapper.
     if(pseudoMirrorSkyBelowHorizon && viewRayIntersectsGround)
     {
-        const float horizonCZA = cosZenithAngleOfHorizon(altitude);
-        const float viewElev  = asin(clampCosine(cosViewZenithAngle));
-        const float horizElev = asin(clampCosine(horizonCZA));
-        const float newViewElev = 2*horizElev - viewElev;
-        const float viewDirXYnorm = length(viewDir-zenith*cosViewZenithAngle);
+        CONST float horizonCZA = cosZenithAngleOfHorizon(altitude);
+        CONST float viewElev  = asin(clampCosine(cosViewZenithAngle));
+        CONST float horizElev = asin(clampCosine(horizonCZA));
+        CONST float newViewElev = 2*horizElev - viewElev;
+        CONST float viewDirXYnorm = length(viewDir-zenith*cosViewZenithAngle);
         if(viewDirXYnorm == 0)
         {
             viewDir = zenith;
@@ -274,27 +288,27 @@ void main()
         viewRayIntersectsGround = false;
     }
 
-    const float cosSunZenithAngle =dot(zenith,sunDirection);
-    const float dotViewSun=dot(viewDir,sunDirection);
+    CONST float cosSunZenithAngle =dot(zenith,sunDirection);
+    CONST float dotViewSun=dot(viewDir,sunDirection);
 
-    const vec3 sunXYunnorm=sunDirection-dot(sunDirection,zenith)*zenith;
-    const vec3 viewXYunnorm=viewDir-dot(viewDir,zenith)*zenith;
-    const vec3 sunXY = sunXYunnorm.x!=0 || sunXYunnorm.y!=0 || sunXYunnorm.z!=0 ? normalize(sunXYunnorm) : vec3(0);
-    const vec3 viewXY = viewXYunnorm.x!=0 || viewXYunnorm.y!=0 || viewXYunnorm.z!=0 ? normalize(viewXYunnorm) : vec3(0);
-    const float azimuthRelativeToSun=safeAtan(dot(cross(sunXY, viewXY), zenith), dot(sunXY, viewXY));
+    CONST vec3 sunXYunnorm=sunDirection-dot(sunDirection,zenith)*zenith;
+    CONST vec3 viewXYunnorm=viewDir-dot(viewDir,zenith)*zenith;
+    CONST vec3 sunXY = sunXYunnorm.x!=0 || sunXYunnorm.y!=0 || sunXYunnorm.z!=0 ? normalize(sunXYunnorm) : vec3(0);
+    CONST vec3 viewXY = viewXYunnorm.x!=0 || viewXYunnorm.y!=0 || viewXYunnorm.z!=0 ? normalize(viewXYunnorm) : vec3(0);
+    CONST float azimuthRelativeToSun=safeAtan(dot(cross(sunXY, viewXY), zenith), dot(sunXY, viewXY));
 
-#if RENDERING_ZERO_SCATTERING
+#if 0 /*RENDERING_ZERO_SCATTERING*/
     vec4 radiance;
     if(viewRayIntersectsGround)
     {
         // XXX: keep in sync with the same code in computeScatteringDensity(), but don't forget about
         //      the difference in the usage of viewDir vs incDir.
-        const float distToGround = distanceToGround(cosViewZenithAngle, altitude);
-        const vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
-        const vec3 groundNormal = normalize(zenith*(earthRadius+altitude)+viewDir*distToGround);
-        const vec4 groundIrradiance = irradiance(dot(groundNormal, sunDirection), 0);
+        CONST float distToGround = distanceToGround(cosViewZenithAngle, altitude);
+        CONST vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
+        CONST vec3 groundNormal = normalize(zenith*(earthRadius+altitude)+viewDir*distToGround);
+        CONST vec4 groundIrradiance = irradiance(dot(groundNormal, sunDirection), 0);
         // Radiation scattered by the ground
-        const float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
+        CONST float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
         radiance = transmittanceToGround*groundAlbedo*groundIrradiance*solarIrradianceFixup*groundBRDF
                  + lightPollutionGroundLuminance*lightPollutionRelativeRadiance;
     }
@@ -313,20 +327,20 @@ void main()
     radianceOutput=radiance;
 #elif 1 /*RENDERING_ECLIPSED_ZERO_SCATTERING*/
     vec4 radiance;
-    const float dotViewMoon=dot(viewDir,normalize(moonPosition-cameraPosition));
+    CONST float dotViewMoon=dot(viewDir,normalize(moonPosition-cameraPosition));
     if(viewRayIntersectsGround)
     {
         // XXX: keep in sync with the similar code in non-eclipsed zero scattering rendering.
-        const float distToGround = distanceToGround(cosViewZenithAngle, altitude);
-        const vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
-        const vec3 pointOnGround = cameraPosition+viewDir*distToGround;
-        const vec4 directGroundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDirection, moonPosition);
+        CONST float distToGround = distanceToGround(cosViewZenithAngle, altitude);
+        CONST vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
+        CONST vec3 pointOnGround = cameraPosition+viewDir*distToGround;
+        CONST vec4 directGroundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDirection, moonPosition);
         // FIXME: add first-order indirect irradiance too: it's done in non-eclipsed irradiance (in the same
         // conditions: when limited to 2 orders). This should be calculated at the same time when second order
         // is: all the infrastructure is already there.
-        const vec4 groundIrradiance = directGroundIrradiance;
+        CONST vec4 groundIrradiance = directGroundIrradiance;
         // Radiation scattered by the ground
-        const float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
+        CONST float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
         radiance = transmittanceToGround*groundAlbedo*groundIrradiance*solarIrradianceFixup*groundBRDF
                  + lightPollutionGroundLuminance*lightPollutionRelativeRadiance;
     }
@@ -343,53 +357,53 @@ void main()
     }
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_ON_THE_FLY
-    const vec4 scattering=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPosition,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_ON_THE_FLY*/
+    CONST vec4 scattering=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPosition,
                                                           viewRayIntersectsGround);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE
-    const vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE*/
+    CONST vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                      viewRayIntersectsGround, eclipsedSingleScatteringTextureSize);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact at the point where azimuth texture coordinate changes from 1 to 0 (at azimuthRelativeToSun crossing
     // 0). This happens when I simply call texture(eclipsedScatteringTexture, texCoords) without specifying LOD.
     // Apparently, the driver uses the derivative for some reason, even though it shouldn't.
-    const vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
+    CONST vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE
-    const vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
+    CONST vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                      viewRayIntersectsGround, eclipsedSingleScatteringTextureSize);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact at the point where azimuth texture coordinate changes from 1 to 0 (at azimuthRelativeToSun crossing
     // 0). This happens when I simply call texture(eclipsedScatteringTexture, texCoords) without specifying LOD.
     // Apparently, the driver uses the derivative for some reason, even though it shouldn't.
-    const vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
+    CONST vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
     luminance=scattering*currentPhaseFunction(dotViewSun);
-#elif RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_RADIANCE
+#elif 0 /*RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_RADIANCE*/
     vec4 radiance=exp(sampleEclipseDoubleScattering3DTexture(eclipsedDoubleScatteringTexture,
                                                              cosSunZenithAngle, cosViewZenithAngle, azimuthRelativeToSun,
                                                              altitude, viewRayIntersectsGround));
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_LUMINANCE
+#elif 0 /*RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
     luminance=exp(sampleEclipseDoubleScattering3DTexture(eclipsedDoubleScatteringTexture,
                                                          cosSunZenithAngle, cosViewZenithAngle, azimuthRelativeToSun,
                                                          altitude, viewRayIntersectsGround));
-#elif RENDERING_SINGLE_SCATTERING_ON_THE_FLY
-    const vec4 scattering=computeSingleScattering(cosSunZenithAngle,cosViewZenithAngle,dotViewSun,
+#elif 0 /*RENDERING_SINGLE_SCATTERING_ON_THE_FLY*/
+    CONST vec4 scattering=computeSingleScattering(cosSunZenithAngle,cosViewZenithAngle,dotViewSun,
                                                   altitude,viewRayIntersectsGround);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE
+#elif 0 /*RENDERING_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE*/
     vec4 scattering;
     if(useInterpolationGuides)
     {
@@ -406,7 +420,7 @@ void main()
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE
+#elif 0 /*RENDERING_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
     vec4 scattering;
     if(useInterpolationGuides)
     {
@@ -420,18 +434,18 @@ void main()
                                      dotViewSun, altitude, viewRayIntersectsGround);
     }
     luminance=scattering * (bool(PHASE_FUNCTION_IS_EMBEDDED) ? vec4(1) : currentPhaseFunction(dotViewSun));
-#elif RENDERING_MULTIPLE_SCATTERING_LUMINANCE
+#elif 0 /*RENDERING_MULTIPLE_SCATTERING_LUMINANCE*/
     luminance=sample3DTexture(scatteringTexture, cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, viewRayIntersectsGround);
-#elif RENDERING_MULTIPLE_SCATTERING_RADIANCE
+#elif 0 /*RENDERING_MULTIPLE_SCATTERING_RADIANCE*/
     vec4 radiance=sample3DTexture(scatteringTexture, cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, viewRayIntersectsGround);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_LIGHT_POLLUTION_RADIANCE
+#elif 0 /*RENDERING_LIGHT_POLLUTION_RADIANCE*/
     vec4 radiance=lightPollutionGroundLuminance*lightPollutionScattering(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_LIGHT_POLLUTION_LUMINANCE
+#elif 0 /*RENDERING_LIGHT_POLLUTION_LUMINANCE*/
     luminance=lightPollutionGroundLuminance*lightPollutionScattering(altitude, cosViewZenithAngle, viewRayIntersectsGround);
 #else
 #error What to render?

--- a/atmosphere/default/shaders/eclipsed-zero-order-scattering/2/texture-coordinates.frag
+++ b/atmosphere/default/shaders/eclipsed-zero-order-scattering/2/texture-coordinates.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-coordinates.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,8 +45,8 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.35000004e-05,1.33100002e-05,9.4
 const vec4 wavelengths=vec4(610.666687,642,673.333313,704.666687);
 const int wlSetIndex=2;
 #endif
-#line 5 0 // texture-coordinates.frag
-#line 1 2 // texture-coordinates.h.glsl
+#line 4 0 // texture-coordinates.frag
+#line 1 3 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -104,8 +115,8 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 6 0 // texture-coordinates.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-coordinates.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -137,7 +148,7 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-coordinates.frag
+#line 6 0 // texture-coordinates.frag
 
 const float LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA=sqrt(atmosphereHeight*(atmosphereHeight+2*earthRadius));
 
@@ -205,18 +216,18 @@ vec3 indicesToTexCoords(const vec3 indices, const vec3 texSizes)
 
 TransmittanceTexVars transmittanceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
+    CONST float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
                                 texCoordToUnitRange(texCoord.t,transmittanceTextureSize.t);
     // Distance from Earth center to camera
-    const float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
-    const float altitude=r-earthRadius;
+    CONST float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
+    CONST float altitude=r-earthRadius;
 
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
     // distance to border of visible atmosphere from the view point
-    const float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
+    CONST float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
     // d==0 can happen when altitude==atmosphereHeight
-    const float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
+    CONST float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
     return TransmittanceTexVars(cosVZA,altitude);
 }
 
@@ -235,53 +246,53 @@ vec2 transmittanceTexVarsToTexCoord(const float cosVZA, float altitude)
     if(altitude<0)
         altitude=0;
 
-    const float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
+    CONST float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
                                       transmittanceTextureSize.t);
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
-    const float d=distanceToAtmosphereBorder(cosVZA,altitude);
-    const float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float d=distanceToAtmosphereBorder(cosVZA,altitude);
+    CONST float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
     return vec2(s,t);
 }
 
 // Output: vec2(cos(sunZenithAngle), altitude)
 IrradianceTexVars irradianceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
-    const float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
+    CONST float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
+    CONST float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
     return IrradianceTexVars(cosSZA,alt);
 }
 
 vec2 irradianceTexVarsToTexCoord(const float cosSunZenithAngle, const float altitude)
 {
-    const float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
-    const float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
+    CONST float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
+    CONST float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
     return vec2(s,t);
 }
 
 float cosSZAToUnitRangeTexCoord(const float cosSunZenithAngle)
 {
     // Distance to top atmosphere border along the ray groundUnderCamera-sun: (altitude, cosSunZenithAngle)
-    const float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name
-    const float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
+    CONST float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
     // TODO: choose a more descriptive name
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     return max(0.,1-a/A)/(a+1);
 }
 
 float unitRangeTexCoordToCosSZA(const float texCoord)
 {
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float a=(A-A*texCoord)/(1+A*texCoord);
-    const float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
+    CONST float a=(A-A*texCoord)/(1+A*texCoord);
+    CONST float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
     return distFromGroundToTopAtmoBorder==0 ? 1 :
         clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distFromGroundToTopAtmoBorder)) /
                     (2*earthRadius*distFromGroundToTopAtmoBorder));
@@ -292,24 +303,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
                                                const float dotViewSun, const float altitude,
                                                const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -317,24 +328,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float dotVSCoord=(dotViewSun+1)/2;
+    CONST float dotVSCoord=(dotViewSun+1)/2;
 
     // ------------------------------------
-    const float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
+    CONST float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
 
     return Scattering4DCoords(cosSZACoord, cosVZACoord, dotVSCoord, altCoord, viewRayIntersectsGround);
 }
 
 TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
@@ -342,16 +353,16 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture coordinates we combine into a single sampler3D coordinate.
-    const float texW = scatteringTextureSize[1];
-    const float texH = scatteringTextureSize[2];
-    const float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
-    const vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
+    CONST float texW = scatteringTextureSize[1];
+    CONST float texH = scatteringTextureSize[2];
+    CONST float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
+    CONST vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
                                         ceil (cosSZAIndex)*texW+coords.dotViewSun*(texW-1)) / (texW*texH-1);
-    const vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
+    CONST vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
 
-    const float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
+    CONST float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
 
-    const float alphaUpper=fract(cosSZAIndex);
+    CONST float alphaUpper=fract(cosSZAIndex);
     return TexCoordPair(vec3(cosVZAtc, combinedCoord.x, altitude), float(1-alphaUpper),
                         vec3(cosVZAtc, combinedCoord.y, altitude), float(alphaUpper));
 }
@@ -359,9 +370,9 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
+    CONST TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
     return texture(tex, texCoords.lower) * texCoords.alphaLower +
            texture(tex, texCoords.upper) * texCoords.alphaUpper;
 }
@@ -369,17 +380,17 @@ vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const f
 // 3D texture is the 3D single-altitude slice of a 4D texture
 vec3 scattering4DCoordsToTex3DCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2);
 
-    const float dvsSize = scatteringTextureSize[1];
-    const float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
+    CONST float dvsSize = scatteringTextureSize[1];
+    CONST float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
 
-    const float cszaSize = scatteringTextureSize[2];
-    const float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
+    CONST float cszaSize = scatteringTextureSize[2];
+    CONST float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
 
     return vec3(cosVZAtc, dotVStc, cosSZAtc);
 }
@@ -394,39 +405,39 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along dotViewSun coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[1];
-    const float posOfRow = indices[1];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[1];
+    CONST float posOfRow = indices[1];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         indexToTexCoord(currRow, numRows-1),
                                                         texCoordVerbatim));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               indexToTexCoord(currRow, numRows-1),
                                                               texCoordVerbatim));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          indexToTexCoord(currRow, numRows-1),
                                          texCoordVerbatim));
@@ -434,14 +445,14 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
 vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolationGuides01Tex,
                                  const vec3 indices)
 {
-    const float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
+    CONST float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
 
-    const float cosVZAIndex = indices[0];
-    const float dotVSIndex = indices[1];
-    const float currRow = floor(dotVSIndex);
-    const float posBetweenRows = dotVSIndex - currRow;
-    const float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cosVZAIndex = indices[0];
+    CONST float dotVSIndex = indices[1];
+    CONST float currRow = floor(dotVSIndex);
+    CONST float posBetweenRows = dotVSIndex - currRow;
+    CONST float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -449,14 +460,14 @@ vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolat
     indicesCurrRow[1] =     currRow;
     indicesNextRow[1] = min(currRow+1, scatteringTextureSize[1]-1.);
 
-    const vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
-    const vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
+    CONST vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
+    CONST vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
 
-    const vec4 valueCurrRow = texture(tex, coordsCurrRow);
-    const vec4 valueNextRow = texture(tex, coordsNextRow);
-    const float epsilon = 1e-37; // Prevents passing zero to log
-    const vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
-    const vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
+    CONST vec4 valueCurrRow = texture(tex, coordsCurrRow);
+    CONST vec4 valueNextRow = texture(tex, coordsNextRow);
+    CONST float epsilon = 1e-37; // Prevents passing zero to log
+    CONST vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
+    CONST vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
     return (logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow;
 }
 
@@ -465,37 +476,37 @@ float findGuide02Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along SZA coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[2];
-    const float posOfRow = indices[2];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[2];
+    CONST float posOfRow = indices[2];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
 }
@@ -505,19 +516,19 @@ vec4 sample3DTextureGuided(const sampler3D tex,
                            const float cosSunZenithAngle, const float cosViewZenithAngle,
                            const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
                                                                     dotViewSun, altitude, viewRayIntersectsGround);
     // Handle the external interpolation guides: the guides between a pair of VZA-dotViewSun 2D "pictures".
-    const vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
-    const vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
-    const float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
+    CONST vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
+    CONST float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
 
-    const float cvzaIndex = indices[0];
-    const float cszaIndex = indices[2];
-    const float currRow = floor(cszaIndex);
-    const float posBetweenRows = cszaIndex - currRow;
-    const float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cvzaIndex = indices[0];
+    CONST float cszaIndex = indices[2];
+    CONST float currRow = floor(cszaIndex);
+    CONST float posBetweenRows = cszaIndex - currRow;
+    CONST float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -526,58 +537,58 @@ vec4 sample3DTextureGuided(const sampler3D tex,
     indicesNextRow[2] = min(currRow+1, scatteringTextureSize[2]-1);
 
     // The caller will handle the internal interpolation guides: the ones between rows in each 2D "picture".
-    const vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
-    const vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
+    CONST vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
+    CONST vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
     return exp((logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow);
 }
 
 vec4 sample3DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
     return texture(tex, texCoords);
 }
 
 ScatteringTexVars scatteringTex4DCoordsToTexVars(const Scattering4DCoords coords)
 {
-    const float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
     // ------------------------------------
     float cosViewZenithAngle;
     if(coords.viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
     // ------------------------------------
-    const float dotViewSun=coords.dotViewSun*2-1;
+    CONST float dotViewSun=coords.dotViewSun*2-1;
 
     // ------------------------------------
-    const float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
+    CONST float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
 
     return ScatteringTexVars(cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, coords.viewRayIntersectsGround);
 }
 
 Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 {
-    const vec4 indexMax=scatteringTextureSize-vec4(1);
+    CONST vec4 indexMax=scatteringTextureSize-vec4(1);
     Scattering4DCoords coords4d;
     coords4d.viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
     // The following formulas assume that scatteringTextureSize[0] is even. For odd sizes they would change.
@@ -593,8 +604,8 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture indices we combine into a single sampler3D coordinate.
-    const float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
-    const float combinedIndex=texIndices[1];
+    CONST float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
+    CONST float combinedIndex=texIndices[1];
     coords4d.dotViewSun=mod(combinedIndex,texW)/(texW-1);
     coords4d.cosSunZenithAngle=floor(combinedIndex/texW)/(texH-1);
 
@@ -608,11 +619,11 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
 ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 {
-    const Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
+    CONST Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
     ScatteringTexVars vars=scatteringTex4DCoordsToTexVars(coords4d);
     // Clamp dotViewSun to its valid range of values, given cosViewZenithAngle and cosSunZenithAngle. This is
     // needed to prevent NaNs when computing the scattering texture.
-    const float cosVZA=vars.cosViewZenithAngle,
+    CONST float cosVZA=vars.cosViewZenithAngle,
                 cosSZA=vars.cosSunZenithAngle;
     vars.dotViewSun=clamp(vars.dotViewSun,
                           cosVZA*cosSZA-safeSqrt((1-sqr(cosVZA))*(1-sqr(cosSZA))),
@@ -622,54 +633,54 @@ ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 
 EclipseScatteringTexVars eclipseTexCoordsToTexVars(const vec2 texCoords, const float altitude)
 {
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
-    const bool viewRayIntersectsGround = texCoords.t<0.5;
+    CONST bool viewRayIntersectsGround = texCoords.t<0.5;
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
-    const float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
+    CONST float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
     return EclipseScatteringTexVars(azimuthRelativeToSun, cosViewZenithAngle, viewRayIntersectsGround);
 }
 
 EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                                    const float altitude, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -677,13 +688,13 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
-    const float azimuthCoord = azimuthRelativeToSun/(2*PI);
+    CONST float azimuthCoord = azimuthRelativeToSun/(2*PI);
 
     return EclipseScattering2DCoords(azimuthCoord, cosVZACoord);
 }
@@ -691,14 +702,14 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
 vec2 eclipseTexVarsToTexCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                const float altitude, const bool viewRayIntersectsGround, const vec2 texSize)
 {
-    const EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+    CONST EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                                     viewRayIntersectsGround);
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2);
-    const float azimuthTC = coords.azimuth + 1/(2*texSize.s);
+    CONST float azimuthTC = coords.azimuth + 1/(2*texSize.s);
 
     return vec2(azimuthTC, cosVZAtc);
 }
@@ -707,42 +718,42 @@ vec4 sampleEclipseDoubleScattering3DTexture(const sampler3D tex, const float cos
                                             const float cosViewZenithAngle, const float azimuthRelativeToSun,
                                             const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
+    CONST vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
                                                   eclipsedDoubleScatteringTextureSize.st);
-    const float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
-    const vec3 texCoords=vec3(coords2d, cosSZACoord);
+    CONST float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
+    CONST vec3 texCoords=vec3(coords2d, cosSZACoord);
 
     return texture(tex, texCoords);
 }
 
 LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 texIndices)
 {
-    const vec2 indexMax=lightPollutionTextureSize-vec2(1);
+    CONST vec2 indexMax=lightPollutionTextureSize-vec2(1);
 
-    const float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
-    const float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
+    CONST float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
-    const bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
-    const float cosViewZenithAngleCoord = viewRayIntersectsGround ?
+    CONST bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
+    CONST float cosViewZenithAngleCoord = viewRayIntersectsGround ?
                                    1-2*texIndices[0]/(indexMax[0]-1) :
                                    2*(texIndices[0]-1)/(indexMax[0]-1)-1;
     // ------------------------------------
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
@@ -753,23 +764,23 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 
 LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -777,27 +788,27 @@ LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, con
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     return LightPollution2DCoords(cosVZACoord, altCoord);
 }
 
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
-    const vec2 texSize = lightPollutionTextureSize;
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 texSize = lightPollutionTextureSize;
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2);
-    const float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
+    CONST float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
     return vec2(cosVZAtc, altitudeTC);
 }

--- a/atmosphere/default/shaders/eclipsed-zero-order-scattering/2/texture-sampling-functions.frag
+++ b/atmosphere/default/shaders/eclipsed-zero-order-scattering/2/texture-sampling-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-sampling-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,13 +45,13 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.35000004e-05,1.33100002e-05,9.4
 const vec4 wavelengths=vec4(610.666687,642,673.333313,704.666687);
 const int wlSetIndex=2;
 #endif
-#line 5 0 // texture-sampling-functions.frag
-#line 1 2 // phase-functions.h.glsl
+#line 4 0 // texture-sampling-functions.frag
+#line 1 3 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 6 0 // texture-sampling-functions.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-sampling-functions.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -72,8 +83,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-sampling-functions.frag
-#line 1 4 // texture-coordinates.h.glsl
+#line 6 0 // texture-sampling-functions.frag
+#line 1 5 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -142,7 +153,7 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 8 0 // texture-sampling-functions.frag
+#line 7 0 // texture-sampling-functions.frag
 
 uniform sampler2D transmittanceTexture;
 uniform sampler2D irradianceTexture;
@@ -154,13 +165,13 @@ uniform sampler2D lightPollutionScatteringTexture;
 
 vec4 irradiance(const float cosSunZenithAngle, const float altitude)
 {
-    const vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
+    CONST vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
     return texture(irradianceTexture, texCoords);
 }
 
 vec4 opticalDepthToAtmosphereBorder(const float cosViewZenithAngle, const float altitude)
 {
-    const vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
+    CONST vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact when looking into nadir from TOA at some values of texture sizes (in particular, size of
     // transmittance texture for altitude being 4096). This happens when I simply call texture(eclipsedScatteringTexture,
@@ -178,11 +189,11 @@ vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float
 vec4 transmittance(const float cosViewZenithAngle, const float altitude, const float dist,
                    const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle view ray endpoint
     // in space here.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
 
     vec4 depth;
     if(viewRayIntersectsGround)
@@ -201,7 +212,7 @@ vec4 transmittance(const float cosViewZenithAngle, const float altitude, const f
 vec4 calcFirstScattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                          const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
+    CONST vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
                                           dotViewSun, altitude, viewRayIntersectsGround);
     return scattering*currentPhaseFunction(dotViewSun);
 }
@@ -220,6 +231,6 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
 
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     return texture(lightPollutionScatteringTexture, coords);
 }

--- a/atmosphere/default/shaders/eclipsed-zero-order-scattering/3/common-functions.frag
+++ b/atmosphere/default/shaders/eclipsed-zero-order-scattering/3/common-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // common-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // common-functions.frag
+#line 4 0 // common-functions.frag
 
 bool dbgDataPresent=false;
 bool debugDataPresent()
@@ -69,7 +80,7 @@ void setDebugData(float a,float b, float c, float d)
 
 void swap(inout float x, inout float y)
 {
-    const float t = x;
+    CONST float t = x;
     x = y;
     y = t;
 }
@@ -83,7 +94,7 @@ float safeSqrt(const float x)
 
 float safeAtan(const float y, const float x)
 {
-    const float a = atan(y,x);
+    CONST float a = atan(y,x);
     return x==0 && y==0 ? 0 : a;
 }
 
@@ -116,23 +127,23 @@ float pointAltitude(vec3 point)
 
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float Ratm=earthRadius+atmosphereHeight;
-    const float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float Ratm=earthRadius+atmosphereHeight;
+    CONST float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float distanceToGround(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(-safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float cosZenithAngleOfHorizon(const float altitude)
 {
-    const float R=earthRadius;
-    const float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
+    CONST float R=earthRadius;
+    CONST float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
     return -sqrt(2*h*R+sqr(h))/(R+h);
 }
 
@@ -151,8 +162,8 @@ float distanceToNearestAtmosphereBoundary(const float cosZenithAngle, const floa
 float sunVisibility(const float cosSunZenithAngle, float altitude)
 {
     if(altitude<0) altitude=0;
-    const float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
-    const float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
+    CONST float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
+    CONST float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
     /* Approximating visible fraction of solar disk by smoothstep between the position of the Sun
      * touching the horizon by its upper part and the position with lower part touching the horizon.
      * The calculation assumes that solar angular radius is small and thus approximately equals its sine.
@@ -182,13 +193,13 @@ float circlesIntersectionArea(float R1, float R2, float d)
 
 float angleBetween(const vec3 a, const vec3 b)
 {
-    const float d=dot(a,b);
-    const float c=length(cross(a,b));
+    CONST float d=dot(a,b);
+    CONST float c=length(cross(a,b));
     // To avoid loss of precision, don't use dot product near the singularity
     // of acos, and cross product near the singularity of asin
     if(abs(d) < abs(c))
         return acos(d/(length(a)*length(b)));
-    const float smallerAngle = asin(c/(length(a)*length(b)));
+    CONST float smallerAngle = asin(c/(length(a)*length(b)));
     if(d<0) return PI-smallerAngle;
     return smallerAngle;
 }
@@ -205,11 +216,11 @@ float moonAngularRadius(const vec3 cameraPosition, const vec3 moonPosition)
 
 float visibleSolidAngleOfSun(const vec3 camera, const vec3 sunDir, const vec3 moonPos)
 {
-    const float Rs=sunAngularRadius;
-    const float Rm=moonAngularRadius(camera,moonPos);
+    CONST float Rs=sunAngularRadius;
+    CONST float Rm=moonAngularRadius(camera,moonPos);
     float visibleSolidAngle=PI*sqr(Rs);
 
-    const float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
+    CONST float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
     if(dSM<Rs+Rm)
     {
         visibleSolidAngle -= circlesIntersectionArea(Rm,Rs,dSM);
@@ -229,12 +240,12 @@ float sphereIntegrationSolidAngleDifferential(const int pointCountOnSphere)
 }
 vec3 sphereIntegrationSampleDir(const int index, const int pointCountOnSphere)
 {
-    const float goldenRatio=1.6180339887499;
+    CONST float goldenRatio=1.6180339887499;
     // The range of n is 0.5, 1.5, ..., pointCountOnSphere-0.5
-    const float n=index+0.5;
+    CONST float n=index+0.5;
     // Explanation of the Fibonacci grid generation can be seen at https://stackoverflow.com/a/44164075/673852
-    const float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
-    const float azimuth=n*(2*PI*goldenRatio);
+    CONST float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
+    CONST float azimuth=n*(2*PI*goldenRatio);
     return vec3(cos(azimuth)*sin(zenithAngle),
                 sin(azimuth)*sin(zenithAngle),
                 cos(zenithAngle));

--- a/atmosphere/default/shaders/eclipsed-zero-order-scattering/3/direct-irradiance.frag
+++ b/atmosphere/default/shaders/eclipsed-zero-order-scattering/3/direct-irradiance.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // direct-irradiance.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,8 +45,8 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // direct-irradiance.frag
-#line 1 2 // texture-sampling-functions.h.glsl
+#line 4 0 // direct-irradiance.frag
+#line 1 3 // texture-sampling-functions.h.glsl
 #ifndef INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 #define INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float altitude);
@@ -47,7 +58,7 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                 const int scatteringOrder);
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 #endif
-#line 6 0 // direct-irradiance.frag
+#line 5 0 // direct-irradiance.frag
 
 vec4 computeDirectGroundIrradiance(const float cosSunZenithAngle, const float altitude)
 {
@@ -58,7 +69,7 @@ vec4 computeDirectGroundIrradiance(const float cosSunZenithAngle, const float al
     //   value in the center of the solar disk, assuming it to be a kind of "average".
     // * When the Sun is partially behind the astronomical horizon, we approximate the radiative view factor (i.e.
     //   cosine factor integrated over the solar disk) with a simple quadratic spline.
-    const float averageCosFactor = cosSunZenithAngle < -sunAngularRadius ? 0
+    CONST float averageCosFactor = cosSunZenithAngle < -sunAngularRadius ? 0
                                       : cosSunZenithAngle > sunAngularRadius ? cosSunZenithAngle
                                       : sqr(cosSunZenithAngle+sunAngularRadius)/(4*sunAngularRadius);
     return solarIrradianceAtTOA * transmittanceToAtmosphereBorder(cosSunZenithAngle, altitude) * averageCosFactor;

--- a/atmosphere/default/shaders/eclipsed-zero-order-scattering/3/eclipsed-direct-irradiance.frag
+++ b/atmosphere/default/shaders/eclipsed-zero-order-scattering/3/eclipsed-direct-irradiance.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // eclipsed-direct-irradiance.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,8 +45,8 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // eclipsed-direct-irradiance.frag
-#line 1 2 // common-functions.h.glsl
+#line 4 0 // eclipsed-direct-irradiance.frag
+#line 1 3 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -67,16 +78,16 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 6 0 // eclipsed-direct-irradiance.frag
-#line 1 3 // direct-irradiance.h.glsl
+#line 5 0 // eclipsed-direct-irradiance.frag
+#line 1 4 // direct-irradiance.h.glsl
 #ifndef INCLUDE_ONCE_58AEF899_1A84_4A2F_AD71_4E7680B83E29
 #define INCLUDE_ONCE_58AEF899_1A84_4A2F_AD71_4E7680B83E29
 
 vec4 computeDirectGroundIrradiance(const float cosSunZenithAngle, const float altitude);
 
 #endif
-#line 7 0 // eclipsed-direct-irradiance.frag
-#line 1 4 // texture-sampling-functions.h.glsl
+#line 6 0 // eclipsed-direct-irradiance.frag
+#line 1 5 // texture-sampling-functions.h.glsl
 #ifndef INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 #define INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float altitude);
@@ -88,15 +99,15 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                 const int scatteringOrder);
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 #endif
-#line 8 0 // eclipsed-direct-irradiance.frag
+#line 7 0 // eclipsed-direct-irradiance.frag
 
 vec4 calcEclipsedDirectGroundIrradiance(const vec3 pointOnGround, const vec3 sunDir, const vec3 moonPos)
 {
-    const float altitude=0; // we are on the ground, after all
-    const vec3 zenith=normalize(pointOnGround-earthCenter);
-    const float cosSunZenithAngle=dot(sunDir,zenith);
+    CONST float altitude=0; // we are on the ground, after all
+    CONST vec3 zenith=normalize(pointOnGround-earthCenter);
+    CONST float cosSunZenithAngle=dot(sunDir,zenith);
 
-    const float visibility=sunVisibilityDueToMoon(pointOnGround, sunDir, moonPos)
+    CONST float visibility=sunVisibilityDueToMoon(pointOnGround, sunDir, moonPos)
                                                     *
                       // FIXME: this ignores orientation of the crescent of eclipsed Sun WRT horizon
                                     sunVisibility(cosSunZenithAngle, altitude);

--- a/atmosphere/default/shaders/eclipsed-zero-order-scattering/3/phase-functions.frag
+++ b/atmosphere/default/shaders/eclipsed-zero-order-scattering/3/phase-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // phase-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // phase-functions.frag
+#line 4 0 // phase-functions.frag
 
 vec4 phaseFunction_molecules(float dotViewSun)
 {
@@ -42,8 +53,8 @@ vec4 phaseFunction_molecules(float dotViewSun)
 }
 vec4 phaseFunction_aerosols(float dotViewSun)
 {
-        const float g=0.76;
-        const float g2=g*g;
-        const float k = 3/(8*PI)*(1-g2)/(2+g2);
+        CONST float g=0.76;
+        CONST float g2=g*g;
+        CONST float k = 3/(8*PI)*(1-g2)/(2+g2);
         return vec4(k * (1+sqr(dotViewSun)) / pow(1+g2 - 2*g*dotViewSun, 1.5) + 1/((1-dotViewSun)*600+0.05))*0.904;
 }

--- a/atmosphere/default/shaders/eclipsed-zero-order-scattering/3/render.frag
+++ b/atmosphere/default/shaders/eclipsed-zero-order-scattering/3/render.frag
@@ -1,7 +1,21 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
 
-#line 1 1 // const.h.glsl
+
+
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 6 0 // render.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,11 +48,11 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // render.frag
-#line 1 2 // calc-view-dir.h.glsl
+#line 7 0 // render.frag
+#line 1 3 // calc-view-dir.h.glsl
 vec3 calcViewDir();
-#line 6 0 // render.frag
-#line 1 3 // common-functions.h.glsl
+#line 8 0 // render.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -70,11 +84,11 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // render.frag
+#line 9 0 // render.frag
 
 
 
-#line 1 4 // texture-coordinates.h.glsl
+#line 1 5 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -143,11 +157,11 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 11 0 // render.frag
-#line 1 5 // radiance-to-luminance.h.glsl
+#line 13 0 // render.frag
+#line 1 6 // radiance-to-luminance.h.glsl
 const mat4 radianceToLuminance=mat4(19.8756237,7.17745161,0,0.0937032327,  2.13895917,0.772417068,0,0.0149318045,  0.241072536,0.0870557055,0,0,  0.0133876652,0.00483453181,0,0);
-#line 12 0 // render.frag
-#line 1 6 // texture-sampling-functions.h.glsl
+#line 14 0 // render.frag
+#line 1 7 // texture-sampling-functions.h.glsl
 #ifndef INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 #define INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float altitude);
@@ -159,15 +173,15 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                 const int scatteringOrder);
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 #endif
-#line 13 0 // render.frag
-#line 1 7 // eclipsed-direct-irradiance.h.glsl
+#line 15 0 // render.frag
+#line 1 8 // eclipsed-direct-irradiance.h.glsl
 #ifndef INCLUDE_ONCE_8E9C53B3_83A0_4DD7_9106_32A13BD8935D
 #define INCLUDE_ONCE_8E9C53B3_83A0_4DD7_9106_32A13BD8935D
 
 vec4 calcEclipsedDirectGroundIrradiance(const vec3 pointOnGround, const vec3 sunDir, const vec3 moonPos);
 
 #endif
-#line 14 0 // render.frag
+#line 16 0 // render.frag
 
 
 uniform sampler3D scatteringTextureInterpolationGuides01;
@@ -202,18 +216,18 @@ void main()
     // this approximation has the same order of magnitude as the assumption that the Earth and its atmosphere
     // are spherical.
     float altitude = max(cameraPosition.z, 0.);
-    const vec3 oldCamPos=cameraPosition;
+    CONST vec3 oldCamPos=cameraPosition;
     // Hide the uniform with this name, thus effectively modifying it for the following code
     vec3 cameraPosition=vec3(oldCamPos.xy, altitude);
 
     bool lookingIntoAtmosphere=true;
     if(altitude>atmosphereHeight)
     {
-        const vec3 p = cameraPosition - earthCenter;
-        const float p_dot_v = dot(p, viewDir);
-        const float p_dot_p = dot(p, p);
-        const float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
-        const float distanceToTOA = -p_dot_v - sqrt(sqr(earthRadius+atmosphereHeight) - squaredDistBetweenViewRayAndEarthCenter);
+        CONST vec3 p = cameraPosition - earthCenter;
+        CONST float p_dot_v = dot(p, viewDir);
+        CONST float p_dot_p = dot(p, p);
+        CONST float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
+        CONST float distanceToTOA = -p_dot_v - sqrt(sqr(earthRadius+atmosphereHeight) - squaredDistBetweenViewRayAndEarthCenter);
         if(distanceToTOA>=0)
         {
             cameraPosition += viewDir*distanceToTOA;
@@ -231,16 +245,16 @@ void main()
         }
     }
 
-    const vec3 zenith=normalize(cameraPosition-earthCenter);
+    CONST vec3 zenith=normalize(cameraPosition-earthCenter);
     float cosViewZenithAngle=dot(zenith,viewDir);
 
     bool viewRayIntersectsGround=false;
     {
-        const vec3 p = cameraPosition - earthCenter;
-        const float p_dot_v = dot(p, viewDir);
-        const float p_dot_p = dot(p, p);
-        const float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
-        const float distanceToIntersection = -p_dot_v - sqrt(sqr(earthRadius) - squaredDistBetweenViewRayAndEarthCenter);
+        CONST vec3 p = cameraPosition - earthCenter;
+        CONST float p_dot_v = dot(p, viewDir);
+        CONST float p_dot_p = dot(p, p);
+        CONST float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
+        CONST float distanceToIntersection = -p_dot_v - sqrt(sqr(earthRadius) - squaredDistBetweenViewRayAndEarthCenter);
         // altitude==0 is a special case where distance to intersection calculation
         // is unreliable (has a lot of noise in its sign), so check it separately
         if(distanceToIntersection>0 || (altitude==0 && cosViewZenithAngle<0))
@@ -251,11 +265,11 @@ void main()
     // Aside from aesthetics, this affects brightness input to Stellarium's tone mapper.
     if(pseudoMirrorSkyBelowHorizon && viewRayIntersectsGround)
     {
-        const float horizonCZA = cosZenithAngleOfHorizon(altitude);
-        const float viewElev  = asin(clampCosine(cosViewZenithAngle));
-        const float horizElev = asin(clampCosine(horizonCZA));
-        const float newViewElev = 2*horizElev - viewElev;
-        const float viewDirXYnorm = length(viewDir-zenith*cosViewZenithAngle);
+        CONST float horizonCZA = cosZenithAngleOfHorizon(altitude);
+        CONST float viewElev  = asin(clampCosine(cosViewZenithAngle));
+        CONST float horizElev = asin(clampCosine(horizonCZA));
+        CONST float newViewElev = 2*horizElev - viewElev;
+        CONST float viewDirXYnorm = length(viewDir-zenith*cosViewZenithAngle);
         if(viewDirXYnorm == 0)
         {
             viewDir = zenith;
@@ -274,27 +288,27 @@ void main()
         viewRayIntersectsGround = false;
     }
 
-    const float cosSunZenithAngle =dot(zenith,sunDirection);
-    const float dotViewSun=dot(viewDir,sunDirection);
+    CONST float cosSunZenithAngle =dot(zenith,sunDirection);
+    CONST float dotViewSun=dot(viewDir,sunDirection);
 
-    const vec3 sunXYunnorm=sunDirection-dot(sunDirection,zenith)*zenith;
-    const vec3 viewXYunnorm=viewDir-dot(viewDir,zenith)*zenith;
-    const vec3 sunXY = sunXYunnorm.x!=0 || sunXYunnorm.y!=0 || sunXYunnorm.z!=0 ? normalize(sunXYunnorm) : vec3(0);
-    const vec3 viewXY = viewXYunnorm.x!=0 || viewXYunnorm.y!=0 || viewXYunnorm.z!=0 ? normalize(viewXYunnorm) : vec3(0);
-    const float azimuthRelativeToSun=safeAtan(dot(cross(sunXY, viewXY), zenith), dot(sunXY, viewXY));
+    CONST vec3 sunXYunnorm=sunDirection-dot(sunDirection,zenith)*zenith;
+    CONST vec3 viewXYunnorm=viewDir-dot(viewDir,zenith)*zenith;
+    CONST vec3 sunXY = sunXYunnorm.x!=0 || sunXYunnorm.y!=0 || sunXYunnorm.z!=0 ? normalize(sunXYunnorm) : vec3(0);
+    CONST vec3 viewXY = viewXYunnorm.x!=0 || viewXYunnorm.y!=0 || viewXYunnorm.z!=0 ? normalize(viewXYunnorm) : vec3(0);
+    CONST float azimuthRelativeToSun=safeAtan(dot(cross(sunXY, viewXY), zenith), dot(sunXY, viewXY));
 
-#if RENDERING_ZERO_SCATTERING
+#if 0 /*RENDERING_ZERO_SCATTERING*/
     vec4 radiance;
     if(viewRayIntersectsGround)
     {
         // XXX: keep in sync with the same code in computeScatteringDensity(), but don't forget about
         //      the difference in the usage of viewDir vs incDir.
-        const float distToGround = distanceToGround(cosViewZenithAngle, altitude);
-        const vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
-        const vec3 groundNormal = normalize(zenith*(earthRadius+altitude)+viewDir*distToGround);
-        const vec4 groundIrradiance = irradiance(dot(groundNormal, sunDirection), 0);
+        CONST float distToGround = distanceToGround(cosViewZenithAngle, altitude);
+        CONST vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
+        CONST vec3 groundNormal = normalize(zenith*(earthRadius+altitude)+viewDir*distToGround);
+        CONST vec4 groundIrradiance = irradiance(dot(groundNormal, sunDirection), 0);
         // Radiation scattered by the ground
-        const float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
+        CONST float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
         radiance = transmittanceToGround*groundAlbedo*groundIrradiance*solarIrradianceFixup*groundBRDF
                  + lightPollutionGroundLuminance*lightPollutionRelativeRadiance;
     }
@@ -313,20 +327,20 @@ void main()
     radianceOutput=radiance;
 #elif 1 /*RENDERING_ECLIPSED_ZERO_SCATTERING*/
     vec4 radiance;
-    const float dotViewMoon=dot(viewDir,normalize(moonPosition-cameraPosition));
+    CONST float dotViewMoon=dot(viewDir,normalize(moonPosition-cameraPosition));
     if(viewRayIntersectsGround)
     {
         // XXX: keep in sync with the similar code in non-eclipsed zero scattering rendering.
-        const float distToGround = distanceToGround(cosViewZenithAngle, altitude);
-        const vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
-        const vec3 pointOnGround = cameraPosition+viewDir*distToGround;
-        const vec4 directGroundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDirection, moonPosition);
+        CONST float distToGround = distanceToGround(cosViewZenithAngle, altitude);
+        CONST vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
+        CONST vec3 pointOnGround = cameraPosition+viewDir*distToGround;
+        CONST vec4 directGroundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDirection, moonPosition);
         // FIXME: add first-order indirect irradiance too: it's done in non-eclipsed irradiance (in the same
         // conditions: when limited to 2 orders). This should be calculated at the same time when second order
         // is: all the infrastructure is already there.
-        const vec4 groundIrradiance = directGroundIrradiance;
+        CONST vec4 groundIrradiance = directGroundIrradiance;
         // Radiation scattered by the ground
-        const float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
+        CONST float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
         radiance = transmittanceToGround*groundAlbedo*groundIrradiance*solarIrradianceFixup*groundBRDF
                  + lightPollutionGroundLuminance*lightPollutionRelativeRadiance;
     }
@@ -343,53 +357,53 @@ void main()
     }
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_ON_THE_FLY
-    const vec4 scattering=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPosition,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_ON_THE_FLY*/
+    CONST vec4 scattering=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPosition,
                                                           viewRayIntersectsGround);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE
-    const vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE*/
+    CONST vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                      viewRayIntersectsGround, eclipsedSingleScatteringTextureSize);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact at the point where azimuth texture coordinate changes from 1 to 0 (at azimuthRelativeToSun crossing
     // 0). This happens when I simply call texture(eclipsedScatteringTexture, texCoords) without specifying LOD.
     // Apparently, the driver uses the derivative for some reason, even though it shouldn't.
-    const vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
+    CONST vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE
-    const vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
+    CONST vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                      viewRayIntersectsGround, eclipsedSingleScatteringTextureSize);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact at the point where azimuth texture coordinate changes from 1 to 0 (at azimuthRelativeToSun crossing
     // 0). This happens when I simply call texture(eclipsedScatteringTexture, texCoords) without specifying LOD.
     // Apparently, the driver uses the derivative for some reason, even though it shouldn't.
-    const vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
+    CONST vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
     luminance=scattering*currentPhaseFunction(dotViewSun);
-#elif RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_RADIANCE
+#elif 0 /*RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_RADIANCE*/
     vec4 radiance=exp(sampleEclipseDoubleScattering3DTexture(eclipsedDoubleScatteringTexture,
                                                              cosSunZenithAngle, cosViewZenithAngle, azimuthRelativeToSun,
                                                              altitude, viewRayIntersectsGround));
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_LUMINANCE
+#elif 0 /*RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
     luminance=exp(sampleEclipseDoubleScattering3DTexture(eclipsedDoubleScatteringTexture,
                                                          cosSunZenithAngle, cosViewZenithAngle, azimuthRelativeToSun,
                                                          altitude, viewRayIntersectsGround));
-#elif RENDERING_SINGLE_SCATTERING_ON_THE_FLY
-    const vec4 scattering=computeSingleScattering(cosSunZenithAngle,cosViewZenithAngle,dotViewSun,
+#elif 0 /*RENDERING_SINGLE_SCATTERING_ON_THE_FLY*/
+    CONST vec4 scattering=computeSingleScattering(cosSunZenithAngle,cosViewZenithAngle,dotViewSun,
                                                   altitude,viewRayIntersectsGround);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE
+#elif 0 /*RENDERING_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE*/
     vec4 scattering;
     if(useInterpolationGuides)
     {
@@ -406,7 +420,7 @@ void main()
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE
+#elif 0 /*RENDERING_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
     vec4 scattering;
     if(useInterpolationGuides)
     {
@@ -420,18 +434,18 @@ void main()
                                      dotViewSun, altitude, viewRayIntersectsGround);
     }
     luminance=scattering * (bool(PHASE_FUNCTION_IS_EMBEDDED) ? vec4(1) : currentPhaseFunction(dotViewSun));
-#elif RENDERING_MULTIPLE_SCATTERING_LUMINANCE
+#elif 0 /*RENDERING_MULTIPLE_SCATTERING_LUMINANCE*/
     luminance=sample3DTexture(scatteringTexture, cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, viewRayIntersectsGround);
-#elif RENDERING_MULTIPLE_SCATTERING_RADIANCE
+#elif 0 /*RENDERING_MULTIPLE_SCATTERING_RADIANCE*/
     vec4 radiance=sample3DTexture(scatteringTexture, cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, viewRayIntersectsGround);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_LIGHT_POLLUTION_RADIANCE
+#elif 0 /*RENDERING_LIGHT_POLLUTION_RADIANCE*/
     vec4 radiance=lightPollutionGroundLuminance*lightPollutionScattering(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_LIGHT_POLLUTION_LUMINANCE
+#elif 0 /*RENDERING_LIGHT_POLLUTION_LUMINANCE*/
     luminance=lightPollutionGroundLuminance*lightPollutionScattering(altitude, cosViewZenithAngle, viewRayIntersectsGround);
 #else
 #error What to render?

--- a/atmosphere/default/shaders/eclipsed-zero-order-scattering/3/texture-coordinates.frag
+++ b/atmosphere/default/shaders/eclipsed-zero-order-scattering/3/texture-coordinates.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-coordinates.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,8 +45,8 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // texture-coordinates.frag
-#line 1 2 // texture-coordinates.h.glsl
+#line 4 0 // texture-coordinates.frag
+#line 1 3 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -104,8 +115,8 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 6 0 // texture-coordinates.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-coordinates.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -137,7 +148,7 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-coordinates.frag
+#line 6 0 // texture-coordinates.frag
 
 const float LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA=sqrt(atmosphereHeight*(atmosphereHeight+2*earthRadius));
 
@@ -205,18 +216,18 @@ vec3 indicesToTexCoords(const vec3 indices, const vec3 texSizes)
 
 TransmittanceTexVars transmittanceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
+    CONST float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
                                 texCoordToUnitRange(texCoord.t,transmittanceTextureSize.t);
     // Distance from Earth center to camera
-    const float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
-    const float altitude=r-earthRadius;
+    CONST float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
+    CONST float altitude=r-earthRadius;
 
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
     // distance to border of visible atmosphere from the view point
-    const float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
+    CONST float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
     // d==0 can happen when altitude==atmosphereHeight
-    const float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
+    CONST float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
     return TransmittanceTexVars(cosVZA,altitude);
 }
 
@@ -235,53 +246,53 @@ vec2 transmittanceTexVarsToTexCoord(const float cosVZA, float altitude)
     if(altitude<0)
         altitude=0;
 
-    const float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
+    CONST float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
                                       transmittanceTextureSize.t);
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
-    const float d=distanceToAtmosphereBorder(cosVZA,altitude);
-    const float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float d=distanceToAtmosphereBorder(cosVZA,altitude);
+    CONST float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
     return vec2(s,t);
 }
 
 // Output: vec2(cos(sunZenithAngle), altitude)
 IrradianceTexVars irradianceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
-    const float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
+    CONST float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
+    CONST float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
     return IrradianceTexVars(cosSZA,alt);
 }
 
 vec2 irradianceTexVarsToTexCoord(const float cosSunZenithAngle, const float altitude)
 {
-    const float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
-    const float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
+    CONST float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
+    CONST float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
     return vec2(s,t);
 }
 
 float cosSZAToUnitRangeTexCoord(const float cosSunZenithAngle)
 {
     // Distance to top atmosphere border along the ray groundUnderCamera-sun: (altitude, cosSunZenithAngle)
-    const float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name
-    const float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
+    CONST float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
     // TODO: choose a more descriptive name
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     return max(0.,1-a/A)/(a+1);
 }
 
 float unitRangeTexCoordToCosSZA(const float texCoord)
 {
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float a=(A-A*texCoord)/(1+A*texCoord);
-    const float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
+    CONST float a=(A-A*texCoord)/(1+A*texCoord);
+    CONST float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
     return distFromGroundToTopAtmoBorder==0 ? 1 :
         clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distFromGroundToTopAtmoBorder)) /
                     (2*earthRadius*distFromGroundToTopAtmoBorder));
@@ -292,24 +303,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
                                                const float dotViewSun, const float altitude,
                                                const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -317,24 +328,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float dotVSCoord=(dotViewSun+1)/2;
+    CONST float dotVSCoord=(dotViewSun+1)/2;
 
     // ------------------------------------
-    const float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
+    CONST float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
 
     return Scattering4DCoords(cosSZACoord, cosVZACoord, dotVSCoord, altCoord, viewRayIntersectsGround);
 }
 
 TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
@@ -342,16 +353,16 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture coordinates we combine into a single sampler3D coordinate.
-    const float texW = scatteringTextureSize[1];
-    const float texH = scatteringTextureSize[2];
-    const float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
-    const vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
+    CONST float texW = scatteringTextureSize[1];
+    CONST float texH = scatteringTextureSize[2];
+    CONST float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
+    CONST vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
                                         ceil (cosSZAIndex)*texW+coords.dotViewSun*(texW-1)) / (texW*texH-1);
-    const vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
+    CONST vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
 
-    const float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
+    CONST float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
 
-    const float alphaUpper=fract(cosSZAIndex);
+    CONST float alphaUpper=fract(cosSZAIndex);
     return TexCoordPair(vec3(cosVZAtc, combinedCoord.x, altitude), float(1-alphaUpper),
                         vec3(cosVZAtc, combinedCoord.y, altitude), float(alphaUpper));
 }
@@ -359,9 +370,9 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
+    CONST TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
     return texture(tex, texCoords.lower) * texCoords.alphaLower +
            texture(tex, texCoords.upper) * texCoords.alphaUpper;
 }
@@ -369,17 +380,17 @@ vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const f
 // 3D texture is the 3D single-altitude slice of a 4D texture
 vec3 scattering4DCoordsToTex3DCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2);
 
-    const float dvsSize = scatteringTextureSize[1];
-    const float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
+    CONST float dvsSize = scatteringTextureSize[1];
+    CONST float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
 
-    const float cszaSize = scatteringTextureSize[2];
-    const float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
+    CONST float cszaSize = scatteringTextureSize[2];
+    CONST float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
 
     return vec3(cosVZAtc, dotVStc, cosSZAtc);
 }
@@ -394,39 +405,39 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along dotViewSun coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[1];
-    const float posOfRow = indices[1];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[1];
+    CONST float posOfRow = indices[1];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         indexToTexCoord(currRow, numRows-1),
                                                         texCoordVerbatim));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               indexToTexCoord(currRow, numRows-1),
                                                               texCoordVerbatim));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          indexToTexCoord(currRow, numRows-1),
                                          texCoordVerbatim));
@@ -434,14 +445,14 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
 vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolationGuides01Tex,
                                  const vec3 indices)
 {
-    const float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
+    CONST float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
 
-    const float cosVZAIndex = indices[0];
-    const float dotVSIndex = indices[1];
-    const float currRow = floor(dotVSIndex);
-    const float posBetweenRows = dotVSIndex - currRow;
-    const float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cosVZAIndex = indices[0];
+    CONST float dotVSIndex = indices[1];
+    CONST float currRow = floor(dotVSIndex);
+    CONST float posBetweenRows = dotVSIndex - currRow;
+    CONST float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -449,14 +460,14 @@ vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolat
     indicesCurrRow[1] =     currRow;
     indicesNextRow[1] = min(currRow+1, scatteringTextureSize[1]-1.);
 
-    const vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
-    const vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
+    CONST vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
+    CONST vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
 
-    const vec4 valueCurrRow = texture(tex, coordsCurrRow);
-    const vec4 valueNextRow = texture(tex, coordsNextRow);
-    const float epsilon = 1e-37; // Prevents passing zero to log
-    const vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
-    const vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
+    CONST vec4 valueCurrRow = texture(tex, coordsCurrRow);
+    CONST vec4 valueNextRow = texture(tex, coordsNextRow);
+    CONST float epsilon = 1e-37; // Prevents passing zero to log
+    CONST vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
+    CONST vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
     return (logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow;
 }
 
@@ -465,37 +476,37 @@ float findGuide02Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along SZA coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[2];
-    const float posOfRow = indices[2];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[2];
+    CONST float posOfRow = indices[2];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
 }
@@ -505,19 +516,19 @@ vec4 sample3DTextureGuided(const sampler3D tex,
                            const float cosSunZenithAngle, const float cosViewZenithAngle,
                            const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
                                                                     dotViewSun, altitude, viewRayIntersectsGround);
     // Handle the external interpolation guides: the guides between a pair of VZA-dotViewSun 2D "pictures".
-    const vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
-    const vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
-    const float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
+    CONST vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
+    CONST float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
 
-    const float cvzaIndex = indices[0];
-    const float cszaIndex = indices[2];
-    const float currRow = floor(cszaIndex);
-    const float posBetweenRows = cszaIndex - currRow;
-    const float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cvzaIndex = indices[0];
+    CONST float cszaIndex = indices[2];
+    CONST float currRow = floor(cszaIndex);
+    CONST float posBetweenRows = cszaIndex - currRow;
+    CONST float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -526,58 +537,58 @@ vec4 sample3DTextureGuided(const sampler3D tex,
     indicesNextRow[2] = min(currRow+1, scatteringTextureSize[2]-1);
 
     // The caller will handle the internal interpolation guides: the ones between rows in each 2D "picture".
-    const vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
-    const vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
+    CONST vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
+    CONST vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
     return exp((logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow);
 }
 
 vec4 sample3DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
     return texture(tex, texCoords);
 }
 
 ScatteringTexVars scatteringTex4DCoordsToTexVars(const Scattering4DCoords coords)
 {
-    const float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
     // ------------------------------------
     float cosViewZenithAngle;
     if(coords.viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
     // ------------------------------------
-    const float dotViewSun=coords.dotViewSun*2-1;
+    CONST float dotViewSun=coords.dotViewSun*2-1;
 
     // ------------------------------------
-    const float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
+    CONST float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
 
     return ScatteringTexVars(cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, coords.viewRayIntersectsGround);
 }
 
 Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 {
-    const vec4 indexMax=scatteringTextureSize-vec4(1);
+    CONST vec4 indexMax=scatteringTextureSize-vec4(1);
     Scattering4DCoords coords4d;
     coords4d.viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
     // The following formulas assume that scatteringTextureSize[0] is even. For odd sizes they would change.
@@ -593,8 +604,8 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture indices we combine into a single sampler3D coordinate.
-    const float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
-    const float combinedIndex=texIndices[1];
+    CONST float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
+    CONST float combinedIndex=texIndices[1];
     coords4d.dotViewSun=mod(combinedIndex,texW)/(texW-1);
     coords4d.cosSunZenithAngle=floor(combinedIndex/texW)/(texH-1);
 
@@ -608,11 +619,11 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
 ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 {
-    const Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
+    CONST Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
     ScatteringTexVars vars=scatteringTex4DCoordsToTexVars(coords4d);
     // Clamp dotViewSun to its valid range of values, given cosViewZenithAngle and cosSunZenithAngle. This is
     // needed to prevent NaNs when computing the scattering texture.
-    const float cosVZA=vars.cosViewZenithAngle,
+    CONST float cosVZA=vars.cosViewZenithAngle,
                 cosSZA=vars.cosSunZenithAngle;
     vars.dotViewSun=clamp(vars.dotViewSun,
                           cosVZA*cosSZA-safeSqrt((1-sqr(cosVZA))*(1-sqr(cosSZA))),
@@ -622,54 +633,54 @@ ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 
 EclipseScatteringTexVars eclipseTexCoordsToTexVars(const vec2 texCoords, const float altitude)
 {
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
-    const bool viewRayIntersectsGround = texCoords.t<0.5;
+    CONST bool viewRayIntersectsGround = texCoords.t<0.5;
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
-    const float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
+    CONST float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
     return EclipseScatteringTexVars(azimuthRelativeToSun, cosViewZenithAngle, viewRayIntersectsGround);
 }
 
 EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                                    const float altitude, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -677,13 +688,13 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
-    const float azimuthCoord = azimuthRelativeToSun/(2*PI);
+    CONST float azimuthCoord = azimuthRelativeToSun/(2*PI);
 
     return EclipseScattering2DCoords(azimuthCoord, cosVZACoord);
 }
@@ -691,14 +702,14 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
 vec2 eclipseTexVarsToTexCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                const float altitude, const bool viewRayIntersectsGround, const vec2 texSize)
 {
-    const EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+    CONST EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                                     viewRayIntersectsGround);
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2);
-    const float azimuthTC = coords.azimuth + 1/(2*texSize.s);
+    CONST float azimuthTC = coords.azimuth + 1/(2*texSize.s);
 
     return vec2(azimuthTC, cosVZAtc);
 }
@@ -707,42 +718,42 @@ vec4 sampleEclipseDoubleScattering3DTexture(const sampler3D tex, const float cos
                                             const float cosViewZenithAngle, const float azimuthRelativeToSun,
                                             const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
+    CONST vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
                                                   eclipsedDoubleScatteringTextureSize.st);
-    const float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
-    const vec3 texCoords=vec3(coords2d, cosSZACoord);
+    CONST float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
+    CONST vec3 texCoords=vec3(coords2d, cosSZACoord);
 
     return texture(tex, texCoords);
 }
 
 LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 texIndices)
 {
-    const vec2 indexMax=lightPollutionTextureSize-vec2(1);
+    CONST vec2 indexMax=lightPollutionTextureSize-vec2(1);
 
-    const float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
-    const float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
+    CONST float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
-    const bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
-    const float cosViewZenithAngleCoord = viewRayIntersectsGround ?
+    CONST bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
+    CONST float cosViewZenithAngleCoord = viewRayIntersectsGround ?
                                    1-2*texIndices[0]/(indexMax[0]-1) :
                                    2*(texIndices[0]-1)/(indexMax[0]-1)-1;
     // ------------------------------------
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
@@ -753,23 +764,23 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 
 LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -777,27 +788,27 @@ LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, con
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     return LightPollution2DCoords(cosVZACoord, altCoord);
 }
 
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
-    const vec2 texSize = lightPollutionTextureSize;
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 texSize = lightPollutionTextureSize;
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2);
-    const float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
+    CONST float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
     return vec2(cosVZAtc, altitudeTC);
 }

--- a/atmosphere/default/shaders/eclipsed-zero-order-scattering/3/texture-sampling-functions.frag
+++ b/atmosphere/default/shaders/eclipsed-zero-order-scattering/3/texture-sampling-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-sampling-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,13 +45,13 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // texture-sampling-functions.frag
-#line 1 2 // phase-functions.h.glsl
+#line 4 0 // texture-sampling-functions.frag
+#line 1 3 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 6 0 // texture-sampling-functions.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-sampling-functions.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -72,8 +83,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-sampling-functions.frag
-#line 1 4 // texture-coordinates.h.glsl
+#line 6 0 // texture-sampling-functions.frag
+#line 1 5 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -142,7 +153,7 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 8 0 // texture-sampling-functions.frag
+#line 7 0 // texture-sampling-functions.frag
 
 uniform sampler2D transmittanceTexture;
 uniform sampler2D irradianceTexture;
@@ -154,13 +165,13 @@ uniform sampler2D lightPollutionScatteringTexture;
 
 vec4 irradiance(const float cosSunZenithAngle, const float altitude)
 {
-    const vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
+    CONST vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
     return texture(irradianceTexture, texCoords);
 }
 
 vec4 opticalDepthToAtmosphereBorder(const float cosViewZenithAngle, const float altitude)
 {
-    const vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
+    CONST vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact when looking into nadir from TOA at some values of texture sizes (in particular, size of
     // transmittance texture for altitude being 4096). This happens when I simply call texture(eclipsedScatteringTexture,
@@ -178,11 +189,11 @@ vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float
 vec4 transmittance(const float cosViewZenithAngle, const float altitude, const float dist,
                    const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle view ray endpoint
     // in space here.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
 
     vec4 depth;
     if(viewRayIntersectsGround)
@@ -201,7 +212,7 @@ vec4 transmittance(const float cosViewZenithAngle, const float altitude, const f
 vec4 calcFirstScattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                          const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
+    CONST vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
                                           dotViewSun, altitude, viewRayIntersectsGround);
     return scattering*currentPhaseFunction(dotViewSun);
 }
@@ -220,6 +231,6 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
 
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     return texture(lightPollutionScatteringTexture, coords);
 }

--- a/atmosphere/default/shaders/light-pollution/common-functions.frag
+++ b/atmosphere/default/shaders/light-pollution/common-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // common-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // common-functions.frag
+#line 4 0 // common-functions.frag
 
 bool dbgDataPresent=false;
 bool debugDataPresent()
@@ -69,7 +80,7 @@ void setDebugData(float a,float b, float c, float d)
 
 void swap(inout float x, inout float y)
 {
-    const float t = x;
+    CONST float t = x;
     x = y;
     y = t;
 }
@@ -83,7 +94,7 @@ float safeSqrt(const float x)
 
 float safeAtan(const float y, const float x)
 {
-    const float a = atan(y,x);
+    CONST float a = atan(y,x);
     return x==0 && y==0 ? 0 : a;
 }
 
@@ -116,23 +127,23 @@ float pointAltitude(vec3 point)
 
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float Ratm=earthRadius+atmosphereHeight;
-    const float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float Ratm=earthRadius+atmosphereHeight;
+    CONST float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float distanceToGround(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(-safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float cosZenithAngleOfHorizon(const float altitude)
 {
-    const float R=earthRadius;
-    const float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
+    CONST float R=earthRadius;
+    CONST float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
     return -sqrt(2*h*R+sqr(h))/(R+h);
 }
 
@@ -151,8 +162,8 @@ float distanceToNearestAtmosphereBoundary(const float cosZenithAngle, const floa
 float sunVisibility(const float cosSunZenithAngle, float altitude)
 {
     if(altitude<0) altitude=0;
-    const float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
-    const float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
+    CONST float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
+    CONST float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
     /* Approximating visible fraction of solar disk by smoothstep between the position of the Sun
      * touching the horizon by its upper part and the position with lower part touching the horizon.
      * The calculation assumes that solar angular radius is small and thus approximately equals its sine.
@@ -182,13 +193,13 @@ float circlesIntersectionArea(float R1, float R2, float d)
 
 float angleBetween(const vec3 a, const vec3 b)
 {
-    const float d=dot(a,b);
-    const float c=length(cross(a,b));
+    CONST float d=dot(a,b);
+    CONST float c=length(cross(a,b));
     // To avoid loss of precision, don't use dot product near the singularity
     // of acos, and cross product near the singularity of asin
     if(abs(d) < abs(c))
         return acos(d/(length(a)*length(b)));
-    const float smallerAngle = asin(c/(length(a)*length(b)));
+    CONST float smallerAngle = asin(c/(length(a)*length(b)));
     if(d<0) return PI-smallerAngle;
     return smallerAngle;
 }
@@ -205,11 +216,11 @@ float moonAngularRadius(const vec3 cameraPosition, const vec3 moonPosition)
 
 float visibleSolidAngleOfSun(const vec3 camera, const vec3 sunDir, const vec3 moonPos)
 {
-    const float Rs=sunAngularRadius;
-    const float Rm=moonAngularRadius(camera,moonPos);
+    CONST float Rs=sunAngularRadius;
+    CONST float Rm=moonAngularRadius(camera,moonPos);
     float visibleSolidAngle=PI*sqr(Rs);
 
-    const float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
+    CONST float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
     if(dSM<Rs+Rm)
     {
         visibleSolidAngle -= circlesIntersectionArea(Rm,Rs,dSM);
@@ -229,12 +240,12 @@ float sphereIntegrationSolidAngleDifferential(const int pointCountOnSphere)
 }
 vec3 sphereIntegrationSampleDir(const int index, const int pointCountOnSphere)
 {
-    const float goldenRatio=1.6180339887499;
+    CONST float goldenRatio=1.6180339887499;
     // The range of n is 0.5, 1.5, ..., pointCountOnSphere-0.5
-    const float n=index+0.5;
+    CONST float n=index+0.5;
     // Explanation of the Fibonacci grid generation can be seen at https://stackoverflow.com/a/44164075/673852
-    const float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
-    const float azimuth=n*(2*PI*goldenRatio);
+    CONST float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
+    CONST float azimuth=n*(2*PI*goldenRatio);
     return vec3(cos(azimuth)*sin(zenithAngle),
                 sin(azimuth)*sin(zenithAngle),
                 cos(zenithAngle));

--- a/atmosphere/default/shaders/light-pollution/phase-functions.frag
+++ b/atmosphere/default/shaders/light-pollution/phase-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // phase-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // phase-functions.frag
+#line 4 0 // phase-functions.frag
 
 vec4 phaseFunction_molecules(float dotViewSun)
 {
@@ -42,8 +53,8 @@ vec4 phaseFunction_molecules(float dotViewSun)
 }
 vec4 phaseFunction_aerosols(float dotViewSun)
 {
-        const float g=0.76;
-        const float g2=g*g;
-        const float k = 3/(8*PI)*(1-g2)/(2+g2);
+        CONST float g=0.76;
+        CONST float g2=g*g;
+        CONST float k = 3/(8*PI)*(1-g2)/(2+g2);
         return vec4(k * (1+sqr(dotViewSun)) / pow(1+g2 - 2*g*dotViewSun, 1.5) + 1/((1-dotViewSun)*600+0.05))*0.904;
 }

--- a/atmosphere/default/shaders/light-pollution/render.frag
+++ b/atmosphere/default/shaders/light-pollution/render.frag
@@ -1,7 +1,21 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
 
-#line 1 1 // const.h.glsl
+
+
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 6 0 // render.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,11 +48,11 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // render.frag
-#line 1 2 // calc-view-dir.h.glsl
+#line 7 0 // render.frag
+#line 1 3 // calc-view-dir.h.glsl
 vec3 calcViewDir();
-#line 6 0 // render.frag
-#line 1 3 // common-functions.h.glsl
+#line 8 0 // render.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -70,11 +84,11 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // render.frag
+#line 9 0 // render.frag
 
 
 
-#line 1 4 // texture-coordinates.h.glsl
+#line 1 5 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -143,13 +157,13 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 11 0 // render.frag
-#line 1 5 // radiance-to-luminance.h.glsl
+#line 13 0 // render.frag
+#line 1 6 // radiance-to-luminance.h.glsl
 const mat4 radianceToLuminance=mat4(1.38997746,0.0419133306,6.48549128,0,  105.968163,3.00652099,500.960266,142.641495,  3776.24023,119.971481,18207.7598,6412.0166,  6910.01318,981.06665,37504.0586,26741.9102);
-#line 12 0 // render.frag
+#line 14 0 // render.frag
 
 
-#line 1 6 // texture-sampling-functions.h.glsl
+#line 1 7 // texture-sampling-functions.h.glsl
 #ifndef INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 #define INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float altitude);
@@ -161,7 +175,7 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                 const int scatteringOrder);
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 #endif
-#line 15 0 // render.frag
+#line 17 0 // render.frag
 
 uniform sampler3D scatteringTextureInterpolationGuides01;
 uniform sampler3D scatteringTextureInterpolationGuides02;
@@ -195,18 +209,18 @@ void main()
     // this approximation has the same order of magnitude as the assumption that the Earth and its atmosphere
     // are spherical.
     float altitude = max(cameraPosition.z, 0.);
-    const vec3 oldCamPos=cameraPosition;
+    CONST vec3 oldCamPos=cameraPosition;
     // Hide the uniform with this name, thus effectively modifying it for the following code
     vec3 cameraPosition=vec3(oldCamPos.xy, altitude);
 
     bool lookingIntoAtmosphere=true;
     if(altitude>atmosphereHeight)
     {
-        const vec3 p = cameraPosition - earthCenter;
-        const float p_dot_v = dot(p, viewDir);
-        const float p_dot_p = dot(p, p);
-        const float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
-        const float distanceToTOA = -p_dot_v - sqrt(sqr(earthRadius+atmosphereHeight) - squaredDistBetweenViewRayAndEarthCenter);
+        CONST vec3 p = cameraPosition - earthCenter;
+        CONST float p_dot_v = dot(p, viewDir);
+        CONST float p_dot_p = dot(p, p);
+        CONST float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
+        CONST float distanceToTOA = -p_dot_v - sqrt(sqr(earthRadius+atmosphereHeight) - squaredDistBetweenViewRayAndEarthCenter);
         if(distanceToTOA>=0)
         {
             cameraPosition += viewDir*distanceToTOA;
@@ -214,7 +228,7 @@ void main()
         }
         else
         {
-#if RENDERING_ANY_ZERO_SCATTERING
+#if 0 /*RENDERING_ANY_ZERO_SCATTERING*/
             lookingIntoAtmosphere=false;
 #else
             luminance=vec4(0);
@@ -224,16 +238,16 @@ void main()
         }
     }
 
-    const vec3 zenith=normalize(cameraPosition-earthCenter);
+    CONST vec3 zenith=normalize(cameraPosition-earthCenter);
     float cosViewZenithAngle=dot(zenith,viewDir);
 
     bool viewRayIntersectsGround=false;
     {
-        const vec3 p = cameraPosition - earthCenter;
-        const float p_dot_v = dot(p, viewDir);
-        const float p_dot_p = dot(p, p);
-        const float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
-        const float distanceToIntersection = -p_dot_v - sqrt(sqr(earthRadius) - squaredDistBetweenViewRayAndEarthCenter);
+        CONST vec3 p = cameraPosition - earthCenter;
+        CONST float p_dot_v = dot(p, viewDir);
+        CONST float p_dot_p = dot(p, p);
+        CONST float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
+        CONST float distanceToIntersection = -p_dot_v - sqrt(sqr(earthRadius) - squaredDistBetweenViewRayAndEarthCenter);
         // altitude==0 is a special case where distance to intersection calculation
         // is unreliable (has a lot of noise in its sign), so check it separately
         if(distanceToIntersection>0 || (altitude==0 && cosViewZenithAngle<0))
@@ -244,11 +258,11 @@ void main()
     // Aside from aesthetics, this affects brightness input to Stellarium's tone mapper.
     if(pseudoMirrorSkyBelowHorizon && viewRayIntersectsGround)
     {
-        const float horizonCZA = cosZenithAngleOfHorizon(altitude);
-        const float viewElev  = asin(clampCosine(cosViewZenithAngle));
-        const float horizElev = asin(clampCosine(horizonCZA));
-        const float newViewElev = 2*horizElev - viewElev;
-        const float viewDirXYnorm = length(viewDir-zenith*cosViewZenithAngle);
+        CONST float horizonCZA = cosZenithAngleOfHorizon(altitude);
+        CONST float viewElev  = asin(clampCosine(cosViewZenithAngle));
+        CONST float horizElev = asin(clampCosine(horizonCZA));
+        CONST float newViewElev = 2*horizElev - viewElev;
+        CONST float viewDirXYnorm = length(viewDir-zenith*cosViewZenithAngle);
         if(viewDirXYnorm == 0)
         {
             viewDir = zenith;
@@ -267,27 +281,27 @@ void main()
         viewRayIntersectsGround = false;
     }
 
-    const float cosSunZenithAngle =dot(zenith,sunDirection);
-    const float dotViewSun=dot(viewDir,sunDirection);
+    CONST float cosSunZenithAngle =dot(zenith,sunDirection);
+    CONST float dotViewSun=dot(viewDir,sunDirection);
 
-    const vec3 sunXYunnorm=sunDirection-dot(sunDirection,zenith)*zenith;
-    const vec3 viewXYunnorm=viewDir-dot(viewDir,zenith)*zenith;
-    const vec3 sunXY = sunXYunnorm.x!=0 || sunXYunnorm.y!=0 || sunXYunnorm.z!=0 ? normalize(sunXYunnorm) : vec3(0);
-    const vec3 viewXY = viewXYunnorm.x!=0 || viewXYunnorm.y!=0 || viewXYunnorm.z!=0 ? normalize(viewXYunnorm) : vec3(0);
-    const float azimuthRelativeToSun=safeAtan(dot(cross(sunXY, viewXY), zenith), dot(sunXY, viewXY));
+    CONST vec3 sunXYunnorm=sunDirection-dot(sunDirection,zenith)*zenith;
+    CONST vec3 viewXYunnorm=viewDir-dot(viewDir,zenith)*zenith;
+    CONST vec3 sunXY = sunXYunnorm.x!=0 || sunXYunnorm.y!=0 || sunXYunnorm.z!=0 ? normalize(sunXYunnorm) : vec3(0);
+    CONST vec3 viewXY = viewXYunnorm.x!=0 || viewXYunnorm.y!=0 || viewXYunnorm.z!=0 ? normalize(viewXYunnorm) : vec3(0);
+    CONST float azimuthRelativeToSun=safeAtan(dot(cross(sunXY, viewXY), zenith), dot(sunXY, viewXY));
 
-#if RENDERING_ZERO_SCATTERING
+#if 0 /*RENDERING_ZERO_SCATTERING*/
     vec4 radiance;
     if(viewRayIntersectsGround)
     {
         // XXX: keep in sync with the same code in computeScatteringDensity(), but don't forget about
         //      the difference in the usage of viewDir vs incDir.
-        const float distToGround = distanceToGround(cosViewZenithAngle, altitude);
-        const vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
-        const vec3 groundNormal = normalize(zenith*(earthRadius+altitude)+viewDir*distToGround);
-        const vec4 groundIrradiance = irradiance(dot(groundNormal, sunDirection), 0);
+        CONST float distToGround = distanceToGround(cosViewZenithAngle, altitude);
+        CONST vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
+        CONST vec3 groundNormal = normalize(zenith*(earthRadius+altitude)+viewDir*distToGround);
+        CONST vec4 groundIrradiance = irradiance(dot(groundNormal, sunDirection), 0);
         // Radiation scattered by the ground
-        const float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
+        CONST float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
         radiance = transmittanceToGround*groundAlbedo*groundIrradiance*solarIrradianceFixup*groundBRDF
                  + lightPollutionGroundLuminance*lightPollutionRelativeRadiance;
     }
@@ -304,22 +318,22 @@ void main()
     }
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_ZERO_SCATTERING
+#elif 0 /*RENDERING_ECLIPSED_ZERO_SCATTERING*/
     vec4 radiance;
-    const float dotViewMoon=dot(viewDir,normalize(moonPosition-cameraPosition));
+    CONST float dotViewMoon=dot(viewDir,normalize(moonPosition-cameraPosition));
     if(viewRayIntersectsGround)
     {
         // XXX: keep in sync with the similar code in non-eclipsed zero scattering rendering.
-        const float distToGround = distanceToGround(cosViewZenithAngle, altitude);
-        const vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
-        const vec3 pointOnGround = cameraPosition+viewDir*distToGround;
-        const vec4 directGroundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDirection, moonPosition);
+        CONST float distToGround = distanceToGround(cosViewZenithAngle, altitude);
+        CONST vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
+        CONST vec3 pointOnGround = cameraPosition+viewDir*distToGround;
+        CONST vec4 directGroundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDirection, moonPosition);
         // FIXME: add first-order indirect irradiance too: it's done in non-eclipsed irradiance (in the same
         // conditions: when limited to 2 orders). This should be calculated at the same time when second order
         // is: all the infrastructure is already there.
-        const vec4 groundIrradiance = directGroundIrradiance;
+        CONST vec4 groundIrradiance = directGroundIrradiance;
         // Radiation scattered by the ground
-        const float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
+        CONST float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
         radiance = transmittanceToGround*groundAlbedo*groundIrradiance*solarIrradianceFixup*groundBRDF
                  + lightPollutionGroundLuminance*lightPollutionRelativeRadiance;
     }
@@ -336,53 +350,53 @@ void main()
     }
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_ON_THE_FLY
-    const vec4 scattering=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPosition,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_ON_THE_FLY*/
+    CONST vec4 scattering=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPosition,
                                                           viewRayIntersectsGround);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE
-    const vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE*/
+    CONST vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                      viewRayIntersectsGround, eclipsedSingleScatteringTextureSize);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact at the point where azimuth texture coordinate changes from 1 to 0 (at azimuthRelativeToSun crossing
     // 0). This happens when I simply call texture(eclipsedScatteringTexture, texCoords) without specifying LOD.
     // Apparently, the driver uses the derivative for some reason, even though it shouldn't.
-    const vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
+    CONST vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE
-    const vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
+    CONST vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                      viewRayIntersectsGround, eclipsedSingleScatteringTextureSize);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact at the point where azimuth texture coordinate changes from 1 to 0 (at azimuthRelativeToSun crossing
     // 0). This happens when I simply call texture(eclipsedScatteringTexture, texCoords) without specifying LOD.
     // Apparently, the driver uses the derivative for some reason, even though it shouldn't.
-    const vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
+    CONST vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
     luminance=scattering*currentPhaseFunction(dotViewSun);
-#elif RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_RADIANCE
+#elif 0 /*RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_RADIANCE*/
     vec4 radiance=exp(sampleEclipseDoubleScattering3DTexture(eclipsedDoubleScatteringTexture,
                                                              cosSunZenithAngle, cosViewZenithAngle, azimuthRelativeToSun,
                                                              altitude, viewRayIntersectsGround));
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_LUMINANCE
+#elif 0 /*RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
     luminance=exp(sampleEclipseDoubleScattering3DTexture(eclipsedDoubleScatteringTexture,
                                                          cosSunZenithAngle, cosViewZenithAngle, azimuthRelativeToSun,
                                                          altitude, viewRayIntersectsGround));
-#elif RENDERING_SINGLE_SCATTERING_ON_THE_FLY
-    const vec4 scattering=computeSingleScattering(cosSunZenithAngle,cosViewZenithAngle,dotViewSun,
+#elif 0 /*RENDERING_SINGLE_SCATTERING_ON_THE_FLY*/
+    CONST vec4 scattering=computeSingleScattering(cosSunZenithAngle,cosViewZenithAngle,dotViewSun,
                                                   altitude,viewRayIntersectsGround);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE
+#elif 0 /*RENDERING_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE*/
     vec4 scattering;
     if(useInterpolationGuides)
     {
@@ -399,7 +413,7 @@ void main()
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE
+#elif 0 /*RENDERING_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
     vec4 scattering;
     if(useInterpolationGuides)
     {
@@ -413,14 +427,14 @@ void main()
                                      dotViewSun, altitude, viewRayIntersectsGround);
     }
     luminance=scattering * (bool(PHASE_FUNCTION_IS_EMBEDDED) ? vec4(1) : currentPhaseFunction(dotViewSun));
-#elif RENDERING_MULTIPLE_SCATTERING_LUMINANCE
+#elif 0 /*RENDERING_MULTIPLE_SCATTERING_LUMINANCE*/
     luminance=sample3DTexture(scatteringTexture, cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, viewRayIntersectsGround);
-#elif RENDERING_MULTIPLE_SCATTERING_RADIANCE
+#elif 0 /*RENDERING_MULTIPLE_SCATTERING_RADIANCE*/
     vec4 radiance=sample3DTexture(scatteringTexture, cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, viewRayIntersectsGround);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_LIGHT_POLLUTION_RADIANCE
+#elif 0 /*RENDERING_LIGHT_POLLUTION_RADIANCE*/
     vec4 radiance=lightPollutionGroundLuminance*lightPollutionScattering(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;

--- a/atmosphere/default/shaders/light-pollution/texture-coordinates.frag
+++ b/atmosphere/default/shaders/light-pollution/texture-coordinates.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-coordinates.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,8 +45,8 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // texture-coordinates.frag
-#line 1 2 // texture-coordinates.h.glsl
+#line 4 0 // texture-coordinates.frag
+#line 1 3 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -104,8 +115,8 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 6 0 // texture-coordinates.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-coordinates.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -137,7 +148,7 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-coordinates.frag
+#line 6 0 // texture-coordinates.frag
 
 const float LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA=sqrt(atmosphereHeight*(atmosphereHeight+2*earthRadius));
 
@@ -205,18 +216,18 @@ vec3 indicesToTexCoords(const vec3 indices, const vec3 texSizes)
 
 TransmittanceTexVars transmittanceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
+    CONST float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
                                 texCoordToUnitRange(texCoord.t,transmittanceTextureSize.t);
     // Distance from Earth center to camera
-    const float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
-    const float altitude=r-earthRadius;
+    CONST float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
+    CONST float altitude=r-earthRadius;
 
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
     // distance to border of visible atmosphere from the view point
-    const float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
+    CONST float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
     // d==0 can happen when altitude==atmosphereHeight
-    const float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
+    CONST float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
     return TransmittanceTexVars(cosVZA,altitude);
 }
 
@@ -235,53 +246,53 @@ vec2 transmittanceTexVarsToTexCoord(const float cosVZA, float altitude)
     if(altitude<0)
         altitude=0;
 
-    const float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
+    CONST float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
                                       transmittanceTextureSize.t);
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
-    const float d=distanceToAtmosphereBorder(cosVZA,altitude);
-    const float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float d=distanceToAtmosphereBorder(cosVZA,altitude);
+    CONST float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
     return vec2(s,t);
 }
 
 // Output: vec2(cos(sunZenithAngle), altitude)
 IrradianceTexVars irradianceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
-    const float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
+    CONST float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
+    CONST float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
     return IrradianceTexVars(cosSZA,alt);
 }
 
 vec2 irradianceTexVarsToTexCoord(const float cosSunZenithAngle, const float altitude)
 {
-    const float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
-    const float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
+    CONST float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
+    CONST float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
     return vec2(s,t);
 }
 
 float cosSZAToUnitRangeTexCoord(const float cosSunZenithAngle)
 {
     // Distance to top atmosphere border along the ray groundUnderCamera-sun: (altitude, cosSunZenithAngle)
-    const float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name
-    const float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
+    CONST float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
     // TODO: choose a more descriptive name
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     return max(0.,1-a/A)/(a+1);
 }
 
 float unitRangeTexCoordToCosSZA(const float texCoord)
 {
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float a=(A-A*texCoord)/(1+A*texCoord);
-    const float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
+    CONST float a=(A-A*texCoord)/(1+A*texCoord);
+    CONST float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
     return distFromGroundToTopAtmoBorder==0 ? 1 :
         clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distFromGroundToTopAtmoBorder)) /
                     (2*earthRadius*distFromGroundToTopAtmoBorder));
@@ -292,24 +303,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
                                                const float dotViewSun, const float altitude,
                                                const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -317,24 +328,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float dotVSCoord=(dotViewSun+1)/2;
+    CONST float dotVSCoord=(dotViewSun+1)/2;
 
     // ------------------------------------
-    const float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
+    CONST float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
 
     return Scattering4DCoords(cosSZACoord, cosVZACoord, dotVSCoord, altCoord, viewRayIntersectsGround);
 }
 
 TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
@@ -342,16 +353,16 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture coordinates we combine into a single sampler3D coordinate.
-    const float texW = scatteringTextureSize[1];
-    const float texH = scatteringTextureSize[2];
-    const float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
-    const vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
+    CONST float texW = scatteringTextureSize[1];
+    CONST float texH = scatteringTextureSize[2];
+    CONST float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
+    CONST vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
                                         ceil (cosSZAIndex)*texW+coords.dotViewSun*(texW-1)) / (texW*texH-1);
-    const vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
+    CONST vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
 
-    const float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
+    CONST float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
 
-    const float alphaUpper=fract(cosSZAIndex);
+    CONST float alphaUpper=fract(cosSZAIndex);
     return TexCoordPair(vec3(cosVZAtc, combinedCoord.x, altitude), float(1-alphaUpper),
                         vec3(cosVZAtc, combinedCoord.y, altitude), float(alphaUpper));
 }
@@ -359,9 +370,9 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
+    CONST TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
     return texture(tex, texCoords.lower) * texCoords.alphaLower +
            texture(tex, texCoords.upper) * texCoords.alphaUpper;
 }
@@ -369,17 +380,17 @@ vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const f
 // 3D texture is the 3D single-altitude slice of a 4D texture
 vec3 scattering4DCoordsToTex3DCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2);
 
-    const float dvsSize = scatteringTextureSize[1];
-    const float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
+    CONST float dvsSize = scatteringTextureSize[1];
+    CONST float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
 
-    const float cszaSize = scatteringTextureSize[2];
-    const float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
+    CONST float cszaSize = scatteringTextureSize[2];
+    CONST float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
 
     return vec3(cosVZAtc, dotVStc, cosSZAtc);
 }
@@ -394,39 +405,39 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along dotViewSun coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[1];
-    const float posOfRow = indices[1];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[1];
+    CONST float posOfRow = indices[1];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         indexToTexCoord(currRow, numRows-1),
                                                         texCoordVerbatim));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               indexToTexCoord(currRow, numRows-1),
                                                               texCoordVerbatim));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          indexToTexCoord(currRow, numRows-1),
                                          texCoordVerbatim));
@@ -434,14 +445,14 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
 vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolationGuides01Tex,
                                  const vec3 indices)
 {
-    const float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
+    CONST float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
 
-    const float cosVZAIndex = indices[0];
-    const float dotVSIndex = indices[1];
-    const float currRow = floor(dotVSIndex);
-    const float posBetweenRows = dotVSIndex - currRow;
-    const float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cosVZAIndex = indices[0];
+    CONST float dotVSIndex = indices[1];
+    CONST float currRow = floor(dotVSIndex);
+    CONST float posBetweenRows = dotVSIndex - currRow;
+    CONST float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -449,14 +460,14 @@ vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolat
     indicesCurrRow[1] =     currRow;
     indicesNextRow[1] = min(currRow+1, scatteringTextureSize[1]-1.);
 
-    const vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
-    const vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
+    CONST vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
+    CONST vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
 
-    const vec4 valueCurrRow = texture(tex, coordsCurrRow);
-    const vec4 valueNextRow = texture(tex, coordsNextRow);
-    const float epsilon = 1e-37; // Prevents passing zero to log
-    const vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
-    const vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
+    CONST vec4 valueCurrRow = texture(tex, coordsCurrRow);
+    CONST vec4 valueNextRow = texture(tex, coordsNextRow);
+    CONST float epsilon = 1e-37; // Prevents passing zero to log
+    CONST vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
+    CONST vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
     return (logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow;
 }
 
@@ -465,37 +476,37 @@ float findGuide02Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along SZA coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[2];
-    const float posOfRow = indices[2];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[2];
+    CONST float posOfRow = indices[2];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
 }
@@ -505,19 +516,19 @@ vec4 sample3DTextureGuided(const sampler3D tex,
                            const float cosSunZenithAngle, const float cosViewZenithAngle,
                            const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
                                                                     dotViewSun, altitude, viewRayIntersectsGround);
     // Handle the external interpolation guides: the guides between a pair of VZA-dotViewSun 2D "pictures".
-    const vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
-    const vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
-    const float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
+    CONST vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
+    CONST float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
 
-    const float cvzaIndex = indices[0];
-    const float cszaIndex = indices[2];
-    const float currRow = floor(cszaIndex);
-    const float posBetweenRows = cszaIndex - currRow;
-    const float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cvzaIndex = indices[0];
+    CONST float cszaIndex = indices[2];
+    CONST float currRow = floor(cszaIndex);
+    CONST float posBetweenRows = cszaIndex - currRow;
+    CONST float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -526,58 +537,58 @@ vec4 sample3DTextureGuided(const sampler3D tex,
     indicesNextRow[2] = min(currRow+1, scatteringTextureSize[2]-1);
 
     // The caller will handle the internal interpolation guides: the ones between rows in each 2D "picture".
-    const vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
-    const vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
+    CONST vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
+    CONST vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
     return exp((logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow);
 }
 
 vec4 sample3DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
     return texture(tex, texCoords);
 }
 
 ScatteringTexVars scatteringTex4DCoordsToTexVars(const Scattering4DCoords coords)
 {
-    const float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
     // ------------------------------------
     float cosViewZenithAngle;
     if(coords.viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
     // ------------------------------------
-    const float dotViewSun=coords.dotViewSun*2-1;
+    CONST float dotViewSun=coords.dotViewSun*2-1;
 
     // ------------------------------------
-    const float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
+    CONST float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
 
     return ScatteringTexVars(cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, coords.viewRayIntersectsGround);
 }
 
 Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 {
-    const vec4 indexMax=scatteringTextureSize-vec4(1);
+    CONST vec4 indexMax=scatteringTextureSize-vec4(1);
     Scattering4DCoords coords4d;
     coords4d.viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
     // The following formulas assume that scatteringTextureSize[0] is even. For odd sizes they would change.
@@ -593,8 +604,8 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture indices we combine into a single sampler3D coordinate.
-    const float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
-    const float combinedIndex=texIndices[1];
+    CONST float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
+    CONST float combinedIndex=texIndices[1];
     coords4d.dotViewSun=mod(combinedIndex,texW)/(texW-1);
     coords4d.cosSunZenithAngle=floor(combinedIndex/texW)/(texH-1);
 
@@ -608,11 +619,11 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
 ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 {
-    const Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
+    CONST Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
     ScatteringTexVars vars=scatteringTex4DCoordsToTexVars(coords4d);
     // Clamp dotViewSun to its valid range of values, given cosViewZenithAngle and cosSunZenithAngle. This is
     // needed to prevent NaNs when computing the scattering texture.
-    const float cosVZA=vars.cosViewZenithAngle,
+    CONST float cosVZA=vars.cosViewZenithAngle,
                 cosSZA=vars.cosSunZenithAngle;
     vars.dotViewSun=clamp(vars.dotViewSun,
                           cosVZA*cosSZA-safeSqrt((1-sqr(cosVZA))*(1-sqr(cosSZA))),
@@ -622,54 +633,54 @@ ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 
 EclipseScatteringTexVars eclipseTexCoordsToTexVars(const vec2 texCoords, const float altitude)
 {
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
-    const bool viewRayIntersectsGround = texCoords.t<0.5;
+    CONST bool viewRayIntersectsGround = texCoords.t<0.5;
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
-    const float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
+    CONST float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
     return EclipseScatteringTexVars(azimuthRelativeToSun, cosViewZenithAngle, viewRayIntersectsGround);
 }
 
 EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                                    const float altitude, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -677,13 +688,13 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
-    const float azimuthCoord = azimuthRelativeToSun/(2*PI);
+    CONST float azimuthCoord = azimuthRelativeToSun/(2*PI);
 
     return EclipseScattering2DCoords(azimuthCoord, cosVZACoord);
 }
@@ -691,14 +702,14 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
 vec2 eclipseTexVarsToTexCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                const float altitude, const bool viewRayIntersectsGround, const vec2 texSize)
 {
-    const EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+    CONST EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                                     viewRayIntersectsGround);
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2);
-    const float azimuthTC = coords.azimuth + 1/(2*texSize.s);
+    CONST float azimuthTC = coords.azimuth + 1/(2*texSize.s);
 
     return vec2(azimuthTC, cosVZAtc);
 }
@@ -707,42 +718,42 @@ vec4 sampleEclipseDoubleScattering3DTexture(const sampler3D tex, const float cos
                                             const float cosViewZenithAngle, const float azimuthRelativeToSun,
                                             const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
+    CONST vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
                                                   eclipsedDoubleScatteringTextureSize.st);
-    const float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
-    const vec3 texCoords=vec3(coords2d, cosSZACoord);
+    CONST float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
+    CONST vec3 texCoords=vec3(coords2d, cosSZACoord);
 
     return texture(tex, texCoords);
 }
 
 LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 texIndices)
 {
-    const vec2 indexMax=lightPollutionTextureSize-vec2(1);
+    CONST vec2 indexMax=lightPollutionTextureSize-vec2(1);
 
-    const float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
-    const float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
+    CONST float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
-    const bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
-    const float cosViewZenithAngleCoord = viewRayIntersectsGround ?
+    CONST bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
+    CONST float cosViewZenithAngleCoord = viewRayIntersectsGround ?
                                    1-2*texIndices[0]/(indexMax[0]-1) :
                                    2*(texIndices[0]-1)/(indexMax[0]-1)-1;
     // ------------------------------------
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
@@ -753,23 +764,23 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 
 LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -777,27 +788,27 @@ LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, con
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     return LightPollution2DCoords(cosVZACoord, altCoord);
 }
 
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
-    const vec2 texSize = lightPollutionTextureSize;
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 texSize = lightPollutionTextureSize;
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2);
-    const float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
+    CONST float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
     return vec2(cosVZAtc, altitudeTC);
 }

--- a/atmosphere/default/shaders/light-pollution/texture-sampling-functions.frag
+++ b/atmosphere/default/shaders/light-pollution/texture-sampling-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-sampling-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,13 +45,13 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // texture-sampling-functions.frag
-#line 1 2 // phase-functions.h.glsl
+#line 4 0 // texture-sampling-functions.frag
+#line 1 3 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 6 0 // texture-sampling-functions.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-sampling-functions.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -72,8 +83,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-sampling-functions.frag
-#line 1 4 // texture-coordinates.h.glsl
+#line 6 0 // texture-sampling-functions.frag
+#line 1 5 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -142,7 +153,7 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 8 0 // texture-sampling-functions.frag
+#line 7 0 // texture-sampling-functions.frag
 
 uniform sampler2D transmittanceTexture;
 uniform sampler2D irradianceTexture;
@@ -154,13 +165,13 @@ uniform sampler2D lightPollutionScatteringTexture;
 
 vec4 irradiance(const float cosSunZenithAngle, const float altitude)
 {
-    const vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
+    CONST vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
     return texture(irradianceTexture, texCoords);
 }
 
 vec4 opticalDepthToAtmosphereBorder(const float cosViewZenithAngle, const float altitude)
 {
-    const vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
+    CONST vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact when looking into nadir from TOA at some values of texture sizes (in particular, size of
     // transmittance texture for altitude being 4096). This happens when I simply call texture(eclipsedScatteringTexture,
@@ -178,11 +189,11 @@ vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float
 vec4 transmittance(const float cosViewZenithAngle, const float altitude, const float dist,
                    const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle view ray endpoint
     // in space here.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
 
     vec4 depth;
     if(viewRayIntersectsGround)
@@ -201,7 +212,7 @@ vec4 transmittance(const float cosViewZenithAngle, const float altitude, const f
 vec4 calcFirstScattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                          const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
+    CONST vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
                                           dotViewSun, altitude, viewRayIntersectsGround);
     return scattering*currentPhaseFunction(dotViewSun);
 }
@@ -220,6 +231,6 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
 
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     return texture(lightPollutionScatteringTexture, coords);
 }

--- a/atmosphere/default/shaders/multiple-scattering/common-functions.frag
+++ b/atmosphere/default/shaders/multiple-scattering/common-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // common-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // common-functions.frag
+#line 4 0 // common-functions.frag
 
 bool dbgDataPresent=false;
 bool debugDataPresent()
@@ -69,7 +80,7 @@ void setDebugData(float a,float b, float c, float d)
 
 void swap(inout float x, inout float y)
 {
-    const float t = x;
+    CONST float t = x;
     x = y;
     y = t;
 }
@@ -83,7 +94,7 @@ float safeSqrt(const float x)
 
 float safeAtan(const float y, const float x)
 {
-    const float a = atan(y,x);
+    CONST float a = atan(y,x);
     return x==0 && y==0 ? 0 : a;
 }
 
@@ -116,23 +127,23 @@ float pointAltitude(vec3 point)
 
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float Ratm=earthRadius+atmosphereHeight;
-    const float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float Ratm=earthRadius+atmosphereHeight;
+    CONST float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float distanceToGround(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(-safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float cosZenithAngleOfHorizon(const float altitude)
 {
-    const float R=earthRadius;
-    const float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
+    CONST float R=earthRadius;
+    CONST float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
     return -sqrt(2*h*R+sqr(h))/(R+h);
 }
 
@@ -151,8 +162,8 @@ float distanceToNearestAtmosphereBoundary(const float cosZenithAngle, const floa
 float sunVisibility(const float cosSunZenithAngle, float altitude)
 {
     if(altitude<0) altitude=0;
-    const float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
-    const float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
+    CONST float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
+    CONST float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
     /* Approximating visible fraction of solar disk by smoothstep between the position of the Sun
      * touching the horizon by its upper part and the position with lower part touching the horizon.
      * The calculation assumes that solar angular radius is small and thus approximately equals its sine.
@@ -182,13 +193,13 @@ float circlesIntersectionArea(float R1, float R2, float d)
 
 float angleBetween(const vec3 a, const vec3 b)
 {
-    const float d=dot(a,b);
-    const float c=length(cross(a,b));
+    CONST float d=dot(a,b);
+    CONST float c=length(cross(a,b));
     // To avoid loss of precision, don't use dot product near the singularity
     // of acos, and cross product near the singularity of asin
     if(abs(d) < abs(c))
         return acos(d/(length(a)*length(b)));
-    const float smallerAngle = asin(c/(length(a)*length(b)));
+    CONST float smallerAngle = asin(c/(length(a)*length(b)));
     if(d<0) return PI-smallerAngle;
     return smallerAngle;
 }
@@ -205,11 +216,11 @@ float moonAngularRadius(const vec3 cameraPosition, const vec3 moonPosition)
 
 float visibleSolidAngleOfSun(const vec3 camera, const vec3 sunDir, const vec3 moonPos)
 {
-    const float Rs=sunAngularRadius;
-    const float Rm=moonAngularRadius(camera,moonPos);
+    CONST float Rs=sunAngularRadius;
+    CONST float Rm=moonAngularRadius(camera,moonPos);
     float visibleSolidAngle=PI*sqr(Rs);
 
-    const float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
+    CONST float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
     if(dSM<Rs+Rm)
     {
         visibleSolidAngle -= circlesIntersectionArea(Rm,Rs,dSM);
@@ -229,12 +240,12 @@ float sphereIntegrationSolidAngleDifferential(const int pointCountOnSphere)
 }
 vec3 sphereIntegrationSampleDir(const int index, const int pointCountOnSphere)
 {
-    const float goldenRatio=1.6180339887499;
+    CONST float goldenRatio=1.6180339887499;
     // The range of n is 0.5, 1.5, ..., pointCountOnSphere-0.5
-    const float n=index+0.5;
+    CONST float n=index+0.5;
     // Explanation of the Fibonacci grid generation can be seen at https://stackoverflow.com/a/44164075/673852
-    const float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
-    const float azimuth=n*(2*PI*goldenRatio);
+    CONST float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
+    CONST float azimuth=n*(2*PI*goldenRatio);
     return vec3(cos(azimuth)*sin(zenithAngle),
                 sin(azimuth)*sin(zenithAngle),
                 cos(zenithAngle));

--- a/atmosphere/default/shaders/multiple-scattering/render.frag
+++ b/atmosphere/default/shaders/multiple-scattering/render.frag
@@ -1,7 +1,21 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
 
-#line 1 1 // const.h.glsl
+
+
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 6 0 // render.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,11 +48,11 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // render.frag
-#line 1 2 // calc-view-dir.h.glsl
+#line 7 0 // render.frag
+#line 1 3 // calc-view-dir.h.glsl
 vec3 calcViewDir();
-#line 6 0 // render.frag
-#line 1 3 // common-functions.h.glsl
+#line 8 0 // render.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -70,11 +84,11 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // render.frag
+#line 9 0 // render.frag
 
 
 
-#line 1 4 // texture-coordinates.h.glsl
+#line 1 5 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -143,10 +157,10 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 11 0 // render.frag
-#line 1 5 // radiance-to-luminance.h.glsl
+#line 13 0 // render.frag
+#line 1 6 // radiance-to-luminance.h.glsl
 const mat4 radianceToLuminance=mat4(19.8756237,7.17745161,0,0.0937032327,  2.13895917,0.772417068,0,0.0149318045,  0.241072536,0.0870557055,0,0,  0.0133876652,0.00483453181,0,0);
-#line 12 0 // render.frag
+#line 14 0 // render.frag
 
 
 
@@ -183,18 +197,18 @@ void main()
     // this approximation has the same order of magnitude as the assumption that the Earth and its atmosphere
     // are spherical.
     float altitude = max(cameraPosition.z, 0.);
-    const vec3 oldCamPos=cameraPosition;
+    CONST vec3 oldCamPos=cameraPosition;
     // Hide the uniform with this name, thus effectively modifying it for the following code
     vec3 cameraPosition=vec3(oldCamPos.xy, altitude);
 
     bool lookingIntoAtmosphere=true;
     if(altitude>atmosphereHeight)
     {
-        const vec3 p = cameraPosition - earthCenter;
-        const float p_dot_v = dot(p, viewDir);
-        const float p_dot_p = dot(p, p);
-        const float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
-        const float distanceToTOA = -p_dot_v - sqrt(sqr(earthRadius+atmosphereHeight) - squaredDistBetweenViewRayAndEarthCenter);
+        CONST vec3 p = cameraPosition - earthCenter;
+        CONST float p_dot_v = dot(p, viewDir);
+        CONST float p_dot_p = dot(p, p);
+        CONST float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
+        CONST float distanceToTOA = -p_dot_v - sqrt(sqr(earthRadius+atmosphereHeight) - squaredDistBetweenViewRayAndEarthCenter);
         if(distanceToTOA>=0)
         {
             cameraPosition += viewDir*distanceToTOA;
@@ -202,7 +216,7 @@ void main()
         }
         else
         {
-#if RENDERING_ANY_ZERO_SCATTERING
+#if 0 /*RENDERING_ANY_ZERO_SCATTERING*/
             lookingIntoAtmosphere=false;
 #else
             luminance=vec4(0);
@@ -212,16 +226,16 @@ void main()
         }
     }
 
-    const vec3 zenith=normalize(cameraPosition-earthCenter);
+    CONST vec3 zenith=normalize(cameraPosition-earthCenter);
     float cosViewZenithAngle=dot(zenith,viewDir);
 
     bool viewRayIntersectsGround=false;
     {
-        const vec3 p = cameraPosition - earthCenter;
-        const float p_dot_v = dot(p, viewDir);
-        const float p_dot_p = dot(p, p);
-        const float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
-        const float distanceToIntersection = -p_dot_v - sqrt(sqr(earthRadius) - squaredDistBetweenViewRayAndEarthCenter);
+        CONST vec3 p = cameraPosition - earthCenter;
+        CONST float p_dot_v = dot(p, viewDir);
+        CONST float p_dot_p = dot(p, p);
+        CONST float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
+        CONST float distanceToIntersection = -p_dot_v - sqrt(sqr(earthRadius) - squaredDistBetweenViewRayAndEarthCenter);
         // altitude==0 is a special case where distance to intersection calculation
         // is unreliable (has a lot of noise in its sign), so check it separately
         if(distanceToIntersection>0 || (altitude==0 && cosViewZenithAngle<0))
@@ -232,11 +246,11 @@ void main()
     // Aside from aesthetics, this affects brightness input to Stellarium's tone mapper.
     if(pseudoMirrorSkyBelowHorizon && viewRayIntersectsGround)
     {
-        const float horizonCZA = cosZenithAngleOfHorizon(altitude);
-        const float viewElev  = asin(clampCosine(cosViewZenithAngle));
-        const float horizElev = asin(clampCosine(horizonCZA));
-        const float newViewElev = 2*horizElev - viewElev;
-        const float viewDirXYnorm = length(viewDir-zenith*cosViewZenithAngle);
+        CONST float horizonCZA = cosZenithAngleOfHorizon(altitude);
+        CONST float viewElev  = asin(clampCosine(cosViewZenithAngle));
+        CONST float horizElev = asin(clampCosine(horizonCZA));
+        CONST float newViewElev = 2*horizElev - viewElev;
+        CONST float viewDirXYnorm = length(viewDir-zenith*cosViewZenithAngle);
         if(viewDirXYnorm == 0)
         {
             viewDir = zenith;
@@ -255,27 +269,27 @@ void main()
         viewRayIntersectsGround = false;
     }
 
-    const float cosSunZenithAngle =dot(zenith,sunDirection);
-    const float dotViewSun=dot(viewDir,sunDirection);
+    CONST float cosSunZenithAngle =dot(zenith,sunDirection);
+    CONST float dotViewSun=dot(viewDir,sunDirection);
 
-    const vec3 sunXYunnorm=sunDirection-dot(sunDirection,zenith)*zenith;
-    const vec3 viewXYunnorm=viewDir-dot(viewDir,zenith)*zenith;
-    const vec3 sunXY = sunXYunnorm.x!=0 || sunXYunnorm.y!=0 || sunXYunnorm.z!=0 ? normalize(sunXYunnorm) : vec3(0);
-    const vec3 viewXY = viewXYunnorm.x!=0 || viewXYunnorm.y!=0 || viewXYunnorm.z!=0 ? normalize(viewXYunnorm) : vec3(0);
-    const float azimuthRelativeToSun=safeAtan(dot(cross(sunXY, viewXY), zenith), dot(sunXY, viewXY));
+    CONST vec3 sunXYunnorm=sunDirection-dot(sunDirection,zenith)*zenith;
+    CONST vec3 viewXYunnorm=viewDir-dot(viewDir,zenith)*zenith;
+    CONST vec3 sunXY = sunXYunnorm.x!=0 || sunXYunnorm.y!=0 || sunXYunnorm.z!=0 ? normalize(sunXYunnorm) : vec3(0);
+    CONST vec3 viewXY = viewXYunnorm.x!=0 || viewXYunnorm.y!=0 || viewXYunnorm.z!=0 ? normalize(viewXYunnorm) : vec3(0);
+    CONST float azimuthRelativeToSun=safeAtan(dot(cross(sunXY, viewXY), zenith), dot(sunXY, viewXY));
 
-#if RENDERING_ZERO_SCATTERING
+#if 0 /*RENDERING_ZERO_SCATTERING*/
     vec4 radiance;
     if(viewRayIntersectsGround)
     {
         // XXX: keep in sync with the same code in computeScatteringDensity(), but don't forget about
         //      the difference in the usage of viewDir vs incDir.
-        const float distToGround = distanceToGround(cosViewZenithAngle, altitude);
-        const vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
-        const vec3 groundNormal = normalize(zenith*(earthRadius+altitude)+viewDir*distToGround);
-        const vec4 groundIrradiance = irradiance(dot(groundNormal, sunDirection), 0);
+        CONST float distToGround = distanceToGround(cosViewZenithAngle, altitude);
+        CONST vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
+        CONST vec3 groundNormal = normalize(zenith*(earthRadius+altitude)+viewDir*distToGround);
+        CONST vec4 groundIrradiance = irradiance(dot(groundNormal, sunDirection), 0);
         // Radiation scattered by the ground
-        const float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
+        CONST float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
         radiance = transmittanceToGround*groundAlbedo*groundIrradiance*solarIrradianceFixup*groundBRDF
                  + lightPollutionGroundLuminance*lightPollutionRelativeRadiance;
     }
@@ -292,22 +306,22 @@ void main()
     }
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_ZERO_SCATTERING
+#elif 0 /*RENDERING_ECLIPSED_ZERO_SCATTERING*/
     vec4 radiance;
-    const float dotViewMoon=dot(viewDir,normalize(moonPosition-cameraPosition));
+    CONST float dotViewMoon=dot(viewDir,normalize(moonPosition-cameraPosition));
     if(viewRayIntersectsGround)
     {
         // XXX: keep in sync with the similar code in non-eclipsed zero scattering rendering.
-        const float distToGround = distanceToGround(cosViewZenithAngle, altitude);
-        const vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
-        const vec3 pointOnGround = cameraPosition+viewDir*distToGround;
-        const vec4 directGroundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDirection, moonPosition);
+        CONST float distToGround = distanceToGround(cosViewZenithAngle, altitude);
+        CONST vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
+        CONST vec3 pointOnGround = cameraPosition+viewDir*distToGround;
+        CONST vec4 directGroundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDirection, moonPosition);
         // FIXME: add first-order indirect irradiance too: it's done in non-eclipsed irradiance (in the same
         // conditions: when limited to 2 orders). This should be calculated at the same time when second order
         // is: all the infrastructure is already there.
-        const vec4 groundIrradiance = directGroundIrradiance;
+        CONST vec4 groundIrradiance = directGroundIrradiance;
         // Radiation scattered by the ground
-        const float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
+        CONST float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
         radiance = transmittanceToGround*groundAlbedo*groundIrradiance*solarIrradianceFixup*groundBRDF
                  + lightPollutionGroundLuminance*lightPollutionRelativeRadiance;
     }
@@ -324,53 +338,53 @@ void main()
     }
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_ON_THE_FLY
-    const vec4 scattering=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPosition,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_ON_THE_FLY*/
+    CONST vec4 scattering=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPosition,
                                                           viewRayIntersectsGround);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE
-    const vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE*/
+    CONST vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                      viewRayIntersectsGround, eclipsedSingleScatteringTextureSize);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact at the point where azimuth texture coordinate changes from 1 to 0 (at azimuthRelativeToSun crossing
     // 0). This happens when I simply call texture(eclipsedScatteringTexture, texCoords) without specifying LOD.
     // Apparently, the driver uses the derivative for some reason, even though it shouldn't.
-    const vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
+    CONST vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE
-    const vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
+    CONST vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                      viewRayIntersectsGround, eclipsedSingleScatteringTextureSize);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact at the point where azimuth texture coordinate changes from 1 to 0 (at azimuthRelativeToSun crossing
     // 0). This happens when I simply call texture(eclipsedScatteringTexture, texCoords) without specifying LOD.
     // Apparently, the driver uses the derivative for some reason, even though it shouldn't.
-    const vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
+    CONST vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
     luminance=scattering*currentPhaseFunction(dotViewSun);
-#elif RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_RADIANCE
+#elif 0 /*RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_RADIANCE*/
     vec4 radiance=exp(sampleEclipseDoubleScattering3DTexture(eclipsedDoubleScatteringTexture,
                                                              cosSunZenithAngle, cosViewZenithAngle, azimuthRelativeToSun,
                                                              altitude, viewRayIntersectsGround));
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_LUMINANCE
+#elif 0 /*RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
     luminance=exp(sampleEclipseDoubleScattering3DTexture(eclipsedDoubleScatteringTexture,
                                                          cosSunZenithAngle, cosViewZenithAngle, azimuthRelativeToSun,
                                                          altitude, viewRayIntersectsGround));
-#elif RENDERING_SINGLE_SCATTERING_ON_THE_FLY
-    const vec4 scattering=computeSingleScattering(cosSunZenithAngle,cosViewZenithAngle,dotViewSun,
+#elif 0 /*RENDERING_SINGLE_SCATTERING_ON_THE_FLY*/
+    CONST vec4 scattering=computeSingleScattering(cosSunZenithAngle,cosViewZenithAngle,dotViewSun,
                                                   altitude,viewRayIntersectsGround);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE
+#elif 0 /*RENDERING_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE*/
     vec4 scattering;
     if(useInterpolationGuides)
     {
@@ -387,7 +401,7 @@ void main()
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE
+#elif 0 /*RENDERING_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
     vec4 scattering;
     if(useInterpolationGuides)
     {
@@ -403,16 +417,16 @@ void main()
     luminance=scattering * (bool(PHASE_FUNCTION_IS_EMBEDDED) ? vec4(1) : currentPhaseFunction(dotViewSun));
 #elif 1 /*RENDERING_MULTIPLE_SCATTERING_LUMINANCE*/
     luminance=sample3DTexture(scatteringTexture, cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, viewRayIntersectsGround);
-#elif RENDERING_MULTIPLE_SCATTERING_RADIANCE
+#elif 0 /*RENDERING_MULTIPLE_SCATTERING_RADIANCE*/
     vec4 radiance=sample3DTexture(scatteringTexture, cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, viewRayIntersectsGround);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_LIGHT_POLLUTION_RADIANCE
+#elif 0 /*RENDERING_LIGHT_POLLUTION_RADIANCE*/
     vec4 radiance=lightPollutionGroundLuminance*lightPollutionScattering(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_LIGHT_POLLUTION_LUMINANCE
+#elif 0 /*RENDERING_LIGHT_POLLUTION_LUMINANCE*/
     luminance=lightPollutionGroundLuminance*lightPollutionScattering(altitude, cosViewZenithAngle, viewRayIntersectsGround);
 #else
 #error What to render?

--- a/atmosphere/default/shaders/multiple-scattering/texture-coordinates.frag
+++ b/atmosphere/default/shaders/multiple-scattering/texture-coordinates.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-coordinates.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,8 +45,8 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // texture-coordinates.frag
-#line 1 2 // texture-coordinates.h.glsl
+#line 4 0 // texture-coordinates.frag
+#line 1 3 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -104,8 +115,8 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 6 0 // texture-coordinates.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-coordinates.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -137,7 +148,7 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-coordinates.frag
+#line 6 0 // texture-coordinates.frag
 
 const float LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA=sqrt(atmosphereHeight*(atmosphereHeight+2*earthRadius));
 
@@ -205,18 +216,18 @@ vec3 indicesToTexCoords(const vec3 indices, const vec3 texSizes)
 
 TransmittanceTexVars transmittanceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
+    CONST float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
                                 texCoordToUnitRange(texCoord.t,transmittanceTextureSize.t);
     // Distance from Earth center to camera
-    const float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
-    const float altitude=r-earthRadius;
+    CONST float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
+    CONST float altitude=r-earthRadius;
 
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
     // distance to border of visible atmosphere from the view point
-    const float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
+    CONST float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
     // d==0 can happen when altitude==atmosphereHeight
-    const float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
+    CONST float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
     return TransmittanceTexVars(cosVZA,altitude);
 }
 
@@ -235,53 +246,53 @@ vec2 transmittanceTexVarsToTexCoord(const float cosVZA, float altitude)
     if(altitude<0)
         altitude=0;
 
-    const float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
+    CONST float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
                                       transmittanceTextureSize.t);
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
-    const float d=distanceToAtmosphereBorder(cosVZA,altitude);
-    const float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float d=distanceToAtmosphereBorder(cosVZA,altitude);
+    CONST float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
     return vec2(s,t);
 }
 
 // Output: vec2(cos(sunZenithAngle), altitude)
 IrradianceTexVars irradianceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
-    const float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
+    CONST float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
+    CONST float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
     return IrradianceTexVars(cosSZA,alt);
 }
 
 vec2 irradianceTexVarsToTexCoord(const float cosSunZenithAngle, const float altitude)
 {
-    const float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
-    const float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
+    CONST float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
+    CONST float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
     return vec2(s,t);
 }
 
 float cosSZAToUnitRangeTexCoord(const float cosSunZenithAngle)
 {
     // Distance to top atmosphere border along the ray groundUnderCamera-sun: (altitude, cosSunZenithAngle)
-    const float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name
-    const float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
+    CONST float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
     // TODO: choose a more descriptive name
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     return max(0.,1-a/A)/(a+1);
 }
 
 float unitRangeTexCoordToCosSZA(const float texCoord)
 {
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float a=(A-A*texCoord)/(1+A*texCoord);
-    const float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
+    CONST float a=(A-A*texCoord)/(1+A*texCoord);
+    CONST float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
     return distFromGroundToTopAtmoBorder==0 ? 1 :
         clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distFromGroundToTopAtmoBorder)) /
                     (2*earthRadius*distFromGroundToTopAtmoBorder));
@@ -292,24 +303,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
                                                const float dotViewSun, const float altitude,
                                                const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -317,24 +328,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float dotVSCoord=(dotViewSun+1)/2;
+    CONST float dotVSCoord=(dotViewSun+1)/2;
 
     // ------------------------------------
-    const float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
+    CONST float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
 
     return Scattering4DCoords(cosSZACoord, cosVZACoord, dotVSCoord, altCoord, viewRayIntersectsGround);
 }
 
 TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
@@ -342,16 +353,16 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture coordinates we combine into a single sampler3D coordinate.
-    const float texW = scatteringTextureSize[1];
-    const float texH = scatteringTextureSize[2];
-    const float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
-    const vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
+    CONST float texW = scatteringTextureSize[1];
+    CONST float texH = scatteringTextureSize[2];
+    CONST float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
+    CONST vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
                                         ceil (cosSZAIndex)*texW+coords.dotViewSun*(texW-1)) / (texW*texH-1);
-    const vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
+    CONST vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
 
-    const float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
+    CONST float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
 
-    const float alphaUpper=fract(cosSZAIndex);
+    CONST float alphaUpper=fract(cosSZAIndex);
     return TexCoordPair(vec3(cosVZAtc, combinedCoord.x, altitude), float(1-alphaUpper),
                         vec3(cosVZAtc, combinedCoord.y, altitude), float(alphaUpper));
 }
@@ -359,9 +370,9 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
+    CONST TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
     return texture(tex, texCoords.lower) * texCoords.alphaLower +
            texture(tex, texCoords.upper) * texCoords.alphaUpper;
 }
@@ -369,17 +380,17 @@ vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const f
 // 3D texture is the 3D single-altitude slice of a 4D texture
 vec3 scattering4DCoordsToTex3DCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2);
 
-    const float dvsSize = scatteringTextureSize[1];
-    const float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
+    CONST float dvsSize = scatteringTextureSize[1];
+    CONST float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
 
-    const float cszaSize = scatteringTextureSize[2];
-    const float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
+    CONST float cszaSize = scatteringTextureSize[2];
+    CONST float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
 
     return vec3(cosVZAtc, dotVStc, cosSZAtc);
 }
@@ -394,39 +405,39 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along dotViewSun coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[1];
-    const float posOfRow = indices[1];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[1];
+    CONST float posOfRow = indices[1];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         indexToTexCoord(currRow, numRows-1),
                                                         texCoordVerbatim));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               indexToTexCoord(currRow, numRows-1),
                                                               texCoordVerbatim));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          indexToTexCoord(currRow, numRows-1),
                                          texCoordVerbatim));
@@ -434,14 +445,14 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
 vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolationGuides01Tex,
                                  const vec3 indices)
 {
-    const float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
+    CONST float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
 
-    const float cosVZAIndex = indices[0];
-    const float dotVSIndex = indices[1];
-    const float currRow = floor(dotVSIndex);
-    const float posBetweenRows = dotVSIndex - currRow;
-    const float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cosVZAIndex = indices[0];
+    CONST float dotVSIndex = indices[1];
+    CONST float currRow = floor(dotVSIndex);
+    CONST float posBetweenRows = dotVSIndex - currRow;
+    CONST float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -449,14 +460,14 @@ vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolat
     indicesCurrRow[1] =     currRow;
     indicesNextRow[1] = min(currRow+1, scatteringTextureSize[1]-1.);
 
-    const vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
-    const vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
+    CONST vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
+    CONST vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
 
-    const vec4 valueCurrRow = texture(tex, coordsCurrRow);
-    const vec4 valueNextRow = texture(tex, coordsNextRow);
-    const float epsilon = 1e-37; // Prevents passing zero to log
-    const vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
-    const vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
+    CONST vec4 valueCurrRow = texture(tex, coordsCurrRow);
+    CONST vec4 valueNextRow = texture(tex, coordsNextRow);
+    CONST float epsilon = 1e-37; // Prevents passing zero to log
+    CONST vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
+    CONST vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
     return (logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow;
 }
 
@@ -465,37 +476,37 @@ float findGuide02Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along SZA coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[2];
-    const float posOfRow = indices[2];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[2];
+    CONST float posOfRow = indices[2];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
 }
@@ -505,19 +516,19 @@ vec4 sample3DTextureGuided(const sampler3D tex,
                            const float cosSunZenithAngle, const float cosViewZenithAngle,
                            const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
                                                                     dotViewSun, altitude, viewRayIntersectsGround);
     // Handle the external interpolation guides: the guides between a pair of VZA-dotViewSun 2D "pictures".
-    const vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
-    const vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
-    const float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
+    CONST vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
+    CONST float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
 
-    const float cvzaIndex = indices[0];
-    const float cszaIndex = indices[2];
-    const float currRow = floor(cszaIndex);
-    const float posBetweenRows = cszaIndex - currRow;
-    const float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cvzaIndex = indices[0];
+    CONST float cszaIndex = indices[2];
+    CONST float currRow = floor(cszaIndex);
+    CONST float posBetweenRows = cszaIndex - currRow;
+    CONST float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -526,58 +537,58 @@ vec4 sample3DTextureGuided(const sampler3D tex,
     indicesNextRow[2] = min(currRow+1, scatteringTextureSize[2]-1);
 
     // The caller will handle the internal interpolation guides: the ones between rows in each 2D "picture".
-    const vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
-    const vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
+    CONST vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
+    CONST vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
     return exp((logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow);
 }
 
 vec4 sample3DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
     return texture(tex, texCoords);
 }
 
 ScatteringTexVars scatteringTex4DCoordsToTexVars(const Scattering4DCoords coords)
 {
-    const float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
     // ------------------------------------
     float cosViewZenithAngle;
     if(coords.viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
     // ------------------------------------
-    const float dotViewSun=coords.dotViewSun*2-1;
+    CONST float dotViewSun=coords.dotViewSun*2-1;
 
     // ------------------------------------
-    const float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
+    CONST float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
 
     return ScatteringTexVars(cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, coords.viewRayIntersectsGround);
 }
 
 Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 {
-    const vec4 indexMax=scatteringTextureSize-vec4(1);
+    CONST vec4 indexMax=scatteringTextureSize-vec4(1);
     Scattering4DCoords coords4d;
     coords4d.viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
     // The following formulas assume that scatteringTextureSize[0] is even. For odd sizes they would change.
@@ -593,8 +604,8 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture indices we combine into a single sampler3D coordinate.
-    const float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
-    const float combinedIndex=texIndices[1];
+    CONST float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
+    CONST float combinedIndex=texIndices[1];
     coords4d.dotViewSun=mod(combinedIndex,texW)/(texW-1);
     coords4d.cosSunZenithAngle=floor(combinedIndex/texW)/(texH-1);
 
@@ -608,11 +619,11 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
 ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 {
-    const Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
+    CONST Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
     ScatteringTexVars vars=scatteringTex4DCoordsToTexVars(coords4d);
     // Clamp dotViewSun to its valid range of values, given cosViewZenithAngle and cosSunZenithAngle. This is
     // needed to prevent NaNs when computing the scattering texture.
-    const float cosVZA=vars.cosViewZenithAngle,
+    CONST float cosVZA=vars.cosViewZenithAngle,
                 cosSZA=vars.cosSunZenithAngle;
     vars.dotViewSun=clamp(vars.dotViewSun,
                           cosVZA*cosSZA-safeSqrt((1-sqr(cosVZA))*(1-sqr(cosSZA))),
@@ -622,54 +633,54 @@ ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 
 EclipseScatteringTexVars eclipseTexCoordsToTexVars(const vec2 texCoords, const float altitude)
 {
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
-    const bool viewRayIntersectsGround = texCoords.t<0.5;
+    CONST bool viewRayIntersectsGround = texCoords.t<0.5;
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
-    const float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
+    CONST float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
     return EclipseScatteringTexVars(azimuthRelativeToSun, cosViewZenithAngle, viewRayIntersectsGround);
 }
 
 EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                                    const float altitude, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -677,13 +688,13 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
-    const float azimuthCoord = azimuthRelativeToSun/(2*PI);
+    CONST float azimuthCoord = azimuthRelativeToSun/(2*PI);
 
     return EclipseScattering2DCoords(azimuthCoord, cosVZACoord);
 }
@@ -691,14 +702,14 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
 vec2 eclipseTexVarsToTexCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                const float altitude, const bool viewRayIntersectsGround, const vec2 texSize)
 {
-    const EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+    CONST EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                                     viewRayIntersectsGround);
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2);
-    const float azimuthTC = coords.azimuth + 1/(2*texSize.s);
+    CONST float azimuthTC = coords.azimuth + 1/(2*texSize.s);
 
     return vec2(azimuthTC, cosVZAtc);
 }
@@ -707,42 +718,42 @@ vec4 sampleEclipseDoubleScattering3DTexture(const sampler3D tex, const float cos
                                             const float cosViewZenithAngle, const float azimuthRelativeToSun,
                                             const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
+    CONST vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
                                                   eclipsedDoubleScatteringTextureSize.st);
-    const float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
-    const vec3 texCoords=vec3(coords2d, cosSZACoord);
+    CONST float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
+    CONST vec3 texCoords=vec3(coords2d, cosSZACoord);
 
     return texture(tex, texCoords);
 }
 
 LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 texIndices)
 {
-    const vec2 indexMax=lightPollutionTextureSize-vec2(1);
+    CONST vec2 indexMax=lightPollutionTextureSize-vec2(1);
 
-    const float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
-    const float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
+    CONST float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
-    const bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
-    const float cosViewZenithAngleCoord = viewRayIntersectsGround ?
+    CONST bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
+    CONST float cosViewZenithAngleCoord = viewRayIntersectsGround ?
                                    1-2*texIndices[0]/(indexMax[0]-1) :
                                    2*(texIndices[0]-1)/(indexMax[0]-1)-1;
     // ------------------------------------
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
@@ -753,23 +764,23 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 
 LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -777,27 +788,27 @@ LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, con
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     return LightPollution2DCoords(cosVZACoord, altCoord);
 }
 
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
-    const vec2 texSize = lightPollutionTextureSize;
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 texSize = lightPollutionTextureSize;
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2);
-    const float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
+    CONST float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
     return vec2(cosVZAtc, altitudeTC);
 }

--- a/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/0/aerosols/common-functions.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/0/aerosols/common-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // common-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // common-functions.frag
+#line 4 0 // common-functions.frag
 
 bool dbgDataPresent=false;
 bool debugDataPresent()
@@ -69,7 +80,7 @@ void setDebugData(float a,float b, float c, float d)
 
 void swap(inout float x, inout float y)
 {
-    const float t = x;
+    CONST float t = x;
     x = y;
     y = t;
 }
@@ -83,7 +94,7 @@ float safeSqrt(const float x)
 
 float safeAtan(const float y, const float x)
 {
-    const float a = atan(y,x);
+    CONST float a = atan(y,x);
     return x==0 && y==0 ? 0 : a;
 }
 
@@ -116,23 +127,23 @@ float pointAltitude(vec3 point)
 
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float Ratm=earthRadius+atmosphereHeight;
-    const float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float Ratm=earthRadius+atmosphereHeight;
+    CONST float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float distanceToGround(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(-safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float cosZenithAngleOfHorizon(const float altitude)
 {
-    const float R=earthRadius;
-    const float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
+    CONST float R=earthRadius;
+    CONST float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
     return -sqrt(2*h*R+sqr(h))/(R+h);
 }
 
@@ -151,8 +162,8 @@ float distanceToNearestAtmosphereBoundary(const float cosZenithAngle, const floa
 float sunVisibility(const float cosSunZenithAngle, float altitude)
 {
     if(altitude<0) altitude=0;
-    const float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
-    const float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
+    CONST float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
+    CONST float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
     /* Approximating visible fraction of solar disk by smoothstep between the position of the Sun
      * touching the horizon by its upper part and the position with lower part touching the horizon.
      * The calculation assumes that solar angular radius is small and thus approximately equals its sine.
@@ -182,13 +193,13 @@ float circlesIntersectionArea(float R1, float R2, float d)
 
 float angleBetween(const vec3 a, const vec3 b)
 {
-    const float d=dot(a,b);
-    const float c=length(cross(a,b));
+    CONST float d=dot(a,b);
+    CONST float c=length(cross(a,b));
     // To avoid loss of precision, don't use dot product near the singularity
     // of acos, and cross product near the singularity of asin
     if(abs(d) < abs(c))
         return acos(d/(length(a)*length(b)));
-    const float smallerAngle = asin(c/(length(a)*length(b)));
+    CONST float smallerAngle = asin(c/(length(a)*length(b)));
     if(d<0) return PI-smallerAngle;
     return smallerAngle;
 }
@@ -205,11 +216,11 @@ float moonAngularRadius(const vec3 cameraPosition, const vec3 moonPosition)
 
 float visibleSolidAngleOfSun(const vec3 camera, const vec3 sunDir, const vec3 moonPos)
 {
-    const float Rs=sunAngularRadius;
-    const float Rm=moonAngularRadius(camera,moonPos);
+    CONST float Rs=sunAngularRadius;
+    CONST float Rm=moonAngularRadius(camera,moonPos);
     float visibleSolidAngle=PI*sqr(Rs);
 
-    const float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
+    CONST float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
     if(dSM<Rs+Rm)
     {
         visibleSolidAngle -= circlesIntersectionArea(Rm,Rs,dSM);
@@ -229,12 +240,12 @@ float sphereIntegrationSolidAngleDifferential(const int pointCountOnSphere)
 }
 vec3 sphereIntegrationSampleDir(const int index, const int pointCountOnSphere)
 {
-    const float goldenRatio=1.6180339887499;
+    CONST float goldenRatio=1.6180339887499;
     // The range of n is 0.5, 1.5, ..., pointCountOnSphere-0.5
-    const float n=index+0.5;
+    CONST float n=index+0.5;
     // Explanation of the Fibonacci grid generation can be seen at https://stackoverflow.com/a/44164075/673852
-    const float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
-    const float azimuth=n*(2*PI*goldenRatio);
+    CONST float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
+    CONST float azimuth=n*(2*PI*goldenRatio);
     return vec3(cos(azimuth)*sin(zenithAngle),
                 sin(azimuth)*sin(zenithAngle),
                 cos(zenithAngle));

--- a/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/0/aerosols/densities.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/0/aerosols/densities.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // densities.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,20 +45,20 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // densities.frag
+#line 4 0 // densities.frag
 float scattererNumberDensity_molecules(float altitude)
 {
-        const float rayleighScaleHeight=8*km;
+        CONST float rayleighScaleHeight=8*km;
         return 3.08458e25*exp(-1/rayleighScaleHeight * altitude);
 }
 float scattererNumberDensity_aerosols(float altitude)
 {
-        const float mieScaleHeight=1.2*km;
+        CONST float mieScaleHeight=1.2*km;
         return 1.03333e8*exp(-1/mieScaleHeight*altitude);
 }
 float absorberNumberDensity_ozone(float altitude)
 {
-        const float totalOzoneAmount=370*dobsonUnit;
+        CONST float totalOzoneAmount=370*dobsonUnit;
 
         float density;
 

--- a/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/0/aerosols/phase-functions.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/0/aerosols/phase-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // phase-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // phase-functions.frag
+#line 4 0 // phase-functions.frag
 
 vec4 phaseFunction_molecules(float dotViewSun)
 {
@@ -42,9 +53,9 @@ vec4 phaseFunction_molecules(float dotViewSun)
 }
 vec4 phaseFunction_aerosols(float dotViewSun)
 {
-        const float g=0.76;
-        const float g2=g*g;
-        const float k = 3/(8*PI)*(1-g2)/(2+g2);
+        CONST float g=0.76;
+        CONST float g2=g*g;
+        CONST float k = 3/(8*PI)*(1-g2)/(2+g2);
         return vec4(k * (1+sqr(dotViewSun)) / pow(1+g2 - 2*g*dotViewSun, 1.5) + 1/((1-dotViewSun)*600+0.05))*0.904;
 }
 vec4 currentPhaseFunction(float dotViewSun) { return phaseFunction_aerosols(dotViewSun); }

--- a/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/0/aerosols/render.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/0/aerosols/render.frag
@@ -1,7 +1,21 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
 
-#line 1 1 // const.h.glsl
+
+
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 6 0 // render.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,11 +48,11 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // render.frag
-#line 1 2 // calc-view-dir.h.glsl
+#line 7 0 // render.frag
+#line 1 3 // calc-view-dir.h.glsl
 vec3 calcViewDir();
-#line 6 0 // render.frag
-#line 1 3 // common-functions.h.glsl
+#line 8 0 // render.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -70,14 +84,14 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // render.frag
-#line 1 4 // phase-functions.h.glsl
+#line 9 0 // render.frag
+#line 1 5 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 8 0 // render.frag
+#line 10 0 // render.frag
 
-#line 1 5 // single-scattering-eclipsed.h.glsl
+#line 1 6 // single-scattering-eclipsed.h.glsl
 #ifndef INCLUDE_ONCE_050024D2_BD56_434E_8D40_2055DA0B78EC
 #define INCLUDE_ONCE_050024D2_BD56_434E_8D40_2055DA0B78EC
 
@@ -85,8 +99,8 @@ vec4 computeSingleScatteringEclipsed(const vec3 camera, const vec3 viewDir, cons
                                      const bool viewRayIntersectsGround);
 
 #endif
-#line 10 0 // render.frag
-#line 1 6 // texture-coordinates.h.glsl
+#line 12 0 // render.frag
+#line 1 7 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -155,10 +169,10 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 11 0 // render.frag
-#line 1 7 // radiance-to-luminance.h.glsl
+#line 13 0 // render.frag
+#line 1 8 // radiance-to-luminance.h.glsl
 const mat4 radianceToLuminance=mat4(1.38997746,0.0419133306,6.48549128,0,  105.968163,3.00652099,500.960266,142.641495,  3776.24023,119.971481,18207.7598,6412.0166,  6910.01318,981.06665,37504.0586,26741.9102);
-#line 12 0 // render.frag
+#line 14 0 // render.frag
 
 
 
@@ -195,18 +209,18 @@ void main()
     // this approximation has the same order of magnitude as the assumption that the Earth and its atmosphere
     // are spherical.
     float altitude = max(cameraPosition.z, 0.);
-    const vec3 oldCamPos=cameraPosition;
+    CONST vec3 oldCamPos=cameraPosition;
     // Hide the uniform with this name, thus effectively modifying it for the following code
     vec3 cameraPosition=vec3(oldCamPos.xy, altitude);
 
     bool lookingIntoAtmosphere=true;
     if(altitude>atmosphereHeight)
     {
-        const vec3 p = cameraPosition - earthCenter;
-        const float p_dot_v = dot(p, viewDir);
-        const float p_dot_p = dot(p, p);
-        const float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
-        const float distanceToTOA = -p_dot_v - sqrt(sqr(earthRadius+atmosphereHeight) - squaredDistBetweenViewRayAndEarthCenter);
+        CONST vec3 p = cameraPosition - earthCenter;
+        CONST float p_dot_v = dot(p, viewDir);
+        CONST float p_dot_p = dot(p, p);
+        CONST float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
+        CONST float distanceToTOA = -p_dot_v - sqrt(sqr(earthRadius+atmosphereHeight) - squaredDistBetweenViewRayAndEarthCenter);
         if(distanceToTOA>=0)
         {
             cameraPosition += viewDir*distanceToTOA;
@@ -214,7 +228,7 @@ void main()
         }
         else
         {
-#if RENDERING_ANY_ZERO_SCATTERING
+#if 0 /*RENDERING_ANY_ZERO_SCATTERING*/
             lookingIntoAtmosphere=false;
 #else
             luminance=vec4(0);
@@ -224,16 +238,16 @@ void main()
         }
     }
 
-    const vec3 zenith=normalize(cameraPosition-earthCenter);
+    CONST vec3 zenith=normalize(cameraPosition-earthCenter);
     float cosViewZenithAngle=dot(zenith,viewDir);
 
     bool viewRayIntersectsGround=false;
     {
-        const vec3 p = cameraPosition - earthCenter;
-        const float p_dot_v = dot(p, viewDir);
-        const float p_dot_p = dot(p, p);
-        const float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
-        const float distanceToIntersection = -p_dot_v - sqrt(sqr(earthRadius) - squaredDistBetweenViewRayAndEarthCenter);
+        CONST vec3 p = cameraPosition - earthCenter;
+        CONST float p_dot_v = dot(p, viewDir);
+        CONST float p_dot_p = dot(p, p);
+        CONST float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
+        CONST float distanceToIntersection = -p_dot_v - sqrt(sqr(earthRadius) - squaredDistBetweenViewRayAndEarthCenter);
         // altitude==0 is a special case where distance to intersection calculation
         // is unreliable (has a lot of noise in its sign), so check it separately
         if(distanceToIntersection>0 || (altitude==0 && cosViewZenithAngle<0))
@@ -244,11 +258,11 @@ void main()
     // Aside from aesthetics, this affects brightness input to Stellarium's tone mapper.
     if(pseudoMirrorSkyBelowHorizon && viewRayIntersectsGround)
     {
-        const float horizonCZA = cosZenithAngleOfHorizon(altitude);
-        const float viewElev  = asin(clampCosine(cosViewZenithAngle));
-        const float horizElev = asin(clampCosine(horizonCZA));
-        const float newViewElev = 2*horizElev - viewElev;
-        const float viewDirXYnorm = length(viewDir-zenith*cosViewZenithAngle);
+        CONST float horizonCZA = cosZenithAngleOfHorizon(altitude);
+        CONST float viewElev  = asin(clampCosine(cosViewZenithAngle));
+        CONST float horizElev = asin(clampCosine(horizonCZA));
+        CONST float newViewElev = 2*horizElev - viewElev;
+        CONST float viewDirXYnorm = length(viewDir-zenith*cosViewZenithAngle);
         if(viewDirXYnorm == 0)
         {
             viewDir = zenith;
@@ -267,27 +281,27 @@ void main()
         viewRayIntersectsGround = false;
     }
 
-    const float cosSunZenithAngle =dot(zenith,sunDirection);
-    const float dotViewSun=dot(viewDir,sunDirection);
+    CONST float cosSunZenithAngle =dot(zenith,sunDirection);
+    CONST float dotViewSun=dot(viewDir,sunDirection);
 
-    const vec3 sunXYunnorm=sunDirection-dot(sunDirection,zenith)*zenith;
-    const vec3 viewXYunnorm=viewDir-dot(viewDir,zenith)*zenith;
-    const vec3 sunXY = sunXYunnorm.x!=0 || sunXYunnorm.y!=0 || sunXYunnorm.z!=0 ? normalize(sunXYunnorm) : vec3(0);
-    const vec3 viewXY = viewXYunnorm.x!=0 || viewXYunnorm.y!=0 || viewXYunnorm.z!=0 ? normalize(viewXYunnorm) : vec3(0);
-    const float azimuthRelativeToSun=safeAtan(dot(cross(sunXY, viewXY), zenith), dot(sunXY, viewXY));
+    CONST vec3 sunXYunnorm=sunDirection-dot(sunDirection,zenith)*zenith;
+    CONST vec3 viewXYunnorm=viewDir-dot(viewDir,zenith)*zenith;
+    CONST vec3 sunXY = sunXYunnorm.x!=0 || sunXYunnorm.y!=0 || sunXYunnorm.z!=0 ? normalize(sunXYunnorm) : vec3(0);
+    CONST vec3 viewXY = viewXYunnorm.x!=0 || viewXYunnorm.y!=0 || viewXYunnorm.z!=0 ? normalize(viewXYunnorm) : vec3(0);
+    CONST float azimuthRelativeToSun=safeAtan(dot(cross(sunXY, viewXY), zenith), dot(sunXY, viewXY));
 
-#if RENDERING_ZERO_SCATTERING
+#if 0 /*RENDERING_ZERO_SCATTERING*/
     vec4 radiance;
     if(viewRayIntersectsGround)
     {
         // XXX: keep in sync with the same code in computeScatteringDensity(), but don't forget about
         //      the difference in the usage of viewDir vs incDir.
-        const float distToGround = distanceToGround(cosViewZenithAngle, altitude);
-        const vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
-        const vec3 groundNormal = normalize(zenith*(earthRadius+altitude)+viewDir*distToGround);
-        const vec4 groundIrradiance = irradiance(dot(groundNormal, sunDirection), 0);
+        CONST float distToGround = distanceToGround(cosViewZenithAngle, altitude);
+        CONST vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
+        CONST vec3 groundNormal = normalize(zenith*(earthRadius+altitude)+viewDir*distToGround);
+        CONST vec4 groundIrradiance = irradiance(dot(groundNormal, sunDirection), 0);
         // Radiation scattered by the ground
-        const float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
+        CONST float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
         radiance = transmittanceToGround*groundAlbedo*groundIrradiance*solarIrradianceFixup*groundBRDF
                  + lightPollutionGroundLuminance*lightPollutionRelativeRadiance;
     }
@@ -304,22 +318,22 @@ void main()
     }
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_ZERO_SCATTERING
+#elif 0 /*RENDERING_ECLIPSED_ZERO_SCATTERING*/
     vec4 radiance;
-    const float dotViewMoon=dot(viewDir,normalize(moonPosition-cameraPosition));
+    CONST float dotViewMoon=dot(viewDir,normalize(moonPosition-cameraPosition));
     if(viewRayIntersectsGround)
     {
         // XXX: keep in sync with the similar code in non-eclipsed zero scattering rendering.
-        const float distToGround = distanceToGround(cosViewZenithAngle, altitude);
-        const vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
-        const vec3 pointOnGround = cameraPosition+viewDir*distToGround;
-        const vec4 directGroundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDirection, moonPosition);
+        CONST float distToGround = distanceToGround(cosViewZenithAngle, altitude);
+        CONST vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
+        CONST vec3 pointOnGround = cameraPosition+viewDir*distToGround;
+        CONST vec4 directGroundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDirection, moonPosition);
         // FIXME: add first-order indirect irradiance too: it's done in non-eclipsed irradiance (in the same
         // conditions: when limited to 2 orders). This should be calculated at the same time when second order
         // is: all the infrastructure is already there.
-        const vec4 groundIrradiance = directGroundIrradiance;
+        CONST vec4 groundIrradiance = directGroundIrradiance;
         // Radiation scattered by the ground
-        const float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
+        CONST float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
         radiance = transmittanceToGround*groundAlbedo*groundIrradiance*solarIrradianceFixup*groundBRDF
                  + lightPollutionGroundLuminance*lightPollutionRelativeRadiance;
     }
@@ -337,52 +351,52 @@ void main()
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
 #elif 1 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_ON_THE_FLY*/
-    const vec4 scattering=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPosition,
+    CONST vec4 scattering=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPosition,
                                                           viewRayIntersectsGround);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE
-    const vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE*/
+    CONST vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                      viewRayIntersectsGround, eclipsedSingleScatteringTextureSize);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact at the point where azimuth texture coordinate changes from 1 to 0 (at azimuthRelativeToSun crossing
     // 0). This happens when I simply call texture(eclipsedScatteringTexture, texCoords) without specifying LOD.
     // Apparently, the driver uses the derivative for some reason, even though it shouldn't.
-    const vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
+    CONST vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE
-    const vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
+    CONST vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                      viewRayIntersectsGround, eclipsedSingleScatteringTextureSize);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact at the point where azimuth texture coordinate changes from 1 to 0 (at azimuthRelativeToSun crossing
     // 0). This happens when I simply call texture(eclipsedScatteringTexture, texCoords) without specifying LOD.
     // Apparently, the driver uses the derivative for some reason, even though it shouldn't.
-    const vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
+    CONST vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
     luminance=scattering*currentPhaseFunction(dotViewSun);
-#elif RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_RADIANCE
+#elif 0 /*RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_RADIANCE*/
     vec4 radiance=exp(sampleEclipseDoubleScattering3DTexture(eclipsedDoubleScatteringTexture,
                                                              cosSunZenithAngle, cosViewZenithAngle, azimuthRelativeToSun,
                                                              altitude, viewRayIntersectsGround));
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_LUMINANCE
+#elif 0 /*RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
     luminance=exp(sampleEclipseDoubleScattering3DTexture(eclipsedDoubleScatteringTexture,
                                                          cosSunZenithAngle, cosViewZenithAngle, azimuthRelativeToSun,
                                                          altitude, viewRayIntersectsGround));
-#elif RENDERING_SINGLE_SCATTERING_ON_THE_FLY
-    const vec4 scattering=computeSingleScattering(cosSunZenithAngle,cosViewZenithAngle,dotViewSun,
+#elif 0 /*RENDERING_SINGLE_SCATTERING_ON_THE_FLY*/
+    CONST vec4 scattering=computeSingleScattering(cosSunZenithAngle,cosViewZenithAngle,dotViewSun,
                                                   altitude,viewRayIntersectsGround);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE
+#elif 0 /*RENDERING_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE*/
     vec4 scattering;
     if(useInterpolationGuides)
     {
@@ -399,7 +413,7 @@ void main()
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE
+#elif 0 /*RENDERING_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
     vec4 scattering;
     if(useInterpolationGuides)
     {
@@ -413,18 +427,18 @@ void main()
                                      dotViewSun, altitude, viewRayIntersectsGround);
     }
     luminance=scattering * (bool(PHASE_FUNCTION_IS_EMBEDDED) ? vec4(1) : currentPhaseFunction(dotViewSun));
-#elif RENDERING_MULTIPLE_SCATTERING_LUMINANCE
+#elif 0 /*RENDERING_MULTIPLE_SCATTERING_LUMINANCE*/
     luminance=sample3DTexture(scatteringTexture, cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, viewRayIntersectsGround);
-#elif RENDERING_MULTIPLE_SCATTERING_RADIANCE
+#elif 0 /*RENDERING_MULTIPLE_SCATTERING_RADIANCE*/
     vec4 radiance=sample3DTexture(scatteringTexture, cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, viewRayIntersectsGround);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_LIGHT_POLLUTION_RADIANCE
+#elif 0 /*RENDERING_LIGHT_POLLUTION_RADIANCE*/
     vec4 radiance=lightPollutionGroundLuminance*lightPollutionScattering(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_LIGHT_POLLUTION_LUMINANCE
+#elif 0 /*RENDERING_LIGHT_POLLUTION_LUMINANCE*/
     luminance=lightPollutionGroundLuminance*lightPollutionScattering(altitude, cosViewZenithAngle, viewRayIntersectsGround);
 #else
 #error What to render?

--- a/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/0/aerosols/single-scattering-eclipsed.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/0/aerosols/single-scattering-eclipsed.frag
@@ -1,7 +1,21 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
 
-#line 1 1 // const.h.glsl
+
+
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 6 0 // single-scattering-eclipsed.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,15 +48,15 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // single-scattering-eclipsed.frag
-#line 1 2 // densities.h.glsl
+#line 7 0 // single-scattering-eclipsed.frag
+#line 1 3 // densities.h.glsl
 float scattererNumberDensity_molecules(float altitude);
 float scattererNumberDensity_aerosols(float altitude);
 float absorberNumberDensity_ozone(float altitude);
 vec4 scatteringCrossSection();
 float scattererDensity(float altitude);
-#line 6 0 // single-scattering-eclipsed.frag
-#line 1 3 // common-functions.h.glsl
+#line 8 0 // single-scattering-eclipsed.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -74,8 +88,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // single-scattering-eclipsed.frag
-#line 1 4 // texture-sampling-functions.h.glsl
+#line 9 0 // single-scattering-eclipsed.frag
+#line 1 5 // texture-sampling-functions.h.glsl
 #ifndef INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 #define INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float altitude);
@@ -87,7 +101,7 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                 const int scatteringOrder);
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 #endif
-#line 8 0 // single-scattering-eclipsed.frag
+#line 10 0 // single-scattering-eclipsed.frag
 
 
 float cosZenithAngle(vec3 origin, vec3 direction)
@@ -101,13 +115,13 @@ vec4 computeSingleScatteringIntegrandEclipsed(const float cosSunZenithAngle, con
                                               const float dist, const bool viewRayIntersectsGround,
                                               const vec3 scatterer, const vec3 sunDir, const vec3 moonPos)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle here the case when the
     // endpoint of the view ray intentionally appears in outer space.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosSunZenithAngleAtDist=clampCosine((r*cosSunZenithAngle+dist*dotViewSun)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosSunZenithAngleAtDist=clampCosine((r*cosSunZenithAngle+dist*dotViewSun)/(earthRadius+altAtDist));
 
-    const vec4 xmittance=transmittance(cosViewZenithAngle, altitude, dist, viewRayIntersectsGround)
+    CONST vec4 xmittance=transmittance(cosViewZenithAngle, altitude, dist, viewRayIntersectsGround)
                                                     *
                          transmittanceToAtmosphereBorder(cosSunZenithAngleAtDist, altAtDist)
                                                     *
@@ -115,7 +129,7 @@ vec4 computeSingleScatteringIntegrandEclipsed(const float cosSunZenithAngle, con
                                                     *
                             // FIXME: this ignores orientation of the crescent of eclipsed Sun WRT horizon
                                     sunVisibility(cosSunZenithAngleAtDist, altAtDist);
-#if ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION
+#if 0 /*ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION*/
     COMPUTE_TOTAL_SCATTERING_COEFFICIENT;
     return xmittance * totalScatteringCoefficient;
 #else
@@ -126,26 +140,26 @@ vec4 computeSingleScatteringIntegrandEclipsed(const float cosSunZenithAngle, con
 vec4 computeSingleScatteringEclipsed(const vec3 camera, const vec3 viewDir, const vec3 sunDir, const vec3 moonPos,
                                      const bool viewRayIntersectsGround)
 {
-    const float cosViewZenithAngle=cosZenithAngle(camera,viewDir);
-    const float cosSunZenithAngle=cosZenithAngle(camera,sunDir);
-    const float altitude=pointAltitude(camera);
-    const float dotViewSun=dot(viewDir,sunDir);
-    const float integrInterval=distanceToNearestAtmosphereBoundary(cosViewZenithAngle, altitude,
+    CONST float cosViewZenithAngle=cosZenithAngle(camera,viewDir);
+    CONST float cosSunZenithAngle=cosZenithAngle(camera,sunDir);
+    CONST float altitude=pointAltitude(camera);
+    CONST float dotViewSun=dot(viewDir,sunDir);
+    CONST float integrInterval=distanceToNearestAtmosphereBoundary(cosViewZenithAngle, altitude,
                                                                    viewRayIntersectsGround);
 
     // Using the midpoint rule for quadrature
     vec4 spectrum=vec4(0);
-    const float dl=integrInterval/radialIntegrationPoints;
+    CONST float dl=integrInterval/radialIntegrationPoints;
     for(int n=0; n<radialIntegrationPoints; ++n)
     {
-        const float dist=(n+0.5)*dl;
+        CONST float dist=(n+0.5)*dl;
         spectrum += computeSingleScatteringIntegrandEclipsed(cosSunZenithAngle, cosViewZenithAngle, dotViewSun,
                                                              altitude, dist, viewRayIntersectsGround,
                                                              camera+viewDir*dist, sunDir, moonPos);
     }
 
     spectrum *= dl*solarIrradianceAtTOA
-#if ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION
+#if 0 /*ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION*/
                                 // the multiplier is already included
 #else
                                         * scatteringCrossSection()

--- a/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/0/aerosols/texture-coordinates.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/0/aerosols/texture-coordinates.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-coordinates.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,8 +45,8 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // texture-coordinates.frag
-#line 1 2 // texture-coordinates.h.glsl
+#line 4 0 // texture-coordinates.frag
+#line 1 3 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -104,8 +115,8 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 6 0 // texture-coordinates.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-coordinates.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -137,7 +148,7 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-coordinates.frag
+#line 6 0 // texture-coordinates.frag
 
 const float LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA=sqrt(atmosphereHeight*(atmosphereHeight+2*earthRadius));
 
@@ -205,18 +216,18 @@ vec3 indicesToTexCoords(const vec3 indices, const vec3 texSizes)
 
 TransmittanceTexVars transmittanceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
+    CONST float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
                                 texCoordToUnitRange(texCoord.t,transmittanceTextureSize.t);
     // Distance from Earth center to camera
-    const float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
-    const float altitude=r-earthRadius;
+    CONST float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
+    CONST float altitude=r-earthRadius;
 
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
     // distance to border of visible atmosphere from the view point
-    const float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
+    CONST float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
     // d==0 can happen when altitude==atmosphereHeight
-    const float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
+    CONST float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
     return TransmittanceTexVars(cosVZA,altitude);
 }
 
@@ -235,53 +246,53 @@ vec2 transmittanceTexVarsToTexCoord(const float cosVZA, float altitude)
     if(altitude<0)
         altitude=0;
 
-    const float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
+    CONST float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
                                       transmittanceTextureSize.t);
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
-    const float d=distanceToAtmosphereBorder(cosVZA,altitude);
-    const float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float d=distanceToAtmosphereBorder(cosVZA,altitude);
+    CONST float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
     return vec2(s,t);
 }
 
 // Output: vec2(cos(sunZenithAngle), altitude)
 IrradianceTexVars irradianceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
-    const float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
+    CONST float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
+    CONST float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
     return IrradianceTexVars(cosSZA,alt);
 }
 
 vec2 irradianceTexVarsToTexCoord(const float cosSunZenithAngle, const float altitude)
 {
-    const float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
-    const float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
+    CONST float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
+    CONST float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
     return vec2(s,t);
 }
 
 float cosSZAToUnitRangeTexCoord(const float cosSunZenithAngle)
 {
     // Distance to top atmosphere border along the ray groundUnderCamera-sun: (altitude, cosSunZenithAngle)
-    const float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name
-    const float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
+    CONST float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
     // TODO: choose a more descriptive name
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     return max(0.,1-a/A)/(a+1);
 }
 
 float unitRangeTexCoordToCosSZA(const float texCoord)
 {
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float a=(A-A*texCoord)/(1+A*texCoord);
-    const float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
+    CONST float a=(A-A*texCoord)/(1+A*texCoord);
+    CONST float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
     return distFromGroundToTopAtmoBorder==0 ? 1 :
         clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distFromGroundToTopAtmoBorder)) /
                     (2*earthRadius*distFromGroundToTopAtmoBorder));
@@ -292,24 +303,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
                                                const float dotViewSun, const float altitude,
                                                const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -317,24 +328,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float dotVSCoord=(dotViewSun+1)/2;
+    CONST float dotVSCoord=(dotViewSun+1)/2;
 
     // ------------------------------------
-    const float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
+    CONST float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
 
     return Scattering4DCoords(cosSZACoord, cosVZACoord, dotVSCoord, altCoord, viewRayIntersectsGround);
 }
 
 TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
@@ -342,16 +353,16 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture coordinates we combine into a single sampler3D coordinate.
-    const float texW = scatteringTextureSize[1];
-    const float texH = scatteringTextureSize[2];
-    const float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
-    const vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
+    CONST float texW = scatteringTextureSize[1];
+    CONST float texH = scatteringTextureSize[2];
+    CONST float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
+    CONST vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
                                         ceil (cosSZAIndex)*texW+coords.dotViewSun*(texW-1)) / (texW*texH-1);
-    const vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
+    CONST vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
 
-    const float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
+    CONST float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
 
-    const float alphaUpper=fract(cosSZAIndex);
+    CONST float alphaUpper=fract(cosSZAIndex);
     return TexCoordPair(vec3(cosVZAtc, combinedCoord.x, altitude), float(1-alphaUpper),
                         vec3(cosVZAtc, combinedCoord.y, altitude), float(alphaUpper));
 }
@@ -359,9 +370,9 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
+    CONST TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
     return texture(tex, texCoords.lower) * texCoords.alphaLower +
            texture(tex, texCoords.upper) * texCoords.alphaUpper;
 }
@@ -369,17 +380,17 @@ vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const f
 // 3D texture is the 3D single-altitude slice of a 4D texture
 vec3 scattering4DCoordsToTex3DCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2);
 
-    const float dvsSize = scatteringTextureSize[1];
-    const float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
+    CONST float dvsSize = scatteringTextureSize[1];
+    CONST float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
 
-    const float cszaSize = scatteringTextureSize[2];
-    const float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
+    CONST float cszaSize = scatteringTextureSize[2];
+    CONST float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
 
     return vec3(cosVZAtc, dotVStc, cosSZAtc);
 }
@@ -394,39 +405,39 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along dotViewSun coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[1];
-    const float posOfRow = indices[1];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[1];
+    CONST float posOfRow = indices[1];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         indexToTexCoord(currRow, numRows-1),
                                                         texCoordVerbatim));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               indexToTexCoord(currRow, numRows-1),
                                                               texCoordVerbatim));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          indexToTexCoord(currRow, numRows-1),
                                          texCoordVerbatim));
@@ -434,14 +445,14 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
 vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolationGuides01Tex,
                                  const vec3 indices)
 {
-    const float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
+    CONST float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
 
-    const float cosVZAIndex = indices[0];
-    const float dotVSIndex = indices[1];
-    const float currRow = floor(dotVSIndex);
-    const float posBetweenRows = dotVSIndex - currRow;
-    const float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cosVZAIndex = indices[0];
+    CONST float dotVSIndex = indices[1];
+    CONST float currRow = floor(dotVSIndex);
+    CONST float posBetweenRows = dotVSIndex - currRow;
+    CONST float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -449,14 +460,14 @@ vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolat
     indicesCurrRow[1] =     currRow;
     indicesNextRow[1] = min(currRow+1, scatteringTextureSize[1]-1.);
 
-    const vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
-    const vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
+    CONST vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
+    CONST vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
 
-    const vec4 valueCurrRow = texture(tex, coordsCurrRow);
-    const vec4 valueNextRow = texture(tex, coordsNextRow);
-    const float epsilon = 1e-37; // Prevents passing zero to log
-    const vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
-    const vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
+    CONST vec4 valueCurrRow = texture(tex, coordsCurrRow);
+    CONST vec4 valueNextRow = texture(tex, coordsNextRow);
+    CONST float epsilon = 1e-37; // Prevents passing zero to log
+    CONST vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
+    CONST vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
     return (logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow;
 }
 
@@ -465,37 +476,37 @@ float findGuide02Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along SZA coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[2];
-    const float posOfRow = indices[2];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[2];
+    CONST float posOfRow = indices[2];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
 }
@@ -505,19 +516,19 @@ vec4 sample3DTextureGuided(const sampler3D tex,
                            const float cosSunZenithAngle, const float cosViewZenithAngle,
                            const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
                                                                     dotViewSun, altitude, viewRayIntersectsGround);
     // Handle the external interpolation guides: the guides between a pair of VZA-dotViewSun 2D "pictures".
-    const vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
-    const vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
-    const float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
+    CONST vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
+    CONST float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
 
-    const float cvzaIndex = indices[0];
-    const float cszaIndex = indices[2];
-    const float currRow = floor(cszaIndex);
-    const float posBetweenRows = cszaIndex - currRow;
-    const float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cvzaIndex = indices[0];
+    CONST float cszaIndex = indices[2];
+    CONST float currRow = floor(cszaIndex);
+    CONST float posBetweenRows = cszaIndex - currRow;
+    CONST float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -526,58 +537,58 @@ vec4 sample3DTextureGuided(const sampler3D tex,
     indicesNextRow[2] = min(currRow+1, scatteringTextureSize[2]-1);
 
     // The caller will handle the internal interpolation guides: the ones between rows in each 2D "picture".
-    const vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
-    const vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
+    CONST vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
+    CONST vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
     return exp((logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow);
 }
 
 vec4 sample3DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
     return texture(tex, texCoords);
 }
 
 ScatteringTexVars scatteringTex4DCoordsToTexVars(const Scattering4DCoords coords)
 {
-    const float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
     // ------------------------------------
     float cosViewZenithAngle;
     if(coords.viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
     // ------------------------------------
-    const float dotViewSun=coords.dotViewSun*2-1;
+    CONST float dotViewSun=coords.dotViewSun*2-1;
 
     // ------------------------------------
-    const float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
+    CONST float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
 
     return ScatteringTexVars(cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, coords.viewRayIntersectsGround);
 }
 
 Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 {
-    const vec4 indexMax=scatteringTextureSize-vec4(1);
+    CONST vec4 indexMax=scatteringTextureSize-vec4(1);
     Scattering4DCoords coords4d;
     coords4d.viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
     // The following formulas assume that scatteringTextureSize[0] is even. For odd sizes they would change.
@@ -593,8 +604,8 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture indices we combine into a single sampler3D coordinate.
-    const float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
-    const float combinedIndex=texIndices[1];
+    CONST float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
+    CONST float combinedIndex=texIndices[1];
     coords4d.dotViewSun=mod(combinedIndex,texW)/(texW-1);
     coords4d.cosSunZenithAngle=floor(combinedIndex/texW)/(texH-1);
 
@@ -608,11 +619,11 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
 ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 {
-    const Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
+    CONST Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
     ScatteringTexVars vars=scatteringTex4DCoordsToTexVars(coords4d);
     // Clamp dotViewSun to its valid range of values, given cosViewZenithAngle and cosSunZenithAngle. This is
     // needed to prevent NaNs when computing the scattering texture.
-    const float cosVZA=vars.cosViewZenithAngle,
+    CONST float cosVZA=vars.cosViewZenithAngle,
                 cosSZA=vars.cosSunZenithAngle;
     vars.dotViewSun=clamp(vars.dotViewSun,
                           cosVZA*cosSZA-safeSqrt((1-sqr(cosVZA))*(1-sqr(cosSZA))),
@@ -622,54 +633,54 @@ ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 
 EclipseScatteringTexVars eclipseTexCoordsToTexVars(const vec2 texCoords, const float altitude)
 {
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
-    const bool viewRayIntersectsGround = texCoords.t<0.5;
+    CONST bool viewRayIntersectsGround = texCoords.t<0.5;
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
-    const float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
+    CONST float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
     return EclipseScatteringTexVars(azimuthRelativeToSun, cosViewZenithAngle, viewRayIntersectsGround);
 }
 
 EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                                    const float altitude, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -677,13 +688,13 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
-    const float azimuthCoord = azimuthRelativeToSun/(2*PI);
+    CONST float azimuthCoord = azimuthRelativeToSun/(2*PI);
 
     return EclipseScattering2DCoords(azimuthCoord, cosVZACoord);
 }
@@ -691,14 +702,14 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
 vec2 eclipseTexVarsToTexCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                const float altitude, const bool viewRayIntersectsGround, const vec2 texSize)
 {
-    const EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+    CONST EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                                     viewRayIntersectsGround);
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2);
-    const float azimuthTC = coords.azimuth + 1/(2*texSize.s);
+    CONST float azimuthTC = coords.azimuth + 1/(2*texSize.s);
 
     return vec2(azimuthTC, cosVZAtc);
 }
@@ -707,42 +718,42 @@ vec4 sampleEclipseDoubleScattering3DTexture(const sampler3D tex, const float cos
                                             const float cosViewZenithAngle, const float azimuthRelativeToSun,
                                             const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
+    CONST vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
                                                   eclipsedDoubleScatteringTextureSize.st);
-    const float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
-    const vec3 texCoords=vec3(coords2d, cosSZACoord);
+    CONST float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
+    CONST vec3 texCoords=vec3(coords2d, cosSZACoord);
 
     return texture(tex, texCoords);
 }
 
 LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 texIndices)
 {
-    const vec2 indexMax=lightPollutionTextureSize-vec2(1);
+    CONST vec2 indexMax=lightPollutionTextureSize-vec2(1);
 
-    const float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
-    const float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
+    CONST float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
-    const bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
-    const float cosViewZenithAngleCoord = viewRayIntersectsGround ?
+    CONST bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
+    CONST float cosViewZenithAngleCoord = viewRayIntersectsGround ?
                                    1-2*texIndices[0]/(indexMax[0]-1) :
                                    2*(texIndices[0]-1)/(indexMax[0]-1)-1;
     // ------------------------------------
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
@@ -753,23 +764,23 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 
 LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -777,27 +788,27 @@ LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, con
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     return LightPollution2DCoords(cosVZACoord, altCoord);
 }
 
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
-    const vec2 texSize = lightPollutionTextureSize;
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 texSize = lightPollutionTextureSize;
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2);
-    const float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
+    CONST float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
     return vec2(cosVZAtc, altitudeTC);
 }

--- a/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/0/aerosols/texture-sampling-functions.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/0/aerosols/texture-sampling-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-sampling-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,13 +45,13 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // texture-sampling-functions.frag
-#line 1 2 // phase-functions.h.glsl
+#line 4 0 // texture-sampling-functions.frag
+#line 1 3 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 6 0 // texture-sampling-functions.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-sampling-functions.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -72,8 +83,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-sampling-functions.frag
-#line 1 4 // texture-coordinates.h.glsl
+#line 6 0 // texture-sampling-functions.frag
+#line 1 5 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -142,7 +153,7 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 8 0 // texture-sampling-functions.frag
+#line 7 0 // texture-sampling-functions.frag
 
 uniform sampler2D transmittanceTexture;
 uniform sampler2D irradianceTexture;
@@ -154,13 +165,13 @@ uniform sampler2D lightPollutionScatteringTexture;
 
 vec4 irradiance(const float cosSunZenithAngle, const float altitude)
 {
-    const vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
+    CONST vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
     return texture(irradianceTexture, texCoords);
 }
 
 vec4 opticalDepthToAtmosphereBorder(const float cosViewZenithAngle, const float altitude)
 {
-    const vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
+    CONST vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact when looking into nadir from TOA at some values of texture sizes (in particular, size of
     // transmittance texture for altitude being 4096). This happens when I simply call texture(eclipsedScatteringTexture,
@@ -178,11 +189,11 @@ vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float
 vec4 transmittance(const float cosViewZenithAngle, const float altitude, const float dist,
                    const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle view ray endpoint
     // in space here.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
 
     vec4 depth;
     if(viewRayIntersectsGround)
@@ -201,7 +212,7 @@ vec4 transmittance(const float cosViewZenithAngle, const float altitude, const f
 vec4 calcFirstScattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                          const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
+    CONST vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
                                           dotViewSun, altitude, viewRayIntersectsGround);
     return scattering*currentPhaseFunction(dotViewSun);
 }
@@ -220,6 +231,6 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
 
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     return texture(lightPollutionScatteringTexture, coords);
 }

--- a/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/0/molecules/common-functions.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/0/molecules/common-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // common-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // common-functions.frag
+#line 4 0 // common-functions.frag
 
 bool dbgDataPresent=false;
 bool debugDataPresent()
@@ -69,7 +80,7 @@ void setDebugData(float a,float b, float c, float d)
 
 void swap(inout float x, inout float y)
 {
-    const float t = x;
+    CONST float t = x;
     x = y;
     y = t;
 }
@@ -83,7 +94,7 @@ float safeSqrt(const float x)
 
 float safeAtan(const float y, const float x)
 {
-    const float a = atan(y,x);
+    CONST float a = atan(y,x);
     return x==0 && y==0 ? 0 : a;
 }
 
@@ -116,23 +127,23 @@ float pointAltitude(vec3 point)
 
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float Ratm=earthRadius+atmosphereHeight;
-    const float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float Ratm=earthRadius+atmosphereHeight;
+    CONST float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float distanceToGround(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(-safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float cosZenithAngleOfHorizon(const float altitude)
 {
-    const float R=earthRadius;
-    const float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
+    CONST float R=earthRadius;
+    CONST float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
     return -sqrt(2*h*R+sqr(h))/(R+h);
 }
 
@@ -151,8 +162,8 @@ float distanceToNearestAtmosphereBoundary(const float cosZenithAngle, const floa
 float sunVisibility(const float cosSunZenithAngle, float altitude)
 {
     if(altitude<0) altitude=0;
-    const float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
-    const float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
+    CONST float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
+    CONST float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
     /* Approximating visible fraction of solar disk by smoothstep between the position of the Sun
      * touching the horizon by its upper part and the position with lower part touching the horizon.
      * The calculation assumes that solar angular radius is small and thus approximately equals its sine.
@@ -182,13 +193,13 @@ float circlesIntersectionArea(float R1, float R2, float d)
 
 float angleBetween(const vec3 a, const vec3 b)
 {
-    const float d=dot(a,b);
-    const float c=length(cross(a,b));
+    CONST float d=dot(a,b);
+    CONST float c=length(cross(a,b));
     // To avoid loss of precision, don't use dot product near the singularity
     // of acos, and cross product near the singularity of asin
     if(abs(d) < abs(c))
         return acos(d/(length(a)*length(b)));
-    const float smallerAngle = asin(c/(length(a)*length(b)));
+    CONST float smallerAngle = asin(c/(length(a)*length(b)));
     if(d<0) return PI-smallerAngle;
     return smallerAngle;
 }
@@ -205,11 +216,11 @@ float moonAngularRadius(const vec3 cameraPosition, const vec3 moonPosition)
 
 float visibleSolidAngleOfSun(const vec3 camera, const vec3 sunDir, const vec3 moonPos)
 {
-    const float Rs=sunAngularRadius;
-    const float Rm=moonAngularRadius(camera,moonPos);
+    CONST float Rs=sunAngularRadius;
+    CONST float Rm=moonAngularRadius(camera,moonPos);
     float visibleSolidAngle=PI*sqr(Rs);
 
-    const float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
+    CONST float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
     if(dSM<Rs+Rm)
     {
         visibleSolidAngle -= circlesIntersectionArea(Rm,Rs,dSM);
@@ -229,12 +240,12 @@ float sphereIntegrationSolidAngleDifferential(const int pointCountOnSphere)
 }
 vec3 sphereIntegrationSampleDir(const int index, const int pointCountOnSphere)
 {
-    const float goldenRatio=1.6180339887499;
+    CONST float goldenRatio=1.6180339887499;
     // The range of n is 0.5, 1.5, ..., pointCountOnSphere-0.5
-    const float n=index+0.5;
+    CONST float n=index+0.5;
     // Explanation of the Fibonacci grid generation can be seen at https://stackoverflow.com/a/44164075/673852
-    const float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
-    const float azimuth=n*(2*PI*goldenRatio);
+    CONST float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
+    CONST float azimuth=n*(2*PI*goldenRatio);
     return vec3(cos(azimuth)*sin(zenithAngle),
                 sin(azimuth)*sin(zenithAngle),
                 cos(zenithAngle));

--- a/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/0/molecules/densities.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/0/molecules/densities.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // densities.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,20 +45,20 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // densities.frag
+#line 4 0 // densities.frag
 float scattererNumberDensity_molecules(float altitude)
 {
-        const float rayleighScaleHeight=8*km;
+        CONST float rayleighScaleHeight=8*km;
         return 3.08458e25*exp(-1/rayleighScaleHeight * altitude);
 }
 float scattererNumberDensity_aerosols(float altitude)
 {
-        const float mieScaleHeight=1.2*km;
+        CONST float mieScaleHeight=1.2*km;
         return 1.03333e8*exp(-1/mieScaleHeight*altitude);
 }
 float absorberNumberDensity_ozone(float altitude)
 {
-        const float totalOzoneAmount=370*dobsonUnit;
+        CONST float totalOzoneAmount=370*dobsonUnit;
 
         float density;
 

--- a/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/0/molecules/phase-functions.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/0/molecules/phase-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // phase-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // phase-functions.frag
+#line 4 0 // phase-functions.frag
 
 vec4 phaseFunction_molecules(float dotViewSun)
 {
@@ -42,9 +53,9 @@ vec4 phaseFunction_molecules(float dotViewSun)
 }
 vec4 phaseFunction_aerosols(float dotViewSun)
 {
-        const float g=0.76;
-        const float g2=g*g;
-        const float k = 3/(8*PI)*(1-g2)/(2+g2);
+        CONST float g=0.76;
+        CONST float g2=g*g;
+        CONST float k = 3/(8*PI)*(1-g2)/(2+g2);
         return vec4(k * (1+sqr(dotViewSun)) / pow(1+g2 - 2*g*dotViewSun, 1.5) + 1/((1-dotViewSun)*600+0.05))*0.904;
 }
 vec4 currentPhaseFunction(float dotViewSun) { return phaseFunction_molecules(dotViewSun); }

--- a/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/0/molecules/render.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/0/molecules/render.frag
@@ -1,7 +1,21 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
 
-#line 1 1 // const.h.glsl
+
+
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 6 0 // render.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,11 +48,11 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // render.frag
-#line 1 2 // calc-view-dir.h.glsl
+#line 7 0 // render.frag
+#line 1 3 // calc-view-dir.h.glsl
 vec3 calcViewDir();
-#line 6 0 // render.frag
-#line 1 3 // common-functions.h.glsl
+#line 8 0 // render.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -70,14 +84,14 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // render.frag
-#line 1 4 // phase-functions.h.glsl
+#line 9 0 // render.frag
+#line 1 5 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 8 0 // render.frag
+#line 10 0 // render.frag
 
-#line 1 5 // single-scattering-eclipsed.h.glsl
+#line 1 6 // single-scattering-eclipsed.h.glsl
 #ifndef INCLUDE_ONCE_050024D2_BD56_434E_8D40_2055DA0B78EC
 #define INCLUDE_ONCE_050024D2_BD56_434E_8D40_2055DA0B78EC
 
@@ -85,8 +99,8 @@ vec4 computeSingleScatteringEclipsed(const vec3 camera, const vec3 viewDir, cons
                                      const bool viewRayIntersectsGround);
 
 #endif
-#line 10 0 // render.frag
-#line 1 6 // texture-coordinates.h.glsl
+#line 12 0 // render.frag
+#line 1 7 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -155,10 +169,10 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 11 0 // render.frag
-#line 1 7 // radiance-to-luminance.h.glsl
+#line 13 0 // render.frag
+#line 1 8 // radiance-to-luminance.h.glsl
 const mat4 radianceToLuminance=mat4(1.38997746,0.0419133306,6.48549128,0,  105.968163,3.00652099,500.960266,142.641495,  3776.24023,119.971481,18207.7598,6412.0166,  6910.01318,981.06665,37504.0586,26741.9102);
-#line 12 0 // render.frag
+#line 14 0 // render.frag
 
 
 
@@ -195,18 +209,18 @@ void main()
     // this approximation has the same order of magnitude as the assumption that the Earth and its atmosphere
     // are spherical.
     float altitude = max(cameraPosition.z, 0.);
-    const vec3 oldCamPos=cameraPosition;
+    CONST vec3 oldCamPos=cameraPosition;
     // Hide the uniform with this name, thus effectively modifying it for the following code
     vec3 cameraPosition=vec3(oldCamPos.xy, altitude);
 
     bool lookingIntoAtmosphere=true;
     if(altitude>atmosphereHeight)
     {
-        const vec3 p = cameraPosition - earthCenter;
-        const float p_dot_v = dot(p, viewDir);
-        const float p_dot_p = dot(p, p);
-        const float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
-        const float distanceToTOA = -p_dot_v - sqrt(sqr(earthRadius+atmosphereHeight) - squaredDistBetweenViewRayAndEarthCenter);
+        CONST vec3 p = cameraPosition - earthCenter;
+        CONST float p_dot_v = dot(p, viewDir);
+        CONST float p_dot_p = dot(p, p);
+        CONST float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
+        CONST float distanceToTOA = -p_dot_v - sqrt(sqr(earthRadius+atmosphereHeight) - squaredDistBetweenViewRayAndEarthCenter);
         if(distanceToTOA>=0)
         {
             cameraPosition += viewDir*distanceToTOA;
@@ -214,7 +228,7 @@ void main()
         }
         else
         {
-#if RENDERING_ANY_ZERO_SCATTERING
+#if 0 /*RENDERING_ANY_ZERO_SCATTERING*/
             lookingIntoAtmosphere=false;
 #else
             luminance=vec4(0);
@@ -224,16 +238,16 @@ void main()
         }
     }
 
-    const vec3 zenith=normalize(cameraPosition-earthCenter);
+    CONST vec3 zenith=normalize(cameraPosition-earthCenter);
     float cosViewZenithAngle=dot(zenith,viewDir);
 
     bool viewRayIntersectsGround=false;
     {
-        const vec3 p = cameraPosition - earthCenter;
-        const float p_dot_v = dot(p, viewDir);
-        const float p_dot_p = dot(p, p);
-        const float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
-        const float distanceToIntersection = -p_dot_v - sqrt(sqr(earthRadius) - squaredDistBetweenViewRayAndEarthCenter);
+        CONST vec3 p = cameraPosition - earthCenter;
+        CONST float p_dot_v = dot(p, viewDir);
+        CONST float p_dot_p = dot(p, p);
+        CONST float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
+        CONST float distanceToIntersection = -p_dot_v - sqrt(sqr(earthRadius) - squaredDistBetweenViewRayAndEarthCenter);
         // altitude==0 is a special case where distance to intersection calculation
         // is unreliable (has a lot of noise in its sign), so check it separately
         if(distanceToIntersection>0 || (altitude==0 && cosViewZenithAngle<0))
@@ -244,11 +258,11 @@ void main()
     // Aside from aesthetics, this affects brightness input to Stellarium's tone mapper.
     if(pseudoMirrorSkyBelowHorizon && viewRayIntersectsGround)
     {
-        const float horizonCZA = cosZenithAngleOfHorizon(altitude);
-        const float viewElev  = asin(clampCosine(cosViewZenithAngle));
-        const float horizElev = asin(clampCosine(horizonCZA));
-        const float newViewElev = 2*horizElev - viewElev;
-        const float viewDirXYnorm = length(viewDir-zenith*cosViewZenithAngle);
+        CONST float horizonCZA = cosZenithAngleOfHorizon(altitude);
+        CONST float viewElev  = asin(clampCosine(cosViewZenithAngle));
+        CONST float horizElev = asin(clampCosine(horizonCZA));
+        CONST float newViewElev = 2*horizElev - viewElev;
+        CONST float viewDirXYnorm = length(viewDir-zenith*cosViewZenithAngle);
         if(viewDirXYnorm == 0)
         {
             viewDir = zenith;
@@ -267,27 +281,27 @@ void main()
         viewRayIntersectsGround = false;
     }
 
-    const float cosSunZenithAngle =dot(zenith,sunDirection);
-    const float dotViewSun=dot(viewDir,sunDirection);
+    CONST float cosSunZenithAngle =dot(zenith,sunDirection);
+    CONST float dotViewSun=dot(viewDir,sunDirection);
 
-    const vec3 sunXYunnorm=sunDirection-dot(sunDirection,zenith)*zenith;
-    const vec3 viewXYunnorm=viewDir-dot(viewDir,zenith)*zenith;
-    const vec3 sunXY = sunXYunnorm.x!=0 || sunXYunnorm.y!=0 || sunXYunnorm.z!=0 ? normalize(sunXYunnorm) : vec3(0);
-    const vec3 viewXY = viewXYunnorm.x!=0 || viewXYunnorm.y!=0 || viewXYunnorm.z!=0 ? normalize(viewXYunnorm) : vec3(0);
-    const float azimuthRelativeToSun=safeAtan(dot(cross(sunXY, viewXY), zenith), dot(sunXY, viewXY));
+    CONST vec3 sunXYunnorm=sunDirection-dot(sunDirection,zenith)*zenith;
+    CONST vec3 viewXYunnorm=viewDir-dot(viewDir,zenith)*zenith;
+    CONST vec3 sunXY = sunXYunnorm.x!=0 || sunXYunnorm.y!=0 || sunXYunnorm.z!=0 ? normalize(sunXYunnorm) : vec3(0);
+    CONST vec3 viewXY = viewXYunnorm.x!=0 || viewXYunnorm.y!=0 || viewXYunnorm.z!=0 ? normalize(viewXYunnorm) : vec3(0);
+    CONST float azimuthRelativeToSun=safeAtan(dot(cross(sunXY, viewXY), zenith), dot(sunXY, viewXY));
 
-#if RENDERING_ZERO_SCATTERING
+#if 0 /*RENDERING_ZERO_SCATTERING*/
     vec4 radiance;
     if(viewRayIntersectsGround)
     {
         // XXX: keep in sync with the same code in computeScatteringDensity(), but don't forget about
         //      the difference in the usage of viewDir vs incDir.
-        const float distToGround = distanceToGround(cosViewZenithAngle, altitude);
-        const vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
-        const vec3 groundNormal = normalize(zenith*(earthRadius+altitude)+viewDir*distToGround);
-        const vec4 groundIrradiance = irradiance(dot(groundNormal, sunDirection), 0);
+        CONST float distToGround = distanceToGround(cosViewZenithAngle, altitude);
+        CONST vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
+        CONST vec3 groundNormal = normalize(zenith*(earthRadius+altitude)+viewDir*distToGround);
+        CONST vec4 groundIrradiance = irradiance(dot(groundNormal, sunDirection), 0);
         // Radiation scattered by the ground
-        const float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
+        CONST float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
         radiance = transmittanceToGround*groundAlbedo*groundIrradiance*solarIrradianceFixup*groundBRDF
                  + lightPollutionGroundLuminance*lightPollutionRelativeRadiance;
     }
@@ -304,22 +318,22 @@ void main()
     }
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_ZERO_SCATTERING
+#elif 0 /*RENDERING_ECLIPSED_ZERO_SCATTERING*/
     vec4 radiance;
-    const float dotViewMoon=dot(viewDir,normalize(moonPosition-cameraPosition));
+    CONST float dotViewMoon=dot(viewDir,normalize(moonPosition-cameraPosition));
     if(viewRayIntersectsGround)
     {
         // XXX: keep in sync with the similar code in non-eclipsed zero scattering rendering.
-        const float distToGround = distanceToGround(cosViewZenithAngle, altitude);
-        const vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
-        const vec3 pointOnGround = cameraPosition+viewDir*distToGround;
-        const vec4 directGroundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDirection, moonPosition);
+        CONST float distToGround = distanceToGround(cosViewZenithAngle, altitude);
+        CONST vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
+        CONST vec3 pointOnGround = cameraPosition+viewDir*distToGround;
+        CONST vec4 directGroundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDirection, moonPosition);
         // FIXME: add first-order indirect irradiance too: it's done in non-eclipsed irradiance (in the same
         // conditions: when limited to 2 orders). This should be calculated at the same time when second order
         // is: all the infrastructure is already there.
-        const vec4 groundIrradiance = directGroundIrradiance;
+        CONST vec4 groundIrradiance = directGroundIrradiance;
         // Radiation scattered by the ground
-        const float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
+        CONST float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
         radiance = transmittanceToGround*groundAlbedo*groundIrradiance*solarIrradianceFixup*groundBRDF
                  + lightPollutionGroundLuminance*lightPollutionRelativeRadiance;
     }
@@ -337,52 +351,52 @@ void main()
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
 #elif 1 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_ON_THE_FLY*/
-    const vec4 scattering=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPosition,
+    CONST vec4 scattering=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPosition,
                                                           viewRayIntersectsGround);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE
-    const vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE*/
+    CONST vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                      viewRayIntersectsGround, eclipsedSingleScatteringTextureSize);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact at the point where azimuth texture coordinate changes from 1 to 0 (at azimuthRelativeToSun crossing
     // 0). This happens when I simply call texture(eclipsedScatteringTexture, texCoords) without specifying LOD.
     // Apparently, the driver uses the derivative for some reason, even though it shouldn't.
-    const vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
+    CONST vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE
-    const vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
+    CONST vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                      viewRayIntersectsGround, eclipsedSingleScatteringTextureSize);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact at the point where azimuth texture coordinate changes from 1 to 0 (at azimuthRelativeToSun crossing
     // 0). This happens when I simply call texture(eclipsedScatteringTexture, texCoords) without specifying LOD.
     // Apparently, the driver uses the derivative for some reason, even though it shouldn't.
-    const vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
+    CONST vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
     luminance=scattering*currentPhaseFunction(dotViewSun);
-#elif RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_RADIANCE
+#elif 0 /*RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_RADIANCE*/
     vec4 radiance=exp(sampleEclipseDoubleScattering3DTexture(eclipsedDoubleScatteringTexture,
                                                              cosSunZenithAngle, cosViewZenithAngle, azimuthRelativeToSun,
                                                              altitude, viewRayIntersectsGround));
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_LUMINANCE
+#elif 0 /*RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
     luminance=exp(sampleEclipseDoubleScattering3DTexture(eclipsedDoubleScatteringTexture,
                                                          cosSunZenithAngle, cosViewZenithAngle, azimuthRelativeToSun,
                                                          altitude, viewRayIntersectsGround));
-#elif RENDERING_SINGLE_SCATTERING_ON_THE_FLY
-    const vec4 scattering=computeSingleScattering(cosSunZenithAngle,cosViewZenithAngle,dotViewSun,
+#elif 0 /*RENDERING_SINGLE_SCATTERING_ON_THE_FLY*/
+    CONST vec4 scattering=computeSingleScattering(cosSunZenithAngle,cosViewZenithAngle,dotViewSun,
                                                   altitude,viewRayIntersectsGround);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE
+#elif 0 /*RENDERING_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE*/
     vec4 scattering;
     if(useInterpolationGuides)
     {
@@ -399,7 +413,7 @@ void main()
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE
+#elif 0 /*RENDERING_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
     vec4 scattering;
     if(useInterpolationGuides)
     {
@@ -413,18 +427,18 @@ void main()
                                      dotViewSun, altitude, viewRayIntersectsGround);
     }
     luminance=scattering * (bool(PHASE_FUNCTION_IS_EMBEDDED) ? vec4(1) : currentPhaseFunction(dotViewSun));
-#elif RENDERING_MULTIPLE_SCATTERING_LUMINANCE
+#elif 0 /*RENDERING_MULTIPLE_SCATTERING_LUMINANCE*/
     luminance=sample3DTexture(scatteringTexture, cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, viewRayIntersectsGround);
-#elif RENDERING_MULTIPLE_SCATTERING_RADIANCE
+#elif 0 /*RENDERING_MULTIPLE_SCATTERING_RADIANCE*/
     vec4 radiance=sample3DTexture(scatteringTexture, cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, viewRayIntersectsGround);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_LIGHT_POLLUTION_RADIANCE
+#elif 0 /*RENDERING_LIGHT_POLLUTION_RADIANCE*/
     vec4 radiance=lightPollutionGroundLuminance*lightPollutionScattering(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_LIGHT_POLLUTION_LUMINANCE
+#elif 0 /*RENDERING_LIGHT_POLLUTION_LUMINANCE*/
     luminance=lightPollutionGroundLuminance*lightPollutionScattering(altitude, cosViewZenithAngle, viewRayIntersectsGround);
 #else
 #error What to render?

--- a/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/0/molecules/single-scattering-eclipsed.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/0/molecules/single-scattering-eclipsed.frag
@@ -1,7 +1,21 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
 
-#line 1 1 // const.h.glsl
+
+
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 6 0 // single-scattering-eclipsed.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,15 +48,15 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // single-scattering-eclipsed.frag
-#line 1 2 // densities.h.glsl
+#line 7 0 // single-scattering-eclipsed.frag
+#line 1 3 // densities.h.glsl
 float scattererNumberDensity_molecules(float altitude);
 float scattererNumberDensity_aerosols(float altitude);
 float absorberNumberDensity_ozone(float altitude);
 vec4 scatteringCrossSection();
 float scattererDensity(float altitude);
-#line 6 0 // single-scattering-eclipsed.frag
-#line 1 3 // common-functions.h.glsl
+#line 8 0 // single-scattering-eclipsed.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -74,8 +88,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // single-scattering-eclipsed.frag
-#line 1 4 // texture-sampling-functions.h.glsl
+#line 9 0 // single-scattering-eclipsed.frag
+#line 1 5 // texture-sampling-functions.h.glsl
 #ifndef INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 #define INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float altitude);
@@ -87,7 +101,7 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                 const int scatteringOrder);
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 #endif
-#line 8 0 // single-scattering-eclipsed.frag
+#line 10 0 // single-scattering-eclipsed.frag
 
 
 float cosZenithAngle(vec3 origin, vec3 direction)
@@ -101,13 +115,13 @@ vec4 computeSingleScatteringIntegrandEclipsed(const float cosSunZenithAngle, con
                                               const float dist, const bool viewRayIntersectsGround,
                                               const vec3 scatterer, const vec3 sunDir, const vec3 moonPos)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle here the case when the
     // endpoint of the view ray intentionally appears in outer space.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosSunZenithAngleAtDist=clampCosine((r*cosSunZenithAngle+dist*dotViewSun)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosSunZenithAngleAtDist=clampCosine((r*cosSunZenithAngle+dist*dotViewSun)/(earthRadius+altAtDist));
 
-    const vec4 xmittance=transmittance(cosViewZenithAngle, altitude, dist, viewRayIntersectsGround)
+    CONST vec4 xmittance=transmittance(cosViewZenithAngle, altitude, dist, viewRayIntersectsGround)
                                                     *
                          transmittanceToAtmosphereBorder(cosSunZenithAngleAtDist, altAtDist)
                                                     *
@@ -115,7 +129,7 @@ vec4 computeSingleScatteringIntegrandEclipsed(const float cosSunZenithAngle, con
                                                     *
                             // FIXME: this ignores orientation of the crescent of eclipsed Sun WRT horizon
                                     sunVisibility(cosSunZenithAngleAtDist, altAtDist);
-#if ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION
+#if 0 /*ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION*/
     COMPUTE_TOTAL_SCATTERING_COEFFICIENT;
     return xmittance * totalScatteringCoefficient;
 #else
@@ -126,26 +140,26 @@ vec4 computeSingleScatteringIntegrandEclipsed(const float cosSunZenithAngle, con
 vec4 computeSingleScatteringEclipsed(const vec3 camera, const vec3 viewDir, const vec3 sunDir, const vec3 moonPos,
                                      const bool viewRayIntersectsGround)
 {
-    const float cosViewZenithAngle=cosZenithAngle(camera,viewDir);
-    const float cosSunZenithAngle=cosZenithAngle(camera,sunDir);
-    const float altitude=pointAltitude(camera);
-    const float dotViewSun=dot(viewDir,sunDir);
-    const float integrInterval=distanceToNearestAtmosphereBoundary(cosViewZenithAngle, altitude,
+    CONST float cosViewZenithAngle=cosZenithAngle(camera,viewDir);
+    CONST float cosSunZenithAngle=cosZenithAngle(camera,sunDir);
+    CONST float altitude=pointAltitude(camera);
+    CONST float dotViewSun=dot(viewDir,sunDir);
+    CONST float integrInterval=distanceToNearestAtmosphereBoundary(cosViewZenithAngle, altitude,
                                                                    viewRayIntersectsGround);
 
     // Using the midpoint rule for quadrature
     vec4 spectrum=vec4(0);
-    const float dl=integrInterval/radialIntegrationPoints;
+    CONST float dl=integrInterval/radialIntegrationPoints;
     for(int n=0; n<radialIntegrationPoints; ++n)
     {
-        const float dist=(n+0.5)*dl;
+        CONST float dist=(n+0.5)*dl;
         spectrum += computeSingleScatteringIntegrandEclipsed(cosSunZenithAngle, cosViewZenithAngle, dotViewSun,
                                                              altitude, dist, viewRayIntersectsGround,
                                                              camera+viewDir*dist, sunDir, moonPos);
     }
 
     spectrum *= dl*solarIrradianceAtTOA
-#if ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION
+#if 0 /*ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION*/
                                 // the multiplier is already included
 #else
                                         * scatteringCrossSection()

--- a/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/0/molecules/texture-coordinates.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/0/molecules/texture-coordinates.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-coordinates.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,8 +45,8 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // texture-coordinates.frag
-#line 1 2 // texture-coordinates.h.glsl
+#line 4 0 // texture-coordinates.frag
+#line 1 3 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -104,8 +115,8 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 6 0 // texture-coordinates.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-coordinates.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -137,7 +148,7 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-coordinates.frag
+#line 6 0 // texture-coordinates.frag
 
 const float LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA=sqrt(atmosphereHeight*(atmosphereHeight+2*earthRadius));
 
@@ -205,18 +216,18 @@ vec3 indicesToTexCoords(const vec3 indices, const vec3 texSizes)
 
 TransmittanceTexVars transmittanceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
+    CONST float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
                                 texCoordToUnitRange(texCoord.t,transmittanceTextureSize.t);
     // Distance from Earth center to camera
-    const float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
-    const float altitude=r-earthRadius;
+    CONST float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
+    CONST float altitude=r-earthRadius;
 
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
     // distance to border of visible atmosphere from the view point
-    const float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
+    CONST float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
     // d==0 can happen when altitude==atmosphereHeight
-    const float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
+    CONST float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
     return TransmittanceTexVars(cosVZA,altitude);
 }
 
@@ -235,53 +246,53 @@ vec2 transmittanceTexVarsToTexCoord(const float cosVZA, float altitude)
     if(altitude<0)
         altitude=0;
 
-    const float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
+    CONST float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
                                       transmittanceTextureSize.t);
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
-    const float d=distanceToAtmosphereBorder(cosVZA,altitude);
-    const float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float d=distanceToAtmosphereBorder(cosVZA,altitude);
+    CONST float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
     return vec2(s,t);
 }
 
 // Output: vec2(cos(sunZenithAngle), altitude)
 IrradianceTexVars irradianceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
-    const float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
+    CONST float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
+    CONST float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
     return IrradianceTexVars(cosSZA,alt);
 }
 
 vec2 irradianceTexVarsToTexCoord(const float cosSunZenithAngle, const float altitude)
 {
-    const float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
-    const float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
+    CONST float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
+    CONST float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
     return vec2(s,t);
 }
 
 float cosSZAToUnitRangeTexCoord(const float cosSunZenithAngle)
 {
     // Distance to top atmosphere border along the ray groundUnderCamera-sun: (altitude, cosSunZenithAngle)
-    const float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name
-    const float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
+    CONST float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
     // TODO: choose a more descriptive name
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     return max(0.,1-a/A)/(a+1);
 }
 
 float unitRangeTexCoordToCosSZA(const float texCoord)
 {
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float a=(A-A*texCoord)/(1+A*texCoord);
-    const float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
+    CONST float a=(A-A*texCoord)/(1+A*texCoord);
+    CONST float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
     return distFromGroundToTopAtmoBorder==0 ? 1 :
         clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distFromGroundToTopAtmoBorder)) /
                     (2*earthRadius*distFromGroundToTopAtmoBorder));
@@ -292,24 +303,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
                                                const float dotViewSun, const float altitude,
                                                const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -317,24 +328,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float dotVSCoord=(dotViewSun+1)/2;
+    CONST float dotVSCoord=(dotViewSun+1)/2;
 
     // ------------------------------------
-    const float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
+    CONST float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
 
     return Scattering4DCoords(cosSZACoord, cosVZACoord, dotVSCoord, altCoord, viewRayIntersectsGround);
 }
 
 TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
@@ -342,16 +353,16 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture coordinates we combine into a single sampler3D coordinate.
-    const float texW = scatteringTextureSize[1];
-    const float texH = scatteringTextureSize[2];
-    const float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
-    const vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
+    CONST float texW = scatteringTextureSize[1];
+    CONST float texH = scatteringTextureSize[2];
+    CONST float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
+    CONST vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
                                         ceil (cosSZAIndex)*texW+coords.dotViewSun*(texW-1)) / (texW*texH-1);
-    const vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
+    CONST vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
 
-    const float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
+    CONST float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
 
-    const float alphaUpper=fract(cosSZAIndex);
+    CONST float alphaUpper=fract(cosSZAIndex);
     return TexCoordPair(vec3(cosVZAtc, combinedCoord.x, altitude), float(1-alphaUpper),
                         vec3(cosVZAtc, combinedCoord.y, altitude), float(alphaUpper));
 }
@@ -359,9 +370,9 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
+    CONST TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
     return texture(tex, texCoords.lower) * texCoords.alphaLower +
            texture(tex, texCoords.upper) * texCoords.alphaUpper;
 }
@@ -369,17 +380,17 @@ vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const f
 // 3D texture is the 3D single-altitude slice of a 4D texture
 vec3 scattering4DCoordsToTex3DCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2);
 
-    const float dvsSize = scatteringTextureSize[1];
-    const float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
+    CONST float dvsSize = scatteringTextureSize[1];
+    CONST float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
 
-    const float cszaSize = scatteringTextureSize[2];
-    const float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
+    CONST float cszaSize = scatteringTextureSize[2];
+    CONST float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
 
     return vec3(cosVZAtc, dotVStc, cosSZAtc);
 }
@@ -394,39 +405,39 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along dotViewSun coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[1];
-    const float posOfRow = indices[1];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[1];
+    CONST float posOfRow = indices[1];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         indexToTexCoord(currRow, numRows-1),
                                                         texCoordVerbatim));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               indexToTexCoord(currRow, numRows-1),
                                                               texCoordVerbatim));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          indexToTexCoord(currRow, numRows-1),
                                          texCoordVerbatim));
@@ -434,14 +445,14 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
 vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolationGuides01Tex,
                                  const vec3 indices)
 {
-    const float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
+    CONST float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
 
-    const float cosVZAIndex = indices[0];
-    const float dotVSIndex = indices[1];
-    const float currRow = floor(dotVSIndex);
-    const float posBetweenRows = dotVSIndex - currRow;
-    const float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cosVZAIndex = indices[0];
+    CONST float dotVSIndex = indices[1];
+    CONST float currRow = floor(dotVSIndex);
+    CONST float posBetweenRows = dotVSIndex - currRow;
+    CONST float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -449,14 +460,14 @@ vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolat
     indicesCurrRow[1] =     currRow;
     indicesNextRow[1] = min(currRow+1, scatteringTextureSize[1]-1.);
 
-    const vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
-    const vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
+    CONST vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
+    CONST vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
 
-    const vec4 valueCurrRow = texture(tex, coordsCurrRow);
-    const vec4 valueNextRow = texture(tex, coordsNextRow);
-    const float epsilon = 1e-37; // Prevents passing zero to log
-    const vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
-    const vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
+    CONST vec4 valueCurrRow = texture(tex, coordsCurrRow);
+    CONST vec4 valueNextRow = texture(tex, coordsNextRow);
+    CONST float epsilon = 1e-37; // Prevents passing zero to log
+    CONST vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
+    CONST vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
     return (logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow;
 }
 
@@ -465,37 +476,37 @@ float findGuide02Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along SZA coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[2];
-    const float posOfRow = indices[2];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[2];
+    CONST float posOfRow = indices[2];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
 }
@@ -505,19 +516,19 @@ vec4 sample3DTextureGuided(const sampler3D tex,
                            const float cosSunZenithAngle, const float cosViewZenithAngle,
                            const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
                                                                     dotViewSun, altitude, viewRayIntersectsGround);
     // Handle the external interpolation guides: the guides between a pair of VZA-dotViewSun 2D "pictures".
-    const vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
-    const vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
-    const float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
+    CONST vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
+    CONST float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
 
-    const float cvzaIndex = indices[0];
-    const float cszaIndex = indices[2];
-    const float currRow = floor(cszaIndex);
-    const float posBetweenRows = cszaIndex - currRow;
-    const float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cvzaIndex = indices[0];
+    CONST float cszaIndex = indices[2];
+    CONST float currRow = floor(cszaIndex);
+    CONST float posBetweenRows = cszaIndex - currRow;
+    CONST float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -526,58 +537,58 @@ vec4 sample3DTextureGuided(const sampler3D tex,
     indicesNextRow[2] = min(currRow+1, scatteringTextureSize[2]-1);
 
     // The caller will handle the internal interpolation guides: the ones between rows in each 2D "picture".
-    const vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
-    const vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
+    CONST vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
+    CONST vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
     return exp((logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow);
 }
 
 vec4 sample3DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
     return texture(tex, texCoords);
 }
 
 ScatteringTexVars scatteringTex4DCoordsToTexVars(const Scattering4DCoords coords)
 {
-    const float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
     // ------------------------------------
     float cosViewZenithAngle;
     if(coords.viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
     // ------------------------------------
-    const float dotViewSun=coords.dotViewSun*2-1;
+    CONST float dotViewSun=coords.dotViewSun*2-1;
 
     // ------------------------------------
-    const float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
+    CONST float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
 
     return ScatteringTexVars(cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, coords.viewRayIntersectsGround);
 }
 
 Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 {
-    const vec4 indexMax=scatteringTextureSize-vec4(1);
+    CONST vec4 indexMax=scatteringTextureSize-vec4(1);
     Scattering4DCoords coords4d;
     coords4d.viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
     // The following formulas assume that scatteringTextureSize[0] is even. For odd sizes they would change.
@@ -593,8 +604,8 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture indices we combine into a single sampler3D coordinate.
-    const float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
-    const float combinedIndex=texIndices[1];
+    CONST float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
+    CONST float combinedIndex=texIndices[1];
     coords4d.dotViewSun=mod(combinedIndex,texW)/(texW-1);
     coords4d.cosSunZenithAngle=floor(combinedIndex/texW)/(texH-1);
 
@@ -608,11 +619,11 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
 ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 {
-    const Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
+    CONST Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
     ScatteringTexVars vars=scatteringTex4DCoordsToTexVars(coords4d);
     // Clamp dotViewSun to its valid range of values, given cosViewZenithAngle and cosSunZenithAngle. This is
     // needed to prevent NaNs when computing the scattering texture.
-    const float cosVZA=vars.cosViewZenithAngle,
+    CONST float cosVZA=vars.cosViewZenithAngle,
                 cosSZA=vars.cosSunZenithAngle;
     vars.dotViewSun=clamp(vars.dotViewSun,
                           cosVZA*cosSZA-safeSqrt((1-sqr(cosVZA))*(1-sqr(cosSZA))),
@@ -622,54 +633,54 @@ ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 
 EclipseScatteringTexVars eclipseTexCoordsToTexVars(const vec2 texCoords, const float altitude)
 {
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
-    const bool viewRayIntersectsGround = texCoords.t<0.5;
+    CONST bool viewRayIntersectsGround = texCoords.t<0.5;
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
-    const float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
+    CONST float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
     return EclipseScatteringTexVars(azimuthRelativeToSun, cosViewZenithAngle, viewRayIntersectsGround);
 }
 
 EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                                    const float altitude, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -677,13 +688,13 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
-    const float azimuthCoord = azimuthRelativeToSun/(2*PI);
+    CONST float azimuthCoord = azimuthRelativeToSun/(2*PI);
 
     return EclipseScattering2DCoords(azimuthCoord, cosVZACoord);
 }
@@ -691,14 +702,14 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
 vec2 eclipseTexVarsToTexCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                const float altitude, const bool viewRayIntersectsGround, const vec2 texSize)
 {
-    const EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+    CONST EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                                     viewRayIntersectsGround);
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2);
-    const float azimuthTC = coords.azimuth + 1/(2*texSize.s);
+    CONST float azimuthTC = coords.azimuth + 1/(2*texSize.s);
 
     return vec2(azimuthTC, cosVZAtc);
 }
@@ -707,42 +718,42 @@ vec4 sampleEclipseDoubleScattering3DTexture(const sampler3D tex, const float cos
                                             const float cosViewZenithAngle, const float azimuthRelativeToSun,
                                             const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
+    CONST vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
                                                   eclipsedDoubleScatteringTextureSize.st);
-    const float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
-    const vec3 texCoords=vec3(coords2d, cosSZACoord);
+    CONST float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
+    CONST vec3 texCoords=vec3(coords2d, cosSZACoord);
 
     return texture(tex, texCoords);
 }
 
 LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 texIndices)
 {
-    const vec2 indexMax=lightPollutionTextureSize-vec2(1);
+    CONST vec2 indexMax=lightPollutionTextureSize-vec2(1);
 
-    const float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
-    const float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
+    CONST float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
-    const bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
-    const float cosViewZenithAngleCoord = viewRayIntersectsGround ?
+    CONST bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
+    CONST float cosViewZenithAngleCoord = viewRayIntersectsGround ?
                                    1-2*texIndices[0]/(indexMax[0]-1) :
                                    2*(texIndices[0]-1)/(indexMax[0]-1)-1;
     // ------------------------------------
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
@@ -753,23 +764,23 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 
 LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -777,27 +788,27 @@ LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, con
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     return LightPollution2DCoords(cosVZACoord, altCoord);
 }
 
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
-    const vec2 texSize = lightPollutionTextureSize;
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 texSize = lightPollutionTextureSize;
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2);
-    const float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
+    CONST float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
     return vec2(cosVZAtc, altitudeTC);
 }

--- a/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/0/molecules/texture-sampling-functions.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/0/molecules/texture-sampling-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-sampling-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,13 +45,13 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // texture-sampling-functions.frag
-#line 1 2 // phase-functions.h.glsl
+#line 4 0 // texture-sampling-functions.frag
+#line 1 3 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 6 0 // texture-sampling-functions.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-sampling-functions.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -72,8 +83,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-sampling-functions.frag
-#line 1 4 // texture-coordinates.h.glsl
+#line 6 0 // texture-sampling-functions.frag
+#line 1 5 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -142,7 +153,7 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 8 0 // texture-sampling-functions.frag
+#line 7 0 // texture-sampling-functions.frag
 
 uniform sampler2D transmittanceTexture;
 uniform sampler2D irradianceTexture;
@@ -154,13 +165,13 @@ uniform sampler2D lightPollutionScatteringTexture;
 
 vec4 irradiance(const float cosSunZenithAngle, const float altitude)
 {
-    const vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
+    CONST vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
     return texture(irradianceTexture, texCoords);
 }
 
 vec4 opticalDepthToAtmosphereBorder(const float cosViewZenithAngle, const float altitude)
 {
-    const vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
+    CONST vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact when looking into nadir from TOA at some values of texture sizes (in particular, size of
     // transmittance texture for altitude being 4096). This happens when I simply call texture(eclipsedScatteringTexture,
@@ -178,11 +189,11 @@ vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float
 vec4 transmittance(const float cosViewZenithAngle, const float altitude, const float dist,
                    const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle view ray endpoint
     // in space here.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
 
     vec4 depth;
     if(viewRayIntersectsGround)
@@ -201,7 +212,7 @@ vec4 transmittance(const float cosViewZenithAngle, const float altitude, const f
 vec4 calcFirstScattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                          const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
+    CONST vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
                                           dotViewSun, altitude, viewRayIntersectsGround);
     return scattering*currentPhaseFunction(dotViewSun);
 }
@@ -220,6 +231,6 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
 
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     return texture(lightPollutionScatteringTexture, coords);
 }

--- a/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/1/aerosols/common-functions.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/1/aerosols/common-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // common-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(2.15e-06,1.11400004e-06,3.8580001
 const vec4 wavelengths=vec4(485.333344,516.666687,548,579.333313);
 const int wlSetIndex=1;
 #endif
-#line 5 0 // common-functions.frag
+#line 4 0 // common-functions.frag
 
 bool dbgDataPresent=false;
 bool debugDataPresent()
@@ -69,7 +80,7 @@ void setDebugData(float a,float b, float c, float d)
 
 void swap(inout float x, inout float y)
 {
-    const float t = x;
+    CONST float t = x;
     x = y;
     y = t;
 }
@@ -83,7 +94,7 @@ float safeSqrt(const float x)
 
 float safeAtan(const float y, const float x)
 {
-    const float a = atan(y,x);
+    CONST float a = atan(y,x);
     return x==0 && y==0 ? 0 : a;
 }
 
@@ -116,23 +127,23 @@ float pointAltitude(vec3 point)
 
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float Ratm=earthRadius+atmosphereHeight;
-    const float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float Ratm=earthRadius+atmosphereHeight;
+    CONST float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float distanceToGround(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(-safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float cosZenithAngleOfHorizon(const float altitude)
 {
-    const float R=earthRadius;
-    const float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
+    CONST float R=earthRadius;
+    CONST float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
     return -sqrt(2*h*R+sqr(h))/(R+h);
 }
 
@@ -151,8 +162,8 @@ float distanceToNearestAtmosphereBoundary(const float cosZenithAngle, const floa
 float sunVisibility(const float cosSunZenithAngle, float altitude)
 {
     if(altitude<0) altitude=0;
-    const float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
-    const float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
+    CONST float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
+    CONST float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
     /* Approximating visible fraction of solar disk by smoothstep between the position of the Sun
      * touching the horizon by its upper part and the position with lower part touching the horizon.
      * The calculation assumes that solar angular radius is small and thus approximately equals its sine.
@@ -182,13 +193,13 @@ float circlesIntersectionArea(float R1, float R2, float d)
 
 float angleBetween(const vec3 a, const vec3 b)
 {
-    const float d=dot(a,b);
-    const float c=length(cross(a,b));
+    CONST float d=dot(a,b);
+    CONST float c=length(cross(a,b));
     // To avoid loss of precision, don't use dot product near the singularity
     // of acos, and cross product near the singularity of asin
     if(abs(d) < abs(c))
         return acos(d/(length(a)*length(b)));
-    const float smallerAngle = asin(c/(length(a)*length(b)));
+    CONST float smallerAngle = asin(c/(length(a)*length(b)));
     if(d<0) return PI-smallerAngle;
     return smallerAngle;
 }
@@ -205,11 +216,11 @@ float moonAngularRadius(const vec3 cameraPosition, const vec3 moonPosition)
 
 float visibleSolidAngleOfSun(const vec3 camera, const vec3 sunDir, const vec3 moonPos)
 {
-    const float Rs=sunAngularRadius;
-    const float Rm=moonAngularRadius(camera,moonPos);
+    CONST float Rs=sunAngularRadius;
+    CONST float Rm=moonAngularRadius(camera,moonPos);
     float visibleSolidAngle=PI*sqr(Rs);
 
-    const float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
+    CONST float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
     if(dSM<Rs+Rm)
     {
         visibleSolidAngle -= circlesIntersectionArea(Rm,Rs,dSM);
@@ -229,12 +240,12 @@ float sphereIntegrationSolidAngleDifferential(const int pointCountOnSphere)
 }
 vec3 sphereIntegrationSampleDir(const int index, const int pointCountOnSphere)
 {
-    const float goldenRatio=1.6180339887499;
+    CONST float goldenRatio=1.6180339887499;
     // The range of n is 0.5, 1.5, ..., pointCountOnSphere-0.5
-    const float n=index+0.5;
+    CONST float n=index+0.5;
     // Explanation of the Fibonacci grid generation can be seen at https://stackoverflow.com/a/44164075/673852
-    const float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
-    const float azimuth=n*(2*PI*goldenRatio);
+    CONST float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
+    CONST float azimuth=n*(2*PI*goldenRatio);
     return vec3(cos(azimuth)*sin(zenithAngle),
                 sin(azimuth)*sin(zenithAngle),
                 cos(zenithAngle));

--- a/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/1/aerosols/densities.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/1/aerosols/densities.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // densities.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,20 +45,20 @@ const vec4 lightPollutionRelativeRadiance=vec4(2.15e-06,1.11400004e-06,3.8580001
 const vec4 wavelengths=vec4(485.333344,516.666687,548,579.333313);
 const int wlSetIndex=1;
 #endif
-#line 5 0 // densities.frag
+#line 4 0 // densities.frag
 float scattererNumberDensity_molecules(float altitude)
 {
-        const float rayleighScaleHeight=8*km;
+        CONST float rayleighScaleHeight=8*km;
         return 3.08458e25*exp(-1/rayleighScaleHeight * altitude);
 }
 float scattererNumberDensity_aerosols(float altitude)
 {
-        const float mieScaleHeight=1.2*km;
+        CONST float mieScaleHeight=1.2*km;
         return 1.03333e8*exp(-1/mieScaleHeight*altitude);
 }
 float absorberNumberDensity_ozone(float altitude)
 {
-        const float totalOzoneAmount=370*dobsonUnit;
+        CONST float totalOzoneAmount=370*dobsonUnit;
 
         float density;
 

--- a/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/1/aerosols/phase-functions.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/1/aerosols/phase-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // phase-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(2.15e-06,1.11400004e-06,3.8580001
 const vec4 wavelengths=vec4(485.333344,516.666687,548,579.333313);
 const int wlSetIndex=1;
 #endif
-#line 5 0 // phase-functions.frag
+#line 4 0 // phase-functions.frag
 
 vec4 phaseFunction_molecules(float dotViewSun)
 {
@@ -42,9 +53,9 @@ vec4 phaseFunction_molecules(float dotViewSun)
 }
 vec4 phaseFunction_aerosols(float dotViewSun)
 {
-        const float g=0.76;
-        const float g2=g*g;
-        const float k = 3/(8*PI)*(1-g2)/(2+g2);
+        CONST float g=0.76;
+        CONST float g2=g*g;
+        CONST float k = 3/(8*PI)*(1-g2)/(2+g2);
         return vec4(k * (1+sqr(dotViewSun)) / pow(1+g2 - 2*g*dotViewSun, 1.5) + 1/((1-dotViewSun)*600+0.05))*0.904;
 }
 vec4 currentPhaseFunction(float dotViewSun) { return phaseFunction_aerosols(dotViewSun); }

--- a/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/1/aerosols/render.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/1/aerosols/render.frag
@@ -1,7 +1,21 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
 
-#line 1 1 // const.h.glsl
+
+
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 6 0 // render.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,11 +48,11 @@ const vec4 lightPollutionRelativeRadiance=vec4(2.15e-06,1.11400004e-06,3.8580001
 const vec4 wavelengths=vec4(485.333344,516.666687,548,579.333313);
 const int wlSetIndex=1;
 #endif
-#line 5 0 // render.frag
-#line 1 2 // calc-view-dir.h.glsl
+#line 7 0 // render.frag
+#line 1 3 // calc-view-dir.h.glsl
 vec3 calcViewDir();
-#line 6 0 // render.frag
-#line 1 3 // common-functions.h.glsl
+#line 8 0 // render.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -70,14 +84,14 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // render.frag
-#line 1 4 // phase-functions.h.glsl
+#line 9 0 // render.frag
+#line 1 5 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 8 0 // render.frag
+#line 10 0 // render.frag
 
-#line 1 5 // single-scattering-eclipsed.h.glsl
+#line 1 6 // single-scattering-eclipsed.h.glsl
 #ifndef INCLUDE_ONCE_050024D2_BD56_434E_8D40_2055DA0B78EC
 #define INCLUDE_ONCE_050024D2_BD56_434E_8D40_2055DA0B78EC
 
@@ -85,8 +99,8 @@ vec4 computeSingleScatteringEclipsed(const vec3 camera, const vec3 viewDir, cons
                                      const bool viewRayIntersectsGround);
 
 #endif
-#line 10 0 // render.frag
-#line 1 6 // texture-coordinates.h.glsl
+#line 12 0 // render.frag
+#line 1 7 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -155,10 +169,10 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 11 0 // render.frag
-#line 1 7 // radiance-to-luminance.h.glsl
+#line 13 0 // render.frag
+#line 1 8 // radiance-to-luminance.h.glsl
 const mat4 radianceToLuminance=mat4(1196.74268,3672.67432,12945.498,45528.7344,  835.02478,13767.5205,2120.37939,51317.4727,  8632.59277,21193.416,222.095078,27381.1602,  19410,18758.1973,35.7829971,6712.12158);
-#line 12 0 // render.frag
+#line 14 0 // render.frag
 
 
 
@@ -195,18 +209,18 @@ void main()
     // this approximation has the same order of magnitude as the assumption that the Earth and its atmosphere
     // are spherical.
     float altitude = max(cameraPosition.z, 0.);
-    const vec3 oldCamPos=cameraPosition;
+    CONST vec3 oldCamPos=cameraPosition;
     // Hide the uniform with this name, thus effectively modifying it for the following code
     vec3 cameraPosition=vec3(oldCamPos.xy, altitude);
 
     bool lookingIntoAtmosphere=true;
     if(altitude>atmosphereHeight)
     {
-        const vec3 p = cameraPosition - earthCenter;
-        const float p_dot_v = dot(p, viewDir);
-        const float p_dot_p = dot(p, p);
-        const float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
-        const float distanceToTOA = -p_dot_v - sqrt(sqr(earthRadius+atmosphereHeight) - squaredDistBetweenViewRayAndEarthCenter);
+        CONST vec3 p = cameraPosition - earthCenter;
+        CONST float p_dot_v = dot(p, viewDir);
+        CONST float p_dot_p = dot(p, p);
+        CONST float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
+        CONST float distanceToTOA = -p_dot_v - sqrt(sqr(earthRadius+atmosphereHeight) - squaredDistBetweenViewRayAndEarthCenter);
         if(distanceToTOA>=0)
         {
             cameraPosition += viewDir*distanceToTOA;
@@ -214,7 +228,7 @@ void main()
         }
         else
         {
-#if RENDERING_ANY_ZERO_SCATTERING
+#if 0 /*RENDERING_ANY_ZERO_SCATTERING*/
             lookingIntoAtmosphere=false;
 #else
             luminance=vec4(0);
@@ -224,16 +238,16 @@ void main()
         }
     }
 
-    const vec3 zenith=normalize(cameraPosition-earthCenter);
+    CONST vec3 zenith=normalize(cameraPosition-earthCenter);
     float cosViewZenithAngle=dot(zenith,viewDir);
 
     bool viewRayIntersectsGround=false;
     {
-        const vec3 p = cameraPosition - earthCenter;
-        const float p_dot_v = dot(p, viewDir);
-        const float p_dot_p = dot(p, p);
-        const float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
-        const float distanceToIntersection = -p_dot_v - sqrt(sqr(earthRadius) - squaredDistBetweenViewRayAndEarthCenter);
+        CONST vec3 p = cameraPosition - earthCenter;
+        CONST float p_dot_v = dot(p, viewDir);
+        CONST float p_dot_p = dot(p, p);
+        CONST float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
+        CONST float distanceToIntersection = -p_dot_v - sqrt(sqr(earthRadius) - squaredDistBetweenViewRayAndEarthCenter);
         // altitude==0 is a special case where distance to intersection calculation
         // is unreliable (has a lot of noise in its sign), so check it separately
         if(distanceToIntersection>0 || (altitude==0 && cosViewZenithAngle<0))
@@ -244,11 +258,11 @@ void main()
     // Aside from aesthetics, this affects brightness input to Stellarium's tone mapper.
     if(pseudoMirrorSkyBelowHorizon && viewRayIntersectsGround)
     {
-        const float horizonCZA = cosZenithAngleOfHorizon(altitude);
-        const float viewElev  = asin(clampCosine(cosViewZenithAngle));
-        const float horizElev = asin(clampCosine(horizonCZA));
-        const float newViewElev = 2*horizElev - viewElev;
-        const float viewDirXYnorm = length(viewDir-zenith*cosViewZenithAngle);
+        CONST float horizonCZA = cosZenithAngleOfHorizon(altitude);
+        CONST float viewElev  = asin(clampCosine(cosViewZenithAngle));
+        CONST float horizElev = asin(clampCosine(horizonCZA));
+        CONST float newViewElev = 2*horizElev - viewElev;
+        CONST float viewDirXYnorm = length(viewDir-zenith*cosViewZenithAngle);
         if(viewDirXYnorm == 0)
         {
             viewDir = zenith;
@@ -267,27 +281,27 @@ void main()
         viewRayIntersectsGround = false;
     }
 
-    const float cosSunZenithAngle =dot(zenith,sunDirection);
-    const float dotViewSun=dot(viewDir,sunDirection);
+    CONST float cosSunZenithAngle =dot(zenith,sunDirection);
+    CONST float dotViewSun=dot(viewDir,sunDirection);
 
-    const vec3 sunXYunnorm=sunDirection-dot(sunDirection,zenith)*zenith;
-    const vec3 viewXYunnorm=viewDir-dot(viewDir,zenith)*zenith;
-    const vec3 sunXY = sunXYunnorm.x!=0 || sunXYunnorm.y!=0 || sunXYunnorm.z!=0 ? normalize(sunXYunnorm) : vec3(0);
-    const vec3 viewXY = viewXYunnorm.x!=0 || viewXYunnorm.y!=0 || viewXYunnorm.z!=0 ? normalize(viewXYunnorm) : vec3(0);
-    const float azimuthRelativeToSun=safeAtan(dot(cross(sunXY, viewXY), zenith), dot(sunXY, viewXY));
+    CONST vec3 sunXYunnorm=sunDirection-dot(sunDirection,zenith)*zenith;
+    CONST vec3 viewXYunnorm=viewDir-dot(viewDir,zenith)*zenith;
+    CONST vec3 sunXY = sunXYunnorm.x!=0 || sunXYunnorm.y!=0 || sunXYunnorm.z!=0 ? normalize(sunXYunnorm) : vec3(0);
+    CONST vec3 viewXY = viewXYunnorm.x!=0 || viewXYunnorm.y!=0 || viewXYunnorm.z!=0 ? normalize(viewXYunnorm) : vec3(0);
+    CONST float azimuthRelativeToSun=safeAtan(dot(cross(sunXY, viewXY), zenith), dot(sunXY, viewXY));
 
-#if RENDERING_ZERO_SCATTERING
+#if 0 /*RENDERING_ZERO_SCATTERING*/
     vec4 radiance;
     if(viewRayIntersectsGround)
     {
         // XXX: keep in sync with the same code in computeScatteringDensity(), but don't forget about
         //      the difference in the usage of viewDir vs incDir.
-        const float distToGround = distanceToGround(cosViewZenithAngle, altitude);
-        const vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
-        const vec3 groundNormal = normalize(zenith*(earthRadius+altitude)+viewDir*distToGround);
-        const vec4 groundIrradiance = irradiance(dot(groundNormal, sunDirection), 0);
+        CONST float distToGround = distanceToGround(cosViewZenithAngle, altitude);
+        CONST vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
+        CONST vec3 groundNormal = normalize(zenith*(earthRadius+altitude)+viewDir*distToGround);
+        CONST vec4 groundIrradiance = irradiance(dot(groundNormal, sunDirection), 0);
         // Radiation scattered by the ground
-        const float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
+        CONST float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
         radiance = transmittanceToGround*groundAlbedo*groundIrradiance*solarIrradianceFixup*groundBRDF
                  + lightPollutionGroundLuminance*lightPollutionRelativeRadiance;
     }
@@ -304,22 +318,22 @@ void main()
     }
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_ZERO_SCATTERING
+#elif 0 /*RENDERING_ECLIPSED_ZERO_SCATTERING*/
     vec4 radiance;
-    const float dotViewMoon=dot(viewDir,normalize(moonPosition-cameraPosition));
+    CONST float dotViewMoon=dot(viewDir,normalize(moonPosition-cameraPosition));
     if(viewRayIntersectsGround)
     {
         // XXX: keep in sync with the similar code in non-eclipsed zero scattering rendering.
-        const float distToGround = distanceToGround(cosViewZenithAngle, altitude);
-        const vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
-        const vec3 pointOnGround = cameraPosition+viewDir*distToGround;
-        const vec4 directGroundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDirection, moonPosition);
+        CONST float distToGround = distanceToGround(cosViewZenithAngle, altitude);
+        CONST vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
+        CONST vec3 pointOnGround = cameraPosition+viewDir*distToGround;
+        CONST vec4 directGroundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDirection, moonPosition);
         // FIXME: add first-order indirect irradiance too: it's done in non-eclipsed irradiance (in the same
         // conditions: when limited to 2 orders). This should be calculated at the same time when second order
         // is: all the infrastructure is already there.
-        const vec4 groundIrradiance = directGroundIrradiance;
+        CONST vec4 groundIrradiance = directGroundIrradiance;
         // Radiation scattered by the ground
-        const float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
+        CONST float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
         radiance = transmittanceToGround*groundAlbedo*groundIrradiance*solarIrradianceFixup*groundBRDF
                  + lightPollutionGroundLuminance*lightPollutionRelativeRadiance;
     }
@@ -337,52 +351,52 @@ void main()
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
 #elif 1 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_ON_THE_FLY*/
-    const vec4 scattering=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPosition,
+    CONST vec4 scattering=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPosition,
                                                           viewRayIntersectsGround);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE
-    const vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE*/
+    CONST vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                      viewRayIntersectsGround, eclipsedSingleScatteringTextureSize);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact at the point where azimuth texture coordinate changes from 1 to 0 (at azimuthRelativeToSun crossing
     // 0). This happens when I simply call texture(eclipsedScatteringTexture, texCoords) without specifying LOD.
     // Apparently, the driver uses the derivative for some reason, even though it shouldn't.
-    const vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
+    CONST vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE
-    const vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
+    CONST vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                      viewRayIntersectsGround, eclipsedSingleScatteringTextureSize);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact at the point where azimuth texture coordinate changes from 1 to 0 (at azimuthRelativeToSun crossing
     // 0). This happens when I simply call texture(eclipsedScatteringTexture, texCoords) without specifying LOD.
     // Apparently, the driver uses the derivative for some reason, even though it shouldn't.
-    const vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
+    CONST vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
     luminance=scattering*currentPhaseFunction(dotViewSun);
-#elif RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_RADIANCE
+#elif 0 /*RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_RADIANCE*/
     vec4 radiance=exp(sampleEclipseDoubleScattering3DTexture(eclipsedDoubleScatteringTexture,
                                                              cosSunZenithAngle, cosViewZenithAngle, azimuthRelativeToSun,
                                                              altitude, viewRayIntersectsGround));
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_LUMINANCE
+#elif 0 /*RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
     luminance=exp(sampleEclipseDoubleScattering3DTexture(eclipsedDoubleScatteringTexture,
                                                          cosSunZenithAngle, cosViewZenithAngle, azimuthRelativeToSun,
                                                          altitude, viewRayIntersectsGround));
-#elif RENDERING_SINGLE_SCATTERING_ON_THE_FLY
-    const vec4 scattering=computeSingleScattering(cosSunZenithAngle,cosViewZenithAngle,dotViewSun,
+#elif 0 /*RENDERING_SINGLE_SCATTERING_ON_THE_FLY*/
+    CONST vec4 scattering=computeSingleScattering(cosSunZenithAngle,cosViewZenithAngle,dotViewSun,
                                                   altitude,viewRayIntersectsGround);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE
+#elif 0 /*RENDERING_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE*/
     vec4 scattering;
     if(useInterpolationGuides)
     {
@@ -399,7 +413,7 @@ void main()
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE
+#elif 0 /*RENDERING_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
     vec4 scattering;
     if(useInterpolationGuides)
     {
@@ -413,18 +427,18 @@ void main()
                                      dotViewSun, altitude, viewRayIntersectsGround);
     }
     luminance=scattering * (bool(PHASE_FUNCTION_IS_EMBEDDED) ? vec4(1) : currentPhaseFunction(dotViewSun));
-#elif RENDERING_MULTIPLE_SCATTERING_LUMINANCE
+#elif 0 /*RENDERING_MULTIPLE_SCATTERING_LUMINANCE*/
     luminance=sample3DTexture(scatteringTexture, cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, viewRayIntersectsGround);
-#elif RENDERING_MULTIPLE_SCATTERING_RADIANCE
+#elif 0 /*RENDERING_MULTIPLE_SCATTERING_RADIANCE*/
     vec4 radiance=sample3DTexture(scatteringTexture, cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, viewRayIntersectsGround);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_LIGHT_POLLUTION_RADIANCE
+#elif 0 /*RENDERING_LIGHT_POLLUTION_RADIANCE*/
     vec4 radiance=lightPollutionGroundLuminance*lightPollutionScattering(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_LIGHT_POLLUTION_LUMINANCE
+#elif 0 /*RENDERING_LIGHT_POLLUTION_LUMINANCE*/
     luminance=lightPollutionGroundLuminance*lightPollutionScattering(altitude, cosViewZenithAngle, viewRayIntersectsGround);
 #else
 #error What to render?

--- a/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/1/aerosols/single-scattering-eclipsed.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/1/aerosols/single-scattering-eclipsed.frag
@@ -1,7 +1,21 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
 
-#line 1 1 // const.h.glsl
+
+
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 6 0 // single-scattering-eclipsed.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,15 +48,15 @@ const vec4 lightPollutionRelativeRadiance=vec4(2.15e-06,1.11400004e-06,3.8580001
 const vec4 wavelengths=vec4(485.333344,516.666687,548,579.333313);
 const int wlSetIndex=1;
 #endif
-#line 5 0 // single-scattering-eclipsed.frag
-#line 1 2 // densities.h.glsl
+#line 7 0 // single-scattering-eclipsed.frag
+#line 1 3 // densities.h.glsl
 float scattererNumberDensity_molecules(float altitude);
 float scattererNumberDensity_aerosols(float altitude);
 float absorberNumberDensity_ozone(float altitude);
 vec4 scatteringCrossSection();
 float scattererDensity(float altitude);
-#line 6 0 // single-scattering-eclipsed.frag
-#line 1 3 // common-functions.h.glsl
+#line 8 0 // single-scattering-eclipsed.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -74,8 +88,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // single-scattering-eclipsed.frag
-#line 1 4 // texture-sampling-functions.h.glsl
+#line 9 0 // single-scattering-eclipsed.frag
+#line 1 5 // texture-sampling-functions.h.glsl
 #ifndef INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 #define INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float altitude);
@@ -87,7 +101,7 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                 const int scatteringOrder);
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 #endif
-#line 8 0 // single-scattering-eclipsed.frag
+#line 10 0 // single-scattering-eclipsed.frag
 
 
 float cosZenithAngle(vec3 origin, vec3 direction)
@@ -101,13 +115,13 @@ vec4 computeSingleScatteringIntegrandEclipsed(const float cosSunZenithAngle, con
                                               const float dist, const bool viewRayIntersectsGround,
                                               const vec3 scatterer, const vec3 sunDir, const vec3 moonPos)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle here the case when the
     // endpoint of the view ray intentionally appears in outer space.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosSunZenithAngleAtDist=clampCosine((r*cosSunZenithAngle+dist*dotViewSun)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosSunZenithAngleAtDist=clampCosine((r*cosSunZenithAngle+dist*dotViewSun)/(earthRadius+altAtDist));
 
-    const vec4 xmittance=transmittance(cosViewZenithAngle, altitude, dist, viewRayIntersectsGround)
+    CONST vec4 xmittance=transmittance(cosViewZenithAngle, altitude, dist, viewRayIntersectsGround)
                                                     *
                          transmittanceToAtmosphereBorder(cosSunZenithAngleAtDist, altAtDist)
                                                     *
@@ -115,7 +129,7 @@ vec4 computeSingleScatteringIntegrandEclipsed(const float cosSunZenithAngle, con
                                                     *
                             // FIXME: this ignores orientation of the crescent of eclipsed Sun WRT horizon
                                     sunVisibility(cosSunZenithAngleAtDist, altAtDist);
-#if ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION
+#if 0 /*ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION*/
     COMPUTE_TOTAL_SCATTERING_COEFFICIENT;
     return xmittance * totalScatteringCoefficient;
 #else
@@ -126,26 +140,26 @@ vec4 computeSingleScatteringIntegrandEclipsed(const float cosSunZenithAngle, con
 vec4 computeSingleScatteringEclipsed(const vec3 camera, const vec3 viewDir, const vec3 sunDir, const vec3 moonPos,
                                      const bool viewRayIntersectsGround)
 {
-    const float cosViewZenithAngle=cosZenithAngle(camera,viewDir);
-    const float cosSunZenithAngle=cosZenithAngle(camera,sunDir);
-    const float altitude=pointAltitude(camera);
-    const float dotViewSun=dot(viewDir,sunDir);
-    const float integrInterval=distanceToNearestAtmosphereBoundary(cosViewZenithAngle, altitude,
+    CONST float cosViewZenithAngle=cosZenithAngle(camera,viewDir);
+    CONST float cosSunZenithAngle=cosZenithAngle(camera,sunDir);
+    CONST float altitude=pointAltitude(camera);
+    CONST float dotViewSun=dot(viewDir,sunDir);
+    CONST float integrInterval=distanceToNearestAtmosphereBoundary(cosViewZenithAngle, altitude,
                                                                    viewRayIntersectsGround);
 
     // Using the midpoint rule for quadrature
     vec4 spectrum=vec4(0);
-    const float dl=integrInterval/radialIntegrationPoints;
+    CONST float dl=integrInterval/radialIntegrationPoints;
     for(int n=0; n<radialIntegrationPoints; ++n)
     {
-        const float dist=(n+0.5)*dl;
+        CONST float dist=(n+0.5)*dl;
         spectrum += computeSingleScatteringIntegrandEclipsed(cosSunZenithAngle, cosViewZenithAngle, dotViewSun,
                                                              altitude, dist, viewRayIntersectsGround,
                                                              camera+viewDir*dist, sunDir, moonPos);
     }
 
     spectrum *= dl*solarIrradianceAtTOA
-#if ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION
+#if 0 /*ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION*/
                                 // the multiplier is already included
 #else
                                         * scatteringCrossSection()

--- a/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/1/aerosols/texture-coordinates.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/1/aerosols/texture-coordinates.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-coordinates.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,8 +45,8 @@ const vec4 lightPollutionRelativeRadiance=vec4(2.15e-06,1.11400004e-06,3.8580001
 const vec4 wavelengths=vec4(485.333344,516.666687,548,579.333313);
 const int wlSetIndex=1;
 #endif
-#line 5 0 // texture-coordinates.frag
-#line 1 2 // texture-coordinates.h.glsl
+#line 4 0 // texture-coordinates.frag
+#line 1 3 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -104,8 +115,8 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 6 0 // texture-coordinates.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-coordinates.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -137,7 +148,7 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-coordinates.frag
+#line 6 0 // texture-coordinates.frag
 
 const float LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA=sqrt(atmosphereHeight*(atmosphereHeight+2*earthRadius));
 
@@ -205,18 +216,18 @@ vec3 indicesToTexCoords(const vec3 indices, const vec3 texSizes)
 
 TransmittanceTexVars transmittanceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
+    CONST float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
                                 texCoordToUnitRange(texCoord.t,transmittanceTextureSize.t);
     // Distance from Earth center to camera
-    const float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
-    const float altitude=r-earthRadius;
+    CONST float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
+    CONST float altitude=r-earthRadius;
 
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
     // distance to border of visible atmosphere from the view point
-    const float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
+    CONST float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
     // d==0 can happen when altitude==atmosphereHeight
-    const float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
+    CONST float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
     return TransmittanceTexVars(cosVZA,altitude);
 }
 
@@ -235,53 +246,53 @@ vec2 transmittanceTexVarsToTexCoord(const float cosVZA, float altitude)
     if(altitude<0)
         altitude=0;
 
-    const float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
+    CONST float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
                                       transmittanceTextureSize.t);
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
-    const float d=distanceToAtmosphereBorder(cosVZA,altitude);
-    const float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float d=distanceToAtmosphereBorder(cosVZA,altitude);
+    CONST float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
     return vec2(s,t);
 }
 
 // Output: vec2(cos(sunZenithAngle), altitude)
 IrradianceTexVars irradianceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
-    const float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
+    CONST float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
+    CONST float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
     return IrradianceTexVars(cosSZA,alt);
 }
 
 vec2 irradianceTexVarsToTexCoord(const float cosSunZenithAngle, const float altitude)
 {
-    const float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
-    const float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
+    CONST float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
+    CONST float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
     return vec2(s,t);
 }
 
 float cosSZAToUnitRangeTexCoord(const float cosSunZenithAngle)
 {
     // Distance to top atmosphere border along the ray groundUnderCamera-sun: (altitude, cosSunZenithAngle)
-    const float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name
-    const float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
+    CONST float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
     // TODO: choose a more descriptive name
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     return max(0.,1-a/A)/(a+1);
 }
 
 float unitRangeTexCoordToCosSZA(const float texCoord)
 {
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float a=(A-A*texCoord)/(1+A*texCoord);
-    const float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
+    CONST float a=(A-A*texCoord)/(1+A*texCoord);
+    CONST float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
     return distFromGroundToTopAtmoBorder==0 ? 1 :
         clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distFromGroundToTopAtmoBorder)) /
                     (2*earthRadius*distFromGroundToTopAtmoBorder));
@@ -292,24 +303,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
                                                const float dotViewSun, const float altitude,
                                                const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -317,24 +328,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float dotVSCoord=(dotViewSun+1)/2;
+    CONST float dotVSCoord=(dotViewSun+1)/2;
 
     // ------------------------------------
-    const float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
+    CONST float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
 
     return Scattering4DCoords(cosSZACoord, cosVZACoord, dotVSCoord, altCoord, viewRayIntersectsGround);
 }
 
 TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
@@ -342,16 +353,16 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture coordinates we combine into a single sampler3D coordinate.
-    const float texW = scatteringTextureSize[1];
-    const float texH = scatteringTextureSize[2];
-    const float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
-    const vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
+    CONST float texW = scatteringTextureSize[1];
+    CONST float texH = scatteringTextureSize[2];
+    CONST float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
+    CONST vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
                                         ceil (cosSZAIndex)*texW+coords.dotViewSun*(texW-1)) / (texW*texH-1);
-    const vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
+    CONST vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
 
-    const float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
+    CONST float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
 
-    const float alphaUpper=fract(cosSZAIndex);
+    CONST float alphaUpper=fract(cosSZAIndex);
     return TexCoordPair(vec3(cosVZAtc, combinedCoord.x, altitude), float(1-alphaUpper),
                         vec3(cosVZAtc, combinedCoord.y, altitude), float(alphaUpper));
 }
@@ -359,9 +370,9 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
+    CONST TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
     return texture(tex, texCoords.lower) * texCoords.alphaLower +
            texture(tex, texCoords.upper) * texCoords.alphaUpper;
 }
@@ -369,17 +380,17 @@ vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const f
 // 3D texture is the 3D single-altitude slice of a 4D texture
 vec3 scattering4DCoordsToTex3DCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2);
 
-    const float dvsSize = scatteringTextureSize[1];
-    const float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
+    CONST float dvsSize = scatteringTextureSize[1];
+    CONST float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
 
-    const float cszaSize = scatteringTextureSize[2];
-    const float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
+    CONST float cszaSize = scatteringTextureSize[2];
+    CONST float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
 
     return vec3(cosVZAtc, dotVStc, cosSZAtc);
 }
@@ -394,39 +405,39 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along dotViewSun coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[1];
-    const float posOfRow = indices[1];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[1];
+    CONST float posOfRow = indices[1];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         indexToTexCoord(currRow, numRows-1),
                                                         texCoordVerbatim));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               indexToTexCoord(currRow, numRows-1),
                                                               texCoordVerbatim));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          indexToTexCoord(currRow, numRows-1),
                                          texCoordVerbatim));
@@ -434,14 +445,14 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
 vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolationGuides01Tex,
                                  const vec3 indices)
 {
-    const float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
+    CONST float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
 
-    const float cosVZAIndex = indices[0];
-    const float dotVSIndex = indices[1];
-    const float currRow = floor(dotVSIndex);
-    const float posBetweenRows = dotVSIndex - currRow;
-    const float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cosVZAIndex = indices[0];
+    CONST float dotVSIndex = indices[1];
+    CONST float currRow = floor(dotVSIndex);
+    CONST float posBetweenRows = dotVSIndex - currRow;
+    CONST float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -449,14 +460,14 @@ vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolat
     indicesCurrRow[1] =     currRow;
     indicesNextRow[1] = min(currRow+1, scatteringTextureSize[1]-1.);
 
-    const vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
-    const vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
+    CONST vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
+    CONST vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
 
-    const vec4 valueCurrRow = texture(tex, coordsCurrRow);
-    const vec4 valueNextRow = texture(tex, coordsNextRow);
-    const float epsilon = 1e-37; // Prevents passing zero to log
-    const vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
-    const vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
+    CONST vec4 valueCurrRow = texture(tex, coordsCurrRow);
+    CONST vec4 valueNextRow = texture(tex, coordsNextRow);
+    CONST float epsilon = 1e-37; // Prevents passing zero to log
+    CONST vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
+    CONST vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
     return (logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow;
 }
 
@@ -465,37 +476,37 @@ float findGuide02Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along SZA coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[2];
-    const float posOfRow = indices[2];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[2];
+    CONST float posOfRow = indices[2];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
 }
@@ -505,19 +516,19 @@ vec4 sample3DTextureGuided(const sampler3D tex,
                            const float cosSunZenithAngle, const float cosViewZenithAngle,
                            const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
                                                                     dotViewSun, altitude, viewRayIntersectsGround);
     // Handle the external interpolation guides: the guides between a pair of VZA-dotViewSun 2D "pictures".
-    const vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
-    const vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
-    const float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
+    CONST vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
+    CONST float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
 
-    const float cvzaIndex = indices[0];
-    const float cszaIndex = indices[2];
-    const float currRow = floor(cszaIndex);
-    const float posBetweenRows = cszaIndex - currRow;
-    const float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cvzaIndex = indices[0];
+    CONST float cszaIndex = indices[2];
+    CONST float currRow = floor(cszaIndex);
+    CONST float posBetweenRows = cszaIndex - currRow;
+    CONST float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -526,58 +537,58 @@ vec4 sample3DTextureGuided(const sampler3D tex,
     indicesNextRow[2] = min(currRow+1, scatteringTextureSize[2]-1);
 
     // The caller will handle the internal interpolation guides: the ones between rows in each 2D "picture".
-    const vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
-    const vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
+    CONST vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
+    CONST vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
     return exp((logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow);
 }
 
 vec4 sample3DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
     return texture(tex, texCoords);
 }
 
 ScatteringTexVars scatteringTex4DCoordsToTexVars(const Scattering4DCoords coords)
 {
-    const float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
     // ------------------------------------
     float cosViewZenithAngle;
     if(coords.viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
     // ------------------------------------
-    const float dotViewSun=coords.dotViewSun*2-1;
+    CONST float dotViewSun=coords.dotViewSun*2-1;
 
     // ------------------------------------
-    const float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
+    CONST float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
 
     return ScatteringTexVars(cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, coords.viewRayIntersectsGround);
 }
 
 Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 {
-    const vec4 indexMax=scatteringTextureSize-vec4(1);
+    CONST vec4 indexMax=scatteringTextureSize-vec4(1);
     Scattering4DCoords coords4d;
     coords4d.viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
     // The following formulas assume that scatteringTextureSize[0] is even. For odd sizes they would change.
@@ -593,8 +604,8 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture indices we combine into a single sampler3D coordinate.
-    const float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
-    const float combinedIndex=texIndices[1];
+    CONST float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
+    CONST float combinedIndex=texIndices[1];
     coords4d.dotViewSun=mod(combinedIndex,texW)/(texW-1);
     coords4d.cosSunZenithAngle=floor(combinedIndex/texW)/(texH-1);
 
@@ -608,11 +619,11 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
 ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 {
-    const Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
+    CONST Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
     ScatteringTexVars vars=scatteringTex4DCoordsToTexVars(coords4d);
     // Clamp dotViewSun to its valid range of values, given cosViewZenithAngle and cosSunZenithAngle. This is
     // needed to prevent NaNs when computing the scattering texture.
-    const float cosVZA=vars.cosViewZenithAngle,
+    CONST float cosVZA=vars.cosViewZenithAngle,
                 cosSZA=vars.cosSunZenithAngle;
     vars.dotViewSun=clamp(vars.dotViewSun,
                           cosVZA*cosSZA-safeSqrt((1-sqr(cosVZA))*(1-sqr(cosSZA))),
@@ -622,54 +633,54 @@ ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 
 EclipseScatteringTexVars eclipseTexCoordsToTexVars(const vec2 texCoords, const float altitude)
 {
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
-    const bool viewRayIntersectsGround = texCoords.t<0.5;
+    CONST bool viewRayIntersectsGround = texCoords.t<0.5;
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
-    const float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
+    CONST float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
     return EclipseScatteringTexVars(azimuthRelativeToSun, cosViewZenithAngle, viewRayIntersectsGround);
 }
 
 EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                                    const float altitude, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -677,13 +688,13 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
-    const float azimuthCoord = azimuthRelativeToSun/(2*PI);
+    CONST float azimuthCoord = azimuthRelativeToSun/(2*PI);
 
     return EclipseScattering2DCoords(azimuthCoord, cosVZACoord);
 }
@@ -691,14 +702,14 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
 vec2 eclipseTexVarsToTexCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                const float altitude, const bool viewRayIntersectsGround, const vec2 texSize)
 {
-    const EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+    CONST EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                                     viewRayIntersectsGround);
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2);
-    const float azimuthTC = coords.azimuth + 1/(2*texSize.s);
+    CONST float azimuthTC = coords.azimuth + 1/(2*texSize.s);
 
     return vec2(azimuthTC, cosVZAtc);
 }
@@ -707,42 +718,42 @@ vec4 sampleEclipseDoubleScattering3DTexture(const sampler3D tex, const float cos
                                             const float cosViewZenithAngle, const float azimuthRelativeToSun,
                                             const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
+    CONST vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
                                                   eclipsedDoubleScatteringTextureSize.st);
-    const float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
-    const vec3 texCoords=vec3(coords2d, cosSZACoord);
+    CONST float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
+    CONST vec3 texCoords=vec3(coords2d, cosSZACoord);
 
     return texture(tex, texCoords);
 }
 
 LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 texIndices)
 {
-    const vec2 indexMax=lightPollutionTextureSize-vec2(1);
+    CONST vec2 indexMax=lightPollutionTextureSize-vec2(1);
 
-    const float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
-    const float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
+    CONST float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
-    const bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
-    const float cosViewZenithAngleCoord = viewRayIntersectsGround ?
+    CONST bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
+    CONST float cosViewZenithAngleCoord = viewRayIntersectsGround ?
                                    1-2*texIndices[0]/(indexMax[0]-1) :
                                    2*(texIndices[0]-1)/(indexMax[0]-1)-1;
     // ------------------------------------
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
@@ -753,23 +764,23 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 
 LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -777,27 +788,27 @@ LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, con
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     return LightPollution2DCoords(cosVZACoord, altCoord);
 }
 
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
-    const vec2 texSize = lightPollutionTextureSize;
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 texSize = lightPollutionTextureSize;
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2);
-    const float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
+    CONST float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
     return vec2(cosVZAtc, altitudeTC);
 }

--- a/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/1/aerosols/texture-sampling-functions.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/1/aerosols/texture-sampling-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-sampling-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,13 +45,13 @@ const vec4 lightPollutionRelativeRadiance=vec4(2.15e-06,1.11400004e-06,3.8580001
 const vec4 wavelengths=vec4(485.333344,516.666687,548,579.333313);
 const int wlSetIndex=1;
 #endif
-#line 5 0 // texture-sampling-functions.frag
-#line 1 2 // phase-functions.h.glsl
+#line 4 0 // texture-sampling-functions.frag
+#line 1 3 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 6 0 // texture-sampling-functions.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-sampling-functions.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -72,8 +83,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-sampling-functions.frag
-#line 1 4 // texture-coordinates.h.glsl
+#line 6 0 // texture-sampling-functions.frag
+#line 1 5 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -142,7 +153,7 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 8 0 // texture-sampling-functions.frag
+#line 7 0 // texture-sampling-functions.frag
 
 uniform sampler2D transmittanceTexture;
 uniform sampler2D irradianceTexture;
@@ -154,13 +165,13 @@ uniform sampler2D lightPollutionScatteringTexture;
 
 vec4 irradiance(const float cosSunZenithAngle, const float altitude)
 {
-    const vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
+    CONST vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
     return texture(irradianceTexture, texCoords);
 }
 
 vec4 opticalDepthToAtmosphereBorder(const float cosViewZenithAngle, const float altitude)
 {
-    const vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
+    CONST vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact when looking into nadir from TOA at some values of texture sizes (in particular, size of
     // transmittance texture for altitude being 4096). This happens when I simply call texture(eclipsedScatteringTexture,
@@ -178,11 +189,11 @@ vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float
 vec4 transmittance(const float cosViewZenithAngle, const float altitude, const float dist,
                    const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle view ray endpoint
     // in space here.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
 
     vec4 depth;
     if(viewRayIntersectsGround)
@@ -201,7 +212,7 @@ vec4 transmittance(const float cosViewZenithAngle, const float altitude, const f
 vec4 calcFirstScattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                          const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
+    CONST vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
                                           dotViewSun, altitude, viewRayIntersectsGround);
     return scattering*currentPhaseFunction(dotViewSun);
 }
@@ -220,6 +231,6 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
 
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     return texture(lightPollutionScatteringTexture, coords);
 }

--- a/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/1/molecules/common-functions.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/1/molecules/common-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // common-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(2.15e-06,1.11400004e-06,3.8580001
 const vec4 wavelengths=vec4(485.333344,516.666687,548,579.333313);
 const int wlSetIndex=1;
 #endif
-#line 5 0 // common-functions.frag
+#line 4 0 // common-functions.frag
 
 bool dbgDataPresent=false;
 bool debugDataPresent()
@@ -69,7 +80,7 @@ void setDebugData(float a,float b, float c, float d)
 
 void swap(inout float x, inout float y)
 {
-    const float t = x;
+    CONST float t = x;
     x = y;
     y = t;
 }
@@ -83,7 +94,7 @@ float safeSqrt(const float x)
 
 float safeAtan(const float y, const float x)
 {
-    const float a = atan(y,x);
+    CONST float a = atan(y,x);
     return x==0 && y==0 ? 0 : a;
 }
 
@@ -116,23 +127,23 @@ float pointAltitude(vec3 point)
 
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float Ratm=earthRadius+atmosphereHeight;
-    const float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float Ratm=earthRadius+atmosphereHeight;
+    CONST float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float distanceToGround(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(-safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float cosZenithAngleOfHorizon(const float altitude)
 {
-    const float R=earthRadius;
-    const float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
+    CONST float R=earthRadius;
+    CONST float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
     return -sqrt(2*h*R+sqr(h))/(R+h);
 }
 
@@ -151,8 +162,8 @@ float distanceToNearestAtmosphereBoundary(const float cosZenithAngle, const floa
 float sunVisibility(const float cosSunZenithAngle, float altitude)
 {
     if(altitude<0) altitude=0;
-    const float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
-    const float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
+    CONST float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
+    CONST float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
     /* Approximating visible fraction of solar disk by smoothstep between the position of the Sun
      * touching the horizon by its upper part and the position with lower part touching the horizon.
      * The calculation assumes that solar angular radius is small and thus approximately equals its sine.
@@ -182,13 +193,13 @@ float circlesIntersectionArea(float R1, float R2, float d)
 
 float angleBetween(const vec3 a, const vec3 b)
 {
-    const float d=dot(a,b);
-    const float c=length(cross(a,b));
+    CONST float d=dot(a,b);
+    CONST float c=length(cross(a,b));
     // To avoid loss of precision, don't use dot product near the singularity
     // of acos, and cross product near the singularity of asin
     if(abs(d) < abs(c))
         return acos(d/(length(a)*length(b)));
-    const float smallerAngle = asin(c/(length(a)*length(b)));
+    CONST float smallerAngle = asin(c/(length(a)*length(b)));
     if(d<0) return PI-smallerAngle;
     return smallerAngle;
 }
@@ -205,11 +216,11 @@ float moonAngularRadius(const vec3 cameraPosition, const vec3 moonPosition)
 
 float visibleSolidAngleOfSun(const vec3 camera, const vec3 sunDir, const vec3 moonPos)
 {
-    const float Rs=sunAngularRadius;
-    const float Rm=moonAngularRadius(camera,moonPos);
+    CONST float Rs=sunAngularRadius;
+    CONST float Rm=moonAngularRadius(camera,moonPos);
     float visibleSolidAngle=PI*sqr(Rs);
 
-    const float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
+    CONST float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
     if(dSM<Rs+Rm)
     {
         visibleSolidAngle -= circlesIntersectionArea(Rm,Rs,dSM);
@@ -229,12 +240,12 @@ float sphereIntegrationSolidAngleDifferential(const int pointCountOnSphere)
 }
 vec3 sphereIntegrationSampleDir(const int index, const int pointCountOnSphere)
 {
-    const float goldenRatio=1.6180339887499;
+    CONST float goldenRatio=1.6180339887499;
     // The range of n is 0.5, 1.5, ..., pointCountOnSphere-0.5
-    const float n=index+0.5;
+    CONST float n=index+0.5;
     // Explanation of the Fibonacci grid generation can be seen at https://stackoverflow.com/a/44164075/673852
-    const float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
-    const float azimuth=n*(2*PI*goldenRatio);
+    CONST float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
+    CONST float azimuth=n*(2*PI*goldenRatio);
     return vec3(cos(azimuth)*sin(zenithAngle),
                 sin(azimuth)*sin(zenithAngle),
                 cos(zenithAngle));

--- a/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/1/molecules/densities.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/1/molecules/densities.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // densities.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,20 +45,20 @@ const vec4 lightPollutionRelativeRadiance=vec4(2.15e-06,1.11400004e-06,3.8580001
 const vec4 wavelengths=vec4(485.333344,516.666687,548,579.333313);
 const int wlSetIndex=1;
 #endif
-#line 5 0 // densities.frag
+#line 4 0 // densities.frag
 float scattererNumberDensity_molecules(float altitude)
 {
-        const float rayleighScaleHeight=8*km;
+        CONST float rayleighScaleHeight=8*km;
         return 3.08458e25*exp(-1/rayleighScaleHeight * altitude);
 }
 float scattererNumberDensity_aerosols(float altitude)
 {
-        const float mieScaleHeight=1.2*km;
+        CONST float mieScaleHeight=1.2*km;
         return 1.03333e8*exp(-1/mieScaleHeight*altitude);
 }
 float absorberNumberDensity_ozone(float altitude)
 {
-        const float totalOzoneAmount=370*dobsonUnit;
+        CONST float totalOzoneAmount=370*dobsonUnit;
 
         float density;
 

--- a/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/1/molecules/phase-functions.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/1/molecules/phase-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // phase-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(2.15e-06,1.11400004e-06,3.8580001
 const vec4 wavelengths=vec4(485.333344,516.666687,548,579.333313);
 const int wlSetIndex=1;
 #endif
-#line 5 0 // phase-functions.frag
+#line 4 0 // phase-functions.frag
 
 vec4 phaseFunction_molecules(float dotViewSun)
 {
@@ -42,9 +53,9 @@ vec4 phaseFunction_molecules(float dotViewSun)
 }
 vec4 phaseFunction_aerosols(float dotViewSun)
 {
-        const float g=0.76;
-        const float g2=g*g;
-        const float k = 3/(8*PI)*(1-g2)/(2+g2);
+        CONST float g=0.76;
+        CONST float g2=g*g;
+        CONST float k = 3/(8*PI)*(1-g2)/(2+g2);
         return vec4(k * (1+sqr(dotViewSun)) / pow(1+g2 - 2*g*dotViewSun, 1.5) + 1/((1-dotViewSun)*600+0.05))*0.904;
 }
 vec4 currentPhaseFunction(float dotViewSun) { return phaseFunction_molecules(dotViewSun); }

--- a/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/1/molecules/render.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/1/molecules/render.frag
@@ -1,7 +1,21 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
 
-#line 1 1 // const.h.glsl
+
+
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 6 0 // render.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,11 +48,11 @@ const vec4 lightPollutionRelativeRadiance=vec4(2.15e-06,1.11400004e-06,3.8580001
 const vec4 wavelengths=vec4(485.333344,516.666687,548,579.333313);
 const int wlSetIndex=1;
 #endif
-#line 5 0 // render.frag
-#line 1 2 // calc-view-dir.h.glsl
+#line 7 0 // render.frag
+#line 1 3 // calc-view-dir.h.glsl
 vec3 calcViewDir();
-#line 6 0 // render.frag
-#line 1 3 // common-functions.h.glsl
+#line 8 0 // render.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -70,14 +84,14 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // render.frag
-#line 1 4 // phase-functions.h.glsl
+#line 9 0 // render.frag
+#line 1 5 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 8 0 // render.frag
+#line 10 0 // render.frag
 
-#line 1 5 // single-scattering-eclipsed.h.glsl
+#line 1 6 // single-scattering-eclipsed.h.glsl
 #ifndef INCLUDE_ONCE_050024D2_BD56_434E_8D40_2055DA0B78EC
 #define INCLUDE_ONCE_050024D2_BD56_434E_8D40_2055DA0B78EC
 
@@ -85,8 +99,8 @@ vec4 computeSingleScatteringEclipsed(const vec3 camera, const vec3 viewDir, cons
                                      const bool viewRayIntersectsGround);
 
 #endif
-#line 10 0 // render.frag
-#line 1 6 // texture-coordinates.h.glsl
+#line 12 0 // render.frag
+#line 1 7 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -155,10 +169,10 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 11 0 // render.frag
-#line 1 7 // radiance-to-luminance.h.glsl
+#line 13 0 // render.frag
+#line 1 8 // radiance-to-luminance.h.glsl
 const mat4 radianceToLuminance=mat4(1196.74268,3672.67432,12945.498,45528.7344,  835.02478,13767.5205,2120.37939,51317.4727,  8632.59277,21193.416,222.095078,27381.1602,  19410,18758.1973,35.7829971,6712.12158);
-#line 12 0 // render.frag
+#line 14 0 // render.frag
 
 
 
@@ -195,18 +209,18 @@ void main()
     // this approximation has the same order of magnitude as the assumption that the Earth and its atmosphere
     // are spherical.
     float altitude = max(cameraPosition.z, 0.);
-    const vec3 oldCamPos=cameraPosition;
+    CONST vec3 oldCamPos=cameraPosition;
     // Hide the uniform with this name, thus effectively modifying it for the following code
     vec3 cameraPosition=vec3(oldCamPos.xy, altitude);
 
     bool lookingIntoAtmosphere=true;
     if(altitude>atmosphereHeight)
     {
-        const vec3 p = cameraPosition - earthCenter;
-        const float p_dot_v = dot(p, viewDir);
-        const float p_dot_p = dot(p, p);
-        const float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
-        const float distanceToTOA = -p_dot_v - sqrt(sqr(earthRadius+atmosphereHeight) - squaredDistBetweenViewRayAndEarthCenter);
+        CONST vec3 p = cameraPosition - earthCenter;
+        CONST float p_dot_v = dot(p, viewDir);
+        CONST float p_dot_p = dot(p, p);
+        CONST float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
+        CONST float distanceToTOA = -p_dot_v - sqrt(sqr(earthRadius+atmosphereHeight) - squaredDistBetweenViewRayAndEarthCenter);
         if(distanceToTOA>=0)
         {
             cameraPosition += viewDir*distanceToTOA;
@@ -214,7 +228,7 @@ void main()
         }
         else
         {
-#if RENDERING_ANY_ZERO_SCATTERING
+#if 0 /*RENDERING_ANY_ZERO_SCATTERING*/
             lookingIntoAtmosphere=false;
 #else
             luminance=vec4(0);
@@ -224,16 +238,16 @@ void main()
         }
     }
 
-    const vec3 zenith=normalize(cameraPosition-earthCenter);
+    CONST vec3 zenith=normalize(cameraPosition-earthCenter);
     float cosViewZenithAngle=dot(zenith,viewDir);
 
     bool viewRayIntersectsGround=false;
     {
-        const vec3 p = cameraPosition - earthCenter;
-        const float p_dot_v = dot(p, viewDir);
-        const float p_dot_p = dot(p, p);
-        const float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
-        const float distanceToIntersection = -p_dot_v - sqrt(sqr(earthRadius) - squaredDistBetweenViewRayAndEarthCenter);
+        CONST vec3 p = cameraPosition - earthCenter;
+        CONST float p_dot_v = dot(p, viewDir);
+        CONST float p_dot_p = dot(p, p);
+        CONST float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
+        CONST float distanceToIntersection = -p_dot_v - sqrt(sqr(earthRadius) - squaredDistBetweenViewRayAndEarthCenter);
         // altitude==0 is a special case where distance to intersection calculation
         // is unreliable (has a lot of noise in its sign), so check it separately
         if(distanceToIntersection>0 || (altitude==0 && cosViewZenithAngle<0))
@@ -244,11 +258,11 @@ void main()
     // Aside from aesthetics, this affects brightness input to Stellarium's tone mapper.
     if(pseudoMirrorSkyBelowHorizon && viewRayIntersectsGround)
     {
-        const float horizonCZA = cosZenithAngleOfHorizon(altitude);
-        const float viewElev  = asin(clampCosine(cosViewZenithAngle));
-        const float horizElev = asin(clampCosine(horizonCZA));
-        const float newViewElev = 2*horizElev - viewElev;
-        const float viewDirXYnorm = length(viewDir-zenith*cosViewZenithAngle);
+        CONST float horizonCZA = cosZenithAngleOfHorizon(altitude);
+        CONST float viewElev  = asin(clampCosine(cosViewZenithAngle));
+        CONST float horizElev = asin(clampCosine(horizonCZA));
+        CONST float newViewElev = 2*horizElev - viewElev;
+        CONST float viewDirXYnorm = length(viewDir-zenith*cosViewZenithAngle);
         if(viewDirXYnorm == 0)
         {
             viewDir = zenith;
@@ -267,27 +281,27 @@ void main()
         viewRayIntersectsGround = false;
     }
 
-    const float cosSunZenithAngle =dot(zenith,sunDirection);
-    const float dotViewSun=dot(viewDir,sunDirection);
+    CONST float cosSunZenithAngle =dot(zenith,sunDirection);
+    CONST float dotViewSun=dot(viewDir,sunDirection);
 
-    const vec3 sunXYunnorm=sunDirection-dot(sunDirection,zenith)*zenith;
-    const vec3 viewXYunnorm=viewDir-dot(viewDir,zenith)*zenith;
-    const vec3 sunXY = sunXYunnorm.x!=0 || sunXYunnorm.y!=0 || sunXYunnorm.z!=0 ? normalize(sunXYunnorm) : vec3(0);
-    const vec3 viewXY = viewXYunnorm.x!=0 || viewXYunnorm.y!=0 || viewXYunnorm.z!=0 ? normalize(viewXYunnorm) : vec3(0);
-    const float azimuthRelativeToSun=safeAtan(dot(cross(sunXY, viewXY), zenith), dot(sunXY, viewXY));
+    CONST vec3 sunXYunnorm=sunDirection-dot(sunDirection,zenith)*zenith;
+    CONST vec3 viewXYunnorm=viewDir-dot(viewDir,zenith)*zenith;
+    CONST vec3 sunXY = sunXYunnorm.x!=0 || sunXYunnorm.y!=0 || sunXYunnorm.z!=0 ? normalize(sunXYunnorm) : vec3(0);
+    CONST vec3 viewXY = viewXYunnorm.x!=0 || viewXYunnorm.y!=0 || viewXYunnorm.z!=0 ? normalize(viewXYunnorm) : vec3(0);
+    CONST float azimuthRelativeToSun=safeAtan(dot(cross(sunXY, viewXY), zenith), dot(sunXY, viewXY));
 
-#if RENDERING_ZERO_SCATTERING
+#if 0 /*RENDERING_ZERO_SCATTERING*/
     vec4 radiance;
     if(viewRayIntersectsGround)
     {
         // XXX: keep in sync with the same code in computeScatteringDensity(), but don't forget about
         //      the difference in the usage of viewDir vs incDir.
-        const float distToGround = distanceToGround(cosViewZenithAngle, altitude);
-        const vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
-        const vec3 groundNormal = normalize(zenith*(earthRadius+altitude)+viewDir*distToGround);
-        const vec4 groundIrradiance = irradiance(dot(groundNormal, sunDirection), 0);
+        CONST float distToGround = distanceToGround(cosViewZenithAngle, altitude);
+        CONST vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
+        CONST vec3 groundNormal = normalize(zenith*(earthRadius+altitude)+viewDir*distToGround);
+        CONST vec4 groundIrradiance = irradiance(dot(groundNormal, sunDirection), 0);
         // Radiation scattered by the ground
-        const float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
+        CONST float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
         radiance = transmittanceToGround*groundAlbedo*groundIrradiance*solarIrradianceFixup*groundBRDF
                  + lightPollutionGroundLuminance*lightPollutionRelativeRadiance;
     }
@@ -304,22 +318,22 @@ void main()
     }
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_ZERO_SCATTERING
+#elif 0 /*RENDERING_ECLIPSED_ZERO_SCATTERING*/
     vec4 radiance;
-    const float dotViewMoon=dot(viewDir,normalize(moonPosition-cameraPosition));
+    CONST float dotViewMoon=dot(viewDir,normalize(moonPosition-cameraPosition));
     if(viewRayIntersectsGround)
     {
         // XXX: keep in sync with the similar code in non-eclipsed zero scattering rendering.
-        const float distToGround = distanceToGround(cosViewZenithAngle, altitude);
-        const vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
-        const vec3 pointOnGround = cameraPosition+viewDir*distToGround;
-        const vec4 directGroundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDirection, moonPosition);
+        CONST float distToGround = distanceToGround(cosViewZenithAngle, altitude);
+        CONST vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
+        CONST vec3 pointOnGround = cameraPosition+viewDir*distToGround;
+        CONST vec4 directGroundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDirection, moonPosition);
         // FIXME: add first-order indirect irradiance too: it's done in non-eclipsed irradiance (in the same
         // conditions: when limited to 2 orders). This should be calculated at the same time when second order
         // is: all the infrastructure is already there.
-        const vec4 groundIrradiance = directGroundIrradiance;
+        CONST vec4 groundIrradiance = directGroundIrradiance;
         // Radiation scattered by the ground
-        const float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
+        CONST float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
         radiance = transmittanceToGround*groundAlbedo*groundIrradiance*solarIrradianceFixup*groundBRDF
                  + lightPollutionGroundLuminance*lightPollutionRelativeRadiance;
     }
@@ -337,52 +351,52 @@ void main()
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
 #elif 1 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_ON_THE_FLY*/
-    const vec4 scattering=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPosition,
+    CONST vec4 scattering=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPosition,
                                                           viewRayIntersectsGround);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE
-    const vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE*/
+    CONST vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                      viewRayIntersectsGround, eclipsedSingleScatteringTextureSize);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact at the point where azimuth texture coordinate changes from 1 to 0 (at azimuthRelativeToSun crossing
     // 0). This happens when I simply call texture(eclipsedScatteringTexture, texCoords) without specifying LOD.
     // Apparently, the driver uses the derivative for some reason, even though it shouldn't.
-    const vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
+    CONST vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE
-    const vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
+    CONST vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                      viewRayIntersectsGround, eclipsedSingleScatteringTextureSize);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact at the point where azimuth texture coordinate changes from 1 to 0 (at azimuthRelativeToSun crossing
     // 0). This happens when I simply call texture(eclipsedScatteringTexture, texCoords) without specifying LOD.
     // Apparently, the driver uses the derivative for some reason, even though it shouldn't.
-    const vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
+    CONST vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
     luminance=scattering*currentPhaseFunction(dotViewSun);
-#elif RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_RADIANCE
+#elif 0 /*RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_RADIANCE*/
     vec4 radiance=exp(sampleEclipseDoubleScattering3DTexture(eclipsedDoubleScatteringTexture,
                                                              cosSunZenithAngle, cosViewZenithAngle, azimuthRelativeToSun,
                                                              altitude, viewRayIntersectsGround));
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_LUMINANCE
+#elif 0 /*RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
     luminance=exp(sampleEclipseDoubleScattering3DTexture(eclipsedDoubleScatteringTexture,
                                                          cosSunZenithAngle, cosViewZenithAngle, azimuthRelativeToSun,
                                                          altitude, viewRayIntersectsGround));
-#elif RENDERING_SINGLE_SCATTERING_ON_THE_FLY
-    const vec4 scattering=computeSingleScattering(cosSunZenithAngle,cosViewZenithAngle,dotViewSun,
+#elif 0 /*RENDERING_SINGLE_SCATTERING_ON_THE_FLY*/
+    CONST vec4 scattering=computeSingleScattering(cosSunZenithAngle,cosViewZenithAngle,dotViewSun,
                                                   altitude,viewRayIntersectsGround);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE
+#elif 0 /*RENDERING_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE*/
     vec4 scattering;
     if(useInterpolationGuides)
     {
@@ -399,7 +413,7 @@ void main()
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE
+#elif 0 /*RENDERING_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
     vec4 scattering;
     if(useInterpolationGuides)
     {
@@ -413,18 +427,18 @@ void main()
                                      dotViewSun, altitude, viewRayIntersectsGround);
     }
     luminance=scattering * (bool(PHASE_FUNCTION_IS_EMBEDDED) ? vec4(1) : currentPhaseFunction(dotViewSun));
-#elif RENDERING_MULTIPLE_SCATTERING_LUMINANCE
+#elif 0 /*RENDERING_MULTIPLE_SCATTERING_LUMINANCE*/
     luminance=sample3DTexture(scatteringTexture, cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, viewRayIntersectsGround);
-#elif RENDERING_MULTIPLE_SCATTERING_RADIANCE
+#elif 0 /*RENDERING_MULTIPLE_SCATTERING_RADIANCE*/
     vec4 radiance=sample3DTexture(scatteringTexture, cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, viewRayIntersectsGround);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_LIGHT_POLLUTION_RADIANCE
+#elif 0 /*RENDERING_LIGHT_POLLUTION_RADIANCE*/
     vec4 radiance=lightPollutionGroundLuminance*lightPollutionScattering(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_LIGHT_POLLUTION_LUMINANCE
+#elif 0 /*RENDERING_LIGHT_POLLUTION_LUMINANCE*/
     luminance=lightPollutionGroundLuminance*lightPollutionScattering(altitude, cosViewZenithAngle, viewRayIntersectsGround);
 #else
 #error What to render?

--- a/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/1/molecules/single-scattering-eclipsed.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/1/molecules/single-scattering-eclipsed.frag
@@ -1,7 +1,21 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
 
-#line 1 1 // const.h.glsl
+
+
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 6 0 // single-scattering-eclipsed.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,15 +48,15 @@ const vec4 lightPollutionRelativeRadiance=vec4(2.15e-06,1.11400004e-06,3.8580001
 const vec4 wavelengths=vec4(485.333344,516.666687,548,579.333313);
 const int wlSetIndex=1;
 #endif
-#line 5 0 // single-scattering-eclipsed.frag
-#line 1 2 // densities.h.glsl
+#line 7 0 // single-scattering-eclipsed.frag
+#line 1 3 // densities.h.glsl
 float scattererNumberDensity_molecules(float altitude);
 float scattererNumberDensity_aerosols(float altitude);
 float absorberNumberDensity_ozone(float altitude);
 vec4 scatteringCrossSection();
 float scattererDensity(float altitude);
-#line 6 0 // single-scattering-eclipsed.frag
-#line 1 3 // common-functions.h.glsl
+#line 8 0 // single-scattering-eclipsed.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -74,8 +88,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // single-scattering-eclipsed.frag
-#line 1 4 // texture-sampling-functions.h.glsl
+#line 9 0 // single-scattering-eclipsed.frag
+#line 1 5 // texture-sampling-functions.h.glsl
 #ifndef INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 #define INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float altitude);
@@ -87,7 +101,7 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                 const int scatteringOrder);
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 #endif
-#line 8 0 // single-scattering-eclipsed.frag
+#line 10 0 // single-scattering-eclipsed.frag
 
 
 float cosZenithAngle(vec3 origin, vec3 direction)
@@ -101,13 +115,13 @@ vec4 computeSingleScatteringIntegrandEclipsed(const float cosSunZenithAngle, con
                                               const float dist, const bool viewRayIntersectsGround,
                                               const vec3 scatterer, const vec3 sunDir, const vec3 moonPos)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle here the case when the
     // endpoint of the view ray intentionally appears in outer space.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosSunZenithAngleAtDist=clampCosine((r*cosSunZenithAngle+dist*dotViewSun)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosSunZenithAngleAtDist=clampCosine((r*cosSunZenithAngle+dist*dotViewSun)/(earthRadius+altAtDist));
 
-    const vec4 xmittance=transmittance(cosViewZenithAngle, altitude, dist, viewRayIntersectsGround)
+    CONST vec4 xmittance=transmittance(cosViewZenithAngle, altitude, dist, viewRayIntersectsGround)
                                                     *
                          transmittanceToAtmosphereBorder(cosSunZenithAngleAtDist, altAtDist)
                                                     *
@@ -115,7 +129,7 @@ vec4 computeSingleScatteringIntegrandEclipsed(const float cosSunZenithAngle, con
                                                     *
                             // FIXME: this ignores orientation of the crescent of eclipsed Sun WRT horizon
                                     sunVisibility(cosSunZenithAngleAtDist, altAtDist);
-#if ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION
+#if 0 /*ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION*/
     COMPUTE_TOTAL_SCATTERING_COEFFICIENT;
     return xmittance * totalScatteringCoefficient;
 #else
@@ -126,26 +140,26 @@ vec4 computeSingleScatteringIntegrandEclipsed(const float cosSunZenithAngle, con
 vec4 computeSingleScatteringEclipsed(const vec3 camera, const vec3 viewDir, const vec3 sunDir, const vec3 moonPos,
                                      const bool viewRayIntersectsGround)
 {
-    const float cosViewZenithAngle=cosZenithAngle(camera,viewDir);
-    const float cosSunZenithAngle=cosZenithAngle(camera,sunDir);
-    const float altitude=pointAltitude(camera);
-    const float dotViewSun=dot(viewDir,sunDir);
-    const float integrInterval=distanceToNearestAtmosphereBoundary(cosViewZenithAngle, altitude,
+    CONST float cosViewZenithAngle=cosZenithAngle(camera,viewDir);
+    CONST float cosSunZenithAngle=cosZenithAngle(camera,sunDir);
+    CONST float altitude=pointAltitude(camera);
+    CONST float dotViewSun=dot(viewDir,sunDir);
+    CONST float integrInterval=distanceToNearestAtmosphereBoundary(cosViewZenithAngle, altitude,
                                                                    viewRayIntersectsGround);
 
     // Using the midpoint rule for quadrature
     vec4 spectrum=vec4(0);
-    const float dl=integrInterval/radialIntegrationPoints;
+    CONST float dl=integrInterval/radialIntegrationPoints;
     for(int n=0; n<radialIntegrationPoints; ++n)
     {
-        const float dist=(n+0.5)*dl;
+        CONST float dist=(n+0.5)*dl;
         spectrum += computeSingleScatteringIntegrandEclipsed(cosSunZenithAngle, cosViewZenithAngle, dotViewSun,
                                                              altitude, dist, viewRayIntersectsGround,
                                                              camera+viewDir*dist, sunDir, moonPos);
     }
 
     spectrum *= dl*solarIrradianceAtTOA
-#if ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION
+#if 0 /*ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION*/
                                 // the multiplier is already included
 #else
                                         * scatteringCrossSection()

--- a/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/1/molecules/texture-coordinates.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/1/molecules/texture-coordinates.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-coordinates.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,8 +45,8 @@ const vec4 lightPollutionRelativeRadiance=vec4(2.15e-06,1.11400004e-06,3.8580001
 const vec4 wavelengths=vec4(485.333344,516.666687,548,579.333313);
 const int wlSetIndex=1;
 #endif
-#line 5 0 // texture-coordinates.frag
-#line 1 2 // texture-coordinates.h.glsl
+#line 4 0 // texture-coordinates.frag
+#line 1 3 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -104,8 +115,8 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 6 0 // texture-coordinates.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-coordinates.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -137,7 +148,7 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-coordinates.frag
+#line 6 0 // texture-coordinates.frag
 
 const float LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA=sqrt(atmosphereHeight*(atmosphereHeight+2*earthRadius));
 
@@ -205,18 +216,18 @@ vec3 indicesToTexCoords(const vec3 indices, const vec3 texSizes)
 
 TransmittanceTexVars transmittanceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
+    CONST float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
                                 texCoordToUnitRange(texCoord.t,transmittanceTextureSize.t);
     // Distance from Earth center to camera
-    const float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
-    const float altitude=r-earthRadius;
+    CONST float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
+    CONST float altitude=r-earthRadius;
 
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
     // distance to border of visible atmosphere from the view point
-    const float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
+    CONST float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
     // d==0 can happen when altitude==atmosphereHeight
-    const float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
+    CONST float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
     return TransmittanceTexVars(cosVZA,altitude);
 }
 
@@ -235,53 +246,53 @@ vec2 transmittanceTexVarsToTexCoord(const float cosVZA, float altitude)
     if(altitude<0)
         altitude=0;
 
-    const float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
+    CONST float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
                                       transmittanceTextureSize.t);
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
-    const float d=distanceToAtmosphereBorder(cosVZA,altitude);
-    const float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float d=distanceToAtmosphereBorder(cosVZA,altitude);
+    CONST float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
     return vec2(s,t);
 }
 
 // Output: vec2(cos(sunZenithAngle), altitude)
 IrradianceTexVars irradianceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
-    const float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
+    CONST float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
+    CONST float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
     return IrradianceTexVars(cosSZA,alt);
 }
 
 vec2 irradianceTexVarsToTexCoord(const float cosSunZenithAngle, const float altitude)
 {
-    const float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
-    const float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
+    CONST float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
+    CONST float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
     return vec2(s,t);
 }
 
 float cosSZAToUnitRangeTexCoord(const float cosSunZenithAngle)
 {
     // Distance to top atmosphere border along the ray groundUnderCamera-sun: (altitude, cosSunZenithAngle)
-    const float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name
-    const float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
+    CONST float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
     // TODO: choose a more descriptive name
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     return max(0.,1-a/A)/(a+1);
 }
 
 float unitRangeTexCoordToCosSZA(const float texCoord)
 {
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float a=(A-A*texCoord)/(1+A*texCoord);
-    const float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
+    CONST float a=(A-A*texCoord)/(1+A*texCoord);
+    CONST float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
     return distFromGroundToTopAtmoBorder==0 ? 1 :
         clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distFromGroundToTopAtmoBorder)) /
                     (2*earthRadius*distFromGroundToTopAtmoBorder));
@@ -292,24 +303,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
                                                const float dotViewSun, const float altitude,
                                                const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -317,24 +328,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float dotVSCoord=(dotViewSun+1)/2;
+    CONST float dotVSCoord=(dotViewSun+1)/2;
 
     // ------------------------------------
-    const float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
+    CONST float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
 
     return Scattering4DCoords(cosSZACoord, cosVZACoord, dotVSCoord, altCoord, viewRayIntersectsGround);
 }
 
 TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
@@ -342,16 +353,16 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture coordinates we combine into a single sampler3D coordinate.
-    const float texW = scatteringTextureSize[1];
-    const float texH = scatteringTextureSize[2];
-    const float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
-    const vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
+    CONST float texW = scatteringTextureSize[1];
+    CONST float texH = scatteringTextureSize[2];
+    CONST float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
+    CONST vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
                                         ceil (cosSZAIndex)*texW+coords.dotViewSun*(texW-1)) / (texW*texH-1);
-    const vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
+    CONST vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
 
-    const float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
+    CONST float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
 
-    const float alphaUpper=fract(cosSZAIndex);
+    CONST float alphaUpper=fract(cosSZAIndex);
     return TexCoordPair(vec3(cosVZAtc, combinedCoord.x, altitude), float(1-alphaUpper),
                         vec3(cosVZAtc, combinedCoord.y, altitude), float(alphaUpper));
 }
@@ -359,9 +370,9 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
+    CONST TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
     return texture(tex, texCoords.lower) * texCoords.alphaLower +
            texture(tex, texCoords.upper) * texCoords.alphaUpper;
 }
@@ -369,17 +380,17 @@ vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const f
 // 3D texture is the 3D single-altitude slice of a 4D texture
 vec3 scattering4DCoordsToTex3DCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2);
 
-    const float dvsSize = scatteringTextureSize[1];
-    const float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
+    CONST float dvsSize = scatteringTextureSize[1];
+    CONST float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
 
-    const float cszaSize = scatteringTextureSize[2];
-    const float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
+    CONST float cszaSize = scatteringTextureSize[2];
+    CONST float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
 
     return vec3(cosVZAtc, dotVStc, cosSZAtc);
 }
@@ -394,39 +405,39 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along dotViewSun coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[1];
-    const float posOfRow = indices[1];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[1];
+    CONST float posOfRow = indices[1];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         indexToTexCoord(currRow, numRows-1),
                                                         texCoordVerbatim));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               indexToTexCoord(currRow, numRows-1),
                                                               texCoordVerbatim));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          indexToTexCoord(currRow, numRows-1),
                                          texCoordVerbatim));
@@ -434,14 +445,14 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
 vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolationGuides01Tex,
                                  const vec3 indices)
 {
-    const float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
+    CONST float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
 
-    const float cosVZAIndex = indices[0];
-    const float dotVSIndex = indices[1];
-    const float currRow = floor(dotVSIndex);
-    const float posBetweenRows = dotVSIndex - currRow;
-    const float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cosVZAIndex = indices[0];
+    CONST float dotVSIndex = indices[1];
+    CONST float currRow = floor(dotVSIndex);
+    CONST float posBetweenRows = dotVSIndex - currRow;
+    CONST float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -449,14 +460,14 @@ vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolat
     indicesCurrRow[1] =     currRow;
     indicesNextRow[1] = min(currRow+1, scatteringTextureSize[1]-1.);
 
-    const vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
-    const vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
+    CONST vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
+    CONST vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
 
-    const vec4 valueCurrRow = texture(tex, coordsCurrRow);
-    const vec4 valueNextRow = texture(tex, coordsNextRow);
-    const float epsilon = 1e-37; // Prevents passing zero to log
-    const vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
-    const vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
+    CONST vec4 valueCurrRow = texture(tex, coordsCurrRow);
+    CONST vec4 valueNextRow = texture(tex, coordsNextRow);
+    CONST float epsilon = 1e-37; // Prevents passing zero to log
+    CONST vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
+    CONST vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
     return (logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow;
 }
 
@@ -465,37 +476,37 @@ float findGuide02Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along SZA coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[2];
-    const float posOfRow = indices[2];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[2];
+    CONST float posOfRow = indices[2];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
 }
@@ -505,19 +516,19 @@ vec4 sample3DTextureGuided(const sampler3D tex,
                            const float cosSunZenithAngle, const float cosViewZenithAngle,
                            const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
                                                                     dotViewSun, altitude, viewRayIntersectsGround);
     // Handle the external interpolation guides: the guides between a pair of VZA-dotViewSun 2D "pictures".
-    const vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
-    const vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
-    const float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
+    CONST vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
+    CONST float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
 
-    const float cvzaIndex = indices[0];
-    const float cszaIndex = indices[2];
-    const float currRow = floor(cszaIndex);
-    const float posBetweenRows = cszaIndex - currRow;
-    const float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cvzaIndex = indices[0];
+    CONST float cszaIndex = indices[2];
+    CONST float currRow = floor(cszaIndex);
+    CONST float posBetweenRows = cszaIndex - currRow;
+    CONST float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -526,58 +537,58 @@ vec4 sample3DTextureGuided(const sampler3D tex,
     indicesNextRow[2] = min(currRow+1, scatteringTextureSize[2]-1);
 
     // The caller will handle the internal interpolation guides: the ones between rows in each 2D "picture".
-    const vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
-    const vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
+    CONST vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
+    CONST vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
     return exp((logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow);
 }
 
 vec4 sample3DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
     return texture(tex, texCoords);
 }
 
 ScatteringTexVars scatteringTex4DCoordsToTexVars(const Scattering4DCoords coords)
 {
-    const float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
     // ------------------------------------
     float cosViewZenithAngle;
     if(coords.viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
     // ------------------------------------
-    const float dotViewSun=coords.dotViewSun*2-1;
+    CONST float dotViewSun=coords.dotViewSun*2-1;
 
     // ------------------------------------
-    const float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
+    CONST float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
 
     return ScatteringTexVars(cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, coords.viewRayIntersectsGround);
 }
 
 Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 {
-    const vec4 indexMax=scatteringTextureSize-vec4(1);
+    CONST vec4 indexMax=scatteringTextureSize-vec4(1);
     Scattering4DCoords coords4d;
     coords4d.viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
     // The following formulas assume that scatteringTextureSize[0] is even. For odd sizes they would change.
@@ -593,8 +604,8 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture indices we combine into a single sampler3D coordinate.
-    const float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
-    const float combinedIndex=texIndices[1];
+    CONST float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
+    CONST float combinedIndex=texIndices[1];
     coords4d.dotViewSun=mod(combinedIndex,texW)/(texW-1);
     coords4d.cosSunZenithAngle=floor(combinedIndex/texW)/(texH-1);
 
@@ -608,11 +619,11 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
 ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 {
-    const Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
+    CONST Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
     ScatteringTexVars vars=scatteringTex4DCoordsToTexVars(coords4d);
     // Clamp dotViewSun to its valid range of values, given cosViewZenithAngle and cosSunZenithAngle. This is
     // needed to prevent NaNs when computing the scattering texture.
-    const float cosVZA=vars.cosViewZenithAngle,
+    CONST float cosVZA=vars.cosViewZenithAngle,
                 cosSZA=vars.cosSunZenithAngle;
     vars.dotViewSun=clamp(vars.dotViewSun,
                           cosVZA*cosSZA-safeSqrt((1-sqr(cosVZA))*(1-sqr(cosSZA))),
@@ -622,54 +633,54 @@ ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 
 EclipseScatteringTexVars eclipseTexCoordsToTexVars(const vec2 texCoords, const float altitude)
 {
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
-    const bool viewRayIntersectsGround = texCoords.t<0.5;
+    CONST bool viewRayIntersectsGround = texCoords.t<0.5;
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
-    const float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
+    CONST float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
     return EclipseScatteringTexVars(azimuthRelativeToSun, cosViewZenithAngle, viewRayIntersectsGround);
 }
 
 EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                                    const float altitude, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -677,13 +688,13 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
-    const float azimuthCoord = azimuthRelativeToSun/(2*PI);
+    CONST float azimuthCoord = azimuthRelativeToSun/(2*PI);
 
     return EclipseScattering2DCoords(azimuthCoord, cosVZACoord);
 }
@@ -691,14 +702,14 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
 vec2 eclipseTexVarsToTexCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                const float altitude, const bool viewRayIntersectsGround, const vec2 texSize)
 {
-    const EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+    CONST EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                                     viewRayIntersectsGround);
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2);
-    const float azimuthTC = coords.azimuth + 1/(2*texSize.s);
+    CONST float azimuthTC = coords.azimuth + 1/(2*texSize.s);
 
     return vec2(azimuthTC, cosVZAtc);
 }
@@ -707,42 +718,42 @@ vec4 sampleEclipseDoubleScattering3DTexture(const sampler3D tex, const float cos
                                             const float cosViewZenithAngle, const float azimuthRelativeToSun,
                                             const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
+    CONST vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
                                                   eclipsedDoubleScatteringTextureSize.st);
-    const float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
-    const vec3 texCoords=vec3(coords2d, cosSZACoord);
+    CONST float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
+    CONST vec3 texCoords=vec3(coords2d, cosSZACoord);
 
     return texture(tex, texCoords);
 }
 
 LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 texIndices)
 {
-    const vec2 indexMax=lightPollutionTextureSize-vec2(1);
+    CONST vec2 indexMax=lightPollutionTextureSize-vec2(1);
 
-    const float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
-    const float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
+    CONST float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
-    const bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
-    const float cosViewZenithAngleCoord = viewRayIntersectsGround ?
+    CONST bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
+    CONST float cosViewZenithAngleCoord = viewRayIntersectsGround ?
                                    1-2*texIndices[0]/(indexMax[0]-1) :
                                    2*(texIndices[0]-1)/(indexMax[0]-1)-1;
     // ------------------------------------
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
@@ -753,23 +764,23 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 
 LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -777,27 +788,27 @@ LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, con
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     return LightPollution2DCoords(cosVZACoord, altCoord);
 }
 
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
-    const vec2 texSize = lightPollutionTextureSize;
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 texSize = lightPollutionTextureSize;
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2);
-    const float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
+    CONST float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
     return vec2(cosVZAtc, altitudeTC);
 }

--- a/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/1/molecules/texture-sampling-functions.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/1/molecules/texture-sampling-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-sampling-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,13 +45,13 @@ const vec4 lightPollutionRelativeRadiance=vec4(2.15e-06,1.11400004e-06,3.8580001
 const vec4 wavelengths=vec4(485.333344,516.666687,548,579.333313);
 const int wlSetIndex=1;
 #endif
-#line 5 0 // texture-sampling-functions.frag
-#line 1 2 // phase-functions.h.glsl
+#line 4 0 // texture-sampling-functions.frag
+#line 1 3 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 6 0 // texture-sampling-functions.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-sampling-functions.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -72,8 +83,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-sampling-functions.frag
-#line 1 4 // texture-coordinates.h.glsl
+#line 6 0 // texture-sampling-functions.frag
+#line 1 5 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -142,7 +153,7 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 8 0 // texture-sampling-functions.frag
+#line 7 0 // texture-sampling-functions.frag
 
 uniform sampler2D transmittanceTexture;
 uniform sampler2D irradianceTexture;
@@ -154,13 +165,13 @@ uniform sampler2D lightPollutionScatteringTexture;
 
 vec4 irradiance(const float cosSunZenithAngle, const float altitude)
 {
-    const vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
+    CONST vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
     return texture(irradianceTexture, texCoords);
 }
 
 vec4 opticalDepthToAtmosphereBorder(const float cosViewZenithAngle, const float altitude)
 {
-    const vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
+    CONST vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact when looking into nadir from TOA at some values of texture sizes (in particular, size of
     // transmittance texture for altitude being 4096). This happens when I simply call texture(eclipsedScatteringTexture,
@@ -178,11 +189,11 @@ vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float
 vec4 transmittance(const float cosViewZenithAngle, const float altitude, const float dist,
                    const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle view ray endpoint
     // in space here.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
 
     vec4 depth;
     if(viewRayIntersectsGround)
@@ -201,7 +212,7 @@ vec4 transmittance(const float cosViewZenithAngle, const float altitude, const f
 vec4 calcFirstScattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                          const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
+    CONST vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
                                           dotViewSun, altitude, viewRayIntersectsGround);
     return scattering*currentPhaseFunction(dotViewSun);
 }
@@ -220,6 +231,6 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
 
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     return texture(lightPollutionScatteringTexture, coords);
 }

--- a/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/2/aerosols/common-functions.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/2/aerosols/common-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // common-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.35000004e-05,1.33100002e-05,9.4
 const vec4 wavelengths=vec4(610.666687,642,673.333313,704.666687);
 const int wlSetIndex=2;
 #endif
-#line 5 0 // common-functions.frag
+#line 4 0 // common-functions.frag
 
 bool dbgDataPresent=false;
 bool debugDataPresent()
@@ -69,7 +80,7 @@ void setDebugData(float a,float b, float c, float d)
 
 void swap(inout float x, inout float y)
 {
-    const float t = x;
+    CONST float t = x;
     x = y;
     y = t;
 }
@@ -83,7 +94,7 @@ float safeSqrt(const float x)
 
 float safeAtan(const float y, const float x)
 {
-    const float a = atan(y,x);
+    CONST float a = atan(y,x);
     return x==0 && y==0 ? 0 : a;
 }
 
@@ -116,23 +127,23 @@ float pointAltitude(vec3 point)
 
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float Ratm=earthRadius+atmosphereHeight;
-    const float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float Ratm=earthRadius+atmosphereHeight;
+    CONST float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float distanceToGround(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(-safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float cosZenithAngleOfHorizon(const float altitude)
 {
-    const float R=earthRadius;
-    const float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
+    CONST float R=earthRadius;
+    CONST float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
     return -sqrt(2*h*R+sqr(h))/(R+h);
 }
 
@@ -151,8 +162,8 @@ float distanceToNearestAtmosphereBoundary(const float cosZenithAngle, const floa
 float sunVisibility(const float cosSunZenithAngle, float altitude)
 {
     if(altitude<0) altitude=0;
-    const float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
-    const float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
+    CONST float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
+    CONST float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
     /* Approximating visible fraction of solar disk by smoothstep between the position of the Sun
      * touching the horizon by its upper part and the position with lower part touching the horizon.
      * The calculation assumes that solar angular radius is small and thus approximately equals its sine.
@@ -182,13 +193,13 @@ float circlesIntersectionArea(float R1, float R2, float d)
 
 float angleBetween(const vec3 a, const vec3 b)
 {
-    const float d=dot(a,b);
-    const float c=length(cross(a,b));
+    CONST float d=dot(a,b);
+    CONST float c=length(cross(a,b));
     // To avoid loss of precision, don't use dot product near the singularity
     // of acos, and cross product near the singularity of asin
     if(abs(d) < abs(c))
         return acos(d/(length(a)*length(b)));
-    const float smallerAngle = asin(c/(length(a)*length(b)));
+    CONST float smallerAngle = asin(c/(length(a)*length(b)));
     if(d<0) return PI-smallerAngle;
     return smallerAngle;
 }
@@ -205,11 +216,11 @@ float moonAngularRadius(const vec3 cameraPosition, const vec3 moonPosition)
 
 float visibleSolidAngleOfSun(const vec3 camera, const vec3 sunDir, const vec3 moonPos)
 {
-    const float Rs=sunAngularRadius;
-    const float Rm=moonAngularRadius(camera,moonPos);
+    CONST float Rs=sunAngularRadius;
+    CONST float Rm=moonAngularRadius(camera,moonPos);
     float visibleSolidAngle=PI*sqr(Rs);
 
-    const float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
+    CONST float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
     if(dSM<Rs+Rm)
     {
         visibleSolidAngle -= circlesIntersectionArea(Rm,Rs,dSM);
@@ -229,12 +240,12 @@ float sphereIntegrationSolidAngleDifferential(const int pointCountOnSphere)
 }
 vec3 sphereIntegrationSampleDir(const int index, const int pointCountOnSphere)
 {
-    const float goldenRatio=1.6180339887499;
+    CONST float goldenRatio=1.6180339887499;
     // The range of n is 0.5, 1.5, ..., pointCountOnSphere-0.5
-    const float n=index+0.5;
+    CONST float n=index+0.5;
     // Explanation of the Fibonacci grid generation can be seen at https://stackoverflow.com/a/44164075/673852
-    const float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
-    const float azimuth=n*(2*PI*goldenRatio);
+    CONST float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
+    CONST float azimuth=n*(2*PI*goldenRatio);
     return vec3(cos(azimuth)*sin(zenithAngle),
                 sin(azimuth)*sin(zenithAngle),
                 cos(zenithAngle));

--- a/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/2/aerosols/densities.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/2/aerosols/densities.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // densities.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,20 +45,20 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.35000004e-05,1.33100002e-05,9.4
 const vec4 wavelengths=vec4(610.666687,642,673.333313,704.666687);
 const int wlSetIndex=2;
 #endif
-#line 5 0 // densities.frag
+#line 4 0 // densities.frag
 float scattererNumberDensity_molecules(float altitude)
 {
-        const float rayleighScaleHeight=8*km;
+        CONST float rayleighScaleHeight=8*km;
         return 3.08458e25*exp(-1/rayleighScaleHeight * altitude);
 }
 float scattererNumberDensity_aerosols(float altitude)
 {
-        const float mieScaleHeight=1.2*km;
+        CONST float mieScaleHeight=1.2*km;
         return 1.03333e8*exp(-1/mieScaleHeight*altitude);
 }
 float absorberNumberDensity_ozone(float altitude)
 {
-        const float totalOzoneAmount=370*dobsonUnit;
+        CONST float totalOzoneAmount=370*dobsonUnit;
 
         float density;
 

--- a/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/2/aerosols/phase-functions.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/2/aerosols/phase-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // phase-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.35000004e-05,1.33100002e-05,9.4
 const vec4 wavelengths=vec4(610.666687,642,673.333313,704.666687);
 const int wlSetIndex=2;
 #endif
-#line 5 0 // phase-functions.frag
+#line 4 0 // phase-functions.frag
 
 vec4 phaseFunction_molecules(float dotViewSun)
 {
@@ -42,9 +53,9 @@ vec4 phaseFunction_molecules(float dotViewSun)
 }
 vec4 phaseFunction_aerosols(float dotViewSun)
 {
-        const float g=0.76;
-        const float g2=g*g;
-        const float k = 3/(8*PI)*(1-g2)/(2+g2);
+        CONST float g=0.76;
+        CONST float g2=g*g;
+        CONST float k = 3/(8*PI)*(1-g2)/(2+g2);
         return vec4(k * (1+sqr(dotViewSun)) / pow(1+g2 - 2*g*dotViewSun, 1.5) + 1/((1-dotViewSun)*600+0.05))*0.904;
 }
 vec4 currentPhaseFunction(float dotViewSun) { return phaseFunction_aerosols(dotViewSun); }

--- a/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/2/aerosols/render.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/2/aerosols/render.frag
@@ -1,7 +1,21 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
 
-#line 1 1 // const.h.glsl
+
+
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 6 0 // render.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,11 +48,11 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.35000004e-05,1.33100002e-05,9.4
 const vec4 wavelengths=vec4(610.666687,642,673.333313,704.666687);
 const int wlSetIndex=2;
 #endif
-#line 5 0 // render.frag
-#line 1 2 // calc-view-dir.h.glsl
+#line 7 0 // render.frag
+#line 1 3 // calc-view-dir.h.glsl
 vec3 calcViewDir();
-#line 6 0 // render.frag
-#line 1 3 // common-functions.h.glsl
+#line 8 0 // render.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -70,14 +84,14 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // render.frag
-#line 1 4 // phase-functions.h.glsl
+#line 9 0 // render.frag
+#line 1 5 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 8 0 // render.frag
+#line 10 0 // render.frag
 
-#line 1 5 // single-scattering-eclipsed.h.glsl
+#line 1 6 // single-scattering-eclipsed.h.glsl
 #ifndef INCLUDE_ONCE_050024D2_BD56_434E_8D40_2055DA0B78EC
 #define INCLUDE_ONCE_050024D2_BD56_434E_8D40_2055DA0B78EC
 
@@ -85,8 +99,8 @@ vec4 computeSingleScatteringEclipsed(const vec3 camera, const vec3 viewDir, cons
                                      const bool viewRayIntersectsGround);
 
 #endif
-#line 10 0 // render.frag
-#line 1 6 // texture-coordinates.h.glsl
+#line 12 0 // render.frag
+#line 1 7 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -155,10 +169,10 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 11 0 // render.frag
-#line 1 7 // radiance-to-luminance.h.glsl
+#line 13 0 // render.frag
+#line 1 8 // radiance-to-luminance.h.glsl
 const mat4 radianceToLuminance=mat4(21296.1113,10585.7773,6.80903196,807.40564,  8819.19727,3416.5498,0.346691847,67.973465,  1511.18506,551.902527,0,6.17586422,  177.630722,64.1456985,0,0.693584085);
-#line 12 0 // render.frag
+#line 14 0 // render.frag
 
 
 
@@ -195,18 +209,18 @@ void main()
     // this approximation has the same order of magnitude as the assumption that the Earth and its atmosphere
     // are spherical.
     float altitude = max(cameraPosition.z, 0.);
-    const vec3 oldCamPos=cameraPosition;
+    CONST vec3 oldCamPos=cameraPosition;
     // Hide the uniform with this name, thus effectively modifying it for the following code
     vec3 cameraPosition=vec3(oldCamPos.xy, altitude);
 
     bool lookingIntoAtmosphere=true;
     if(altitude>atmosphereHeight)
     {
-        const vec3 p = cameraPosition - earthCenter;
-        const float p_dot_v = dot(p, viewDir);
-        const float p_dot_p = dot(p, p);
-        const float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
-        const float distanceToTOA = -p_dot_v - sqrt(sqr(earthRadius+atmosphereHeight) - squaredDistBetweenViewRayAndEarthCenter);
+        CONST vec3 p = cameraPosition - earthCenter;
+        CONST float p_dot_v = dot(p, viewDir);
+        CONST float p_dot_p = dot(p, p);
+        CONST float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
+        CONST float distanceToTOA = -p_dot_v - sqrt(sqr(earthRadius+atmosphereHeight) - squaredDistBetweenViewRayAndEarthCenter);
         if(distanceToTOA>=0)
         {
             cameraPosition += viewDir*distanceToTOA;
@@ -214,7 +228,7 @@ void main()
         }
         else
         {
-#if RENDERING_ANY_ZERO_SCATTERING
+#if 0 /*RENDERING_ANY_ZERO_SCATTERING*/
             lookingIntoAtmosphere=false;
 #else
             luminance=vec4(0);
@@ -224,16 +238,16 @@ void main()
         }
     }
 
-    const vec3 zenith=normalize(cameraPosition-earthCenter);
+    CONST vec3 zenith=normalize(cameraPosition-earthCenter);
     float cosViewZenithAngle=dot(zenith,viewDir);
 
     bool viewRayIntersectsGround=false;
     {
-        const vec3 p = cameraPosition - earthCenter;
-        const float p_dot_v = dot(p, viewDir);
-        const float p_dot_p = dot(p, p);
-        const float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
-        const float distanceToIntersection = -p_dot_v - sqrt(sqr(earthRadius) - squaredDistBetweenViewRayAndEarthCenter);
+        CONST vec3 p = cameraPosition - earthCenter;
+        CONST float p_dot_v = dot(p, viewDir);
+        CONST float p_dot_p = dot(p, p);
+        CONST float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
+        CONST float distanceToIntersection = -p_dot_v - sqrt(sqr(earthRadius) - squaredDistBetweenViewRayAndEarthCenter);
         // altitude==0 is a special case where distance to intersection calculation
         // is unreliable (has a lot of noise in its sign), so check it separately
         if(distanceToIntersection>0 || (altitude==0 && cosViewZenithAngle<0))
@@ -244,11 +258,11 @@ void main()
     // Aside from aesthetics, this affects brightness input to Stellarium's tone mapper.
     if(pseudoMirrorSkyBelowHorizon && viewRayIntersectsGround)
     {
-        const float horizonCZA = cosZenithAngleOfHorizon(altitude);
-        const float viewElev  = asin(clampCosine(cosViewZenithAngle));
-        const float horizElev = asin(clampCosine(horizonCZA));
-        const float newViewElev = 2*horizElev - viewElev;
-        const float viewDirXYnorm = length(viewDir-zenith*cosViewZenithAngle);
+        CONST float horizonCZA = cosZenithAngleOfHorizon(altitude);
+        CONST float viewElev  = asin(clampCosine(cosViewZenithAngle));
+        CONST float horizElev = asin(clampCosine(horizonCZA));
+        CONST float newViewElev = 2*horizElev - viewElev;
+        CONST float viewDirXYnorm = length(viewDir-zenith*cosViewZenithAngle);
         if(viewDirXYnorm == 0)
         {
             viewDir = zenith;
@@ -267,27 +281,27 @@ void main()
         viewRayIntersectsGround = false;
     }
 
-    const float cosSunZenithAngle =dot(zenith,sunDirection);
-    const float dotViewSun=dot(viewDir,sunDirection);
+    CONST float cosSunZenithAngle =dot(zenith,sunDirection);
+    CONST float dotViewSun=dot(viewDir,sunDirection);
 
-    const vec3 sunXYunnorm=sunDirection-dot(sunDirection,zenith)*zenith;
-    const vec3 viewXYunnorm=viewDir-dot(viewDir,zenith)*zenith;
-    const vec3 sunXY = sunXYunnorm.x!=0 || sunXYunnorm.y!=0 || sunXYunnorm.z!=0 ? normalize(sunXYunnorm) : vec3(0);
-    const vec3 viewXY = viewXYunnorm.x!=0 || viewXYunnorm.y!=0 || viewXYunnorm.z!=0 ? normalize(viewXYunnorm) : vec3(0);
-    const float azimuthRelativeToSun=safeAtan(dot(cross(sunXY, viewXY), zenith), dot(sunXY, viewXY));
+    CONST vec3 sunXYunnorm=sunDirection-dot(sunDirection,zenith)*zenith;
+    CONST vec3 viewXYunnorm=viewDir-dot(viewDir,zenith)*zenith;
+    CONST vec3 sunXY = sunXYunnorm.x!=0 || sunXYunnorm.y!=0 || sunXYunnorm.z!=0 ? normalize(sunXYunnorm) : vec3(0);
+    CONST vec3 viewXY = viewXYunnorm.x!=0 || viewXYunnorm.y!=0 || viewXYunnorm.z!=0 ? normalize(viewXYunnorm) : vec3(0);
+    CONST float azimuthRelativeToSun=safeAtan(dot(cross(sunXY, viewXY), zenith), dot(sunXY, viewXY));
 
-#if RENDERING_ZERO_SCATTERING
+#if 0 /*RENDERING_ZERO_SCATTERING*/
     vec4 radiance;
     if(viewRayIntersectsGround)
     {
         // XXX: keep in sync with the same code in computeScatteringDensity(), but don't forget about
         //      the difference in the usage of viewDir vs incDir.
-        const float distToGround = distanceToGround(cosViewZenithAngle, altitude);
-        const vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
-        const vec3 groundNormal = normalize(zenith*(earthRadius+altitude)+viewDir*distToGround);
-        const vec4 groundIrradiance = irradiance(dot(groundNormal, sunDirection), 0);
+        CONST float distToGround = distanceToGround(cosViewZenithAngle, altitude);
+        CONST vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
+        CONST vec3 groundNormal = normalize(zenith*(earthRadius+altitude)+viewDir*distToGround);
+        CONST vec4 groundIrradiance = irradiance(dot(groundNormal, sunDirection), 0);
         // Radiation scattered by the ground
-        const float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
+        CONST float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
         radiance = transmittanceToGround*groundAlbedo*groundIrradiance*solarIrradianceFixup*groundBRDF
                  + lightPollutionGroundLuminance*lightPollutionRelativeRadiance;
     }
@@ -304,22 +318,22 @@ void main()
     }
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_ZERO_SCATTERING
+#elif 0 /*RENDERING_ECLIPSED_ZERO_SCATTERING*/
     vec4 radiance;
-    const float dotViewMoon=dot(viewDir,normalize(moonPosition-cameraPosition));
+    CONST float dotViewMoon=dot(viewDir,normalize(moonPosition-cameraPosition));
     if(viewRayIntersectsGround)
     {
         // XXX: keep in sync with the similar code in non-eclipsed zero scattering rendering.
-        const float distToGround = distanceToGround(cosViewZenithAngle, altitude);
-        const vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
-        const vec3 pointOnGround = cameraPosition+viewDir*distToGround;
-        const vec4 directGroundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDirection, moonPosition);
+        CONST float distToGround = distanceToGround(cosViewZenithAngle, altitude);
+        CONST vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
+        CONST vec3 pointOnGround = cameraPosition+viewDir*distToGround;
+        CONST vec4 directGroundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDirection, moonPosition);
         // FIXME: add first-order indirect irradiance too: it's done in non-eclipsed irradiance (in the same
         // conditions: when limited to 2 orders). This should be calculated at the same time when second order
         // is: all the infrastructure is already there.
-        const vec4 groundIrradiance = directGroundIrradiance;
+        CONST vec4 groundIrradiance = directGroundIrradiance;
         // Radiation scattered by the ground
-        const float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
+        CONST float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
         radiance = transmittanceToGround*groundAlbedo*groundIrradiance*solarIrradianceFixup*groundBRDF
                  + lightPollutionGroundLuminance*lightPollutionRelativeRadiance;
     }
@@ -337,52 +351,52 @@ void main()
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
 #elif 1 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_ON_THE_FLY*/
-    const vec4 scattering=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPosition,
+    CONST vec4 scattering=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPosition,
                                                           viewRayIntersectsGround);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE
-    const vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE*/
+    CONST vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                      viewRayIntersectsGround, eclipsedSingleScatteringTextureSize);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact at the point where azimuth texture coordinate changes from 1 to 0 (at azimuthRelativeToSun crossing
     // 0). This happens when I simply call texture(eclipsedScatteringTexture, texCoords) without specifying LOD.
     // Apparently, the driver uses the derivative for some reason, even though it shouldn't.
-    const vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
+    CONST vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE
-    const vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
+    CONST vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                      viewRayIntersectsGround, eclipsedSingleScatteringTextureSize);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact at the point where azimuth texture coordinate changes from 1 to 0 (at azimuthRelativeToSun crossing
     // 0). This happens when I simply call texture(eclipsedScatteringTexture, texCoords) without specifying LOD.
     // Apparently, the driver uses the derivative for some reason, even though it shouldn't.
-    const vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
+    CONST vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
     luminance=scattering*currentPhaseFunction(dotViewSun);
-#elif RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_RADIANCE
+#elif 0 /*RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_RADIANCE*/
     vec4 radiance=exp(sampleEclipseDoubleScattering3DTexture(eclipsedDoubleScatteringTexture,
                                                              cosSunZenithAngle, cosViewZenithAngle, azimuthRelativeToSun,
                                                              altitude, viewRayIntersectsGround));
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_LUMINANCE
+#elif 0 /*RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
     luminance=exp(sampleEclipseDoubleScattering3DTexture(eclipsedDoubleScatteringTexture,
                                                          cosSunZenithAngle, cosViewZenithAngle, azimuthRelativeToSun,
                                                          altitude, viewRayIntersectsGround));
-#elif RENDERING_SINGLE_SCATTERING_ON_THE_FLY
-    const vec4 scattering=computeSingleScattering(cosSunZenithAngle,cosViewZenithAngle,dotViewSun,
+#elif 0 /*RENDERING_SINGLE_SCATTERING_ON_THE_FLY*/
+    CONST vec4 scattering=computeSingleScattering(cosSunZenithAngle,cosViewZenithAngle,dotViewSun,
                                                   altitude,viewRayIntersectsGround);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE
+#elif 0 /*RENDERING_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE*/
     vec4 scattering;
     if(useInterpolationGuides)
     {
@@ -399,7 +413,7 @@ void main()
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE
+#elif 0 /*RENDERING_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
     vec4 scattering;
     if(useInterpolationGuides)
     {
@@ -413,18 +427,18 @@ void main()
                                      dotViewSun, altitude, viewRayIntersectsGround);
     }
     luminance=scattering * (bool(PHASE_FUNCTION_IS_EMBEDDED) ? vec4(1) : currentPhaseFunction(dotViewSun));
-#elif RENDERING_MULTIPLE_SCATTERING_LUMINANCE
+#elif 0 /*RENDERING_MULTIPLE_SCATTERING_LUMINANCE*/
     luminance=sample3DTexture(scatteringTexture, cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, viewRayIntersectsGround);
-#elif RENDERING_MULTIPLE_SCATTERING_RADIANCE
+#elif 0 /*RENDERING_MULTIPLE_SCATTERING_RADIANCE*/
     vec4 radiance=sample3DTexture(scatteringTexture, cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, viewRayIntersectsGround);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_LIGHT_POLLUTION_RADIANCE
+#elif 0 /*RENDERING_LIGHT_POLLUTION_RADIANCE*/
     vec4 radiance=lightPollutionGroundLuminance*lightPollutionScattering(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_LIGHT_POLLUTION_LUMINANCE
+#elif 0 /*RENDERING_LIGHT_POLLUTION_LUMINANCE*/
     luminance=lightPollutionGroundLuminance*lightPollutionScattering(altitude, cosViewZenithAngle, viewRayIntersectsGround);
 #else
 #error What to render?

--- a/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/2/aerosols/single-scattering-eclipsed.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/2/aerosols/single-scattering-eclipsed.frag
@@ -1,7 +1,21 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
 
-#line 1 1 // const.h.glsl
+
+
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 6 0 // single-scattering-eclipsed.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,15 +48,15 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.35000004e-05,1.33100002e-05,9.4
 const vec4 wavelengths=vec4(610.666687,642,673.333313,704.666687);
 const int wlSetIndex=2;
 #endif
-#line 5 0 // single-scattering-eclipsed.frag
-#line 1 2 // densities.h.glsl
+#line 7 0 // single-scattering-eclipsed.frag
+#line 1 3 // densities.h.glsl
 float scattererNumberDensity_molecules(float altitude);
 float scattererNumberDensity_aerosols(float altitude);
 float absorberNumberDensity_ozone(float altitude);
 vec4 scatteringCrossSection();
 float scattererDensity(float altitude);
-#line 6 0 // single-scattering-eclipsed.frag
-#line 1 3 // common-functions.h.glsl
+#line 8 0 // single-scattering-eclipsed.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -74,8 +88,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // single-scattering-eclipsed.frag
-#line 1 4 // texture-sampling-functions.h.glsl
+#line 9 0 // single-scattering-eclipsed.frag
+#line 1 5 // texture-sampling-functions.h.glsl
 #ifndef INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 #define INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float altitude);
@@ -87,7 +101,7 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                 const int scatteringOrder);
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 #endif
-#line 8 0 // single-scattering-eclipsed.frag
+#line 10 0 // single-scattering-eclipsed.frag
 
 
 float cosZenithAngle(vec3 origin, vec3 direction)
@@ -101,13 +115,13 @@ vec4 computeSingleScatteringIntegrandEclipsed(const float cosSunZenithAngle, con
                                               const float dist, const bool viewRayIntersectsGround,
                                               const vec3 scatterer, const vec3 sunDir, const vec3 moonPos)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle here the case when the
     // endpoint of the view ray intentionally appears in outer space.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosSunZenithAngleAtDist=clampCosine((r*cosSunZenithAngle+dist*dotViewSun)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosSunZenithAngleAtDist=clampCosine((r*cosSunZenithAngle+dist*dotViewSun)/(earthRadius+altAtDist));
 
-    const vec4 xmittance=transmittance(cosViewZenithAngle, altitude, dist, viewRayIntersectsGround)
+    CONST vec4 xmittance=transmittance(cosViewZenithAngle, altitude, dist, viewRayIntersectsGround)
                                                     *
                          transmittanceToAtmosphereBorder(cosSunZenithAngleAtDist, altAtDist)
                                                     *
@@ -115,7 +129,7 @@ vec4 computeSingleScatteringIntegrandEclipsed(const float cosSunZenithAngle, con
                                                     *
                             // FIXME: this ignores orientation of the crescent of eclipsed Sun WRT horizon
                                     sunVisibility(cosSunZenithAngleAtDist, altAtDist);
-#if ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION
+#if 0 /*ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION*/
     COMPUTE_TOTAL_SCATTERING_COEFFICIENT;
     return xmittance * totalScatteringCoefficient;
 #else
@@ -126,26 +140,26 @@ vec4 computeSingleScatteringIntegrandEclipsed(const float cosSunZenithAngle, con
 vec4 computeSingleScatteringEclipsed(const vec3 camera, const vec3 viewDir, const vec3 sunDir, const vec3 moonPos,
                                      const bool viewRayIntersectsGround)
 {
-    const float cosViewZenithAngle=cosZenithAngle(camera,viewDir);
-    const float cosSunZenithAngle=cosZenithAngle(camera,sunDir);
-    const float altitude=pointAltitude(camera);
-    const float dotViewSun=dot(viewDir,sunDir);
-    const float integrInterval=distanceToNearestAtmosphereBoundary(cosViewZenithAngle, altitude,
+    CONST float cosViewZenithAngle=cosZenithAngle(camera,viewDir);
+    CONST float cosSunZenithAngle=cosZenithAngle(camera,sunDir);
+    CONST float altitude=pointAltitude(camera);
+    CONST float dotViewSun=dot(viewDir,sunDir);
+    CONST float integrInterval=distanceToNearestAtmosphereBoundary(cosViewZenithAngle, altitude,
                                                                    viewRayIntersectsGround);
 
     // Using the midpoint rule for quadrature
     vec4 spectrum=vec4(0);
-    const float dl=integrInterval/radialIntegrationPoints;
+    CONST float dl=integrInterval/radialIntegrationPoints;
     for(int n=0; n<radialIntegrationPoints; ++n)
     {
-        const float dist=(n+0.5)*dl;
+        CONST float dist=(n+0.5)*dl;
         spectrum += computeSingleScatteringIntegrandEclipsed(cosSunZenithAngle, cosViewZenithAngle, dotViewSun,
                                                              altitude, dist, viewRayIntersectsGround,
                                                              camera+viewDir*dist, sunDir, moonPos);
     }
 
     spectrum *= dl*solarIrradianceAtTOA
-#if ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION
+#if 0 /*ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION*/
                                 // the multiplier is already included
 #else
                                         * scatteringCrossSection()

--- a/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/2/aerosols/texture-coordinates.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/2/aerosols/texture-coordinates.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-coordinates.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,8 +45,8 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.35000004e-05,1.33100002e-05,9.4
 const vec4 wavelengths=vec4(610.666687,642,673.333313,704.666687);
 const int wlSetIndex=2;
 #endif
-#line 5 0 // texture-coordinates.frag
-#line 1 2 // texture-coordinates.h.glsl
+#line 4 0 // texture-coordinates.frag
+#line 1 3 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -104,8 +115,8 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 6 0 // texture-coordinates.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-coordinates.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -137,7 +148,7 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-coordinates.frag
+#line 6 0 // texture-coordinates.frag
 
 const float LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA=sqrt(atmosphereHeight*(atmosphereHeight+2*earthRadius));
 
@@ -205,18 +216,18 @@ vec3 indicesToTexCoords(const vec3 indices, const vec3 texSizes)
 
 TransmittanceTexVars transmittanceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
+    CONST float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
                                 texCoordToUnitRange(texCoord.t,transmittanceTextureSize.t);
     // Distance from Earth center to camera
-    const float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
-    const float altitude=r-earthRadius;
+    CONST float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
+    CONST float altitude=r-earthRadius;
 
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
     // distance to border of visible atmosphere from the view point
-    const float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
+    CONST float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
     // d==0 can happen when altitude==atmosphereHeight
-    const float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
+    CONST float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
     return TransmittanceTexVars(cosVZA,altitude);
 }
 
@@ -235,53 +246,53 @@ vec2 transmittanceTexVarsToTexCoord(const float cosVZA, float altitude)
     if(altitude<0)
         altitude=0;
 
-    const float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
+    CONST float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
                                       transmittanceTextureSize.t);
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
-    const float d=distanceToAtmosphereBorder(cosVZA,altitude);
-    const float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float d=distanceToAtmosphereBorder(cosVZA,altitude);
+    CONST float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
     return vec2(s,t);
 }
 
 // Output: vec2(cos(sunZenithAngle), altitude)
 IrradianceTexVars irradianceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
-    const float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
+    CONST float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
+    CONST float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
     return IrradianceTexVars(cosSZA,alt);
 }
 
 vec2 irradianceTexVarsToTexCoord(const float cosSunZenithAngle, const float altitude)
 {
-    const float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
-    const float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
+    CONST float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
+    CONST float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
     return vec2(s,t);
 }
 
 float cosSZAToUnitRangeTexCoord(const float cosSunZenithAngle)
 {
     // Distance to top atmosphere border along the ray groundUnderCamera-sun: (altitude, cosSunZenithAngle)
-    const float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name
-    const float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
+    CONST float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
     // TODO: choose a more descriptive name
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     return max(0.,1-a/A)/(a+1);
 }
 
 float unitRangeTexCoordToCosSZA(const float texCoord)
 {
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float a=(A-A*texCoord)/(1+A*texCoord);
-    const float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
+    CONST float a=(A-A*texCoord)/(1+A*texCoord);
+    CONST float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
     return distFromGroundToTopAtmoBorder==0 ? 1 :
         clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distFromGroundToTopAtmoBorder)) /
                     (2*earthRadius*distFromGroundToTopAtmoBorder));
@@ -292,24 +303,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
                                                const float dotViewSun, const float altitude,
                                                const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -317,24 +328,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float dotVSCoord=(dotViewSun+1)/2;
+    CONST float dotVSCoord=(dotViewSun+1)/2;
 
     // ------------------------------------
-    const float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
+    CONST float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
 
     return Scattering4DCoords(cosSZACoord, cosVZACoord, dotVSCoord, altCoord, viewRayIntersectsGround);
 }
 
 TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
@@ -342,16 +353,16 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture coordinates we combine into a single sampler3D coordinate.
-    const float texW = scatteringTextureSize[1];
-    const float texH = scatteringTextureSize[2];
-    const float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
-    const vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
+    CONST float texW = scatteringTextureSize[1];
+    CONST float texH = scatteringTextureSize[2];
+    CONST float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
+    CONST vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
                                         ceil (cosSZAIndex)*texW+coords.dotViewSun*(texW-1)) / (texW*texH-1);
-    const vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
+    CONST vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
 
-    const float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
+    CONST float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
 
-    const float alphaUpper=fract(cosSZAIndex);
+    CONST float alphaUpper=fract(cosSZAIndex);
     return TexCoordPair(vec3(cosVZAtc, combinedCoord.x, altitude), float(1-alphaUpper),
                         vec3(cosVZAtc, combinedCoord.y, altitude), float(alphaUpper));
 }
@@ -359,9 +370,9 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
+    CONST TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
     return texture(tex, texCoords.lower) * texCoords.alphaLower +
            texture(tex, texCoords.upper) * texCoords.alphaUpper;
 }
@@ -369,17 +380,17 @@ vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const f
 // 3D texture is the 3D single-altitude slice of a 4D texture
 vec3 scattering4DCoordsToTex3DCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2);
 
-    const float dvsSize = scatteringTextureSize[1];
-    const float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
+    CONST float dvsSize = scatteringTextureSize[1];
+    CONST float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
 
-    const float cszaSize = scatteringTextureSize[2];
-    const float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
+    CONST float cszaSize = scatteringTextureSize[2];
+    CONST float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
 
     return vec3(cosVZAtc, dotVStc, cosSZAtc);
 }
@@ -394,39 +405,39 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along dotViewSun coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[1];
-    const float posOfRow = indices[1];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[1];
+    CONST float posOfRow = indices[1];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         indexToTexCoord(currRow, numRows-1),
                                                         texCoordVerbatim));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               indexToTexCoord(currRow, numRows-1),
                                                               texCoordVerbatim));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          indexToTexCoord(currRow, numRows-1),
                                          texCoordVerbatim));
@@ -434,14 +445,14 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
 vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolationGuides01Tex,
                                  const vec3 indices)
 {
-    const float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
+    CONST float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
 
-    const float cosVZAIndex = indices[0];
-    const float dotVSIndex = indices[1];
-    const float currRow = floor(dotVSIndex);
-    const float posBetweenRows = dotVSIndex - currRow;
-    const float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cosVZAIndex = indices[0];
+    CONST float dotVSIndex = indices[1];
+    CONST float currRow = floor(dotVSIndex);
+    CONST float posBetweenRows = dotVSIndex - currRow;
+    CONST float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -449,14 +460,14 @@ vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolat
     indicesCurrRow[1] =     currRow;
     indicesNextRow[1] = min(currRow+1, scatteringTextureSize[1]-1.);
 
-    const vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
-    const vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
+    CONST vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
+    CONST vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
 
-    const vec4 valueCurrRow = texture(tex, coordsCurrRow);
-    const vec4 valueNextRow = texture(tex, coordsNextRow);
-    const float epsilon = 1e-37; // Prevents passing zero to log
-    const vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
-    const vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
+    CONST vec4 valueCurrRow = texture(tex, coordsCurrRow);
+    CONST vec4 valueNextRow = texture(tex, coordsNextRow);
+    CONST float epsilon = 1e-37; // Prevents passing zero to log
+    CONST vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
+    CONST vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
     return (logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow;
 }
 
@@ -465,37 +476,37 @@ float findGuide02Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along SZA coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[2];
-    const float posOfRow = indices[2];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[2];
+    CONST float posOfRow = indices[2];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
 }
@@ -505,19 +516,19 @@ vec4 sample3DTextureGuided(const sampler3D tex,
                            const float cosSunZenithAngle, const float cosViewZenithAngle,
                            const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
                                                                     dotViewSun, altitude, viewRayIntersectsGround);
     // Handle the external interpolation guides: the guides between a pair of VZA-dotViewSun 2D "pictures".
-    const vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
-    const vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
-    const float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
+    CONST vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
+    CONST float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
 
-    const float cvzaIndex = indices[0];
-    const float cszaIndex = indices[2];
-    const float currRow = floor(cszaIndex);
-    const float posBetweenRows = cszaIndex - currRow;
-    const float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cvzaIndex = indices[0];
+    CONST float cszaIndex = indices[2];
+    CONST float currRow = floor(cszaIndex);
+    CONST float posBetweenRows = cszaIndex - currRow;
+    CONST float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -526,58 +537,58 @@ vec4 sample3DTextureGuided(const sampler3D tex,
     indicesNextRow[2] = min(currRow+1, scatteringTextureSize[2]-1);
 
     // The caller will handle the internal interpolation guides: the ones between rows in each 2D "picture".
-    const vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
-    const vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
+    CONST vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
+    CONST vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
     return exp((logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow);
 }
 
 vec4 sample3DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
     return texture(tex, texCoords);
 }
 
 ScatteringTexVars scatteringTex4DCoordsToTexVars(const Scattering4DCoords coords)
 {
-    const float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
     // ------------------------------------
     float cosViewZenithAngle;
     if(coords.viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
     // ------------------------------------
-    const float dotViewSun=coords.dotViewSun*2-1;
+    CONST float dotViewSun=coords.dotViewSun*2-1;
 
     // ------------------------------------
-    const float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
+    CONST float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
 
     return ScatteringTexVars(cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, coords.viewRayIntersectsGround);
 }
 
 Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 {
-    const vec4 indexMax=scatteringTextureSize-vec4(1);
+    CONST vec4 indexMax=scatteringTextureSize-vec4(1);
     Scattering4DCoords coords4d;
     coords4d.viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
     // The following formulas assume that scatteringTextureSize[0] is even. For odd sizes they would change.
@@ -593,8 +604,8 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture indices we combine into a single sampler3D coordinate.
-    const float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
-    const float combinedIndex=texIndices[1];
+    CONST float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
+    CONST float combinedIndex=texIndices[1];
     coords4d.dotViewSun=mod(combinedIndex,texW)/(texW-1);
     coords4d.cosSunZenithAngle=floor(combinedIndex/texW)/(texH-1);
 
@@ -608,11 +619,11 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
 ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 {
-    const Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
+    CONST Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
     ScatteringTexVars vars=scatteringTex4DCoordsToTexVars(coords4d);
     // Clamp dotViewSun to its valid range of values, given cosViewZenithAngle and cosSunZenithAngle. This is
     // needed to prevent NaNs when computing the scattering texture.
-    const float cosVZA=vars.cosViewZenithAngle,
+    CONST float cosVZA=vars.cosViewZenithAngle,
                 cosSZA=vars.cosSunZenithAngle;
     vars.dotViewSun=clamp(vars.dotViewSun,
                           cosVZA*cosSZA-safeSqrt((1-sqr(cosVZA))*(1-sqr(cosSZA))),
@@ -622,54 +633,54 @@ ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 
 EclipseScatteringTexVars eclipseTexCoordsToTexVars(const vec2 texCoords, const float altitude)
 {
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
-    const bool viewRayIntersectsGround = texCoords.t<0.5;
+    CONST bool viewRayIntersectsGround = texCoords.t<0.5;
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
-    const float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
+    CONST float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
     return EclipseScatteringTexVars(azimuthRelativeToSun, cosViewZenithAngle, viewRayIntersectsGround);
 }
 
 EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                                    const float altitude, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -677,13 +688,13 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
-    const float azimuthCoord = azimuthRelativeToSun/(2*PI);
+    CONST float azimuthCoord = azimuthRelativeToSun/(2*PI);
 
     return EclipseScattering2DCoords(azimuthCoord, cosVZACoord);
 }
@@ -691,14 +702,14 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
 vec2 eclipseTexVarsToTexCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                const float altitude, const bool viewRayIntersectsGround, const vec2 texSize)
 {
-    const EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+    CONST EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                                     viewRayIntersectsGround);
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2);
-    const float azimuthTC = coords.azimuth + 1/(2*texSize.s);
+    CONST float azimuthTC = coords.azimuth + 1/(2*texSize.s);
 
     return vec2(azimuthTC, cosVZAtc);
 }
@@ -707,42 +718,42 @@ vec4 sampleEclipseDoubleScattering3DTexture(const sampler3D tex, const float cos
                                             const float cosViewZenithAngle, const float azimuthRelativeToSun,
                                             const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
+    CONST vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
                                                   eclipsedDoubleScatteringTextureSize.st);
-    const float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
-    const vec3 texCoords=vec3(coords2d, cosSZACoord);
+    CONST float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
+    CONST vec3 texCoords=vec3(coords2d, cosSZACoord);
 
     return texture(tex, texCoords);
 }
 
 LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 texIndices)
 {
-    const vec2 indexMax=lightPollutionTextureSize-vec2(1);
+    CONST vec2 indexMax=lightPollutionTextureSize-vec2(1);
 
-    const float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
-    const float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
+    CONST float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
-    const bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
-    const float cosViewZenithAngleCoord = viewRayIntersectsGround ?
+    CONST bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
+    CONST float cosViewZenithAngleCoord = viewRayIntersectsGround ?
                                    1-2*texIndices[0]/(indexMax[0]-1) :
                                    2*(texIndices[0]-1)/(indexMax[0]-1)-1;
     // ------------------------------------
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
@@ -753,23 +764,23 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 
 LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -777,27 +788,27 @@ LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, con
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     return LightPollution2DCoords(cosVZACoord, altCoord);
 }
 
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
-    const vec2 texSize = lightPollutionTextureSize;
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 texSize = lightPollutionTextureSize;
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2);
-    const float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
+    CONST float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
     return vec2(cosVZAtc, altitudeTC);
 }

--- a/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/2/aerosols/texture-sampling-functions.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/2/aerosols/texture-sampling-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-sampling-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,13 +45,13 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.35000004e-05,1.33100002e-05,9.4
 const vec4 wavelengths=vec4(610.666687,642,673.333313,704.666687);
 const int wlSetIndex=2;
 #endif
-#line 5 0 // texture-sampling-functions.frag
-#line 1 2 // phase-functions.h.glsl
+#line 4 0 // texture-sampling-functions.frag
+#line 1 3 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 6 0 // texture-sampling-functions.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-sampling-functions.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -72,8 +83,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-sampling-functions.frag
-#line 1 4 // texture-coordinates.h.glsl
+#line 6 0 // texture-sampling-functions.frag
+#line 1 5 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -142,7 +153,7 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 8 0 // texture-sampling-functions.frag
+#line 7 0 // texture-sampling-functions.frag
 
 uniform sampler2D transmittanceTexture;
 uniform sampler2D irradianceTexture;
@@ -154,13 +165,13 @@ uniform sampler2D lightPollutionScatteringTexture;
 
 vec4 irradiance(const float cosSunZenithAngle, const float altitude)
 {
-    const vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
+    CONST vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
     return texture(irradianceTexture, texCoords);
 }
 
 vec4 opticalDepthToAtmosphereBorder(const float cosViewZenithAngle, const float altitude)
 {
-    const vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
+    CONST vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact when looking into nadir from TOA at some values of texture sizes (in particular, size of
     // transmittance texture for altitude being 4096). This happens when I simply call texture(eclipsedScatteringTexture,
@@ -178,11 +189,11 @@ vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float
 vec4 transmittance(const float cosViewZenithAngle, const float altitude, const float dist,
                    const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle view ray endpoint
     // in space here.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
 
     vec4 depth;
     if(viewRayIntersectsGround)
@@ -201,7 +212,7 @@ vec4 transmittance(const float cosViewZenithAngle, const float altitude, const f
 vec4 calcFirstScattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                          const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
+    CONST vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
                                           dotViewSun, altitude, viewRayIntersectsGround);
     return scattering*currentPhaseFunction(dotViewSun);
 }
@@ -220,6 +231,6 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
 
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     return texture(lightPollutionScatteringTexture, coords);
 }

--- a/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/2/molecules/common-functions.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/2/molecules/common-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // common-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.35000004e-05,1.33100002e-05,9.4
 const vec4 wavelengths=vec4(610.666687,642,673.333313,704.666687);
 const int wlSetIndex=2;
 #endif
-#line 5 0 // common-functions.frag
+#line 4 0 // common-functions.frag
 
 bool dbgDataPresent=false;
 bool debugDataPresent()
@@ -69,7 +80,7 @@ void setDebugData(float a,float b, float c, float d)
 
 void swap(inout float x, inout float y)
 {
-    const float t = x;
+    CONST float t = x;
     x = y;
     y = t;
 }
@@ -83,7 +94,7 @@ float safeSqrt(const float x)
 
 float safeAtan(const float y, const float x)
 {
-    const float a = atan(y,x);
+    CONST float a = atan(y,x);
     return x==0 && y==0 ? 0 : a;
 }
 
@@ -116,23 +127,23 @@ float pointAltitude(vec3 point)
 
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float Ratm=earthRadius+atmosphereHeight;
-    const float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float Ratm=earthRadius+atmosphereHeight;
+    CONST float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float distanceToGround(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(-safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float cosZenithAngleOfHorizon(const float altitude)
 {
-    const float R=earthRadius;
-    const float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
+    CONST float R=earthRadius;
+    CONST float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
     return -sqrt(2*h*R+sqr(h))/(R+h);
 }
 
@@ -151,8 +162,8 @@ float distanceToNearestAtmosphereBoundary(const float cosZenithAngle, const floa
 float sunVisibility(const float cosSunZenithAngle, float altitude)
 {
     if(altitude<0) altitude=0;
-    const float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
-    const float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
+    CONST float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
+    CONST float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
     /* Approximating visible fraction of solar disk by smoothstep between the position of the Sun
      * touching the horizon by its upper part and the position with lower part touching the horizon.
      * The calculation assumes that solar angular radius is small and thus approximately equals its sine.
@@ -182,13 +193,13 @@ float circlesIntersectionArea(float R1, float R2, float d)
 
 float angleBetween(const vec3 a, const vec3 b)
 {
-    const float d=dot(a,b);
-    const float c=length(cross(a,b));
+    CONST float d=dot(a,b);
+    CONST float c=length(cross(a,b));
     // To avoid loss of precision, don't use dot product near the singularity
     // of acos, and cross product near the singularity of asin
     if(abs(d) < abs(c))
         return acos(d/(length(a)*length(b)));
-    const float smallerAngle = asin(c/(length(a)*length(b)));
+    CONST float smallerAngle = asin(c/(length(a)*length(b)));
     if(d<0) return PI-smallerAngle;
     return smallerAngle;
 }
@@ -205,11 +216,11 @@ float moonAngularRadius(const vec3 cameraPosition, const vec3 moonPosition)
 
 float visibleSolidAngleOfSun(const vec3 camera, const vec3 sunDir, const vec3 moonPos)
 {
-    const float Rs=sunAngularRadius;
-    const float Rm=moonAngularRadius(camera,moonPos);
+    CONST float Rs=sunAngularRadius;
+    CONST float Rm=moonAngularRadius(camera,moonPos);
     float visibleSolidAngle=PI*sqr(Rs);
 
-    const float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
+    CONST float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
     if(dSM<Rs+Rm)
     {
         visibleSolidAngle -= circlesIntersectionArea(Rm,Rs,dSM);
@@ -229,12 +240,12 @@ float sphereIntegrationSolidAngleDifferential(const int pointCountOnSphere)
 }
 vec3 sphereIntegrationSampleDir(const int index, const int pointCountOnSphere)
 {
-    const float goldenRatio=1.6180339887499;
+    CONST float goldenRatio=1.6180339887499;
     // The range of n is 0.5, 1.5, ..., pointCountOnSphere-0.5
-    const float n=index+0.5;
+    CONST float n=index+0.5;
     // Explanation of the Fibonacci grid generation can be seen at https://stackoverflow.com/a/44164075/673852
-    const float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
-    const float azimuth=n*(2*PI*goldenRatio);
+    CONST float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
+    CONST float azimuth=n*(2*PI*goldenRatio);
     return vec3(cos(azimuth)*sin(zenithAngle),
                 sin(azimuth)*sin(zenithAngle),
                 cos(zenithAngle));

--- a/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/2/molecules/densities.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/2/molecules/densities.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // densities.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,20 +45,20 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.35000004e-05,1.33100002e-05,9.4
 const vec4 wavelengths=vec4(610.666687,642,673.333313,704.666687);
 const int wlSetIndex=2;
 #endif
-#line 5 0 // densities.frag
+#line 4 0 // densities.frag
 float scattererNumberDensity_molecules(float altitude)
 {
-        const float rayleighScaleHeight=8*km;
+        CONST float rayleighScaleHeight=8*km;
         return 3.08458e25*exp(-1/rayleighScaleHeight * altitude);
 }
 float scattererNumberDensity_aerosols(float altitude)
 {
-        const float mieScaleHeight=1.2*km;
+        CONST float mieScaleHeight=1.2*km;
         return 1.03333e8*exp(-1/mieScaleHeight*altitude);
 }
 float absorberNumberDensity_ozone(float altitude)
 {
-        const float totalOzoneAmount=370*dobsonUnit;
+        CONST float totalOzoneAmount=370*dobsonUnit;
 
         float density;
 

--- a/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/2/molecules/phase-functions.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/2/molecules/phase-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // phase-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.35000004e-05,1.33100002e-05,9.4
 const vec4 wavelengths=vec4(610.666687,642,673.333313,704.666687);
 const int wlSetIndex=2;
 #endif
-#line 5 0 // phase-functions.frag
+#line 4 0 // phase-functions.frag
 
 vec4 phaseFunction_molecules(float dotViewSun)
 {
@@ -42,9 +53,9 @@ vec4 phaseFunction_molecules(float dotViewSun)
 }
 vec4 phaseFunction_aerosols(float dotViewSun)
 {
-        const float g=0.76;
-        const float g2=g*g;
-        const float k = 3/(8*PI)*(1-g2)/(2+g2);
+        CONST float g=0.76;
+        CONST float g2=g*g;
+        CONST float k = 3/(8*PI)*(1-g2)/(2+g2);
         return vec4(k * (1+sqr(dotViewSun)) / pow(1+g2 - 2*g*dotViewSun, 1.5) + 1/((1-dotViewSun)*600+0.05))*0.904;
 }
 vec4 currentPhaseFunction(float dotViewSun) { return phaseFunction_molecules(dotViewSun); }

--- a/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/2/molecules/render.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/2/molecules/render.frag
@@ -1,7 +1,21 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
 
-#line 1 1 // const.h.glsl
+
+
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 6 0 // render.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,11 +48,11 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.35000004e-05,1.33100002e-05,9.4
 const vec4 wavelengths=vec4(610.666687,642,673.333313,704.666687);
 const int wlSetIndex=2;
 #endif
-#line 5 0 // render.frag
-#line 1 2 // calc-view-dir.h.glsl
+#line 7 0 // render.frag
+#line 1 3 // calc-view-dir.h.glsl
 vec3 calcViewDir();
-#line 6 0 // render.frag
-#line 1 3 // common-functions.h.glsl
+#line 8 0 // render.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -70,14 +84,14 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // render.frag
-#line 1 4 // phase-functions.h.glsl
+#line 9 0 // render.frag
+#line 1 5 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 8 0 // render.frag
+#line 10 0 // render.frag
 
-#line 1 5 // single-scattering-eclipsed.h.glsl
+#line 1 6 // single-scattering-eclipsed.h.glsl
 #ifndef INCLUDE_ONCE_050024D2_BD56_434E_8D40_2055DA0B78EC
 #define INCLUDE_ONCE_050024D2_BD56_434E_8D40_2055DA0B78EC
 
@@ -85,8 +99,8 @@ vec4 computeSingleScatteringEclipsed(const vec3 camera, const vec3 viewDir, cons
                                      const bool viewRayIntersectsGround);
 
 #endif
-#line 10 0 // render.frag
-#line 1 6 // texture-coordinates.h.glsl
+#line 12 0 // render.frag
+#line 1 7 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -155,10 +169,10 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 11 0 // render.frag
-#line 1 7 // radiance-to-luminance.h.glsl
+#line 13 0 // render.frag
+#line 1 8 // radiance-to-luminance.h.glsl
 const mat4 radianceToLuminance=mat4(21296.1113,10585.7773,6.80903196,807.40564,  8819.19727,3416.5498,0.346691847,67.973465,  1511.18506,551.902527,0,6.17586422,  177.630722,64.1456985,0,0.693584085);
-#line 12 0 // render.frag
+#line 14 0 // render.frag
 
 
 
@@ -195,18 +209,18 @@ void main()
     // this approximation has the same order of magnitude as the assumption that the Earth and its atmosphere
     // are spherical.
     float altitude = max(cameraPosition.z, 0.);
-    const vec3 oldCamPos=cameraPosition;
+    CONST vec3 oldCamPos=cameraPosition;
     // Hide the uniform with this name, thus effectively modifying it for the following code
     vec3 cameraPosition=vec3(oldCamPos.xy, altitude);
 
     bool lookingIntoAtmosphere=true;
     if(altitude>atmosphereHeight)
     {
-        const vec3 p = cameraPosition - earthCenter;
-        const float p_dot_v = dot(p, viewDir);
-        const float p_dot_p = dot(p, p);
-        const float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
-        const float distanceToTOA = -p_dot_v - sqrt(sqr(earthRadius+atmosphereHeight) - squaredDistBetweenViewRayAndEarthCenter);
+        CONST vec3 p = cameraPosition - earthCenter;
+        CONST float p_dot_v = dot(p, viewDir);
+        CONST float p_dot_p = dot(p, p);
+        CONST float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
+        CONST float distanceToTOA = -p_dot_v - sqrt(sqr(earthRadius+atmosphereHeight) - squaredDistBetweenViewRayAndEarthCenter);
         if(distanceToTOA>=0)
         {
             cameraPosition += viewDir*distanceToTOA;
@@ -214,7 +228,7 @@ void main()
         }
         else
         {
-#if RENDERING_ANY_ZERO_SCATTERING
+#if 0 /*RENDERING_ANY_ZERO_SCATTERING*/
             lookingIntoAtmosphere=false;
 #else
             luminance=vec4(0);
@@ -224,16 +238,16 @@ void main()
         }
     }
 
-    const vec3 zenith=normalize(cameraPosition-earthCenter);
+    CONST vec3 zenith=normalize(cameraPosition-earthCenter);
     float cosViewZenithAngle=dot(zenith,viewDir);
 
     bool viewRayIntersectsGround=false;
     {
-        const vec3 p = cameraPosition - earthCenter;
-        const float p_dot_v = dot(p, viewDir);
-        const float p_dot_p = dot(p, p);
-        const float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
-        const float distanceToIntersection = -p_dot_v - sqrt(sqr(earthRadius) - squaredDistBetweenViewRayAndEarthCenter);
+        CONST vec3 p = cameraPosition - earthCenter;
+        CONST float p_dot_v = dot(p, viewDir);
+        CONST float p_dot_p = dot(p, p);
+        CONST float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
+        CONST float distanceToIntersection = -p_dot_v - sqrt(sqr(earthRadius) - squaredDistBetweenViewRayAndEarthCenter);
         // altitude==0 is a special case where distance to intersection calculation
         // is unreliable (has a lot of noise in its sign), so check it separately
         if(distanceToIntersection>0 || (altitude==0 && cosViewZenithAngle<0))
@@ -244,11 +258,11 @@ void main()
     // Aside from aesthetics, this affects brightness input to Stellarium's tone mapper.
     if(pseudoMirrorSkyBelowHorizon && viewRayIntersectsGround)
     {
-        const float horizonCZA = cosZenithAngleOfHorizon(altitude);
-        const float viewElev  = asin(clampCosine(cosViewZenithAngle));
-        const float horizElev = asin(clampCosine(horizonCZA));
-        const float newViewElev = 2*horizElev - viewElev;
-        const float viewDirXYnorm = length(viewDir-zenith*cosViewZenithAngle);
+        CONST float horizonCZA = cosZenithAngleOfHorizon(altitude);
+        CONST float viewElev  = asin(clampCosine(cosViewZenithAngle));
+        CONST float horizElev = asin(clampCosine(horizonCZA));
+        CONST float newViewElev = 2*horizElev - viewElev;
+        CONST float viewDirXYnorm = length(viewDir-zenith*cosViewZenithAngle);
         if(viewDirXYnorm == 0)
         {
             viewDir = zenith;
@@ -267,27 +281,27 @@ void main()
         viewRayIntersectsGround = false;
     }
 
-    const float cosSunZenithAngle =dot(zenith,sunDirection);
-    const float dotViewSun=dot(viewDir,sunDirection);
+    CONST float cosSunZenithAngle =dot(zenith,sunDirection);
+    CONST float dotViewSun=dot(viewDir,sunDirection);
 
-    const vec3 sunXYunnorm=sunDirection-dot(sunDirection,zenith)*zenith;
-    const vec3 viewXYunnorm=viewDir-dot(viewDir,zenith)*zenith;
-    const vec3 sunXY = sunXYunnorm.x!=0 || sunXYunnorm.y!=0 || sunXYunnorm.z!=0 ? normalize(sunXYunnorm) : vec3(0);
-    const vec3 viewXY = viewXYunnorm.x!=0 || viewXYunnorm.y!=0 || viewXYunnorm.z!=0 ? normalize(viewXYunnorm) : vec3(0);
-    const float azimuthRelativeToSun=safeAtan(dot(cross(sunXY, viewXY), zenith), dot(sunXY, viewXY));
+    CONST vec3 sunXYunnorm=sunDirection-dot(sunDirection,zenith)*zenith;
+    CONST vec3 viewXYunnorm=viewDir-dot(viewDir,zenith)*zenith;
+    CONST vec3 sunXY = sunXYunnorm.x!=0 || sunXYunnorm.y!=0 || sunXYunnorm.z!=0 ? normalize(sunXYunnorm) : vec3(0);
+    CONST vec3 viewXY = viewXYunnorm.x!=0 || viewXYunnorm.y!=0 || viewXYunnorm.z!=0 ? normalize(viewXYunnorm) : vec3(0);
+    CONST float azimuthRelativeToSun=safeAtan(dot(cross(sunXY, viewXY), zenith), dot(sunXY, viewXY));
 
-#if RENDERING_ZERO_SCATTERING
+#if 0 /*RENDERING_ZERO_SCATTERING*/
     vec4 radiance;
     if(viewRayIntersectsGround)
     {
         // XXX: keep in sync with the same code in computeScatteringDensity(), but don't forget about
         //      the difference in the usage of viewDir vs incDir.
-        const float distToGround = distanceToGround(cosViewZenithAngle, altitude);
-        const vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
-        const vec3 groundNormal = normalize(zenith*(earthRadius+altitude)+viewDir*distToGround);
-        const vec4 groundIrradiance = irradiance(dot(groundNormal, sunDirection), 0);
+        CONST float distToGround = distanceToGround(cosViewZenithAngle, altitude);
+        CONST vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
+        CONST vec3 groundNormal = normalize(zenith*(earthRadius+altitude)+viewDir*distToGround);
+        CONST vec4 groundIrradiance = irradiance(dot(groundNormal, sunDirection), 0);
         // Radiation scattered by the ground
-        const float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
+        CONST float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
         radiance = transmittanceToGround*groundAlbedo*groundIrradiance*solarIrradianceFixup*groundBRDF
                  + lightPollutionGroundLuminance*lightPollutionRelativeRadiance;
     }
@@ -304,22 +318,22 @@ void main()
     }
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_ZERO_SCATTERING
+#elif 0 /*RENDERING_ECLIPSED_ZERO_SCATTERING*/
     vec4 radiance;
-    const float dotViewMoon=dot(viewDir,normalize(moonPosition-cameraPosition));
+    CONST float dotViewMoon=dot(viewDir,normalize(moonPosition-cameraPosition));
     if(viewRayIntersectsGround)
     {
         // XXX: keep in sync with the similar code in non-eclipsed zero scattering rendering.
-        const float distToGround = distanceToGround(cosViewZenithAngle, altitude);
-        const vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
-        const vec3 pointOnGround = cameraPosition+viewDir*distToGround;
-        const vec4 directGroundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDirection, moonPosition);
+        CONST float distToGround = distanceToGround(cosViewZenithAngle, altitude);
+        CONST vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
+        CONST vec3 pointOnGround = cameraPosition+viewDir*distToGround;
+        CONST vec4 directGroundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDirection, moonPosition);
         // FIXME: add first-order indirect irradiance too: it's done in non-eclipsed irradiance (in the same
         // conditions: when limited to 2 orders). This should be calculated at the same time when second order
         // is: all the infrastructure is already there.
-        const vec4 groundIrradiance = directGroundIrradiance;
+        CONST vec4 groundIrradiance = directGroundIrradiance;
         // Radiation scattered by the ground
-        const float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
+        CONST float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
         radiance = transmittanceToGround*groundAlbedo*groundIrradiance*solarIrradianceFixup*groundBRDF
                  + lightPollutionGroundLuminance*lightPollutionRelativeRadiance;
     }
@@ -337,52 +351,52 @@ void main()
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
 #elif 1 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_ON_THE_FLY*/
-    const vec4 scattering=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPosition,
+    CONST vec4 scattering=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPosition,
                                                           viewRayIntersectsGround);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE
-    const vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE*/
+    CONST vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                      viewRayIntersectsGround, eclipsedSingleScatteringTextureSize);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact at the point where azimuth texture coordinate changes from 1 to 0 (at azimuthRelativeToSun crossing
     // 0). This happens when I simply call texture(eclipsedScatteringTexture, texCoords) without specifying LOD.
     // Apparently, the driver uses the derivative for some reason, even though it shouldn't.
-    const vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
+    CONST vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE
-    const vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
+    CONST vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                      viewRayIntersectsGround, eclipsedSingleScatteringTextureSize);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact at the point where azimuth texture coordinate changes from 1 to 0 (at azimuthRelativeToSun crossing
     // 0). This happens when I simply call texture(eclipsedScatteringTexture, texCoords) without specifying LOD.
     // Apparently, the driver uses the derivative for some reason, even though it shouldn't.
-    const vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
+    CONST vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
     luminance=scattering*currentPhaseFunction(dotViewSun);
-#elif RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_RADIANCE
+#elif 0 /*RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_RADIANCE*/
     vec4 radiance=exp(sampleEclipseDoubleScattering3DTexture(eclipsedDoubleScatteringTexture,
                                                              cosSunZenithAngle, cosViewZenithAngle, azimuthRelativeToSun,
                                                              altitude, viewRayIntersectsGround));
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_LUMINANCE
+#elif 0 /*RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
     luminance=exp(sampleEclipseDoubleScattering3DTexture(eclipsedDoubleScatteringTexture,
                                                          cosSunZenithAngle, cosViewZenithAngle, azimuthRelativeToSun,
                                                          altitude, viewRayIntersectsGround));
-#elif RENDERING_SINGLE_SCATTERING_ON_THE_FLY
-    const vec4 scattering=computeSingleScattering(cosSunZenithAngle,cosViewZenithAngle,dotViewSun,
+#elif 0 /*RENDERING_SINGLE_SCATTERING_ON_THE_FLY*/
+    CONST vec4 scattering=computeSingleScattering(cosSunZenithAngle,cosViewZenithAngle,dotViewSun,
                                                   altitude,viewRayIntersectsGround);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE
+#elif 0 /*RENDERING_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE*/
     vec4 scattering;
     if(useInterpolationGuides)
     {
@@ -399,7 +413,7 @@ void main()
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE
+#elif 0 /*RENDERING_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
     vec4 scattering;
     if(useInterpolationGuides)
     {
@@ -413,18 +427,18 @@ void main()
                                      dotViewSun, altitude, viewRayIntersectsGround);
     }
     luminance=scattering * (bool(PHASE_FUNCTION_IS_EMBEDDED) ? vec4(1) : currentPhaseFunction(dotViewSun));
-#elif RENDERING_MULTIPLE_SCATTERING_LUMINANCE
+#elif 0 /*RENDERING_MULTIPLE_SCATTERING_LUMINANCE*/
     luminance=sample3DTexture(scatteringTexture, cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, viewRayIntersectsGround);
-#elif RENDERING_MULTIPLE_SCATTERING_RADIANCE
+#elif 0 /*RENDERING_MULTIPLE_SCATTERING_RADIANCE*/
     vec4 radiance=sample3DTexture(scatteringTexture, cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, viewRayIntersectsGround);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_LIGHT_POLLUTION_RADIANCE
+#elif 0 /*RENDERING_LIGHT_POLLUTION_RADIANCE*/
     vec4 radiance=lightPollutionGroundLuminance*lightPollutionScattering(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_LIGHT_POLLUTION_LUMINANCE
+#elif 0 /*RENDERING_LIGHT_POLLUTION_LUMINANCE*/
     luminance=lightPollutionGroundLuminance*lightPollutionScattering(altitude, cosViewZenithAngle, viewRayIntersectsGround);
 #else
 #error What to render?

--- a/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/2/molecules/single-scattering-eclipsed.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/2/molecules/single-scattering-eclipsed.frag
@@ -1,7 +1,21 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
 
-#line 1 1 // const.h.glsl
+
+
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 6 0 // single-scattering-eclipsed.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,15 +48,15 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.35000004e-05,1.33100002e-05,9.4
 const vec4 wavelengths=vec4(610.666687,642,673.333313,704.666687);
 const int wlSetIndex=2;
 #endif
-#line 5 0 // single-scattering-eclipsed.frag
-#line 1 2 // densities.h.glsl
+#line 7 0 // single-scattering-eclipsed.frag
+#line 1 3 // densities.h.glsl
 float scattererNumberDensity_molecules(float altitude);
 float scattererNumberDensity_aerosols(float altitude);
 float absorberNumberDensity_ozone(float altitude);
 vec4 scatteringCrossSection();
 float scattererDensity(float altitude);
-#line 6 0 // single-scattering-eclipsed.frag
-#line 1 3 // common-functions.h.glsl
+#line 8 0 // single-scattering-eclipsed.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -74,8 +88,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // single-scattering-eclipsed.frag
-#line 1 4 // texture-sampling-functions.h.glsl
+#line 9 0 // single-scattering-eclipsed.frag
+#line 1 5 // texture-sampling-functions.h.glsl
 #ifndef INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 #define INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float altitude);
@@ -87,7 +101,7 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                 const int scatteringOrder);
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 #endif
-#line 8 0 // single-scattering-eclipsed.frag
+#line 10 0 // single-scattering-eclipsed.frag
 
 
 float cosZenithAngle(vec3 origin, vec3 direction)
@@ -101,13 +115,13 @@ vec4 computeSingleScatteringIntegrandEclipsed(const float cosSunZenithAngle, con
                                               const float dist, const bool viewRayIntersectsGround,
                                               const vec3 scatterer, const vec3 sunDir, const vec3 moonPos)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle here the case when the
     // endpoint of the view ray intentionally appears in outer space.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosSunZenithAngleAtDist=clampCosine((r*cosSunZenithAngle+dist*dotViewSun)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosSunZenithAngleAtDist=clampCosine((r*cosSunZenithAngle+dist*dotViewSun)/(earthRadius+altAtDist));
 
-    const vec4 xmittance=transmittance(cosViewZenithAngle, altitude, dist, viewRayIntersectsGround)
+    CONST vec4 xmittance=transmittance(cosViewZenithAngle, altitude, dist, viewRayIntersectsGround)
                                                     *
                          transmittanceToAtmosphereBorder(cosSunZenithAngleAtDist, altAtDist)
                                                     *
@@ -115,7 +129,7 @@ vec4 computeSingleScatteringIntegrandEclipsed(const float cosSunZenithAngle, con
                                                     *
                             // FIXME: this ignores orientation of the crescent of eclipsed Sun WRT horizon
                                     sunVisibility(cosSunZenithAngleAtDist, altAtDist);
-#if ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION
+#if 0 /*ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION*/
     COMPUTE_TOTAL_SCATTERING_COEFFICIENT;
     return xmittance * totalScatteringCoefficient;
 #else
@@ -126,26 +140,26 @@ vec4 computeSingleScatteringIntegrandEclipsed(const float cosSunZenithAngle, con
 vec4 computeSingleScatteringEclipsed(const vec3 camera, const vec3 viewDir, const vec3 sunDir, const vec3 moonPos,
                                      const bool viewRayIntersectsGround)
 {
-    const float cosViewZenithAngle=cosZenithAngle(camera,viewDir);
-    const float cosSunZenithAngle=cosZenithAngle(camera,sunDir);
-    const float altitude=pointAltitude(camera);
-    const float dotViewSun=dot(viewDir,sunDir);
-    const float integrInterval=distanceToNearestAtmosphereBoundary(cosViewZenithAngle, altitude,
+    CONST float cosViewZenithAngle=cosZenithAngle(camera,viewDir);
+    CONST float cosSunZenithAngle=cosZenithAngle(camera,sunDir);
+    CONST float altitude=pointAltitude(camera);
+    CONST float dotViewSun=dot(viewDir,sunDir);
+    CONST float integrInterval=distanceToNearestAtmosphereBoundary(cosViewZenithAngle, altitude,
                                                                    viewRayIntersectsGround);
 
     // Using the midpoint rule for quadrature
     vec4 spectrum=vec4(0);
-    const float dl=integrInterval/radialIntegrationPoints;
+    CONST float dl=integrInterval/radialIntegrationPoints;
     for(int n=0; n<radialIntegrationPoints; ++n)
     {
-        const float dist=(n+0.5)*dl;
+        CONST float dist=(n+0.5)*dl;
         spectrum += computeSingleScatteringIntegrandEclipsed(cosSunZenithAngle, cosViewZenithAngle, dotViewSun,
                                                              altitude, dist, viewRayIntersectsGround,
                                                              camera+viewDir*dist, sunDir, moonPos);
     }
 
     spectrum *= dl*solarIrradianceAtTOA
-#if ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION
+#if 0 /*ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION*/
                                 // the multiplier is already included
 #else
                                         * scatteringCrossSection()

--- a/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/2/molecules/texture-coordinates.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/2/molecules/texture-coordinates.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-coordinates.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,8 +45,8 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.35000004e-05,1.33100002e-05,9.4
 const vec4 wavelengths=vec4(610.666687,642,673.333313,704.666687);
 const int wlSetIndex=2;
 #endif
-#line 5 0 // texture-coordinates.frag
-#line 1 2 // texture-coordinates.h.glsl
+#line 4 0 // texture-coordinates.frag
+#line 1 3 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -104,8 +115,8 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 6 0 // texture-coordinates.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-coordinates.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -137,7 +148,7 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-coordinates.frag
+#line 6 0 // texture-coordinates.frag
 
 const float LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA=sqrt(atmosphereHeight*(atmosphereHeight+2*earthRadius));
 
@@ -205,18 +216,18 @@ vec3 indicesToTexCoords(const vec3 indices, const vec3 texSizes)
 
 TransmittanceTexVars transmittanceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
+    CONST float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
                                 texCoordToUnitRange(texCoord.t,transmittanceTextureSize.t);
     // Distance from Earth center to camera
-    const float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
-    const float altitude=r-earthRadius;
+    CONST float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
+    CONST float altitude=r-earthRadius;
 
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
     // distance to border of visible atmosphere from the view point
-    const float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
+    CONST float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
     // d==0 can happen when altitude==atmosphereHeight
-    const float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
+    CONST float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
     return TransmittanceTexVars(cosVZA,altitude);
 }
 
@@ -235,53 +246,53 @@ vec2 transmittanceTexVarsToTexCoord(const float cosVZA, float altitude)
     if(altitude<0)
         altitude=0;
 
-    const float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
+    CONST float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
                                       transmittanceTextureSize.t);
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
-    const float d=distanceToAtmosphereBorder(cosVZA,altitude);
-    const float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float d=distanceToAtmosphereBorder(cosVZA,altitude);
+    CONST float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
     return vec2(s,t);
 }
 
 // Output: vec2(cos(sunZenithAngle), altitude)
 IrradianceTexVars irradianceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
-    const float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
+    CONST float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
+    CONST float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
     return IrradianceTexVars(cosSZA,alt);
 }
 
 vec2 irradianceTexVarsToTexCoord(const float cosSunZenithAngle, const float altitude)
 {
-    const float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
-    const float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
+    CONST float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
+    CONST float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
     return vec2(s,t);
 }
 
 float cosSZAToUnitRangeTexCoord(const float cosSunZenithAngle)
 {
     // Distance to top atmosphere border along the ray groundUnderCamera-sun: (altitude, cosSunZenithAngle)
-    const float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name
-    const float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
+    CONST float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
     // TODO: choose a more descriptive name
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     return max(0.,1-a/A)/(a+1);
 }
 
 float unitRangeTexCoordToCosSZA(const float texCoord)
 {
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float a=(A-A*texCoord)/(1+A*texCoord);
-    const float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
+    CONST float a=(A-A*texCoord)/(1+A*texCoord);
+    CONST float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
     return distFromGroundToTopAtmoBorder==0 ? 1 :
         clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distFromGroundToTopAtmoBorder)) /
                     (2*earthRadius*distFromGroundToTopAtmoBorder));
@@ -292,24 +303,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
                                                const float dotViewSun, const float altitude,
                                                const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -317,24 +328,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float dotVSCoord=(dotViewSun+1)/2;
+    CONST float dotVSCoord=(dotViewSun+1)/2;
 
     // ------------------------------------
-    const float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
+    CONST float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
 
     return Scattering4DCoords(cosSZACoord, cosVZACoord, dotVSCoord, altCoord, viewRayIntersectsGround);
 }
 
 TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
@@ -342,16 +353,16 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture coordinates we combine into a single sampler3D coordinate.
-    const float texW = scatteringTextureSize[1];
-    const float texH = scatteringTextureSize[2];
-    const float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
-    const vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
+    CONST float texW = scatteringTextureSize[1];
+    CONST float texH = scatteringTextureSize[2];
+    CONST float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
+    CONST vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
                                         ceil (cosSZAIndex)*texW+coords.dotViewSun*(texW-1)) / (texW*texH-1);
-    const vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
+    CONST vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
 
-    const float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
+    CONST float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
 
-    const float alphaUpper=fract(cosSZAIndex);
+    CONST float alphaUpper=fract(cosSZAIndex);
     return TexCoordPair(vec3(cosVZAtc, combinedCoord.x, altitude), float(1-alphaUpper),
                         vec3(cosVZAtc, combinedCoord.y, altitude), float(alphaUpper));
 }
@@ -359,9 +370,9 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
+    CONST TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
     return texture(tex, texCoords.lower) * texCoords.alphaLower +
            texture(tex, texCoords.upper) * texCoords.alphaUpper;
 }
@@ -369,17 +380,17 @@ vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const f
 // 3D texture is the 3D single-altitude slice of a 4D texture
 vec3 scattering4DCoordsToTex3DCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2);
 
-    const float dvsSize = scatteringTextureSize[1];
-    const float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
+    CONST float dvsSize = scatteringTextureSize[1];
+    CONST float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
 
-    const float cszaSize = scatteringTextureSize[2];
-    const float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
+    CONST float cszaSize = scatteringTextureSize[2];
+    CONST float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
 
     return vec3(cosVZAtc, dotVStc, cosSZAtc);
 }
@@ -394,39 +405,39 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along dotViewSun coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[1];
-    const float posOfRow = indices[1];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[1];
+    CONST float posOfRow = indices[1];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         indexToTexCoord(currRow, numRows-1),
                                                         texCoordVerbatim));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               indexToTexCoord(currRow, numRows-1),
                                                               texCoordVerbatim));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          indexToTexCoord(currRow, numRows-1),
                                          texCoordVerbatim));
@@ -434,14 +445,14 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
 vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolationGuides01Tex,
                                  const vec3 indices)
 {
-    const float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
+    CONST float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
 
-    const float cosVZAIndex = indices[0];
-    const float dotVSIndex = indices[1];
-    const float currRow = floor(dotVSIndex);
-    const float posBetweenRows = dotVSIndex - currRow;
-    const float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cosVZAIndex = indices[0];
+    CONST float dotVSIndex = indices[1];
+    CONST float currRow = floor(dotVSIndex);
+    CONST float posBetweenRows = dotVSIndex - currRow;
+    CONST float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -449,14 +460,14 @@ vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolat
     indicesCurrRow[1] =     currRow;
     indicesNextRow[1] = min(currRow+1, scatteringTextureSize[1]-1.);
 
-    const vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
-    const vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
+    CONST vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
+    CONST vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
 
-    const vec4 valueCurrRow = texture(tex, coordsCurrRow);
-    const vec4 valueNextRow = texture(tex, coordsNextRow);
-    const float epsilon = 1e-37; // Prevents passing zero to log
-    const vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
-    const vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
+    CONST vec4 valueCurrRow = texture(tex, coordsCurrRow);
+    CONST vec4 valueNextRow = texture(tex, coordsNextRow);
+    CONST float epsilon = 1e-37; // Prevents passing zero to log
+    CONST vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
+    CONST vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
     return (logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow;
 }
 
@@ -465,37 +476,37 @@ float findGuide02Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along SZA coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[2];
-    const float posOfRow = indices[2];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[2];
+    CONST float posOfRow = indices[2];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
 }
@@ -505,19 +516,19 @@ vec4 sample3DTextureGuided(const sampler3D tex,
                            const float cosSunZenithAngle, const float cosViewZenithAngle,
                            const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
                                                                     dotViewSun, altitude, viewRayIntersectsGround);
     // Handle the external interpolation guides: the guides between a pair of VZA-dotViewSun 2D "pictures".
-    const vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
-    const vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
-    const float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
+    CONST vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
+    CONST float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
 
-    const float cvzaIndex = indices[0];
-    const float cszaIndex = indices[2];
-    const float currRow = floor(cszaIndex);
-    const float posBetweenRows = cszaIndex - currRow;
-    const float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cvzaIndex = indices[0];
+    CONST float cszaIndex = indices[2];
+    CONST float currRow = floor(cszaIndex);
+    CONST float posBetweenRows = cszaIndex - currRow;
+    CONST float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -526,58 +537,58 @@ vec4 sample3DTextureGuided(const sampler3D tex,
     indicesNextRow[2] = min(currRow+1, scatteringTextureSize[2]-1);
 
     // The caller will handle the internal interpolation guides: the ones between rows in each 2D "picture".
-    const vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
-    const vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
+    CONST vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
+    CONST vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
     return exp((logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow);
 }
 
 vec4 sample3DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
     return texture(tex, texCoords);
 }
 
 ScatteringTexVars scatteringTex4DCoordsToTexVars(const Scattering4DCoords coords)
 {
-    const float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
     // ------------------------------------
     float cosViewZenithAngle;
     if(coords.viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
     // ------------------------------------
-    const float dotViewSun=coords.dotViewSun*2-1;
+    CONST float dotViewSun=coords.dotViewSun*2-1;
 
     // ------------------------------------
-    const float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
+    CONST float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
 
     return ScatteringTexVars(cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, coords.viewRayIntersectsGround);
 }
 
 Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 {
-    const vec4 indexMax=scatteringTextureSize-vec4(1);
+    CONST vec4 indexMax=scatteringTextureSize-vec4(1);
     Scattering4DCoords coords4d;
     coords4d.viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
     // The following formulas assume that scatteringTextureSize[0] is even. For odd sizes they would change.
@@ -593,8 +604,8 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture indices we combine into a single sampler3D coordinate.
-    const float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
-    const float combinedIndex=texIndices[1];
+    CONST float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
+    CONST float combinedIndex=texIndices[1];
     coords4d.dotViewSun=mod(combinedIndex,texW)/(texW-1);
     coords4d.cosSunZenithAngle=floor(combinedIndex/texW)/(texH-1);
 
@@ -608,11 +619,11 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
 ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 {
-    const Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
+    CONST Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
     ScatteringTexVars vars=scatteringTex4DCoordsToTexVars(coords4d);
     // Clamp dotViewSun to its valid range of values, given cosViewZenithAngle and cosSunZenithAngle. This is
     // needed to prevent NaNs when computing the scattering texture.
-    const float cosVZA=vars.cosViewZenithAngle,
+    CONST float cosVZA=vars.cosViewZenithAngle,
                 cosSZA=vars.cosSunZenithAngle;
     vars.dotViewSun=clamp(vars.dotViewSun,
                           cosVZA*cosSZA-safeSqrt((1-sqr(cosVZA))*(1-sqr(cosSZA))),
@@ -622,54 +633,54 @@ ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 
 EclipseScatteringTexVars eclipseTexCoordsToTexVars(const vec2 texCoords, const float altitude)
 {
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
-    const bool viewRayIntersectsGround = texCoords.t<0.5;
+    CONST bool viewRayIntersectsGround = texCoords.t<0.5;
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
-    const float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
+    CONST float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
     return EclipseScatteringTexVars(azimuthRelativeToSun, cosViewZenithAngle, viewRayIntersectsGround);
 }
 
 EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                                    const float altitude, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -677,13 +688,13 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
-    const float azimuthCoord = azimuthRelativeToSun/(2*PI);
+    CONST float azimuthCoord = azimuthRelativeToSun/(2*PI);
 
     return EclipseScattering2DCoords(azimuthCoord, cosVZACoord);
 }
@@ -691,14 +702,14 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
 vec2 eclipseTexVarsToTexCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                const float altitude, const bool viewRayIntersectsGround, const vec2 texSize)
 {
-    const EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+    CONST EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                                     viewRayIntersectsGround);
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2);
-    const float azimuthTC = coords.azimuth + 1/(2*texSize.s);
+    CONST float azimuthTC = coords.azimuth + 1/(2*texSize.s);
 
     return vec2(azimuthTC, cosVZAtc);
 }
@@ -707,42 +718,42 @@ vec4 sampleEclipseDoubleScattering3DTexture(const sampler3D tex, const float cos
                                             const float cosViewZenithAngle, const float azimuthRelativeToSun,
                                             const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
+    CONST vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
                                                   eclipsedDoubleScatteringTextureSize.st);
-    const float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
-    const vec3 texCoords=vec3(coords2d, cosSZACoord);
+    CONST float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
+    CONST vec3 texCoords=vec3(coords2d, cosSZACoord);
 
     return texture(tex, texCoords);
 }
 
 LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 texIndices)
 {
-    const vec2 indexMax=lightPollutionTextureSize-vec2(1);
+    CONST vec2 indexMax=lightPollutionTextureSize-vec2(1);
 
-    const float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
-    const float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
+    CONST float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
-    const bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
-    const float cosViewZenithAngleCoord = viewRayIntersectsGround ?
+    CONST bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
+    CONST float cosViewZenithAngleCoord = viewRayIntersectsGround ?
                                    1-2*texIndices[0]/(indexMax[0]-1) :
                                    2*(texIndices[0]-1)/(indexMax[0]-1)-1;
     // ------------------------------------
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
@@ -753,23 +764,23 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 
 LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -777,27 +788,27 @@ LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, con
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     return LightPollution2DCoords(cosVZACoord, altCoord);
 }
 
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
-    const vec2 texSize = lightPollutionTextureSize;
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 texSize = lightPollutionTextureSize;
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2);
-    const float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
+    CONST float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
     return vec2(cosVZAtc, altitudeTC);
 }

--- a/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/2/molecules/texture-sampling-functions.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/2/molecules/texture-sampling-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-sampling-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,13 +45,13 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.35000004e-05,1.33100002e-05,9.4
 const vec4 wavelengths=vec4(610.666687,642,673.333313,704.666687);
 const int wlSetIndex=2;
 #endif
-#line 5 0 // texture-sampling-functions.frag
-#line 1 2 // phase-functions.h.glsl
+#line 4 0 // texture-sampling-functions.frag
+#line 1 3 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 6 0 // texture-sampling-functions.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-sampling-functions.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -72,8 +83,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-sampling-functions.frag
-#line 1 4 // texture-coordinates.h.glsl
+#line 6 0 // texture-sampling-functions.frag
+#line 1 5 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -142,7 +153,7 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 8 0 // texture-sampling-functions.frag
+#line 7 0 // texture-sampling-functions.frag
 
 uniform sampler2D transmittanceTexture;
 uniform sampler2D irradianceTexture;
@@ -154,13 +165,13 @@ uniform sampler2D lightPollutionScatteringTexture;
 
 vec4 irradiance(const float cosSunZenithAngle, const float altitude)
 {
-    const vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
+    CONST vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
     return texture(irradianceTexture, texCoords);
 }
 
 vec4 opticalDepthToAtmosphereBorder(const float cosViewZenithAngle, const float altitude)
 {
-    const vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
+    CONST vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact when looking into nadir from TOA at some values of texture sizes (in particular, size of
     // transmittance texture for altitude being 4096). This happens when I simply call texture(eclipsedScatteringTexture,
@@ -178,11 +189,11 @@ vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float
 vec4 transmittance(const float cosViewZenithAngle, const float altitude, const float dist,
                    const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle view ray endpoint
     // in space here.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
 
     vec4 depth;
     if(viewRayIntersectsGround)
@@ -201,7 +212,7 @@ vec4 transmittance(const float cosViewZenithAngle, const float altitude, const f
 vec4 calcFirstScattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                          const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
+    CONST vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
                                           dotViewSun, altitude, viewRayIntersectsGround);
     return scattering*currentPhaseFunction(dotViewSun);
 }
@@ -220,6 +231,6 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
 
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     return texture(lightPollutionScatteringTexture, coords);
 }

--- a/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/3/aerosols/common-functions.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/3/aerosols/common-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // common-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // common-functions.frag
+#line 4 0 // common-functions.frag
 
 bool dbgDataPresent=false;
 bool debugDataPresent()
@@ -69,7 +80,7 @@ void setDebugData(float a,float b, float c, float d)
 
 void swap(inout float x, inout float y)
 {
-    const float t = x;
+    CONST float t = x;
     x = y;
     y = t;
 }
@@ -83,7 +94,7 @@ float safeSqrt(const float x)
 
 float safeAtan(const float y, const float x)
 {
-    const float a = atan(y,x);
+    CONST float a = atan(y,x);
     return x==0 && y==0 ? 0 : a;
 }
 
@@ -116,23 +127,23 @@ float pointAltitude(vec3 point)
 
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float Ratm=earthRadius+atmosphereHeight;
-    const float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float Ratm=earthRadius+atmosphereHeight;
+    CONST float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float distanceToGround(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(-safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float cosZenithAngleOfHorizon(const float altitude)
 {
-    const float R=earthRadius;
-    const float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
+    CONST float R=earthRadius;
+    CONST float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
     return -sqrt(2*h*R+sqr(h))/(R+h);
 }
 
@@ -151,8 +162,8 @@ float distanceToNearestAtmosphereBoundary(const float cosZenithAngle, const floa
 float sunVisibility(const float cosSunZenithAngle, float altitude)
 {
     if(altitude<0) altitude=0;
-    const float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
-    const float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
+    CONST float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
+    CONST float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
     /* Approximating visible fraction of solar disk by smoothstep between the position of the Sun
      * touching the horizon by its upper part and the position with lower part touching the horizon.
      * The calculation assumes that solar angular radius is small and thus approximately equals its sine.
@@ -182,13 +193,13 @@ float circlesIntersectionArea(float R1, float R2, float d)
 
 float angleBetween(const vec3 a, const vec3 b)
 {
-    const float d=dot(a,b);
-    const float c=length(cross(a,b));
+    CONST float d=dot(a,b);
+    CONST float c=length(cross(a,b));
     // To avoid loss of precision, don't use dot product near the singularity
     // of acos, and cross product near the singularity of asin
     if(abs(d) < abs(c))
         return acos(d/(length(a)*length(b)));
-    const float smallerAngle = asin(c/(length(a)*length(b)));
+    CONST float smallerAngle = asin(c/(length(a)*length(b)));
     if(d<0) return PI-smallerAngle;
     return smallerAngle;
 }
@@ -205,11 +216,11 @@ float moonAngularRadius(const vec3 cameraPosition, const vec3 moonPosition)
 
 float visibleSolidAngleOfSun(const vec3 camera, const vec3 sunDir, const vec3 moonPos)
 {
-    const float Rs=sunAngularRadius;
-    const float Rm=moonAngularRadius(camera,moonPos);
+    CONST float Rs=sunAngularRadius;
+    CONST float Rm=moonAngularRadius(camera,moonPos);
     float visibleSolidAngle=PI*sqr(Rs);
 
-    const float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
+    CONST float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
     if(dSM<Rs+Rm)
     {
         visibleSolidAngle -= circlesIntersectionArea(Rm,Rs,dSM);
@@ -229,12 +240,12 @@ float sphereIntegrationSolidAngleDifferential(const int pointCountOnSphere)
 }
 vec3 sphereIntegrationSampleDir(const int index, const int pointCountOnSphere)
 {
-    const float goldenRatio=1.6180339887499;
+    CONST float goldenRatio=1.6180339887499;
     // The range of n is 0.5, 1.5, ..., pointCountOnSphere-0.5
-    const float n=index+0.5;
+    CONST float n=index+0.5;
     // Explanation of the Fibonacci grid generation can be seen at https://stackoverflow.com/a/44164075/673852
-    const float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
-    const float azimuth=n*(2*PI*goldenRatio);
+    CONST float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
+    CONST float azimuth=n*(2*PI*goldenRatio);
     return vec3(cos(azimuth)*sin(zenithAngle),
                 sin(azimuth)*sin(zenithAngle),
                 cos(zenithAngle));

--- a/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/3/aerosols/densities.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/3/aerosols/densities.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // densities.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,20 +45,20 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // densities.frag
+#line 4 0 // densities.frag
 float scattererNumberDensity_molecules(float altitude)
 {
-        const float rayleighScaleHeight=8*km;
+        CONST float rayleighScaleHeight=8*km;
         return 3.08458e25*exp(-1/rayleighScaleHeight * altitude);
 }
 float scattererNumberDensity_aerosols(float altitude)
 {
-        const float mieScaleHeight=1.2*km;
+        CONST float mieScaleHeight=1.2*km;
         return 1.03333e8*exp(-1/mieScaleHeight*altitude);
 }
 float absorberNumberDensity_ozone(float altitude)
 {
-        const float totalOzoneAmount=370*dobsonUnit;
+        CONST float totalOzoneAmount=370*dobsonUnit;
 
         float density;
 

--- a/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/3/aerosols/phase-functions.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/3/aerosols/phase-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // phase-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // phase-functions.frag
+#line 4 0 // phase-functions.frag
 
 vec4 phaseFunction_molecules(float dotViewSun)
 {
@@ -42,9 +53,9 @@ vec4 phaseFunction_molecules(float dotViewSun)
 }
 vec4 phaseFunction_aerosols(float dotViewSun)
 {
-        const float g=0.76;
-        const float g2=g*g;
-        const float k = 3/(8*PI)*(1-g2)/(2+g2);
+        CONST float g=0.76;
+        CONST float g2=g*g;
+        CONST float k = 3/(8*PI)*(1-g2)/(2+g2);
         return vec4(k * (1+sqr(dotViewSun)) / pow(1+g2 - 2*g*dotViewSun, 1.5) + 1/((1-dotViewSun)*600+0.05))*0.904;
 }
 vec4 currentPhaseFunction(float dotViewSun) { return phaseFunction_aerosols(dotViewSun); }

--- a/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/3/aerosols/render.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/3/aerosols/render.frag
@@ -1,7 +1,21 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
 
-#line 1 1 // const.h.glsl
+
+
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 6 0 // render.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,11 +48,11 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // render.frag
-#line 1 2 // calc-view-dir.h.glsl
+#line 7 0 // render.frag
+#line 1 3 // calc-view-dir.h.glsl
 vec3 calcViewDir();
-#line 6 0 // render.frag
-#line 1 3 // common-functions.h.glsl
+#line 8 0 // render.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -70,14 +84,14 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // render.frag
-#line 1 4 // phase-functions.h.glsl
+#line 9 0 // render.frag
+#line 1 5 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 8 0 // render.frag
+#line 10 0 // render.frag
 
-#line 1 5 // single-scattering-eclipsed.h.glsl
+#line 1 6 // single-scattering-eclipsed.h.glsl
 #ifndef INCLUDE_ONCE_050024D2_BD56_434E_8D40_2055DA0B78EC
 #define INCLUDE_ONCE_050024D2_BD56_434E_8D40_2055DA0B78EC
 
@@ -85,8 +99,8 @@ vec4 computeSingleScatteringEclipsed(const vec3 camera, const vec3 viewDir, cons
                                      const bool viewRayIntersectsGround);
 
 #endif
-#line 10 0 // render.frag
-#line 1 6 // texture-coordinates.h.glsl
+#line 12 0 // render.frag
+#line 1 7 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -155,10 +169,10 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 11 0 // render.frag
-#line 1 7 // radiance-to-luminance.h.glsl
+#line 13 0 // render.frag
+#line 1 8 // radiance-to-luminance.h.glsl
 const mat4 radianceToLuminance=mat4(19.8756237,7.17745161,0,0.0937032327,  2.13895917,0.772417068,0,0.0149318045,  0.241072536,0.0870557055,0,0,  0.0133876652,0.00483453181,0,0);
-#line 12 0 // render.frag
+#line 14 0 // render.frag
 
 
 
@@ -195,18 +209,18 @@ void main()
     // this approximation has the same order of magnitude as the assumption that the Earth and its atmosphere
     // are spherical.
     float altitude = max(cameraPosition.z, 0.);
-    const vec3 oldCamPos=cameraPosition;
+    CONST vec3 oldCamPos=cameraPosition;
     // Hide the uniform with this name, thus effectively modifying it for the following code
     vec3 cameraPosition=vec3(oldCamPos.xy, altitude);
 
     bool lookingIntoAtmosphere=true;
     if(altitude>atmosphereHeight)
     {
-        const vec3 p = cameraPosition - earthCenter;
-        const float p_dot_v = dot(p, viewDir);
-        const float p_dot_p = dot(p, p);
-        const float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
-        const float distanceToTOA = -p_dot_v - sqrt(sqr(earthRadius+atmosphereHeight) - squaredDistBetweenViewRayAndEarthCenter);
+        CONST vec3 p = cameraPosition - earthCenter;
+        CONST float p_dot_v = dot(p, viewDir);
+        CONST float p_dot_p = dot(p, p);
+        CONST float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
+        CONST float distanceToTOA = -p_dot_v - sqrt(sqr(earthRadius+atmosphereHeight) - squaredDistBetweenViewRayAndEarthCenter);
         if(distanceToTOA>=0)
         {
             cameraPosition += viewDir*distanceToTOA;
@@ -214,7 +228,7 @@ void main()
         }
         else
         {
-#if RENDERING_ANY_ZERO_SCATTERING
+#if 0 /*RENDERING_ANY_ZERO_SCATTERING*/
             lookingIntoAtmosphere=false;
 #else
             luminance=vec4(0);
@@ -224,16 +238,16 @@ void main()
         }
     }
 
-    const vec3 zenith=normalize(cameraPosition-earthCenter);
+    CONST vec3 zenith=normalize(cameraPosition-earthCenter);
     float cosViewZenithAngle=dot(zenith,viewDir);
 
     bool viewRayIntersectsGround=false;
     {
-        const vec3 p = cameraPosition - earthCenter;
-        const float p_dot_v = dot(p, viewDir);
-        const float p_dot_p = dot(p, p);
-        const float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
-        const float distanceToIntersection = -p_dot_v - sqrt(sqr(earthRadius) - squaredDistBetweenViewRayAndEarthCenter);
+        CONST vec3 p = cameraPosition - earthCenter;
+        CONST float p_dot_v = dot(p, viewDir);
+        CONST float p_dot_p = dot(p, p);
+        CONST float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
+        CONST float distanceToIntersection = -p_dot_v - sqrt(sqr(earthRadius) - squaredDistBetweenViewRayAndEarthCenter);
         // altitude==0 is a special case where distance to intersection calculation
         // is unreliable (has a lot of noise in its sign), so check it separately
         if(distanceToIntersection>0 || (altitude==0 && cosViewZenithAngle<0))
@@ -244,11 +258,11 @@ void main()
     // Aside from aesthetics, this affects brightness input to Stellarium's tone mapper.
     if(pseudoMirrorSkyBelowHorizon && viewRayIntersectsGround)
     {
-        const float horizonCZA = cosZenithAngleOfHorizon(altitude);
-        const float viewElev  = asin(clampCosine(cosViewZenithAngle));
-        const float horizElev = asin(clampCosine(horizonCZA));
-        const float newViewElev = 2*horizElev - viewElev;
-        const float viewDirXYnorm = length(viewDir-zenith*cosViewZenithAngle);
+        CONST float horizonCZA = cosZenithAngleOfHorizon(altitude);
+        CONST float viewElev  = asin(clampCosine(cosViewZenithAngle));
+        CONST float horizElev = asin(clampCosine(horizonCZA));
+        CONST float newViewElev = 2*horizElev - viewElev;
+        CONST float viewDirXYnorm = length(viewDir-zenith*cosViewZenithAngle);
         if(viewDirXYnorm == 0)
         {
             viewDir = zenith;
@@ -267,27 +281,27 @@ void main()
         viewRayIntersectsGround = false;
     }
 
-    const float cosSunZenithAngle =dot(zenith,sunDirection);
-    const float dotViewSun=dot(viewDir,sunDirection);
+    CONST float cosSunZenithAngle =dot(zenith,sunDirection);
+    CONST float dotViewSun=dot(viewDir,sunDirection);
 
-    const vec3 sunXYunnorm=sunDirection-dot(sunDirection,zenith)*zenith;
-    const vec3 viewXYunnorm=viewDir-dot(viewDir,zenith)*zenith;
-    const vec3 sunXY = sunXYunnorm.x!=0 || sunXYunnorm.y!=0 || sunXYunnorm.z!=0 ? normalize(sunXYunnorm) : vec3(0);
-    const vec3 viewXY = viewXYunnorm.x!=0 || viewXYunnorm.y!=0 || viewXYunnorm.z!=0 ? normalize(viewXYunnorm) : vec3(0);
-    const float azimuthRelativeToSun=safeAtan(dot(cross(sunXY, viewXY), zenith), dot(sunXY, viewXY));
+    CONST vec3 sunXYunnorm=sunDirection-dot(sunDirection,zenith)*zenith;
+    CONST vec3 viewXYunnorm=viewDir-dot(viewDir,zenith)*zenith;
+    CONST vec3 sunXY = sunXYunnorm.x!=0 || sunXYunnorm.y!=0 || sunXYunnorm.z!=0 ? normalize(sunXYunnorm) : vec3(0);
+    CONST vec3 viewXY = viewXYunnorm.x!=0 || viewXYunnorm.y!=0 || viewXYunnorm.z!=0 ? normalize(viewXYunnorm) : vec3(0);
+    CONST float azimuthRelativeToSun=safeAtan(dot(cross(sunXY, viewXY), zenith), dot(sunXY, viewXY));
 
-#if RENDERING_ZERO_SCATTERING
+#if 0 /*RENDERING_ZERO_SCATTERING*/
     vec4 radiance;
     if(viewRayIntersectsGround)
     {
         // XXX: keep in sync with the same code in computeScatteringDensity(), but don't forget about
         //      the difference in the usage of viewDir vs incDir.
-        const float distToGround = distanceToGround(cosViewZenithAngle, altitude);
-        const vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
-        const vec3 groundNormal = normalize(zenith*(earthRadius+altitude)+viewDir*distToGround);
-        const vec4 groundIrradiance = irradiance(dot(groundNormal, sunDirection), 0);
+        CONST float distToGround = distanceToGround(cosViewZenithAngle, altitude);
+        CONST vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
+        CONST vec3 groundNormal = normalize(zenith*(earthRadius+altitude)+viewDir*distToGround);
+        CONST vec4 groundIrradiance = irradiance(dot(groundNormal, sunDirection), 0);
         // Radiation scattered by the ground
-        const float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
+        CONST float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
         radiance = transmittanceToGround*groundAlbedo*groundIrradiance*solarIrradianceFixup*groundBRDF
                  + lightPollutionGroundLuminance*lightPollutionRelativeRadiance;
     }
@@ -304,22 +318,22 @@ void main()
     }
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_ZERO_SCATTERING
+#elif 0 /*RENDERING_ECLIPSED_ZERO_SCATTERING*/
     vec4 radiance;
-    const float dotViewMoon=dot(viewDir,normalize(moonPosition-cameraPosition));
+    CONST float dotViewMoon=dot(viewDir,normalize(moonPosition-cameraPosition));
     if(viewRayIntersectsGround)
     {
         // XXX: keep in sync with the similar code in non-eclipsed zero scattering rendering.
-        const float distToGround = distanceToGround(cosViewZenithAngle, altitude);
-        const vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
-        const vec3 pointOnGround = cameraPosition+viewDir*distToGround;
-        const vec4 directGroundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDirection, moonPosition);
+        CONST float distToGround = distanceToGround(cosViewZenithAngle, altitude);
+        CONST vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
+        CONST vec3 pointOnGround = cameraPosition+viewDir*distToGround;
+        CONST vec4 directGroundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDirection, moonPosition);
         // FIXME: add first-order indirect irradiance too: it's done in non-eclipsed irradiance (in the same
         // conditions: when limited to 2 orders). This should be calculated at the same time when second order
         // is: all the infrastructure is already there.
-        const vec4 groundIrradiance = directGroundIrradiance;
+        CONST vec4 groundIrradiance = directGroundIrradiance;
         // Radiation scattered by the ground
-        const float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
+        CONST float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
         radiance = transmittanceToGround*groundAlbedo*groundIrradiance*solarIrradianceFixup*groundBRDF
                  + lightPollutionGroundLuminance*lightPollutionRelativeRadiance;
     }
@@ -337,52 +351,52 @@ void main()
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
 #elif 1 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_ON_THE_FLY*/
-    const vec4 scattering=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPosition,
+    CONST vec4 scattering=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPosition,
                                                           viewRayIntersectsGround);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE
-    const vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE*/
+    CONST vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                      viewRayIntersectsGround, eclipsedSingleScatteringTextureSize);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact at the point where azimuth texture coordinate changes from 1 to 0 (at azimuthRelativeToSun crossing
     // 0). This happens when I simply call texture(eclipsedScatteringTexture, texCoords) without specifying LOD.
     // Apparently, the driver uses the derivative for some reason, even though it shouldn't.
-    const vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
+    CONST vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE
-    const vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
+    CONST vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                      viewRayIntersectsGround, eclipsedSingleScatteringTextureSize);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact at the point where azimuth texture coordinate changes from 1 to 0 (at azimuthRelativeToSun crossing
     // 0). This happens when I simply call texture(eclipsedScatteringTexture, texCoords) without specifying LOD.
     // Apparently, the driver uses the derivative for some reason, even though it shouldn't.
-    const vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
+    CONST vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
     luminance=scattering*currentPhaseFunction(dotViewSun);
-#elif RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_RADIANCE
+#elif 0 /*RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_RADIANCE*/
     vec4 radiance=exp(sampleEclipseDoubleScattering3DTexture(eclipsedDoubleScatteringTexture,
                                                              cosSunZenithAngle, cosViewZenithAngle, azimuthRelativeToSun,
                                                              altitude, viewRayIntersectsGround));
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_LUMINANCE
+#elif 0 /*RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
     luminance=exp(sampleEclipseDoubleScattering3DTexture(eclipsedDoubleScatteringTexture,
                                                          cosSunZenithAngle, cosViewZenithAngle, azimuthRelativeToSun,
                                                          altitude, viewRayIntersectsGround));
-#elif RENDERING_SINGLE_SCATTERING_ON_THE_FLY
-    const vec4 scattering=computeSingleScattering(cosSunZenithAngle,cosViewZenithAngle,dotViewSun,
+#elif 0 /*RENDERING_SINGLE_SCATTERING_ON_THE_FLY*/
+    CONST vec4 scattering=computeSingleScattering(cosSunZenithAngle,cosViewZenithAngle,dotViewSun,
                                                   altitude,viewRayIntersectsGround);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE
+#elif 0 /*RENDERING_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE*/
     vec4 scattering;
     if(useInterpolationGuides)
     {
@@ -399,7 +413,7 @@ void main()
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE
+#elif 0 /*RENDERING_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
     vec4 scattering;
     if(useInterpolationGuides)
     {
@@ -413,18 +427,18 @@ void main()
                                      dotViewSun, altitude, viewRayIntersectsGround);
     }
     luminance=scattering * (bool(PHASE_FUNCTION_IS_EMBEDDED) ? vec4(1) : currentPhaseFunction(dotViewSun));
-#elif RENDERING_MULTIPLE_SCATTERING_LUMINANCE
+#elif 0 /*RENDERING_MULTIPLE_SCATTERING_LUMINANCE*/
     luminance=sample3DTexture(scatteringTexture, cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, viewRayIntersectsGround);
-#elif RENDERING_MULTIPLE_SCATTERING_RADIANCE
+#elif 0 /*RENDERING_MULTIPLE_SCATTERING_RADIANCE*/
     vec4 radiance=sample3DTexture(scatteringTexture, cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, viewRayIntersectsGround);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_LIGHT_POLLUTION_RADIANCE
+#elif 0 /*RENDERING_LIGHT_POLLUTION_RADIANCE*/
     vec4 radiance=lightPollutionGroundLuminance*lightPollutionScattering(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_LIGHT_POLLUTION_LUMINANCE
+#elif 0 /*RENDERING_LIGHT_POLLUTION_LUMINANCE*/
     luminance=lightPollutionGroundLuminance*lightPollutionScattering(altitude, cosViewZenithAngle, viewRayIntersectsGround);
 #else
 #error What to render?

--- a/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/3/aerosols/single-scattering-eclipsed.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/3/aerosols/single-scattering-eclipsed.frag
@@ -1,7 +1,21 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
 
-#line 1 1 // const.h.glsl
+
+
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 6 0 // single-scattering-eclipsed.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,15 +48,15 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // single-scattering-eclipsed.frag
-#line 1 2 // densities.h.glsl
+#line 7 0 // single-scattering-eclipsed.frag
+#line 1 3 // densities.h.glsl
 float scattererNumberDensity_molecules(float altitude);
 float scattererNumberDensity_aerosols(float altitude);
 float absorberNumberDensity_ozone(float altitude);
 vec4 scatteringCrossSection();
 float scattererDensity(float altitude);
-#line 6 0 // single-scattering-eclipsed.frag
-#line 1 3 // common-functions.h.glsl
+#line 8 0 // single-scattering-eclipsed.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -74,8 +88,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // single-scattering-eclipsed.frag
-#line 1 4 // texture-sampling-functions.h.glsl
+#line 9 0 // single-scattering-eclipsed.frag
+#line 1 5 // texture-sampling-functions.h.glsl
 #ifndef INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 #define INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float altitude);
@@ -87,7 +101,7 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                 const int scatteringOrder);
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 #endif
-#line 8 0 // single-scattering-eclipsed.frag
+#line 10 0 // single-scattering-eclipsed.frag
 
 
 float cosZenithAngle(vec3 origin, vec3 direction)
@@ -101,13 +115,13 @@ vec4 computeSingleScatteringIntegrandEclipsed(const float cosSunZenithAngle, con
                                               const float dist, const bool viewRayIntersectsGround,
                                               const vec3 scatterer, const vec3 sunDir, const vec3 moonPos)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle here the case when the
     // endpoint of the view ray intentionally appears in outer space.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosSunZenithAngleAtDist=clampCosine((r*cosSunZenithAngle+dist*dotViewSun)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosSunZenithAngleAtDist=clampCosine((r*cosSunZenithAngle+dist*dotViewSun)/(earthRadius+altAtDist));
 
-    const vec4 xmittance=transmittance(cosViewZenithAngle, altitude, dist, viewRayIntersectsGround)
+    CONST vec4 xmittance=transmittance(cosViewZenithAngle, altitude, dist, viewRayIntersectsGround)
                                                     *
                          transmittanceToAtmosphereBorder(cosSunZenithAngleAtDist, altAtDist)
                                                     *
@@ -115,7 +129,7 @@ vec4 computeSingleScatteringIntegrandEclipsed(const float cosSunZenithAngle, con
                                                     *
                             // FIXME: this ignores orientation of the crescent of eclipsed Sun WRT horizon
                                     sunVisibility(cosSunZenithAngleAtDist, altAtDist);
-#if ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION
+#if 0 /*ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION*/
     COMPUTE_TOTAL_SCATTERING_COEFFICIENT;
     return xmittance * totalScatteringCoefficient;
 #else
@@ -126,26 +140,26 @@ vec4 computeSingleScatteringIntegrandEclipsed(const float cosSunZenithAngle, con
 vec4 computeSingleScatteringEclipsed(const vec3 camera, const vec3 viewDir, const vec3 sunDir, const vec3 moonPos,
                                      const bool viewRayIntersectsGround)
 {
-    const float cosViewZenithAngle=cosZenithAngle(camera,viewDir);
-    const float cosSunZenithAngle=cosZenithAngle(camera,sunDir);
-    const float altitude=pointAltitude(camera);
-    const float dotViewSun=dot(viewDir,sunDir);
-    const float integrInterval=distanceToNearestAtmosphereBoundary(cosViewZenithAngle, altitude,
+    CONST float cosViewZenithAngle=cosZenithAngle(camera,viewDir);
+    CONST float cosSunZenithAngle=cosZenithAngle(camera,sunDir);
+    CONST float altitude=pointAltitude(camera);
+    CONST float dotViewSun=dot(viewDir,sunDir);
+    CONST float integrInterval=distanceToNearestAtmosphereBoundary(cosViewZenithAngle, altitude,
                                                                    viewRayIntersectsGround);
 
     // Using the midpoint rule for quadrature
     vec4 spectrum=vec4(0);
-    const float dl=integrInterval/radialIntegrationPoints;
+    CONST float dl=integrInterval/radialIntegrationPoints;
     for(int n=0; n<radialIntegrationPoints; ++n)
     {
-        const float dist=(n+0.5)*dl;
+        CONST float dist=(n+0.5)*dl;
         spectrum += computeSingleScatteringIntegrandEclipsed(cosSunZenithAngle, cosViewZenithAngle, dotViewSun,
                                                              altitude, dist, viewRayIntersectsGround,
                                                              camera+viewDir*dist, sunDir, moonPos);
     }
 
     spectrum *= dl*solarIrradianceAtTOA
-#if ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION
+#if 0 /*ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION*/
                                 // the multiplier is already included
 #else
                                         * scatteringCrossSection()

--- a/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/3/aerosols/texture-coordinates.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/3/aerosols/texture-coordinates.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-coordinates.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,8 +45,8 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // texture-coordinates.frag
-#line 1 2 // texture-coordinates.h.glsl
+#line 4 0 // texture-coordinates.frag
+#line 1 3 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -104,8 +115,8 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 6 0 // texture-coordinates.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-coordinates.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -137,7 +148,7 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-coordinates.frag
+#line 6 0 // texture-coordinates.frag
 
 const float LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA=sqrt(atmosphereHeight*(atmosphereHeight+2*earthRadius));
 
@@ -205,18 +216,18 @@ vec3 indicesToTexCoords(const vec3 indices, const vec3 texSizes)
 
 TransmittanceTexVars transmittanceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
+    CONST float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
                                 texCoordToUnitRange(texCoord.t,transmittanceTextureSize.t);
     // Distance from Earth center to camera
-    const float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
-    const float altitude=r-earthRadius;
+    CONST float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
+    CONST float altitude=r-earthRadius;
 
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
     // distance to border of visible atmosphere from the view point
-    const float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
+    CONST float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
     // d==0 can happen when altitude==atmosphereHeight
-    const float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
+    CONST float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
     return TransmittanceTexVars(cosVZA,altitude);
 }
 
@@ -235,53 +246,53 @@ vec2 transmittanceTexVarsToTexCoord(const float cosVZA, float altitude)
     if(altitude<0)
         altitude=0;
 
-    const float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
+    CONST float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
                                       transmittanceTextureSize.t);
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
-    const float d=distanceToAtmosphereBorder(cosVZA,altitude);
-    const float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float d=distanceToAtmosphereBorder(cosVZA,altitude);
+    CONST float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
     return vec2(s,t);
 }
 
 // Output: vec2(cos(sunZenithAngle), altitude)
 IrradianceTexVars irradianceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
-    const float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
+    CONST float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
+    CONST float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
     return IrradianceTexVars(cosSZA,alt);
 }
 
 vec2 irradianceTexVarsToTexCoord(const float cosSunZenithAngle, const float altitude)
 {
-    const float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
-    const float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
+    CONST float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
+    CONST float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
     return vec2(s,t);
 }
 
 float cosSZAToUnitRangeTexCoord(const float cosSunZenithAngle)
 {
     // Distance to top atmosphere border along the ray groundUnderCamera-sun: (altitude, cosSunZenithAngle)
-    const float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name
-    const float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
+    CONST float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
     // TODO: choose a more descriptive name
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     return max(0.,1-a/A)/(a+1);
 }
 
 float unitRangeTexCoordToCosSZA(const float texCoord)
 {
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float a=(A-A*texCoord)/(1+A*texCoord);
-    const float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
+    CONST float a=(A-A*texCoord)/(1+A*texCoord);
+    CONST float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
     return distFromGroundToTopAtmoBorder==0 ? 1 :
         clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distFromGroundToTopAtmoBorder)) /
                     (2*earthRadius*distFromGroundToTopAtmoBorder));
@@ -292,24 +303,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
                                                const float dotViewSun, const float altitude,
                                                const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -317,24 +328,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float dotVSCoord=(dotViewSun+1)/2;
+    CONST float dotVSCoord=(dotViewSun+1)/2;
 
     // ------------------------------------
-    const float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
+    CONST float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
 
     return Scattering4DCoords(cosSZACoord, cosVZACoord, dotVSCoord, altCoord, viewRayIntersectsGround);
 }
 
 TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
@@ -342,16 +353,16 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture coordinates we combine into a single sampler3D coordinate.
-    const float texW = scatteringTextureSize[1];
-    const float texH = scatteringTextureSize[2];
-    const float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
-    const vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
+    CONST float texW = scatteringTextureSize[1];
+    CONST float texH = scatteringTextureSize[2];
+    CONST float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
+    CONST vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
                                         ceil (cosSZAIndex)*texW+coords.dotViewSun*(texW-1)) / (texW*texH-1);
-    const vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
+    CONST vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
 
-    const float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
+    CONST float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
 
-    const float alphaUpper=fract(cosSZAIndex);
+    CONST float alphaUpper=fract(cosSZAIndex);
     return TexCoordPair(vec3(cosVZAtc, combinedCoord.x, altitude), float(1-alphaUpper),
                         vec3(cosVZAtc, combinedCoord.y, altitude), float(alphaUpper));
 }
@@ -359,9 +370,9 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
+    CONST TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
     return texture(tex, texCoords.lower) * texCoords.alphaLower +
            texture(tex, texCoords.upper) * texCoords.alphaUpper;
 }
@@ -369,17 +380,17 @@ vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const f
 // 3D texture is the 3D single-altitude slice of a 4D texture
 vec3 scattering4DCoordsToTex3DCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2);
 
-    const float dvsSize = scatteringTextureSize[1];
-    const float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
+    CONST float dvsSize = scatteringTextureSize[1];
+    CONST float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
 
-    const float cszaSize = scatteringTextureSize[2];
-    const float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
+    CONST float cszaSize = scatteringTextureSize[2];
+    CONST float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
 
     return vec3(cosVZAtc, dotVStc, cosSZAtc);
 }
@@ -394,39 +405,39 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along dotViewSun coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[1];
-    const float posOfRow = indices[1];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[1];
+    CONST float posOfRow = indices[1];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         indexToTexCoord(currRow, numRows-1),
                                                         texCoordVerbatim));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               indexToTexCoord(currRow, numRows-1),
                                                               texCoordVerbatim));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          indexToTexCoord(currRow, numRows-1),
                                          texCoordVerbatim));
@@ -434,14 +445,14 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
 vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolationGuides01Tex,
                                  const vec3 indices)
 {
-    const float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
+    CONST float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
 
-    const float cosVZAIndex = indices[0];
-    const float dotVSIndex = indices[1];
-    const float currRow = floor(dotVSIndex);
-    const float posBetweenRows = dotVSIndex - currRow;
-    const float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cosVZAIndex = indices[0];
+    CONST float dotVSIndex = indices[1];
+    CONST float currRow = floor(dotVSIndex);
+    CONST float posBetweenRows = dotVSIndex - currRow;
+    CONST float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -449,14 +460,14 @@ vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolat
     indicesCurrRow[1] =     currRow;
     indicesNextRow[1] = min(currRow+1, scatteringTextureSize[1]-1.);
 
-    const vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
-    const vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
+    CONST vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
+    CONST vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
 
-    const vec4 valueCurrRow = texture(tex, coordsCurrRow);
-    const vec4 valueNextRow = texture(tex, coordsNextRow);
-    const float epsilon = 1e-37; // Prevents passing zero to log
-    const vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
-    const vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
+    CONST vec4 valueCurrRow = texture(tex, coordsCurrRow);
+    CONST vec4 valueNextRow = texture(tex, coordsNextRow);
+    CONST float epsilon = 1e-37; // Prevents passing zero to log
+    CONST vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
+    CONST vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
     return (logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow;
 }
 
@@ -465,37 +476,37 @@ float findGuide02Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along SZA coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[2];
-    const float posOfRow = indices[2];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[2];
+    CONST float posOfRow = indices[2];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
 }
@@ -505,19 +516,19 @@ vec4 sample3DTextureGuided(const sampler3D tex,
                            const float cosSunZenithAngle, const float cosViewZenithAngle,
                            const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
                                                                     dotViewSun, altitude, viewRayIntersectsGround);
     // Handle the external interpolation guides: the guides between a pair of VZA-dotViewSun 2D "pictures".
-    const vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
-    const vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
-    const float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
+    CONST vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
+    CONST float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
 
-    const float cvzaIndex = indices[0];
-    const float cszaIndex = indices[2];
-    const float currRow = floor(cszaIndex);
-    const float posBetweenRows = cszaIndex - currRow;
-    const float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cvzaIndex = indices[0];
+    CONST float cszaIndex = indices[2];
+    CONST float currRow = floor(cszaIndex);
+    CONST float posBetweenRows = cszaIndex - currRow;
+    CONST float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -526,58 +537,58 @@ vec4 sample3DTextureGuided(const sampler3D tex,
     indicesNextRow[2] = min(currRow+1, scatteringTextureSize[2]-1);
 
     // The caller will handle the internal interpolation guides: the ones between rows in each 2D "picture".
-    const vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
-    const vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
+    CONST vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
+    CONST vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
     return exp((logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow);
 }
 
 vec4 sample3DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
     return texture(tex, texCoords);
 }
 
 ScatteringTexVars scatteringTex4DCoordsToTexVars(const Scattering4DCoords coords)
 {
-    const float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
     // ------------------------------------
     float cosViewZenithAngle;
     if(coords.viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
     // ------------------------------------
-    const float dotViewSun=coords.dotViewSun*2-1;
+    CONST float dotViewSun=coords.dotViewSun*2-1;
 
     // ------------------------------------
-    const float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
+    CONST float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
 
     return ScatteringTexVars(cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, coords.viewRayIntersectsGround);
 }
 
 Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 {
-    const vec4 indexMax=scatteringTextureSize-vec4(1);
+    CONST vec4 indexMax=scatteringTextureSize-vec4(1);
     Scattering4DCoords coords4d;
     coords4d.viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
     // The following formulas assume that scatteringTextureSize[0] is even. For odd sizes they would change.
@@ -593,8 +604,8 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture indices we combine into a single sampler3D coordinate.
-    const float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
-    const float combinedIndex=texIndices[1];
+    CONST float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
+    CONST float combinedIndex=texIndices[1];
     coords4d.dotViewSun=mod(combinedIndex,texW)/(texW-1);
     coords4d.cosSunZenithAngle=floor(combinedIndex/texW)/(texH-1);
 
@@ -608,11 +619,11 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
 ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 {
-    const Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
+    CONST Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
     ScatteringTexVars vars=scatteringTex4DCoordsToTexVars(coords4d);
     // Clamp dotViewSun to its valid range of values, given cosViewZenithAngle and cosSunZenithAngle. This is
     // needed to prevent NaNs when computing the scattering texture.
-    const float cosVZA=vars.cosViewZenithAngle,
+    CONST float cosVZA=vars.cosViewZenithAngle,
                 cosSZA=vars.cosSunZenithAngle;
     vars.dotViewSun=clamp(vars.dotViewSun,
                           cosVZA*cosSZA-safeSqrt((1-sqr(cosVZA))*(1-sqr(cosSZA))),
@@ -622,54 +633,54 @@ ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 
 EclipseScatteringTexVars eclipseTexCoordsToTexVars(const vec2 texCoords, const float altitude)
 {
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
-    const bool viewRayIntersectsGround = texCoords.t<0.5;
+    CONST bool viewRayIntersectsGround = texCoords.t<0.5;
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
-    const float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
+    CONST float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
     return EclipseScatteringTexVars(azimuthRelativeToSun, cosViewZenithAngle, viewRayIntersectsGround);
 }
 
 EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                                    const float altitude, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -677,13 +688,13 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
-    const float azimuthCoord = azimuthRelativeToSun/(2*PI);
+    CONST float azimuthCoord = azimuthRelativeToSun/(2*PI);
 
     return EclipseScattering2DCoords(azimuthCoord, cosVZACoord);
 }
@@ -691,14 +702,14 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
 vec2 eclipseTexVarsToTexCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                const float altitude, const bool viewRayIntersectsGround, const vec2 texSize)
 {
-    const EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+    CONST EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                                     viewRayIntersectsGround);
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2);
-    const float azimuthTC = coords.azimuth + 1/(2*texSize.s);
+    CONST float azimuthTC = coords.azimuth + 1/(2*texSize.s);
 
     return vec2(azimuthTC, cosVZAtc);
 }
@@ -707,42 +718,42 @@ vec4 sampleEclipseDoubleScattering3DTexture(const sampler3D tex, const float cos
                                             const float cosViewZenithAngle, const float azimuthRelativeToSun,
                                             const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
+    CONST vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
                                                   eclipsedDoubleScatteringTextureSize.st);
-    const float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
-    const vec3 texCoords=vec3(coords2d, cosSZACoord);
+    CONST float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
+    CONST vec3 texCoords=vec3(coords2d, cosSZACoord);
 
     return texture(tex, texCoords);
 }
 
 LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 texIndices)
 {
-    const vec2 indexMax=lightPollutionTextureSize-vec2(1);
+    CONST vec2 indexMax=lightPollutionTextureSize-vec2(1);
 
-    const float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
-    const float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
+    CONST float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
-    const bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
-    const float cosViewZenithAngleCoord = viewRayIntersectsGround ?
+    CONST bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
+    CONST float cosViewZenithAngleCoord = viewRayIntersectsGround ?
                                    1-2*texIndices[0]/(indexMax[0]-1) :
                                    2*(texIndices[0]-1)/(indexMax[0]-1)-1;
     // ------------------------------------
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
@@ -753,23 +764,23 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 
 LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -777,27 +788,27 @@ LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, con
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     return LightPollution2DCoords(cosVZACoord, altCoord);
 }
 
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
-    const vec2 texSize = lightPollutionTextureSize;
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 texSize = lightPollutionTextureSize;
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2);
-    const float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
+    CONST float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
     return vec2(cosVZAtc, altitudeTC);
 }

--- a/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/3/aerosols/texture-sampling-functions.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/3/aerosols/texture-sampling-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-sampling-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,13 +45,13 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // texture-sampling-functions.frag
-#line 1 2 // phase-functions.h.glsl
+#line 4 0 // texture-sampling-functions.frag
+#line 1 3 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 6 0 // texture-sampling-functions.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-sampling-functions.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -72,8 +83,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-sampling-functions.frag
-#line 1 4 // texture-coordinates.h.glsl
+#line 6 0 // texture-sampling-functions.frag
+#line 1 5 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -142,7 +153,7 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 8 0 // texture-sampling-functions.frag
+#line 7 0 // texture-sampling-functions.frag
 
 uniform sampler2D transmittanceTexture;
 uniform sampler2D irradianceTexture;
@@ -154,13 +165,13 @@ uniform sampler2D lightPollutionScatteringTexture;
 
 vec4 irradiance(const float cosSunZenithAngle, const float altitude)
 {
-    const vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
+    CONST vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
     return texture(irradianceTexture, texCoords);
 }
 
 vec4 opticalDepthToAtmosphereBorder(const float cosViewZenithAngle, const float altitude)
 {
-    const vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
+    CONST vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact when looking into nadir from TOA at some values of texture sizes (in particular, size of
     // transmittance texture for altitude being 4096). This happens when I simply call texture(eclipsedScatteringTexture,
@@ -178,11 +189,11 @@ vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float
 vec4 transmittance(const float cosViewZenithAngle, const float altitude, const float dist,
                    const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle view ray endpoint
     // in space here.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
 
     vec4 depth;
     if(viewRayIntersectsGround)
@@ -201,7 +212,7 @@ vec4 transmittance(const float cosViewZenithAngle, const float altitude, const f
 vec4 calcFirstScattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                          const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
+    CONST vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
                                           dotViewSun, altitude, viewRayIntersectsGround);
     return scattering*currentPhaseFunction(dotViewSun);
 }
@@ -220,6 +231,6 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
 
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     return texture(lightPollutionScatteringTexture, coords);
 }

--- a/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/3/molecules/common-functions.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/3/molecules/common-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // common-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // common-functions.frag
+#line 4 0 // common-functions.frag
 
 bool dbgDataPresent=false;
 bool debugDataPresent()
@@ -69,7 +80,7 @@ void setDebugData(float a,float b, float c, float d)
 
 void swap(inout float x, inout float y)
 {
-    const float t = x;
+    CONST float t = x;
     x = y;
     y = t;
 }
@@ -83,7 +94,7 @@ float safeSqrt(const float x)
 
 float safeAtan(const float y, const float x)
 {
-    const float a = atan(y,x);
+    CONST float a = atan(y,x);
     return x==0 && y==0 ? 0 : a;
 }
 
@@ -116,23 +127,23 @@ float pointAltitude(vec3 point)
 
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float Ratm=earthRadius+atmosphereHeight;
-    const float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float Ratm=earthRadius+atmosphereHeight;
+    CONST float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float distanceToGround(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(-safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float cosZenithAngleOfHorizon(const float altitude)
 {
-    const float R=earthRadius;
-    const float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
+    CONST float R=earthRadius;
+    CONST float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
     return -sqrt(2*h*R+sqr(h))/(R+h);
 }
 
@@ -151,8 +162,8 @@ float distanceToNearestAtmosphereBoundary(const float cosZenithAngle, const floa
 float sunVisibility(const float cosSunZenithAngle, float altitude)
 {
     if(altitude<0) altitude=0;
-    const float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
-    const float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
+    CONST float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
+    CONST float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
     /* Approximating visible fraction of solar disk by smoothstep between the position of the Sun
      * touching the horizon by its upper part and the position with lower part touching the horizon.
      * The calculation assumes that solar angular radius is small and thus approximately equals its sine.
@@ -182,13 +193,13 @@ float circlesIntersectionArea(float R1, float R2, float d)
 
 float angleBetween(const vec3 a, const vec3 b)
 {
-    const float d=dot(a,b);
-    const float c=length(cross(a,b));
+    CONST float d=dot(a,b);
+    CONST float c=length(cross(a,b));
     // To avoid loss of precision, don't use dot product near the singularity
     // of acos, and cross product near the singularity of asin
     if(abs(d) < abs(c))
         return acos(d/(length(a)*length(b)));
-    const float smallerAngle = asin(c/(length(a)*length(b)));
+    CONST float smallerAngle = asin(c/(length(a)*length(b)));
     if(d<0) return PI-smallerAngle;
     return smallerAngle;
 }
@@ -205,11 +216,11 @@ float moonAngularRadius(const vec3 cameraPosition, const vec3 moonPosition)
 
 float visibleSolidAngleOfSun(const vec3 camera, const vec3 sunDir, const vec3 moonPos)
 {
-    const float Rs=sunAngularRadius;
-    const float Rm=moonAngularRadius(camera,moonPos);
+    CONST float Rs=sunAngularRadius;
+    CONST float Rm=moonAngularRadius(camera,moonPos);
     float visibleSolidAngle=PI*sqr(Rs);
 
-    const float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
+    CONST float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
     if(dSM<Rs+Rm)
     {
         visibleSolidAngle -= circlesIntersectionArea(Rm,Rs,dSM);
@@ -229,12 +240,12 @@ float sphereIntegrationSolidAngleDifferential(const int pointCountOnSphere)
 }
 vec3 sphereIntegrationSampleDir(const int index, const int pointCountOnSphere)
 {
-    const float goldenRatio=1.6180339887499;
+    CONST float goldenRatio=1.6180339887499;
     // The range of n is 0.5, 1.5, ..., pointCountOnSphere-0.5
-    const float n=index+0.5;
+    CONST float n=index+0.5;
     // Explanation of the Fibonacci grid generation can be seen at https://stackoverflow.com/a/44164075/673852
-    const float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
-    const float azimuth=n*(2*PI*goldenRatio);
+    CONST float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
+    CONST float azimuth=n*(2*PI*goldenRatio);
     return vec3(cos(azimuth)*sin(zenithAngle),
                 sin(azimuth)*sin(zenithAngle),
                 cos(zenithAngle));

--- a/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/3/molecules/densities.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/3/molecules/densities.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // densities.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,20 +45,20 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // densities.frag
+#line 4 0 // densities.frag
 float scattererNumberDensity_molecules(float altitude)
 {
-        const float rayleighScaleHeight=8*km;
+        CONST float rayleighScaleHeight=8*km;
         return 3.08458e25*exp(-1/rayleighScaleHeight * altitude);
 }
 float scattererNumberDensity_aerosols(float altitude)
 {
-        const float mieScaleHeight=1.2*km;
+        CONST float mieScaleHeight=1.2*km;
         return 1.03333e8*exp(-1/mieScaleHeight*altitude);
 }
 float absorberNumberDensity_ozone(float altitude)
 {
-        const float totalOzoneAmount=370*dobsonUnit;
+        CONST float totalOzoneAmount=370*dobsonUnit;
 
         float density;
 

--- a/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/3/molecules/phase-functions.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/3/molecules/phase-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // phase-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // phase-functions.frag
+#line 4 0 // phase-functions.frag
 
 vec4 phaseFunction_molecules(float dotViewSun)
 {
@@ -42,9 +53,9 @@ vec4 phaseFunction_molecules(float dotViewSun)
 }
 vec4 phaseFunction_aerosols(float dotViewSun)
 {
-        const float g=0.76;
-        const float g2=g*g;
-        const float k = 3/(8*PI)*(1-g2)/(2+g2);
+        CONST float g=0.76;
+        CONST float g2=g*g;
+        CONST float k = 3/(8*PI)*(1-g2)/(2+g2);
         return vec4(k * (1+sqr(dotViewSun)) / pow(1+g2 - 2*g*dotViewSun, 1.5) + 1/((1-dotViewSun)*600+0.05))*0.904;
 }
 vec4 currentPhaseFunction(float dotViewSun) { return phaseFunction_molecules(dotViewSun); }

--- a/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/3/molecules/render.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/3/molecules/render.frag
@@ -1,7 +1,21 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
 
-#line 1 1 // const.h.glsl
+
+
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 6 0 // render.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,11 +48,11 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // render.frag
-#line 1 2 // calc-view-dir.h.glsl
+#line 7 0 // render.frag
+#line 1 3 // calc-view-dir.h.glsl
 vec3 calcViewDir();
-#line 6 0 // render.frag
-#line 1 3 // common-functions.h.glsl
+#line 8 0 // render.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -70,14 +84,14 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // render.frag
-#line 1 4 // phase-functions.h.glsl
+#line 9 0 // render.frag
+#line 1 5 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 8 0 // render.frag
+#line 10 0 // render.frag
 
-#line 1 5 // single-scattering-eclipsed.h.glsl
+#line 1 6 // single-scattering-eclipsed.h.glsl
 #ifndef INCLUDE_ONCE_050024D2_BD56_434E_8D40_2055DA0B78EC
 #define INCLUDE_ONCE_050024D2_BD56_434E_8D40_2055DA0B78EC
 
@@ -85,8 +99,8 @@ vec4 computeSingleScatteringEclipsed(const vec3 camera, const vec3 viewDir, cons
                                      const bool viewRayIntersectsGround);
 
 #endif
-#line 10 0 // render.frag
-#line 1 6 // texture-coordinates.h.glsl
+#line 12 0 // render.frag
+#line 1 7 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -155,10 +169,10 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 11 0 // render.frag
-#line 1 7 // radiance-to-luminance.h.glsl
+#line 13 0 // render.frag
+#line 1 8 // radiance-to-luminance.h.glsl
 const mat4 radianceToLuminance=mat4(19.8756237,7.17745161,0,0.0937032327,  2.13895917,0.772417068,0,0.0149318045,  0.241072536,0.0870557055,0,0,  0.0133876652,0.00483453181,0,0);
-#line 12 0 // render.frag
+#line 14 0 // render.frag
 
 
 
@@ -195,18 +209,18 @@ void main()
     // this approximation has the same order of magnitude as the assumption that the Earth and its atmosphere
     // are spherical.
     float altitude = max(cameraPosition.z, 0.);
-    const vec3 oldCamPos=cameraPosition;
+    CONST vec3 oldCamPos=cameraPosition;
     // Hide the uniform with this name, thus effectively modifying it for the following code
     vec3 cameraPosition=vec3(oldCamPos.xy, altitude);
 
     bool lookingIntoAtmosphere=true;
     if(altitude>atmosphereHeight)
     {
-        const vec3 p = cameraPosition - earthCenter;
-        const float p_dot_v = dot(p, viewDir);
-        const float p_dot_p = dot(p, p);
-        const float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
-        const float distanceToTOA = -p_dot_v - sqrt(sqr(earthRadius+atmosphereHeight) - squaredDistBetweenViewRayAndEarthCenter);
+        CONST vec3 p = cameraPosition - earthCenter;
+        CONST float p_dot_v = dot(p, viewDir);
+        CONST float p_dot_p = dot(p, p);
+        CONST float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
+        CONST float distanceToTOA = -p_dot_v - sqrt(sqr(earthRadius+atmosphereHeight) - squaredDistBetweenViewRayAndEarthCenter);
         if(distanceToTOA>=0)
         {
             cameraPosition += viewDir*distanceToTOA;
@@ -214,7 +228,7 @@ void main()
         }
         else
         {
-#if RENDERING_ANY_ZERO_SCATTERING
+#if 0 /*RENDERING_ANY_ZERO_SCATTERING*/
             lookingIntoAtmosphere=false;
 #else
             luminance=vec4(0);
@@ -224,16 +238,16 @@ void main()
         }
     }
 
-    const vec3 zenith=normalize(cameraPosition-earthCenter);
+    CONST vec3 zenith=normalize(cameraPosition-earthCenter);
     float cosViewZenithAngle=dot(zenith,viewDir);
 
     bool viewRayIntersectsGround=false;
     {
-        const vec3 p = cameraPosition - earthCenter;
-        const float p_dot_v = dot(p, viewDir);
-        const float p_dot_p = dot(p, p);
-        const float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
-        const float distanceToIntersection = -p_dot_v - sqrt(sqr(earthRadius) - squaredDistBetweenViewRayAndEarthCenter);
+        CONST vec3 p = cameraPosition - earthCenter;
+        CONST float p_dot_v = dot(p, viewDir);
+        CONST float p_dot_p = dot(p, p);
+        CONST float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
+        CONST float distanceToIntersection = -p_dot_v - sqrt(sqr(earthRadius) - squaredDistBetweenViewRayAndEarthCenter);
         // altitude==0 is a special case where distance to intersection calculation
         // is unreliable (has a lot of noise in its sign), so check it separately
         if(distanceToIntersection>0 || (altitude==0 && cosViewZenithAngle<0))
@@ -244,11 +258,11 @@ void main()
     // Aside from aesthetics, this affects brightness input to Stellarium's tone mapper.
     if(pseudoMirrorSkyBelowHorizon && viewRayIntersectsGround)
     {
-        const float horizonCZA = cosZenithAngleOfHorizon(altitude);
-        const float viewElev  = asin(clampCosine(cosViewZenithAngle));
-        const float horizElev = asin(clampCosine(horizonCZA));
-        const float newViewElev = 2*horizElev - viewElev;
-        const float viewDirXYnorm = length(viewDir-zenith*cosViewZenithAngle);
+        CONST float horizonCZA = cosZenithAngleOfHorizon(altitude);
+        CONST float viewElev  = asin(clampCosine(cosViewZenithAngle));
+        CONST float horizElev = asin(clampCosine(horizonCZA));
+        CONST float newViewElev = 2*horizElev - viewElev;
+        CONST float viewDirXYnorm = length(viewDir-zenith*cosViewZenithAngle);
         if(viewDirXYnorm == 0)
         {
             viewDir = zenith;
@@ -267,27 +281,27 @@ void main()
         viewRayIntersectsGround = false;
     }
 
-    const float cosSunZenithAngle =dot(zenith,sunDirection);
-    const float dotViewSun=dot(viewDir,sunDirection);
+    CONST float cosSunZenithAngle =dot(zenith,sunDirection);
+    CONST float dotViewSun=dot(viewDir,sunDirection);
 
-    const vec3 sunXYunnorm=sunDirection-dot(sunDirection,zenith)*zenith;
-    const vec3 viewXYunnorm=viewDir-dot(viewDir,zenith)*zenith;
-    const vec3 sunXY = sunXYunnorm.x!=0 || sunXYunnorm.y!=0 || sunXYunnorm.z!=0 ? normalize(sunXYunnorm) : vec3(0);
-    const vec3 viewXY = viewXYunnorm.x!=0 || viewXYunnorm.y!=0 || viewXYunnorm.z!=0 ? normalize(viewXYunnorm) : vec3(0);
-    const float azimuthRelativeToSun=safeAtan(dot(cross(sunXY, viewXY), zenith), dot(sunXY, viewXY));
+    CONST vec3 sunXYunnorm=sunDirection-dot(sunDirection,zenith)*zenith;
+    CONST vec3 viewXYunnorm=viewDir-dot(viewDir,zenith)*zenith;
+    CONST vec3 sunXY = sunXYunnorm.x!=0 || sunXYunnorm.y!=0 || sunXYunnorm.z!=0 ? normalize(sunXYunnorm) : vec3(0);
+    CONST vec3 viewXY = viewXYunnorm.x!=0 || viewXYunnorm.y!=0 || viewXYunnorm.z!=0 ? normalize(viewXYunnorm) : vec3(0);
+    CONST float azimuthRelativeToSun=safeAtan(dot(cross(sunXY, viewXY), zenith), dot(sunXY, viewXY));
 
-#if RENDERING_ZERO_SCATTERING
+#if 0 /*RENDERING_ZERO_SCATTERING*/
     vec4 radiance;
     if(viewRayIntersectsGround)
     {
         // XXX: keep in sync with the same code in computeScatteringDensity(), but don't forget about
         //      the difference in the usage of viewDir vs incDir.
-        const float distToGround = distanceToGround(cosViewZenithAngle, altitude);
-        const vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
-        const vec3 groundNormal = normalize(zenith*(earthRadius+altitude)+viewDir*distToGround);
-        const vec4 groundIrradiance = irradiance(dot(groundNormal, sunDirection), 0);
+        CONST float distToGround = distanceToGround(cosViewZenithAngle, altitude);
+        CONST vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
+        CONST vec3 groundNormal = normalize(zenith*(earthRadius+altitude)+viewDir*distToGround);
+        CONST vec4 groundIrradiance = irradiance(dot(groundNormal, sunDirection), 0);
         // Radiation scattered by the ground
-        const float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
+        CONST float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
         radiance = transmittanceToGround*groundAlbedo*groundIrradiance*solarIrradianceFixup*groundBRDF
                  + lightPollutionGroundLuminance*lightPollutionRelativeRadiance;
     }
@@ -304,22 +318,22 @@ void main()
     }
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_ZERO_SCATTERING
+#elif 0 /*RENDERING_ECLIPSED_ZERO_SCATTERING*/
     vec4 radiance;
-    const float dotViewMoon=dot(viewDir,normalize(moonPosition-cameraPosition));
+    CONST float dotViewMoon=dot(viewDir,normalize(moonPosition-cameraPosition));
     if(viewRayIntersectsGround)
     {
         // XXX: keep in sync with the similar code in non-eclipsed zero scattering rendering.
-        const float distToGround = distanceToGround(cosViewZenithAngle, altitude);
-        const vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
-        const vec3 pointOnGround = cameraPosition+viewDir*distToGround;
-        const vec4 directGroundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDirection, moonPosition);
+        CONST float distToGround = distanceToGround(cosViewZenithAngle, altitude);
+        CONST vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
+        CONST vec3 pointOnGround = cameraPosition+viewDir*distToGround;
+        CONST vec4 directGroundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDirection, moonPosition);
         // FIXME: add first-order indirect irradiance too: it's done in non-eclipsed irradiance (in the same
         // conditions: when limited to 2 orders). This should be calculated at the same time when second order
         // is: all the infrastructure is already there.
-        const vec4 groundIrradiance = directGroundIrradiance;
+        CONST vec4 groundIrradiance = directGroundIrradiance;
         // Radiation scattered by the ground
-        const float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
+        CONST float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
         radiance = transmittanceToGround*groundAlbedo*groundIrradiance*solarIrradianceFixup*groundBRDF
                  + lightPollutionGroundLuminance*lightPollutionRelativeRadiance;
     }
@@ -337,52 +351,52 @@ void main()
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
 #elif 1 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_ON_THE_FLY*/
-    const vec4 scattering=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPosition,
+    CONST vec4 scattering=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPosition,
                                                           viewRayIntersectsGround);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE
-    const vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE*/
+    CONST vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                      viewRayIntersectsGround, eclipsedSingleScatteringTextureSize);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact at the point where azimuth texture coordinate changes from 1 to 0 (at azimuthRelativeToSun crossing
     // 0). This happens when I simply call texture(eclipsedScatteringTexture, texCoords) without specifying LOD.
     // Apparently, the driver uses the derivative for some reason, even though it shouldn't.
-    const vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
+    CONST vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE
-    const vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
+    CONST vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                      viewRayIntersectsGround, eclipsedSingleScatteringTextureSize);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact at the point where azimuth texture coordinate changes from 1 to 0 (at azimuthRelativeToSun crossing
     // 0). This happens when I simply call texture(eclipsedScatteringTexture, texCoords) without specifying LOD.
     // Apparently, the driver uses the derivative for some reason, even though it shouldn't.
-    const vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
+    CONST vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
     luminance=scattering*currentPhaseFunction(dotViewSun);
-#elif RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_RADIANCE
+#elif 0 /*RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_RADIANCE*/
     vec4 radiance=exp(sampleEclipseDoubleScattering3DTexture(eclipsedDoubleScatteringTexture,
                                                              cosSunZenithAngle, cosViewZenithAngle, azimuthRelativeToSun,
                                                              altitude, viewRayIntersectsGround));
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_LUMINANCE
+#elif 0 /*RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
     luminance=exp(sampleEclipseDoubleScattering3DTexture(eclipsedDoubleScatteringTexture,
                                                          cosSunZenithAngle, cosViewZenithAngle, azimuthRelativeToSun,
                                                          altitude, viewRayIntersectsGround));
-#elif RENDERING_SINGLE_SCATTERING_ON_THE_FLY
-    const vec4 scattering=computeSingleScattering(cosSunZenithAngle,cosViewZenithAngle,dotViewSun,
+#elif 0 /*RENDERING_SINGLE_SCATTERING_ON_THE_FLY*/
+    CONST vec4 scattering=computeSingleScattering(cosSunZenithAngle,cosViewZenithAngle,dotViewSun,
                                                   altitude,viewRayIntersectsGround);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE
+#elif 0 /*RENDERING_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE*/
     vec4 scattering;
     if(useInterpolationGuides)
     {
@@ -399,7 +413,7 @@ void main()
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE
+#elif 0 /*RENDERING_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
     vec4 scattering;
     if(useInterpolationGuides)
     {
@@ -413,18 +427,18 @@ void main()
                                      dotViewSun, altitude, viewRayIntersectsGround);
     }
     luminance=scattering * (bool(PHASE_FUNCTION_IS_EMBEDDED) ? vec4(1) : currentPhaseFunction(dotViewSun));
-#elif RENDERING_MULTIPLE_SCATTERING_LUMINANCE
+#elif 0 /*RENDERING_MULTIPLE_SCATTERING_LUMINANCE*/
     luminance=sample3DTexture(scatteringTexture, cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, viewRayIntersectsGround);
-#elif RENDERING_MULTIPLE_SCATTERING_RADIANCE
+#elif 0 /*RENDERING_MULTIPLE_SCATTERING_RADIANCE*/
     vec4 radiance=sample3DTexture(scatteringTexture, cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, viewRayIntersectsGround);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_LIGHT_POLLUTION_RADIANCE
+#elif 0 /*RENDERING_LIGHT_POLLUTION_RADIANCE*/
     vec4 radiance=lightPollutionGroundLuminance*lightPollutionScattering(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_LIGHT_POLLUTION_LUMINANCE
+#elif 0 /*RENDERING_LIGHT_POLLUTION_LUMINANCE*/
     luminance=lightPollutionGroundLuminance*lightPollutionScattering(altitude, cosViewZenithAngle, viewRayIntersectsGround);
 #else
 #error What to render?

--- a/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/3/molecules/single-scattering-eclipsed.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/3/molecules/single-scattering-eclipsed.frag
@@ -1,7 +1,21 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
 
-#line 1 1 // const.h.glsl
+
+
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 6 0 // single-scattering-eclipsed.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,15 +48,15 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // single-scattering-eclipsed.frag
-#line 1 2 // densities.h.glsl
+#line 7 0 // single-scattering-eclipsed.frag
+#line 1 3 // densities.h.glsl
 float scattererNumberDensity_molecules(float altitude);
 float scattererNumberDensity_aerosols(float altitude);
 float absorberNumberDensity_ozone(float altitude);
 vec4 scatteringCrossSection();
 float scattererDensity(float altitude);
-#line 6 0 // single-scattering-eclipsed.frag
-#line 1 3 // common-functions.h.glsl
+#line 8 0 // single-scattering-eclipsed.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -74,8 +88,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // single-scattering-eclipsed.frag
-#line 1 4 // texture-sampling-functions.h.glsl
+#line 9 0 // single-scattering-eclipsed.frag
+#line 1 5 // texture-sampling-functions.h.glsl
 #ifndef INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 #define INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float altitude);
@@ -87,7 +101,7 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                 const int scatteringOrder);
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 #endif
-#line 8 0 // single-scattering-eclipsed.frag
+#line 10 0 // single-scattering-eclipsed.frag
 
 
 float cosZenithAngle(vec3 origin, vec3 direction)
@@ -101,13 +115,13 @@ vec4 computeSingleScatteringIntegrandEclipsed(const float cosSunZenithAngle, con
                                               const float dist, const bool viewRayIntersectsGround,
                                               const vec3 scatterer, const vec3 sunDir, const vec3 moonPos)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle here the case when the
     // endpoint of the view ray intentionally appears in outer space.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosSunZenithAngleAtDist=clampCosine((r*cosSunZenithAngle+dist*dotViewSun)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosSunZenithAngleAtDist=clampCosine((r*cosSunZenithAngle+dist*dotViewSun)/(earthRadius+altAtDist));
 
-    const vec4 xmittance=transmittance(cosViewZenithAngle, altitude, dist, viewRayIntersectsGround)
+    CONST vec4 xmittance=transmittance(cosViewZenithAngle, altitude, dist, viewRayIntersectsGround)
                                                     *
                          transmittanceToAtmosphereBorder(cosSunZenithAngleAtDist, altAtDist)
                                                     *
@@ -115,7 +129,7 @@ vec4 computeSingleScatteringIntegrandEclipsed(const float cosSunZenithAngle, con
                                                     *
                             // FIXME: this ignores orientation of the crescent of eclipsed Sun WRT horizon
                                     sunVisibility(cosSunZenithAngleAtDist, altAtDist);
-#if ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION
+#if 0 /*ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION*/
     COMPUTE_TOTAL_SCATTERING_COEFFICIENT;
     return xmittance * totalScatteringCoefficient;
 #else
@@ -126,26 +140,26 @@ vec4 computeSingleScatteringIntegrandEclipsed(const float cosSunZenithAngle, con
 vec4 computeSingleScatteringEclipsed(const vec3 camera, const vec3 viewDir, const vec3 sunDir, const vec3 moonPos,
                                      const bool viewRayIntersectsGround)
 {
-    const float cosViewZenithAngle=cosZenithAngle(camera,viewDir);
-    const float cosSunZenithAngle=cosZenithAngle(camera,sunDir);
-    const float altitude=pointAltitude(camera);
-    const float dotViewSun=dot(viewDir,sunDir);
-    const float integrInterval=distanceToNearestAtmosphereBoundary(cosViewZenithAngle, altitude,
+    CONST float cosViewZenithAngle=cosZenithAngle(camera,viewDir);
+    CONST float cosSunZenithAngle=cosZenithAngle(camera,sunDir);
+    CONST float altitude=pointAltitude(camera);
+    CONST float dotViewSun=dot(viewDir,sunDir);
+    CONST float integrInterval=distanceToNearestAtmosphereBoundary(cosViewZenithAngle, altitude,
                                                                    viewRayIntersectsGround);
 
     // Using the midpoint rule for quadrature
     vec4 spectrum=vec4(0);
-    const float dl=integrInterval/radialIntegrationPoints;
+    CONST float dl=integrInterval/radialIntegrationPoints;
     for(int n=0; n<radialIntegrationPoints; ++n)
     {
-        const float dist=(n+0.5)*dl;
+        CONST float dist=(n+0.5)*dl;
         spectrum += computeSingleScatteringIntegrandEclipsed(cosSunZenithAngle, cosViewZenithAngle, dotViewSun,
                                                              altitude, dist, viewRayIntersectsGround,
                                                              camera+viewDir*dist, sunDir, moonPos);
     }
 
     spectrum *= dl*solarIrradianceAtTOA
-#if ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION
+#if 0 /*ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION*/
                                 // the multiplier is already included
 #else
                                         * scatteringCrossSection()

--- a/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/3/molecules/texture-coordinates.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/3/molecules/texture-coordinates.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-coordinates.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,8 +45,8 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // texture-coordinates.frag
-#line 1 2 // texture-coordinates.h.glsl
+#line 4 0 // texture-coordinates.frag
+#line 1 3 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -104,8 +115,8 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 6 0 // texture-coordinates.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-coordinates.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -137,7 +148,7 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-coordinates.frag
+#line 6 0 // texture-coordinates.frag
 
 const float LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA=sqrt(atmosphereHeight*(atmosphereHeight+2*earthRadius));
 
@@ -205,18 +216,18 @@ vec3 indicesToTexCoords(const vec3 indices, const vec3 texSizes)
 
 TransmittanceTexVars transmittanceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
+    CONST float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
                                 texCoordToUnitRange(texCoord.t,transmittanceTextureSize.t);
     // Distance from Earth center to camera
-    const float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
-    const float altitude=r-earthRadius;
+    CONST float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
+    CONST float altitude=r-earthRadius;
 
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
     // distance to border of visible atmosphere from the view point
-    const float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
+    CONST float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
     // d==0 can happen when altitude==atmosphereHeight
-    const float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
+    CONST float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
     return TransmittanceTexVars(cosVZA,altitude);
 }
 
@@ -235,53 +246,53 @@ vec2 transmittanceTexVarsToTexCoord(const float cosVZA, float altitude)
     if(altitude<0)
         altitude=0;
 
-    const float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
+    CONST float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
                                       transmittanceTextureSize.t);
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
-    const float d=distanceToAtmosphereBorder(cosVZA,altitude);
-    const float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float d=distanceToAtmosphereBorder(cosVZA,altitude);
+    CONST float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
     return vec2(s,t);
 }
 
 // Output: vec2(cos(sunZenithAngle), altitude)
 IrradianceTexVars irradianceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
-    const float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
+    CONST float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
+    CONST float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
     return IrradianceTexVars(cosSZA,alt);
 }
 
 vec2 irradianceTexVarsToTexCoord(const float cosSunZenithAngle, const float altitude)
 {
-    const float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
-    const float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
+    CONST float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
+    CONST float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
     return vec2(s,t);
 }
 
 float cosSZAToUnitRangeTexCoord(const float cosSunZenithAngle)
 {
     // Distance to top atmosphere border along the ray groundUnderCamera-sun: (altitude, cosSunZenithAngle)
-    const float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name
-    const float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
+    CONST float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
     // TODO: choose a more descriptive name
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     return max(0.,1-a/A)/(a+1);
 }
 
 float unitRangeTexCoordToCosSZA(const float texCoord)
 {
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float a=(A-A*texCoord)/(1+A*texCoord);
-    const float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
+    CONST float a=(A-A*texCoord)/(1+A*texCoord);
+    CONST float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
     return distFromGroundToTopAtmoBorder==0 ? 1 :
         clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distFromGroundToTopAtmoBorder)) /
                     (2*earthRadius*distFromGroundToTopAtmoBorder));
@@ -292,24 +303,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
                                                const float dotViewSun, const float altitude,
                                                const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -317,24 +328,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float dotVSCoord=(dotViewSun+1)/2;
+    CONST float dotVSCoord=(dotViewSun+1)/2;
 
     // ------------------------------------
-    const float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
+    CONST float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
 
     return Scattering4DCoords(cosSZACoord, cosVZACoord, dotVSCoord, altCoord, viewRayIntersectsGround);
 }
 
 TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
@@ -342,16 +353,16 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture coordinates we combine into a single sampler3D coordinate.
-    const float texW = scatteringTextureSize[1];
-    const float texH = scatteringTextureSize[2];
-    const float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
-    const vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
+    CONST float texW = scatteringTextureSize[1];
+    CONST float texH = scatteringTextureSize[2];
+    CONST float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
+    CONST vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
                                         ceil (cosSZAIndex)*texW+coords.dotViewSun*(texW-1)) / (texW*texH-1);
-    const vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
+    CONST vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
 
-    const float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
+    CONST float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
 
-    const float alphaUpper=fract(cosSZAIndex);
+    CONST float alphaUpper=fract(cosSZAIndex);
     return TexCoordPair(vec3(cosVZAtc, combinedCoord.x, altitude), float(1-alphaUpper),
                         vec3(cosVZAtc, combinedCoord.y, altitude), float(alphaUpper));
 }
@@ -359,9 +370,9 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
+    CONST TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
     return texture(tex, texCoords.lower) * texCoords.alphaLower +
            texture(tex, texCoords.upper) * texCoords.alphaUpper;
 }
@@ -369,17 +380,17 @@ vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const f
 // 3D texture is the 3D single-altitude slice of a 4D texture
 vec3 scattering4DCoordsToTex3DCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2);
 
-    const float dvsSize = scatteringTextureSize[1];
-    const float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
+    CONST float dvsSize = scatteringTextureSize[1];
+    CONST float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
 
-    const float cszaSize = scatteringTextureSize[2];
-    const float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
+    CONST float cszaSize = scatteringTextureSize[2];
+    CONST float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
 
     return vec3(cosVZAtc, dotVStc, cosSZAtc);
 }
@@ -394,39 +405,39 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along dotViewSun coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[1];
-    const float posOfRow = indices[1];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[1];
+    CONST float posOfRow = indices[1];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         indexToTexCoord(currRow, numRows-1),
                                                         texCoordVerbatim));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               indexToTexCoord(currRow, numRows-1),
                                                               texCoordVerbatim));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          indexToTexCoord(currRow, numRows-1),
                                          texCoordVerbatim));
@@ -434,14 +445,14 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
 vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolationGuides01Tex,
                                  const vec3 indices)
 {
-    const float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
+    CONST float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
 
-    const float cosVZAIndex = indices[0];
-    const float dotVSIndex = indices[1];
-    const float currRow = floor(dotVSIndex);
-    const float posBetweenRows = dotVSIndex - currRow;
-    const float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cosVZAIndex = indices[0];
+    CONST float dotVSIndex = indices[1];
+    CONST float currRow = floor(dotVSIndex);
+    CONST float posBetweenRows = dotVSIndex - currRow;
+    CONST float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -449,14 +460,14 @@ vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolat
     indicesCurrRow[1] =     currRow;
     indicesNextRow[1] = min(currRow+1, scatteringTextureSize[1]-1.);
 
-    const vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
-    const vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
+    CONST vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
+    CONST vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
 
-    const vec4 valueCurrRow = texture(tex, coordsCurrRow);
-    const vec4 valueNextRow = texture(tex, coordsNextRow);
-    const float epsilon = 1e-37; // Prevents passing zero to log
-    const vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
-    const vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
+    CONST vec4 valueCurrRow = texture(tex, coordsCurrRow);
+    CONST vec4 valueNextRow = texture(tex, coordsNextRow);
+    CONST float epsilon = 1e-37; // Prevents passing zero to log
+    CONST vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
+    CONST vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
     return (logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow;
 }
 
@@ -465,37 +476,37 @@ float findGuide02Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along SZA coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[2];
-    const float posOfRow = indices[2];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[2];
+    CONST float posOfRow = indices[2];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
 }
@@ -505,19 +516,19 @@ vec4 sample3DTextureGuided(const sampler3D tex,
                            const float cosSunZenithAngle, const float cosViewZenithAngle,
                            const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
                                                                     dotViewSun, altitude, viewRayIntersectsGround);
     // Handle the external interpolation guides: the guides between a pair of VZA-dotViewSun 2D "pictures".
-    const vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
-    const vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
-    const float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
+    CONST vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
+    CONST float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
 
-    const float cvzaIndex = indices[0];
-    const float cszaIndex = indices[2];
-    const float currRow = floor(cszaIndex);
-    const float posBetweenRows = cszaIndex - currRow;
-    const float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cvzaIndex = indices[0];
+    CONST float cszaIndex = indices[2];
+    CONST float currRow = floor(cszaIndex);
+    CONST float posBetweenRows = cszaIndex - currRow;
+    CONST float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -526,58 +537,58 @@ vec4 sample3DTextureGuided(const sampler3D tex,
     indicesNextRow[2] = min(currRow+1, scatteringTextureSize[2]-1);
 
     // The caller will handle the internal interpolation guides: the ones between rows in each 2D "picture".
-    const vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
-    const vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
+    CONST vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
+    CONST vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
     return exp((logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow);
 }
 
 vec4 sample3DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
     return texture(tex, texCoords);
 }
 
 ScatteringTexVars scatteringTex4DCoordsToTexVars(const Scattering4DCoords coords)
 {
-    const float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
     // ------------------------------------
     float cosViewZenithAngle;
     if(coords.viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
     // ------------------------------------
-    const float dotViewSun=coords.dotViewSun*2-1;
+    CONST float dotViewSun=coords.dotViewSun*2-1;
 
     // ------------------------------------
-    const float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
+    CONST float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
 
     return ScatteringTexVars(cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, coords.viewRayIntersectsGround);
 }
 
 Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 {
-    const vec4 indexMax=scatteringTextureSize-vec4(1);
+    CONST vec4 indexMax=scatteringTextureSize-vec4(1);
     Scattering4DCoords coords4d;
     coords4d.viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
     // The following formulas assume that scatteringTextureSize[0] is even. For odd sizes they would change.
@@ -593,8 +604,8 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture indices we combine into a single sampler3D coordinate.
-    const float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
-    const float combinedIndex=texIndices[1];
+    CONST float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
+    CONST float combinedIndex=texIndices[1];
     coords4d.dotViewSun=mod(combinedIndex,texW)/(texW-1);
     coords4d.cosSunZenithAngle=floor(combinedIndex/texW)/(texH-1);
 
@@ -608,11 +619,11 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
 ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 {
-    const Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
+    CONST Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
     ScatteringTexVars vars=scatteringTex4DCoordsToTexVars(coords4d);
     // Clamp dotViewSun to its valid range of values, given cosViewZenithAngle and cosSunZenithAngle. This is
     // needed to prevent NaNs when computing the scattering texture.
-    const float cosVZA=vars.cosViewZenithAngle,
+    CONST float cosVZA=vars.cosViewZenithAngle,
                 cosSZA=vars.cosSunZenithAngle;
     vars.dotViewSun=clamp(vars.dotViewSun,
                           cosVZA*cosSZA-safeSqrt((1-sqr(cosVZA))*(1-sqr(cosSZA))),
@@ -622,54 +633,54 @@ ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 
 EclipseScatteringTexVars eclipseTexCoordsToTexVars(const vec2 texCoords, const float altitude)
 {
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
-    const bool viewRayIntersectsGround = texCoords.t<0.5;
+    CONST bool viewRayIntersectsGround = texCoords.t<0.5;
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
-    const float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
+    CONST float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
     return EclipseScatteringTexVars(azimuthRelativeToSun, cosViewZenithAngle, viewRayIntersectsGround);
 }
 
 EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                                    const float altitude, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -677,13 +688,13 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
-    const float azimuthCoord = azimuthRelativeToSun/(2*PI);
+    CONST float azimuthCoord = azimuthRelativeToSun/(2*PI);
 
     return EclipseScattering2DCoords(azimuthCoord, cosVZACoord);
 }
@@ -691,14 +702,14 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
 vec2 eclipseTexVarsToTexCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                const float altitude, const bool viewRayIntersectsGround, const vec2 texSize)
 {
-    const EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+    CONST EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                                     viewRayIntersectsGround);
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2);
-    const float azimuthTC = coords.azimuth + 1/(2*texSize.s);
+    CONST float azimuthTC = coords.azimuth + 1/(2*texSize.s);
 
     return vec2(azimuthTC, cosVZAtc);
 }
@@ -707,42 +718,42 @@ vec4 sampleEclipseDoubleScattering3DTexture(const sampler3D tex, const float cos
                                             const float cosViewZenithAngle, const float azimuthRelativeToSun,
                                             const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
+    CONST vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
                                                   eclipsedDoubleScatteringTextureSize.st);
-    const float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
-    const vec3 texCoords=vec3(coords2d, cosSZACoord);
+    CONST float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
+    CONST vec3 texCoords=vec3(coords2d, cosSZACoord);
 
     return texture(tex, texCoords);
 }
 
 LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 texIndices)
 {
-    const vec2 indexMax=lightPollutionTextureSize-vec2(1);
+    CONST vec2 indexMax=lightPollutionTextureSize-vec2(1);
 
-    const float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
-    const float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
+    CONST float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
-    const bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
-    const float cosViewZenithAngleCoord = viewRayIntersectsGround ?
+    CONST bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
+    CONST float cosViewZenithAngleCoord = viewRayIntersectsGround ?
                                    1-2*texIndices[0]/(indexMax[0]-1) :
                                    2*(texIndices[0]-1)/(indexMax[0]-1)-1;
     // ------------------------------------
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
@@ -753,23 +764,23 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 
 LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -777,27 +788,27 @@ LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, con
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     return LightPollution2DCoords(cosVZACoord, altCoord);
 }
 
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
-    const vec2 texSize = lightPollutionTextureSize;
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 texSize = lightPollutionTextureSize;
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2);
-    const float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
+    CONST float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
     return vec2(cosVZAtc, altitudeTC);
 }

--- a/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/3/molecules/texture-sampling-functions.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/on-the-fly/3/molecules/texture-sampling-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-sampling-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,13 +45,13 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // texture-sampling-functions.frag
-#line 1 2 // phase-functions.h.glsl
+#line 4 0 // texture-sampling-functions.frag
+#line 1 3 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 6 0 // texture-sampling-functions.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-sampling-functions.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -72,8 +83,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-sampling-functions.frag
-#line 1 4 // texture-coordinates.h.glsl
+#line 6 0 // texture-sampling-functions.frag
+#line 1 5 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -142,7 +153,7 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 8 0 // texture-sampling-functions.frag
+#line 7 0 // texture-sampling-functions.frag
 
 uniform sampler2D transmittanceTexture;
 uniform sampler2D irradianceTexture;
@@ -154,13 +165,13 @@ uniform sampler2D lightPollutionScatteringTexture;
 
 vec4 irradiance(const float cosSunZenithAngle, const float altitude)
 {
-    const vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
+    CONST vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
     return texture(irradianceTexture, texCoords);
 }
 
 vec4 opticalDepthToAtmosphereBorder(const float cosViewZenithAngle, const float altitude)
 {
-    const vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
+    CONST vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact when looking into nadir from TOA at some values of texture sizes (in particular, size of
     // transmittance texture for altitude being 4096). This happens when I simply call texture(eclipsedScatteringTexture,
@@ -178,11 +189,11 @@ vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float
 vec4 transmittance(const float cosViewZenithAngle, const float altitude, const float dist,
                    const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle view ray endpoint
     // in space here.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
 
     vec4 depth;
     if(viewRayIntersectsGround)
@@ -201,7 +212,7 @@ vec4 transmittance(const float cosViewZenithAngle, const float altitude, const f
 vec4 calcFirstScattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                          const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
+    CONST vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
                                           dotViewSun, altitude, viewRayIntersectsGround);
     return scattering*currentPhaseFunction(dotViewSun);
 }
@@ -220,6 +231,6 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
 
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     return texture(lightPollutionScatteringTexture, coords);
 }

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/0/aerosols/common-functions.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/0/aerosols/common-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // common-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // common-functions.frag
+#line 4 0 // common-functions.frag
 
 bool dbgDataPresent=false;
 bool debugDataPresent()
@@ -69,7 +80,7 @@ void setDebugData(float a,float b, float c, float d)
 
 void swap(inout float x, inout float y)
 {
-    const float t = x;
+    CONST float t = x;
     x = y;
     y = t;
 }
@@ -83,7 +94,7 @@ float safeSqrt(const float x)
 
 float safeAtan(const float y, const float x)
 {
-    const float a = atan(y,x);
+    CONST float a = atan(y,x);
     return x==0 && y==0 ? 0 : a;
 }
 
@@ -116,23 +127,23 @@ float pointAltitude(vec3 point)
 
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float Ratm=earthRadius+atmosphereHeight;
-    const float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float Ratm=earthRadius+atmosphereHeight;
+    CONST float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float distanceToGround(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(-safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float cosZenithAngleOfHorizon(const float altitude)
 {
-    const float R=earthRadius;
-    const float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
+    CONST float R=earthRadius;
+    CONST float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
     return -sqrt(2*h*R+sqr(h))/(R+h);
 }
 
@@ -151,8 +162,8 @@ float distanceToNearestAtmosphereBoundary(const float cosZenithAngle, const floa
 float sunVisibility(const float cosSunZenithAngle, float altitude)
 {
     if(altitude<0) altitude=0;
-    const float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
-    const float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
+    CONST float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
+    CONST float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
     /* Approximating visible fraction of solar disk by smoothstep between the position of the Sun
      * touching the horizon by its upper part and the position with lower part touching the horizon.
      * The calculation assumes that solar angular radius is small and thus approximately equals its sine.
@@ -182,13 +193,13 @@ float circlesIntersectionArea(float R1, float R2, float d)
 
 float angleBetween(const vec3 a, const vec3 b)
 {
-    const float d=dot(a,b);
-    const float c=length(cross(a,b));
+    CONST float d=dot(a,b);
+    CONST float c=length(cross(a,b));
     // To avoid loss of precision, don't use dot product near the singularity
     // of acos, and cross product near the singularity of asin
     if(abs(d) < abs(c))
         return acos(d/(length(a)*length(b)));
-    const float smallerAngle = asin(c/(length(a)*length(b)));
+    CONST float smallerAngle = asin(c/(length(a)*length(b)));
     if(d<0) return PI-smallerAngle;
     return smallerAngle;
 }
@@ -205,11 +216,11 @@ float moonAngularRadius(const vec3 cameraPosition, const vec3 moonPosition)
 
 float visibleSolidAngleOfSun(const vec3 camera, const vec3 sunDir, const vec3 moonPos)
 {
-    const float Rs=sunAngularRadius;
-    const float Rm=moonAngularRadius(camera,moonPos);
+    CONST float Rs=sunAngularRadius;
+    CONST float Rm=moonAngularRadius(camera,moonPos);
     float visibleSolidAngle=PI*sqr(Rs);
 
-    const float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
+    CONST float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
     if(dSM<Rs+Rm)
     {
         visibleSolidAngle -= circlesIntersectionArea(Rm,Rs,dSM);
@@ -229,12 +240,12 @@ float sphereIntegrationSolidAngleDifferential(const int pointCountOnSphere)
 }
 vec3 sphereIntegrationSampleDir(const int index, const int pointCountOnSphere)
 {
-    const float goldenRatio=1.6180339887499;
+    CONST float goldenRatio=1.6180339887499;
     // The range of n is 0.5, 1.5, ..., pointCountOnSphere-0.5
-    const float n=index+0.5;
+    CONST float n=index+0.5;
     // Explanation of the Fibonacci grid generation can be seen at https://stackoverflow.com/a/44164075/673852
-    const float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
-    const float azimuth=n*(2*PI*goldenRatio);
+    CONST float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
+    CONST float azimuth=n*(2*PI*goldenRatio);
     return vec3(cos(azimuth)*sin(zenithAngle),
                 sin(azimuth)*sin(zenithAngle),
                 cos(zenithAngle));

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/0/aerosols/compute-eclipsed-single-scattering.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/0/aerosols/compute-eclipsed-single-scattering.frag
@@ -1,7 +1,21 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
 
-#line 1 1 // const.h.glsl
+
+
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 6 0 // compute-eclipsed-single-scattering.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,8 +48,8 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // compute-eclipsed-single-scattering.frag
-#line 1 2 // texture-coordinates.h.glsl
+#line 7 0 // compute-eclipsed-single-scattering.frag
+#line 1 3 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -104,11 +118,11 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 6 0 // compute-eclipsed-single-scattering.frag
-#line 1 3 // radiance-to-luminance.h.glsl
+#line 8 0 // compute-eclipsed-single-scattering.frag
+#line 1 4 // radiance-to-luminance.h.glsl
 const mat4 radianceToLuminance=mat4(1.38997746,0.0419133306,6.48549128,0,  105.968163,3.00652099,500.960266,142.641495,  3776.24023,119.971481,18207.7598,6412.0166,  6910.01318,981.06665,37504.0586,26741.9102);
-#line 7 0 // compute-eclipsed-single-scattering.frag
-#line 1 4 // single-scattering-eclipsed.h.glsl
+#line 9 0 // compute-eclipsed-single-scattering.frag
+#line 1 5 // single-scattering-eclipsed.h.glsl
 #ifndef INCLUDE_ONCE_050024D2_BD56_434E_8D40_2055DA0B78EC
 #define INCLUDE_ONCE_050024D2_BD56_434E_8D40_2055DA0B78EC
 
@@ -116,7 +130,7 @@ vec4 computeSingleScatteringEclipsed(const vec3 camera, const vec3 viewDir, cons
                                      const bool viewRayIntersectsGround);
 
 #endif
-#line 8 0 // compute-eclipsed-single-scattering.frag
+#line 10 0 // compute-eclipsed-single-scattering.frag
 
 in vec3 position;
 out vec4 scatteringTextureOutput;
@@ -132,16 +146,16 @@ vec4 solarRadiance()
 
 void main()
 {
-    const EclipseScatteringTexVars texVars=eclipseTexCoordsToTexVars(gl_FragCoord.xy/eclipsedSingleScatteringTextureSize, altitude);
-    const float sinViewZenithAngle=sqrt(1-sqr(texVars.cosViewZenithAngle));
-    const vec3 viewDir=vec3(cos(texVars.azimuthRelativeToSun)*sinViewZenithAngle,
+    CONST EclipseScatteringTexVars texVars=eclipseTexCoordsToTexVars(gl_FragCoord.xy/eclipsedSingleScatteringTextureSize, altitude);
+    CONST float sinViewZenithAngle=sqrt(1-sqr(texVars.cosViewZenithAngle));
+    CONST vec3 viewDir=vec3(cos(texVars.azimuthRelativeToSun)*sinViewZenithAngle,
                             sin(texVars.azimuthRelativeToSun)*sinViewZenithAngle,
                             texVars.cosViewZenithAngle);
-    const vec3 cameraPosition=vec3(0,0,altitude);
-    const vec3 sunDirection=vec3(sin(sunZenithAngle), 0, cos(sunZenithAngle));
-    const vec4 radiance=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPositionRelativeToSunAzimuth,
+    CONST vec3 cameraPosition=vec3(0,0,altitude);
+    CONST vec3 sunDirection=vec3(sin(sunZenithAngle), 0, cos(sunZenithAngle));
+    CONST vec4 radiance=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPositionRelativeToSunAzimuth,
                                                         texVars.viewRayIntersectsGround);
-#if COMPUTE_RADIANCE
+#if 0 /*COMPUTE_RADIANCE*/
     scatteringTextureOutput=radiance;
 #elif 1 /*COMPUTE_LUMINANCE*/
     scatteringTextureOutput=radianceToLuminance*radiance;

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/0/aerosols/densities.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/0/aerosols/densities.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // densities.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,20 +45,20 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // densities.frag
+#line 4 0 // densities.frag
 float scattererNumberDensity_molecules(float altitude)
 {
-        const float rayleighScaleHeight=8*km;
+        CONST float rayleighScaleHeight=8*km;
         return 3.08458e25*exp(-1/rayleighScaleHeight * altitude);
 }
 float scattererNumberDensity_aerosols(float altitude)
 {
-        const float mieScaleHeight=1.2*km;
+        CONST float mieScaleHeight=1.2*km;
         return 1.03333e8*exp(-1/mieScaleHeight*altitude);
 }
 float absorberNumberDensity_ozone(float altitude)
 {
-        const float totalOzoneAmount=370*dobsonUnit;
+        CONST float totalOzoneAmount=370*dobsonUnit;
 
         float density;
 

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/0/aerosols/phase-functions.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/0/aerosols/phase-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // phase-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // phase-functions.frag
+#line 4 0 // phase-functions.frag
 
 vec4 phaseFunction_molecules(float dotViewSun)
 {
@@ -42,9 +53,9 @@ vec4 phaseFunction_molecules(float dotViewSun)
 }
 vec4 phaseFunction_aerosols(float dotViewSun)
 {
-        const float g=0.76;
-        const float g2=g*g;
-        const float k = 3/(8*PI)*(1-g2)/(2+g2);
+        CONST float g=0.76;
+        CONST float g2=g*g;
+        CONST float k = 3/(8*PI)*(1-g2)/(2+g2);
         return vec4(k * (1+sqr(dotViewSun)) / pow(1+g2 - 2*g*dotViewSun, 1.5) + 1/((1-dotViewSun)*600+0.05))*0.904;
 }
 vec4 currentPhaseFunction(float dotViewSun) { return phaseFunction_aerosols(dotViewSun); }

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/0/aerosols/single-scattering-eclipsed.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/0/aerosols/single-scattering-eclipsed.frag
@@ -1,7 +1,21 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
 
-#line 1 1 // const.h.glsl
+
+
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 6 0 // single-scattering-eclipsed.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,15 +48,15 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // single-scattering-eclipsed.frag
-#line 1 2 // densities.h.glsl
+#line 7 0 // single-scattering-eclipsed.frag
+#line 1 3 // densities.h.glsl
 float scattererNumberDensity_molecules(float altitude);
 float scattererNumberDensity_aerosols(float altitude);
 float absorberNumberDensity_ozone(float altitude);
 vec4 scatteringCrossSection();
 float scattererDensity(float altitude);
-#line 6 0 // single-scattering-eclipsed.frag
-#line 1 3 // common-functions.h.glsl
+#line 8 0 // single-scattering-eclipsed.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -74,8 +88,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // single-scattering-eclipsed.frag
-#line 1 4 // texture-sampling-functions.h.glsl
+#line 9 0 // single-scattering-eclipsed.frag
+#line 1 5 // texture-sampling-functions.h.glsl
 #ifndef INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 #define INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float altitude);
@@ -87,7 +101,7 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                 const int scatteringOrder);
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 #endif
-#line 8 0 // single-scattering-eclipsed.frag
+#line 10 0 // single-scattering-eclipsed.frag
 
 
 float cosZenithAngle(vec3 origin, vec3 direction)
@@ -101,13 +115,13 @@ vec4 computeSingleScatteringIntegrandEclipsed(const float cosSunZenithAngle, con
                                               const float dist, const bool viewRayIntersectsGround,
                                               const vec3 scatterer, const vec3 sunDir, const vec3 moonPos)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle here the case when the
     // endpoint of the view ray intentionally appears in outer space.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosSunZenithAngleAtDist=clampCosine((r*cosSunZenithAngle+dist*dotViewSun)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosSunZenithAngleAtDist=clampCosine((r*cosSunZenithAngle+dist*dotViewSun)/(earthRadius+altAtDist));
 
-    const vec4 xmittance=transmittance(cosViewZenithAngle, altitude, dist, viewRayIntersectsGround)
+    CONST vec4 xmittance=transmittance(cosViewZenithAngle, altitude, dist, viewRayIntersectsGround)
                                                     *
                          transmittanceToAtmosphereBorder(cosSunZenithAngleAtDist, altAtDist)
                                                     *
@@ -115,7 +129,7 @@ vec4 computeSingleScatteringIntegrandEclipsed(const float cosSunZenithAngle, con
                                                     *
                             // FIXME: this ignores orientation of the crescent of eclipsed Sun WRT horizon
                                     sunVisibility(cosSunZenithAngleAtDist, altAtDist);
-#if ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION
+#if 0 /*ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION*/
     COMPUTE_TOTAL_SCATTERING_COEFFICIENT;
     return xmittance * totalScatteringCoefficient;
 #else
@@ -126,26 +140,26 @@ vec4 computeSingleScatteringIntegrandEclipsed(const float cosSunZenithAngle, con
 vec4 computeSingleScatteringEclipsed(const vec3 camera, const vec3 viewDir, const vec3 sunDir, const vec3 moonPos,
                                      const bool viewRayIntersectsGround)
 {
-    const float cosViewZenithAngle=cosZenithAngle(camera,viewDir);
-    const float cosSunZenithAngle=cosZenithAngle(camera,sunDir);
-    const float altitude=pointAltitude(camera);
-    const float dotViewSun=dot(viewDir,sunDir);
-    const float integrInterval=distanceToNearestAtmosphereBoundary(cosViewZenithAngle, altitude,
+    CONST float cosViewZenithAngle=cosZenithAngle(camera,viewDir);
+    CONST float cosSunZenithAngle=cosZenithAngle(camera,sunDir);
+    CONST float altitude=pointAltitude(camera);
+    CONST float dotViewSun=dot(viewDir,sunDir);
+    CONST float integrInterval=distanceToNearestAtmosphereBoundary(cosViewZenithAngle, altitude,
                                                                    viewRayIntersectsGround);
 
     // Using the midpoint rule for quadrature
     vec4 spectrum=vec4(0);
-    const float dl=integrInterval/radialIntegrationPoints;
+    CONST float dl=integrInterval/radialIntegrationPoints;
     for(int n=0; n<radialIntegrationPoints; ++n)
     {
-        const float dist=(n+0.5)*dl;
+        CONST float dist=(n+0.5)*dl;
         spectrum += computeSingleScatteringIntegrandEclipsed(cosSunZenithAngle, cosViewZenithAngle, dotViewSun,
                                                              altitude, dist, viewRayIntersectsGround,
                                                              camera+viewDir*dist, sunDir, moonPos);
     }
 
     spectrum *= dl*solarIrradianceAtTOA
-#if ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION
+#if 0 /*ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION*/
                                 // the multiplier is already included
 #else
                                         * scatteringCrossSection()

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/0/aerosols/texture-coordinates.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/0/aerosols/texture-coordinates.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-coordinates.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,8 +45,8 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // texture-coordinates.frag
-#line 1 2 // texture-coordinates.h.glsl
+#line 4 0 // texture-coordinates.frag
+#line 1 3 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -104,8 +115,8 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 6 0 // texture-coordinates.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-coordinates.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -137,7 +148,7 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-coordinates.frag
+#line 6 0 // texture-coordinates.frag
 
 const float LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA=sqrt(atmosphereHeight*(atmosphereHeight+2*earthRadius));
 
@@ -205,18 +216,18 @@ vec3 indicesToTexCoords(const vec3 indices, const vec3 texSizes)
 
 TransmittanceTexVars transmittanceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
+    CONST float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
                                 texCoordToUnitRange(texCoord.t,transmittanceTextureSize.t);
     // Distance from Earth center to camera
-    const float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
-    const float altitude=r-earthRadius;
+    CONST float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
+    CONST float altitude=r-earthRadius;
 
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
     // distance to border of visible atmosphere from the view point
-    const float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
+    CONST float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
     // d==0 can happen when altitude==atmosphereHeight
-    const float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
+    CONST float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
     return TransmittanceTexVars(cosVZA,altitude);
 }
 
@@ -235,53 +246,53 @@ vec2 transmittanceTexVarsToTexCoord(const float cosVZA, float altitude)
     if(altitude<0)
         altitude=0;
 
-    const float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
+    CONST float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
                                       transmittanceTextureSize.t);
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
-    const float d=distanceToAtmosphereBorder(cosVZA,altitude);
-    const float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float d=distanceToAtmosphereBorder(cosVZA,altitude);
+    CONST float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
     return vec2(s,t);
 }
 
 // Output: vec2(cos(sunZenithAngle), altitude)
 IrradianceTexVars irradianceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
-    const float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
+    CONST float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
+    CONST float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
     return IrradianceTexVars(cosSZA,alt);
 }
 
 vec2 irradianceTexVarsToTexCoord(const float cosSunZenithAngle, const float altitude)
 {
-    const float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
-    const float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
+    CONST float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
+    CONST float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
     return vec2(s,t);
 }
 
 float cosSZAToUnitRangeTexCoord(const float cosSunZenithAngle)
 {
     // Distance to top atmosphere border along the ray groundUnderCamera-sun: (altitude, cosSunZenithAngle)
-    const float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name
-    const float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
+    CONST float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
     // TODO: choose a more descriptive name
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     return max(0.,1-a/A)/(a+1);
 }
 
 float unitRangeTexCoordToCosSZA(const float texCoord)
 {
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float a=(A-A*texCoord)/(1+A*texCoord);
-    const float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
+    CONST float a=(A-A*texCoord)/(1+A*texCoord);
+    CONST float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
     return distFromGroundToTopAtmoBorder==0 ? 1 :
         clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distFromGroundToTopAtmoBorder)) /
                     (2*earthRadius*distFromGroundToTopAtmoBorder));
@@ -292,24 +303,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
                                                const float dotViewSun, const float altitude,
                                                const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -317,24 +328,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float dotVSCoord=(dotViewSun+1)/2;
+    CONST float dotVSCoord=(dotViewSun+1)/2;
 
     // ------------------------------------
-    const float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
+    CONST float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
 
     return Scattering4DCoords(cosSZACoord, cosVZACoord, dotVSCoord, altCoord, viewRayIntersectsGround);
 }
 
 TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
@@ -342,16 +353,16 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture coordinates we combine into a single sampler3D coordinate.
-    const float texW = scatteringTextureSize[1];
-    const float texH = scatteringTextureSize[2];
-    const float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
-    const vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
+    CONST float texW = scatteringTextureSize[1];
+    CONST float texH = scatteringTextureSize[2];
+    CONST float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
+    CONST vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
                                         ceil (cosSZAIndex)*texW+coords.dotViewSun*(texW-1)) / (texW*texH-1);
-    const vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
+    CONST vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
 
-    const float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
+    CONST float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
 
-    const float alphaUpper=fract(cosSZAIndex);
+    CONST float alphaUpper=fract(cosSZAIndex);
     return TexCoordPair(vec3(cosVZAtc, combinedCoord.x, altitude), float(1-alphaUpper),
                         vec3(cosVZAtc, combinedCoord.y, altitude), float(alphaUpper));
 }
@@ -359,9 +370,9 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
+    CONST TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
     return texture(tex, texCoords.lower) * texCoords.alphaLower +
            texture(tex, texCoords.upper) * texCoords.alphaUpper;
 }
@@ -369,17 +380,17 @@ vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const f
 // 3D texture is the 3D single-altitude slice of a 4D texture
 vec3 scattering4DCoordsToTex3DCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2);
 
-    const float dvsSize = scatteringTextureSize[1];
-    const float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
+    CONST float dvsSize = scatteringTextureSize[1];
+    CONST float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
 
-    const float cszaSize = scatteringTextureSize[2];
-    const float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
+    CONST float cszaSize = scatteringTextureSize[2];
+    CONST float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
 
     return vec3(cosVZAtc, dotVStc, cosSZAtc);
 }
@@ -394,39 +405,39 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along dotViewSun coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[1];
-    const float posOfRow = indices[1];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[1];
+    CONST float posOfRow = indices[1];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         indexToTexCoord(currRow, numRows-1),
                                                         texCoordVerbatim));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               indexToTexCoord(currRow, numRows-1),
                                                               texCoordVerbatim));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          indexToTexCoord(currRow, numRows-1),
                                          texCoordVerbatim));
@@ -434,14 +445,14 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
 vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolationGuides01Tex,
                                  const vec3 indices)
 {
-    const float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
+    CONST float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
 
-    const float cosVZAIndex = indices[0];
-    const float dotVSIndex = indices[1];
-    const float currRow = floor(dotVSIndex);
-    const float posBetweenRows = dotVSIndex - currRow;
-    const float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cosVZAIndex = indices[0];
+    CONST float dotVSIndex = indices[1];
+    CONST float currRow = floor(dotVSIndex);
+    CONST float posBetweenRows = dotVSIndex - currRow;
+    CONST float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -449,14 +460,14 @@ vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolat
     indicesCurrRow[1] =     currRow;
     indicesNextRow[1] = min(currRow+1, scatteringTextureSize[1]-1.);
 
-    const vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
-    const vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
+    CONST vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
+    CONST vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
 
-    const vec4 valueCurrRow = texture(tex, coordsCurrRow);
-    const vec4 valueNextRow = texture(tex, coordsNextRow);
-    const float epsilon = 1e-37; // Prevents passing zero to log
-    const vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
-    const vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
+    CONST vec4 valueCurrRow = texture(tex, coordsCurrRow);
+    CONST vec4 valueNextRow = texture(tex, coordsNextRow);
+    CONST float epsilon = 1e-37; // Prevents passing zero to log
+    CONST vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
+    CONST vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
     return (logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow;
 }
 
@@ -465,37 +476,37 @@ float findGuide02Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along SZA coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[2];
-    const float posOfRow = indices[2];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[2];
+    CONST float posOfRow = indices[2];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
 }
@@ -505,19 +516,19 @@ vec4 sample3DTextureGuided(const sampler3D tex,
                            const float cosSunZenithAngle, const float cosViewZenithAngle,
                            const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
                                                                     dotViewSun, altitude, viewRayIntersectsGround);
     // Handle the external interpolation guides: the guides between a pair of VZA-dotViewSun 2D "pictures".
-    const vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
-    const vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
-    const float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
+    CONST vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
+    CONST float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
 
-    const float cvzaIndex = indices[0];
-    const float cszaIndex = indices[2];
-    const float currRow = floor(cszaIndex);
-    const float posBetweenRows = cszaIndex - currRow;
-    const float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cvzaIndex = indices[0];
+    CONST float cszaIndex = indices[2];
+    CONST float currRow = floor(cszaIndex);
+    CONST float posBetweenRows = cszaIndex - currRow;
+    CONST float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -526,58 +537,58 @@ vec4 sample3DTextureGuided(const sampler3D tex,
     indicesNextRow[2] = min(currRow+1, scatteringTextureSize[2]-1);
 
     // The caller will handle the internal interpolation guides: the ones between rows in each 2D "picture".
-    const vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
-    const vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
+    CONST vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
+    CONST vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
     return exp((logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow);
 }
 
 vec4 sample3DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
     return texture(tex, texCoords);
 }
 
 ScatteringTexVars scatteringTex4DCoordsToTexVars(const Scattering4DCoords coords)
 {
-    const float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
     // ------------------------------------
     float cosViewZenithAngle;
     if(coords.viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
     // ------------------------------------
-    const float dotViewSun=coords.dotViewSun*2-1;
+    CONST float dotViewSun=coords.dotViewSun*2-1;
 
     // ------------------------------------
-    const float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
+    CONST float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
 
     return ScatteringTexVars(cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, coords.viewRayIntersectsGround);
 }
 
 Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 {
-    const vec4 indexMax=scatteringTextureSize-vec4(1);
+    CONST vec4 indexMax=scatteringTextureSize-vec4(1);
     Scattering4DCoords coords4d;
     coords4d.viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
     // The following formulas assume that scatteringTextureSize[0] is even. For odd sizes they would change.
@@ -593,8 +604,8 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture indices we combine into a single sampler3D coordinate.
-    const float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
-    const float combinedIndex=texIndices[1];
+    CONST float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
+    CONST float combinedIndex=texIndices[1];
     coords4d.dotViewSun=mod(combinedIndex,texW)/(texW-1);
     coords4d.cosSunZenithAngle=floor(combinedIndex/texW)/(texH-1);
 
@@ -608,11 +619,11 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
 ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 {
-    const Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
+    CONST Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
     ScatteringTexVars vars=scatteringTex4DCoordsToTexVars(coords4d);
     // Clamp dotViewSun to its valid range of values, given cosViewZenithAngle and cosSunZenithAngle. This is
     // needed to prevent NaNs when computing the scattering texture.
-    const float cosVZA=vars.cosViewZenithAngle,
+    CONST float cosVZA=vars.cosViewZenithAngle,
                 cosSZA=vars.cosSunZenithAngle;
     vars.dotViewSun=clamp(vars.dotViewSun,
                           cosVZA*cosSZA-safeSqrt((1-sqr(cosVZA))*(1-sqr(cosSZA))),
@@ -622,54 +633,54 @@ ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 
 EclipseScatteringTexVars eclipseTexCoordsToTexVars(const vec2 texCoords, const float altitude)
 {
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
-    const bool viewRayIntersectsGround = texCoords.t<0.5;
+    CONST bool viewRayIntersectsGround = texCoords.t<0.5;
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
-    const float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
+    CONST float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
     return EclipseScatteringTexVars(azimuthRelativeToSun, cosViewZenithAngle, viewRayIntersectsGround);
 }
 
 EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                                    const float altitude, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -677,13 +688,13 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
-    const float azimuthCoord = azimuthRelativeToSun/(2*PI);
+    CONST float azimuthCoord = azimuthRelativeToSun/(2*PI);
 
     return EclipseScattering2DCoords(azimuthCoord, cosVZACoord);
 }
@@ -691,14 +702,14 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
 vec2 eclipseTexVarsToTexCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                const float altitude, const bool viewRayIntersectsGround, const vec2 texSize)
 {
-    const EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+    CONST EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                                     viewRayIntersectsGround);
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2);
-    const float azimuthTC = coords.azimuth + 1/(2*texSize.s);
+    CONST float azimuthTC = coords.azimuth + 1/(2*texSize.s);
 
     return vec2(azimuthTC, cosVZAtc);
 }
@@ -707,42 +718,42 @@ vec4 sampleEclipseDoubleScattering3DTexture(const sampler3D tex, const float cos
                                             const float cosViewZenithAngle, const float azimuthRelativeToSun,
                                             const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
+    CONST vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
                                                   eclipsedDoubleScatteringTextureSize.st);
-    const float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
-    const vec3 texCoords=vec3(coords2d, cosSZACoord);
+    CONST float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
+    CONST vec3 texCoords=vec3(coords2d, cosSZACoord);
 
     return texture(tex, texCoords);
 }
 
 LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 texIndices)
 {
-    const vec2 indexMax=lightPollutionTextureSize-vec2(1);
+    CONST vec2 indexMax=lightPollutionTextureSize-vec2(1);
 
-    const float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
-    const float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
+    CONST float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
-    const bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
-    const float cosViewZenithAngleCoord = viewRayIntersectsGround ?
+    CONST bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
+    CONST float cosViewZenithAngleCoord = viewRayIntersectsGround ?
                                    1-2*texIndices[0]/(indexMax[0]-1) :
                                    2*(texIndices[0]-1)/(indexMax[0]-1)-1;
     // ------------------------------------
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
@@ -753,23 +764,23 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 
 LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -777,27 +788,27 @@ LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, con
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     return LightPollution2DCoords(cosVZACoord, altCoord);
 }
 
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
-    const vec2 texSize = lightPollutionTextureSize;
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 texSize = lightPollutionTextureSize;
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2);
-    const float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
+    CONST float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
     return vec2(cosVZAtc, altitudeTC);
 }

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/0/aerosols/texture-sampling-functions.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/0/aerosols/texture-sampling-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-sampling-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,13 +45,13 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // texture-sampling-functions.frag
-#line 1 2 // phase-functions.h.glsl
+#line 4 0 // texture-sampling-functions.frag
+#line 1 3 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 6 0 // texture-sampling-functions.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-sampling-functions.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -72,8 +83,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-sampling-functions.frag
-#line 1 4 // texture-coordinates.h.glsl
+#line 6 0 // texture-sampling-functions.frag
+#line 1 5 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -142,7 +153,7 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 8 0 // texture-sampling-functions.frag
+#line 7 0 // texture-sampling-functions.frag
 
 uniform sampler2D transmittanceTexture;
 uniform sampler2D irradianceTexture;
@@ -154,13 +165,13 @@ uniform sampler2D lightPollutionScatteringTexture;
 
 vec4 irradiance(const float cosSunZenithAngle, const float altitude)
 {
-    const vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
+    CONST vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
     return texture(irradianceTexture, texCoords);
 }
 
 vec4 opticalDepthToAtmosphereBorder(const float cosViewZenithAngle, const float altitude)
 {
-    const vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
+    CONST vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact when looking into nadir from TOA at some values of texture sizes (in particular, size of
     // transmittance texture for altitude being 4096). This happens when I simply call texture(eclipsedScatteringTexture,
@@ -178,11 +189,11 @@ vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float
 vec4 transmittance(const float cosViewZenithAngle, const float altitude, const float dist,
                    const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle view ray endpoint
     // in space here.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
 
     vec4 depth;
     if(viewRayIntersectsGround)
@@ -201,7 +212,7 @@ vec4 transmittance(const float cosViewZenithAngle, const float altitude, const f
 vec4 calcFirstScattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                          const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
+    CONST vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
                                           dotViewSun, altitude, viewRayIntersectsGround);
     return scattering*currentPhaseFunction(dotViewSun);
 }
@@ -220,6 +231,6 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
 
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     return texture(lightPollutionScatteringTexture, coords);
 }

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/0/molecules/common-functions.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/0/molecules/common-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // common-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // common-functions.frag
+#line 4 0 // common-functions.frag
 
 bool dbgDataPresent=false;
 bool debugDataPresent()
@@ -69,7 +80,7 @@ void setDebugData(float a,float b, float c, float d)
 
 void swap(inout float x, inout float y)
 {
-    const float t = x;
+    CONST float t = x;
     x = y;
     y = t;
 }
@@ -83,7 +94,7 @@ float safeSqrt(const float x)
 
 float safeAtan(const float y, const float x)
 {
-    const float a = atan(y,x);
+    CONST float a = atan(y,x);
     return x==0 && y==0 ? 0 : a;
 }
 
@@ -116,23 +127,23 @@ float pointAltitude(vec3 point)
 
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float Ratm=earthRadius+atmosphereHeight;
-    const float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float Ratm=earthRadius+atmosphereHeight;
+    CONST float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float distanceToGround(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(-safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float cosZenithAngleOfHorizon(const float altitude)
 {
-    const float R=earthRadius;
-    const float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
+    CONST float R=earthRadius;
+    CONST float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
     return -sqrt(2*h*R+sqr(h))/(R+h);
 }
 
@@ -151,8 +162,8 @@ float distanceToNearestAtmosphereBoundary(const float cosZenithAngle, const floa
 float sunVisibility(const float cosSunZenithAngle, float altitude)
 {
     if(altitude<0) altitude=0;
-    const float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
-    const float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
+    CONST float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
+    CONST float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
     /* Approximating visible fraction of solar disk by smoothstep between the position of the Sun
      * touching the horizon by its upper part and the position with lower part touching the horizon.
      * The calculation assumes that solar angular radius is small and thus approximately equals its sine.
@@ -182,13 +193,13 @@ float circlesIntersectionArea(float R1, float R2, float d)
 
 float angleBetween(const vec3 a, const vec3 b)
 {
-    const float d=dot(a,b);
-    const float c=length(cross(a,b));
+    CONST float d=dot(a,b);
+    CONST float c=length(cross(a,b));
     // To avoid loss of precision, don't use dot product near the singularity
     // of acos, and cross product near the singularity of asin
     if(abs(d) < abs(c))
         return acos(d/(length(a)*length(b)));
-    const float smallerAngle = asin(c/(length(a)*length(b)));
+    CONST float smallerAngle = asin(c/(length(a)*length(b)));
     if(d<0) return PI-smallerAngle;
     return smallerAngle;
 }
@@ -205,11 +216,11 @@ float moonAngularRadius(const vec3 cameraPosition, const vec3 moonPosition)
 
 float visibleSolidAngleOfSun(const vec3 camera, const vec3 sunDir, const vec3 moonPos)
 {
-    const float Rs=sunAngularRadius;
-    const float Rm=moonAngularRadius(camera,moonPos);
+    CONST float Rs=sunAngularRadius;
+    CONST float Rm=moonAngularRadius(camera,moonPos);
     float visibleSolidAngle=PI*sqr(Rs);
 
-    const float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
+    CONST float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
     if(dSM<Rs+Rm)
     {
         visibleSolidAngle -= circlesIntersectionArea(Rm,Rs,dSM);
@@ -229,12 +240,12 @@ float sphereIntegrationSolidAngleDifferential(const int pointCountOnSphere)
 }
 vec3 sphereIntegrationSampleDir(const int index, const int pointCountOnSphere)
 {
-    const float goldenRatio=1.6180339887499;
+    CONST float goldenRatio=1.6180339887499;
     // The range of n is 0.5, 1.5, ..., pointCountOnSphere-0.5
-    const float n=index+0.5;
+    CONST float n=index+0.5;
     // Explanation of the Fibonacci grid generation can be seen at https://stackoverflow.com/a/44164075/673852
-    const float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
-    const float azimuth=n*(2*PI*goldenRatio);
+    CONST float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
+    CONST float azimuth=n*(2*PI*goldenRatio);
     return vec3(cos(azimuth)*sin(zenithAngle),
                 sin(azimuth)*sin(zenithAngle),
                 cos(zenithAngle));

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/0/molecules/compute-eclipsed-single-scattering.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/0/molecules/compute-eclipsed-single-scattering.frag
@@ -1,7 +1,21 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
 
-#line 1 1 // const.h.glsl
+
+
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 6 0 // compute-eclipsed-single-scattering.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,8 +48,8 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // compute-eclipsed-single-scattering.frag
-#line 1 2 // texture-coordinates.h.glsl
+#line 7 0 // compute-eclipsed-single-scattering.frag
+#line 1 3 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -104,11 +118,11 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 6 0 // compute-eclipsed-single-scattering.frag
-#line 1 3 // radiance-to-luminance.h.glsl
+#line 8 0 // compute-eclipsed-single-scattering.frag
+#line 1 4 // radiance-to-luminance.h.glsl
 const mat4 radianceToLuminance=mat4(1.38997746,0.0419133306,6.48549128,0,  105.968163,3.00652099,500.960266,142.641495,  3776.24023,119.971481,18207.7598,6412.0166,  6910.01318,981.06665,37504.0586,26741.9102);
-#line 7 0 // compute-eclipsed-single-scattering.frag
-#line 1 4 // single-scattering-eclipsed.h.glsl
+#line 9 0 // compute-eclipsed-single-scattering.frag
+#line 1 5 // single-scattering-eclipsed.h.glsl
 #ifndef INCLUDE_ONCE_050024D2_BD56_434E_8D40_2055DA0B78EC
 #define INCLUDE_ONCE_050024D2_BD56_434E_8D40_2055DA0B78EC
 
@@ -116,7 +130,7 @@ vec4 computeSingleScatteringEclipsed(const vec3 camera, const vec3 viewDir, cons
                                      const bool viewRayIntersectsGround);
 
 #endif
-#line 8 0 // compute-eclipsed-single-scattering.frag
+#line 10 0 // compute-eclipsed-single-scattering.frag
 
 in vec3 position;
 out vec4 scatteringTextureOutput;
@@ -132,16 +146,16 @@ vec4 solarRadiance()
 
 void main()
 {
-    const EclipseScatteringTexVars texVars=eclipseTexCoordsToTexVars(gl_FragCoord.xy/eclipsedSingleScatteringTextureSize, altitude);
-    const float sinViewZenithAngle=sqrt(1-sqr(texVars.cosViewZenithAngle));
-    const vec3 viewDir=vec3(cos(texVars.azimuthRelativeToSun)*sinViewZenithAngle,
+    CONST EclipseScatteringTexVars texVars=eclipseTexCoordsToTexVars(gl_FragCoord.xy/eclipsedSingleScatteringTextureSize, altitude);
+    CONST float sinViewZenithAngle=sqrt(1-sqr(texVars.cosViewZenithAngle));
+    CONST vec3 viewDir=vec3(cos(texVars.azimuthRelativeToSun)*sinViewZenithAngle,
                             sin(texVars.azimuthRelativeToSun)*sinViewZenithAngle,
                             texVars.cosViewZenithAngle);
-    const vec3 cameraPosition=vec3(0,0,altitude);
-    const vec3 sunDirection=vec3(sin(sunZenithAngle), 0, cos(sunZenithAngle));
-    const vec4 radiance=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPositionRelativeToSunAzimuth,
+    CONST vec3 cameraPosition=vec3(0,0,altitude);
+    CONST vec3 sunDirection=vec3(sin(sunZenithAngle), 0, cos(sunZenithAngle));
+    CONST vec4 radiance=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPositionRelativeToSunAzimuth,
                                                         texVars.viewRayIntersectsGround);
-#if COMPUTE_RADIANCE
+#if 0 /*COMPUTE_RADIANCE*/
     scatteringTextureOutput=radiance;
 #elif 1 /*COMPUTE_LUMINANCE*/
     scatteringTextureOutput=radianceToLuminance*radiance;

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/0/molecules/densities.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/0/molecules/densities.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // densities.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,20 +45,20 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // densities.frag
+#line 4 0 // densities.frag
 float scattererNumberDensity_molecules(float altitude)
 {
-        const float rayleighScaleHeight=8*km;
+        CONST float rayleighScaleHeight=8*km;
         return 3.08458e25*exp(-1/rayleighScaleHeight * altitude);
 }
 float scattererNumberDensity_aerosols(float altitude)
 {
-        const float mieScaleHeight=1.2*km;
+        CONST float mieScaleHeight=1.2*km;
         return 1.03333e8*exp(-1/mieScaleHeight*altitude);
 }
 float absorberNumberDensity_ozone(float altitude)
 {
-        const float totalOzoneAmount=370*dobsonUnit;
+        CONST float totalOzoneAmount=370*dobsonUnit;
 
         float density;
 

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/0/molecules/phase-functions.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/0/molecules/phase-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // phase-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // phase-functions.frag
+#line 4 0 // phase-functions.frag
 
 vec4 phaseFunction_molecules(float dotViewSun)
 {
@@ -42,9 +53,9 @@ vec4 phaseFunction_molecules(float dotViewSun)
 }
 vec4 phaseFunction_aerosols(float dotViewSun)
 {
-        const float g=0.76;
-        const float g2=g*g;
-        const float k = 3/(8*PI)*(1-g2)/(2+g2);
+        CONST float g=0.76;
+        CONST float g2=g*g;
+        CONST float k = 3/(8*PI)*(1-g2)/(2+g2);
         return vec4(k * (1+sqr(dotViewSun)) / pow(1+g2 - 2*g*dotViewSun, 1.5) + 1/((1-dotViewSun)*600+0.05))*0.904;
 }
 vec4 currentPhaseFunction(float dotViewSun) { return phaseFunction_molecules(dotViewSun); }

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/0/molecules/single-scattering-eclipsed.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/0/molecules/single-scattering-eclipsed.frag
@@ -1,7 +1,21 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
 
-#line 1 1 // const.h.glsl
+
+
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 6 0 // single-scattering-eclipsed.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,15 +48,15 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // single-scattering-eclipsed.frag
-#line 1 2 // densities.h.glsl
+#line 7 0 // single-scattering-eclipsed.frag
+#line 1 3 // densities.h.glsl
 float scattererNumberDensity_molecules(float altitude);
 float scattererNumberDensity_aerosols(float altitude);
 float absorberNumberDensity_ozone(float altitude);
 vec4 scatteringCrossSection();
 float scattererDensity(float altitude);
-#line 6 0 // single-scattering-eclipsed.frag
-#line 1 3 // common-functions.h.glsl
+#line 8 0 // single-scattering-eclipsed.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -74,8 +88,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // single-scattering-eclipsed.frag
-#line 1 4 // texture-sampling-functions.h.glsl
+#line 9 0 // single-scattering-eclipsed.frag
+#line 1 5 // texture-sampling-functions.h.glsl
 #ifndef INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 #define INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float altitude);
@@ -87,7 +101,7 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                 const int scatteringOrder);
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 #endif
-#line 8 0 // single-scattering-eclipsed.frag
+#line 10 0 // single-scattering-eclipsed.frag
 
 
 float cosZenithAngle(vec3 origin, vec3 direction)
@@ -101,13 +115,13 @@ vec4 computeSingleScatteringIntegrandEclipsed(const float cosSunZenithAngle, con
                                               const float dist, const bool viewRayIntersectsGround,
                                               const vec3 scatterer, const vec3 sunDir, const vec3 moonPos)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle here the case when the
     // endpoint of the view ray intentionally appears in outer space.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosSunZenithAngleAtDist=clampCosine((r*cosSunZenithAngle+dist*dotViewSun)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosSunZenithAngleAtDist=clampCosine((r*cosSunZenithAngle+dist*dotViewSun)/(earthRadius+altAtDist));
 
-    const vec4 xmittance=transmittance(cosViewZenithAngle, altitude, dist, viewRayIntersectsGround)
+    CONST vec4 xmittance=transmittance(cosViewZenithAngle, altitude, dist, viewRayIntersectsGround)
                                                     *
                          transmittanceToAtmosphereBorder(cosSunZenithAngleAtDist, altAtDist)
                                                     *
@@ -115,7 +129,7 @@ vec4 computeSingleScatteringIntegrandEclipsed(const float cosSunZenithAngle, con
                                                     *
                             // FIXME: this ignores orientation of the crescent of eclipsed Sun WRT horizon
                                     sunVisibility(cosSunZenithAngleAtDist, altAtDist);
-#if ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION
+#if 0 /*ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION*/
     COMPUTE_TOTAL_SCATTERING_COEFFICIENT;
     return xmittance * totalScatteringCoefficient;
 #else
@@ -126,26 +140,26 @@ vec4 computeSingleScatteringIntegrandEclipsed(const float cosSunZenithAngle, con
 vec4 computeSingleScatteringEclipsed(const vec3 camera, const vec3 viewDir, const vec3 sunDir, const vec3 moonPos,
                                      const bool viewRayIntersectsGround)
 {
-    const float cosViewZenithAngle=cosZenithAngle(camera,viewDir);
-    const float cosSunZenithAngle=cosZenithAngle(camera,sunDir);
-    const float altitude=pointAltitude(camera);
-    const float dotViewSun=dot(viewDir,sunDir);
-    const float integrInterval=distanceToNearestAtmosphereBoundary(cosViewZenithAngle, altitude,
+    CONST float cosViewZenithAngle=cosZenithAngle(camera,viewDir);
+    CONST float cosSunZenithAngle=cosZenithAngle(camera,sunDir);
+    CONST float altitude=pointAltitude(camera);
+    CONST float dotViewSun=dot(viewDir,sunDir);
+    CONST float integrInterval=distanceToNearestAtmosphereBoundary(cosViewZenithAngle, altitude,
                                                                    viewRayIntersectsGround);
 
     // Using the midpoint rule for quadrature
     vec4 spectrum=vec4(0);
-    const float dl=integrInterval/radialIntegrationPoints;
+    CONST float dl=integrInterval/radialIntegrationPoints;
     for(int n=0; n<radialIntegrationPoints; ++n)
     {
-        const float dist=(n+0.5)*dl;
+        CONST float dist=(n+0.5)*dl;
         spectrum += computeSingleScatteringIntegrandEclipsed(cosSunZenithAngle, cosViewZenithAngle, dotViewSun,
                                                              altitude, dist, viewRayIntersectsGround,
                                                              camera+viewDir*dist, sunDir, moonPos);
     }
 
     spectrum *= dl*solarIrradianceAtTOA
-#if ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION
+#if 0 /*ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION*/
                                 // the multiplier is already included
 #else
                                         * scatteringCrossSection()

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/0/molecules/texture-coordinates.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/0/molecules/texture-coordinates.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-coordinates.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,8 +45,8 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // texture-coordinates.frag
-#line 1 2 // texture-coordinates.h.glsl
+#line 4 0 // texture-coordinates.frag
+#line 1 3 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -104,8 +115,8 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 6 0 // texture-coordinates.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-coordinates.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -137,7 +148,7 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-coordinates.frag
+#line 6 0 // texture-coordinates.frag
 
 const float LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA=sqrt(atmosphereHeight*(atmosphereHeight+2*earthRadius));
 
@@ -205,18 +216,18 @@ vec3 indicesToTexCoords(const vec3 indices, const vec3 texSizes)
 
 TransmittanceTexVars transmittanceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
+    CONST float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
                                 texCoordToUnitRange(texCoord.t,transmittanceTextureSize.t);
     // Distance from Earth center to camera
-    const float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
-    const float altitude=r-earthRadius;
+    CONST float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
+    CONST float altitude=r-earthRadius;
 
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
     // distance to border of visible atmosphere from the view point
-    const float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
+    CONST float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
     // d==0 can happen when altitude==atmosphereHeight
-    const float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
+    CONST float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
     return TransmittanceTexVars(cosVZA,altitude);
 }
 
@@ -235,53 +246,53 @@ vec2 transmittanceTexVarsToTexCoord(const float cosVZA, float altitude)
     if(altitude<0)
         altitude=0;
 
-    const float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
+    CONST float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
                                       transmittanceTextureSize.t);
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
-    const float d=distanceToAtmosphereBorder(cosVZA,altitude);
-    const float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float d=distanceToAtmosphereBorder(cosVZA,altitude);
+    CONST float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
     return vec2(s,t);
 }
 
 // Output: vec2(cos(sunZenithAngle), altitude)
 IrradianceTexVars irradianceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
-    const float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
+    CONST float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
+    CONST float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
     return IrradianceTexVars(cosSZA,alt);
 }
 
 vec2 irradianceTexVarsToTexCoord(const float cosSunZenithAngle, const float altitude)
 {
-    const float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
-    const float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
+    CONST float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
+    CONST float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
     return vec2(s,t);
 }
 
 float cosSZAToUnitRangeTexCoord(const float cosSunZenithAngle)
 {
     // Distance to top atmosphere border along the ray groundUnderCamera-sun: (altitude, cosSunZenithAngle)
-    const float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name
-    const float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
+    CONST float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
     // TODO: choose a more descriptive name
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     return max(0.,1-a/A)/(a+1);
 }
 
 float unitRangeTexCoordToCosSZA(const float texCoord)
 {
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float a=(A-A*texCoord)/(1+A*texCoord);
-    const float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
+    CONST float a=(A-A*texCoord)/(1+A*texCoord);
+    CONST float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
     return distFromGroundToTopAtmoBorder==0 ? 1 :
         clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distFromGroundToTopAtmoBorder)) /
                     (2*earthRadius*distFromGroundToTopAtmoBorder));
@@ -292,24 +303,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
                                                const float dotViewSun, const float altitude,
                                                const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -317,24 +328,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float dotVSCoord=(dotViewSun+1)/2;
+    CONST float dotVSCoord=(dotViewSun+1)/2;
 
     // ------------------------------------
-    const float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
+    CONST float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
 
     return Scattering4DCoords(cosSZACoord, cosVZACoord, dotVSCoord, altCoord, viewRayIntersectsGround);
 }
 
 TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
@@ -342,16 +353,16 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture coordinates we combine into a single sampler3D coordinate.
-    const float texW = scatteringTextureSize[1];
-    const float texH = scatteringTextureSize[2];
-    const float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
-    const vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
+    CONST float texW = scatteringTextureSize[1];
+    CONST float texH = scatteringTextureSize[2];
+    CONST float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
+    CONST vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
                                         ceil (cosSZAIndex)*texW+coords.dotViewSun*(texW-1)) / (texW*texH-1);
-    const vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
+    CONST vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
 
-    const float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
+    CONST float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
 
-    const float alphaUpper=fract(cosSZAIndex);
+    CONST float alphaUpper=fract(cosSZAIndex);
     return TexCoordPair(vec3(cosVZAtc, combinedCoord.x, altitude), float(1-alphaUpper),
                         vec3(cosVZAtc, combinedCoord.y, altitude), float(alphaUpper));
 }
@@ -359,9 +370,9 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
+    CONST TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
     return texture(tex, texCoords.lower) * texCoords.alphaLower +
            texture(tex, texCoords.upper) * texCoords.alphaUpper;
 }
@@ -369,17 +380,17 @@ vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const f
 // 3D texture is the 3D single-altitude slice of a 4D texture
 vec3 scattering4DCoordsToTex3DCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2);
 
-    const float dvsSize = scatteringTextureSize[1];
-    const float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
+    CONST float dvsSize = scatteringTextureSize[1];
+    CONST float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
 
-    const float cszaSize = scatteringTextureSize[2];
-    const float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
+    CONST float cszaSize = scatteringTextureSize[2];
+    CONST float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
 
     return vec3(cosVZAtc, dotVStc, cosSZAtc);
 }
@@ -394,39 +405,39 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along dotViewSun coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[1];
-    const float posOfRow = indices[1];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[1];
+    CONST float posOfRow = indices[1];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         indexToTexCoord(currRow, numRows-1),
                                                         texCoordVerbatim));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               indexToTexCoord(currRow, numRows-1),
                                                               texCoordVerbatim));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          indexToTexCoord(currRow, numRows-1),
                                          texCoordVerbatim));
@@ -434,14 +445,14 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
 vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolationGuides01Tex,
                                  const vec3 indices)
 {
-    const float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
+    CONST float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
 
-    const float cosVZAIndex = indices[0];
-    const float dotVSIndex = indices[1];
-    const float currRow = floor(dotVSIndex);
-    const float posBetweenRows = dotVSIndex - currRow;
-    const float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cosVZAIndex = indices[0];
+    CONST float dotVSIndex = indices[1];
+    CONST float currRow = floor(dotVSIndex);
+    CONST float posBetweenRows = dotVSIndex - currRow;
+    CONST float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -449,14 +460,14 @@ vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolat
     indicesCurrRow[1] =     currRow;
     indicesNextRow[1] = min(currRow+1, scatteringTextureSize[1]-1.);
 
-    const vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
-    const vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
+    CONST vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
+    CONST vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
 
-    const vec4 valueCurrRow = texture(tex, coordsCurrRow);
-    const vec4 valueNextRow = texture(tex, coordsNextRow);
-    const float epsilon = 1e-37; // Prevents passing zero to log
-    const vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
-    const vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
+    CONST vec4 valueCurrRow = texture(tex, coordsCurrRow);
+    CONST vec4 valueNextRow = texture(tex, coordsNextRow);
+    CONST float epsilon = 1e-37; // Prevents passing zero to log
+    CONST vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
+    CONST vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
     return (logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow;
 }
 
@@ -465,37 +476,37 @@ float findGuide02Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along SZA coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[2];
-    const float posOfRow = indices[2];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[2];
+    CONST float posOfRow = indices[2];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
 }
@@ -505,19 +516,19 @@ vec4 sample3DTextureGuided(const sampler3D tex,
                            const float cosSunZenithAngle, const float cosViewZenithAngle,
                            const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
                                                                     dotViewSun, altitude, viewRayIntersectsGround);
     // Handle the external interpolation guides: the guides between a pair of VZA-dotViewSun 2D "pictures".
-    const vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
-    const vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
-    const float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
+    CONST vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
+    CONST float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
 
-    const float cvzaIndex = indices[0];
-    const float cszaIndex = indices[2];
-    const float currRow = floor(cszaIndex);
-    const float posBetweenRows = cszaIndex - currRow;
-    const float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cvzaIndex = indices[0];
+    CONST float cszaIndex = indices[2];
+    CONST float currRow = floor(cszaIndex);
+    CONST float posBetweenRows = cszaIndex - currRow;
+    CONST float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -526,58 +537,58 @@ vec4 sample3DTextureGuided(const sampler3D tex,
     indicesNextRow[2] = min(currRow+1, scatteringTextureSize[2]-1);
 
     // The caller will handle the internal interpolation guides: the ones between rows in each 2D "picture".
-    const vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
-    const vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
+    CONST vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
+    CONST vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
     return exp((logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow);
 }
 
 vec4 sample3DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
     return texture(tex, texCoords);
 }
 
 ScatteringTexVars scatteringTex4DCoordsToTexVars(const Scattering4DCoords coords)
 {
-    const float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
     // ------------------------------------
     float cosViewZenithAngle;
     if(coords.viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
     // ------------------------------------
-    const float dotViewSun=coords.dotViewSun*2-1;
+    CONST float dotViewSun=coords.dotViewSun*2-1;
 
     // ------------------------------------
-    const float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
+    CONST float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
 
     return ScatteringTexVars(cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, coords.viewRayIntersectsGround);
 }
 
 Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 {
-    const vec4 indexMax=scatteringTextureSize-vec4(1);
+    CONST vec4 indexMax=scatteringTextureSize-vec4(1);
     Scattering4DCoords coords4d;
     coords4d.viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
     // The following formulas assume that scatteringTextureSize[0] is even. For odd sizes they would change.
@@ -593,8 +604,8 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture indices we combine into a single sampler3D coordinate.
-    const float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
-    const float combinedIndex=texIndices[1];
+    CONST float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
+    CONST float combinedIndex=texIndices[1];
     coords4d.dotViewSun=mod(combinedIndex,texW)/(texW-1);
     coords4d.cosSunZenithAngle=floor(combinedIndex/texW)/(texH-1);
 
@@ -608,11 +619,11 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
 ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 {
-    const Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
+    CONST Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
     ScatteringTexVars vars=scatteringTex4DCoordsToTexVars(coords4d);
     // Clamp dotViewSun to its valid range of values, given cosViewZenithAngle and cosSunZenithAngle. This is
     // needed to prevent NaNs when computing the scattering texture.
-    const float cosVZA=vars.cosViewZenithAngle,
+    CONST float cosVZA=vars.cosViewZenithAngle,
                 cosSZA=vars.cosSunZenithAngle;
     vars.dotViewSun=clamp(vars.dotViewSun,
                           cosVZA*cosSZA-safeSqrt((1-sqr(cosVZA))*(1-sqr(cosSZA))),
@@ -622,54 +633,54 @@ ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 
 EclipseScatteringTexVars eclipseTexCoordsToTexVars(const vec2 texCoords, const float altitude)
 {
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
-    const bool viewRayIntersectsGround = texCoords.t<0.5;
+    CONST bool viewRayIntersectsGround = texCoords.t<0.5;
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
-    const float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
+    CONST float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
     return EclipseScatteringTexVars(azimuthRelativeToSun, cosViewZenithAngle, viewRayIntersectsGround);
 }
 
 EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                                    const float altitude, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -677,13 +688,13 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
-    const float azimuthCoord = azimuthRelativeToSun/(2*PI);
+    CONST float azimuthCoord = azimuthRelativeToSun/(2*PI);
 
     return EclipseScattering2DCoords(azimuthCoord, cosVZACoord);
 }
@@ -691,14 +702,14 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
 vec2 eclipseTexVarsToTexCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                const float altitude, const bool viewRayIntersectsGround, const vec2 texSize)
 {
-    const EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+    CONST EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                                     viewRayIntersectsGround);
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2);
-    const float azimuthTC = coords.azimuth + 1/(2*texSize.s);
+    CONST float azimuthTC = coords.azimuth + 1/(2*texSize.s);
 
     return vec2(azimuthTC, cosVZAtc);
 }
@@ -707,42 +718,42 @@ vec4 sampleEclipseDoubleScattering3DTexture(const sampler3D tex, const float cos
                                             const float cosViewZenithAngle, const float azimuthRelativeToSun,
                                             const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
+    CONST vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
                                                   eclipsedDoubleScatteringTextureSize.st);
-    const float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
-    const vec3 texCoords=vec3(coords2d, cosSZACoord);
+    CONST float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
+    CONST vec3 texCoords=vec3(coords2d, cosSZACoord);
 
     return texture(tex, texCoords);
 }
 
 LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 texIndices)
 {
-    const vec2 indexMax=lightPollutionTextureSize-vec2(1);
+    CONST vec2 indexMax=lightPollutionTextureSize-vec2(1);
 
-    const float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
-    const float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
+    CONST float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
-    const bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
-    const float cosViewZenithAngleCoord = viewRayIntersectsGround ?
+    CONST bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
+    CONST float cosViewZenithAngleCoord = viewRayIntersectsGround ?
                                    1-2*texIndices[0]/(indexMax[0]-1) :
                                    2*(texIndices[0]-1)/(indexMax[0]-1)-1;
     // ------------------------------------
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
@@ -753,23 +764,23 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 
 LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -777,27 +788,27 @@ LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, con
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     return LightPollution2DCoords(cosVZACoord, altCoord);
 }
 
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
-    const vec2 texSize = lightPollutionTextureSize;
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 texSize = lightPollutionTextureSize;
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2);
-    const float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
+    CONST float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
     return vec2(cosVZAtc, altitudeTC);
 }

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/0/molecules/texture-sampling-functions.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/0/molecules/texture-sampling-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-sampling-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,13 +45,13 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // texture-sampling-functions.frag
-#line 1 2 // phase-functions.h.glsl
+#line 4 0 // texture-sampling-functions.frag
+#line 1 3 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 6 0 // texture-sampling-functions.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-sampling-functions.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -72,8 +83,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-sampling-functions.frag
-#line 1 4 // texture-coordinates.h.glsl
+#line 6 0 // texture-sampling-functions.frag
+#line 1 5 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -142,7 +153,7 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 8 0 // texture-sampling-functions.frag
+#line 7 0 // texture-sampling-functions.frag
 
 uniform sampler2D transmittanceTexture;
 uniform sampler2D irradianceTexture;
@@ -154,13 +165,13 @@ uniform sampler2D lightPollutionScatteringTexture;
 
 vec4 irradiance(const float cosSunZenithAngle, const float altitude)
 {
-    const vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
+    CONST vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
     return texture(irradianceTexture, texCoords);
 }
 
 vec4 opticalDepthToAtmosphereBorder(const float cosViewZenithAngle, const float altitude)
 {
-    const vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
+    CONST vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact when looking into nadir from TOA at some values of texture sizes (in particular, size of
     // transmittance texture for altitude being 4096). This happens when I simply call texture(eclipsedScatteringTexture,
@@ -178,11 +189,11 @@ vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float
 vec4 transmittance(const float cosViewZenithAngle, const float altitude, const float dist,
                    const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle view ray endpoint
     // in space here.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
 
     vec4 depth;
     if(viewRayIntersectsGround)
@@ -201,7 +212,7 @@ vec4 transmittance(const float cosViewZenithAngle, const float altitude, const f
 vec4 calcFirstScattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                          const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
+    CONST vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
                                           dotViewSun, altitude, viewRayIntersectsGround);
     return scattering*currentPhaseFunction(dotViewSun);
 }
@@ -220,6 +231,6 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
 
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     return texture(lightPollutionScatteringTexture, coords);
 }

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/1/aerosols/common-functions.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/1/aerosols/common-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // common-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(2.15e-06,1.11400004e-06,3.8580001
 const vec4 wavelengths=vec4(485.333344,516.666687,548,579.333313);
 const int wlSetIndex=1;
 #endif
-#line 5 0 // common-functions.frag
+#line 4 0 // common-functions.frag
 
 bool dbgDataPresent=false;
 bool debugDataPresent()
@@ -69,7 +80,7 @@ void setDebugData(float a,float b, float c, float d)
 
 void swap(inout float x, inout float y)
 {
-    const float t = x;
+    CONST float t = x;
     x = y;
     y = t;
 }
@@ -83,7 +94,7 @@ float safeSqrt(const float x)
 
 float safeAtan(const float y, const float x)
 {
-    const float a = atan(y,x);
+    CONST float a = atan(y,x);
     return x==0 && y==0 ? 0 : a;
 }
 
@@ -116,23 +127,23 @@ float pointAltitude(vec3 point)
 
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float Ratm=earthRadius+atmosphereHeight;
-    const float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float Ratm=earthRadius+atmosphereHeight;
+    CONST float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float distanceToGround(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(-safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float cosZenithAngleOfHorizon(const float altitude)
 {
-    const float R=earthRadius;
-    const float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
+    CONST float R=earthRadius;
+    CONST float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
     return -sqrt(2*h*R+sqr(h))/(R+h);
 }
 
@@ -151,8 +162,8 @@ float distanceToNearestAtmosphereBoundary(const float cosZenithAngle, const floa
 float sunVisibility(const float cosSunZenithAngle, float altitude)
 {
     if(altitude<0) altitude=0;
-    const float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
-    const float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
+    CONST float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
+    CONST float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
     /* Approximating visible fraction of solar disk by smoothstep between the position of the Sun
      * touching the horizon by its upper part and the position with lower part touching the horizon.
      * The calculation assumes that solar angular radius is small and thus approximately equals its sine.
@@ -182,13 +193,13 @@ float circlesIntersectionArea(float R1, float R2, float d)
 
 float angleBetween(const vec3 a, const vec3 b)
 {
-    const float d=dot(a,b);
-    const float c=length(cross(a,b));
+    CONST float d=dot(a,b);
+    CONST float c=length(cross(a,b));
     // To avoid loss of precision, don't use dot product near the singularity
     // of acos, and cross product near the singularity of asin
     if(abs(d) < abs(c))
         return acos(d/(length(a)*length(b)));
-    const float smallerAngle = asin(c/(length(a)*length(b)));
+    CONST float smallerAngle = asin(c/(length(a)*length(b)));
     if(d<0) return PI-smallerAngle;
     return smallerAngle;
 }
@@ -205,11 +216,11 @@ float moonAngularRadius(const vec3 cameraPosition, const vec3 moonPosition)
 
 float visibleSolidAngleOfSun(const vec3 camera, const vec3 sunDir, const vec3 moonPos)
 {
-    const float Rs=sunAngularRadius;
-    const float Rm=moonAngularRadius(camera,moonPos);
+    CONST float Rs=sunAngularRadius;
+    CONST float Rm=moonAngularRadius(camera,moonPos);
     float visibleSolidAngle=PI*sqr(Rs);
 
-    const float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
+    CONST float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
     if(dSM<Rs+Rm)
     {
         visibleSolidAngle -= circlesIntersectionArea(Rm,Rs,dSM);
@@ -229,12 +240,12 @@ float sphereIntegrationSolidAngleDifferential(const int pointCountOnSphere)
 }
 vec3 sphereIntegrationSampleDir(const int index, const int pointCountOnSphere)
 {
-    const float goldenRatio=1.6180339887499;
+    CONST float goldenRatio=1.6180339887499;
     // The range of n is 0.5, 1.5, ..., pointCountOnSphere-0.5
-    const float n=index+0.5;
+    CONST float n=index+0.5;
     // Explanation of the Fibonacci grid generation can be seen at https://stackoverflow.com/a/44164075/673852
-    const float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
-    const float azimuth=n*(2*PI*goldenRatio);
+    CONST float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
+    CONST float azimuth=n*(2*PI*goldenRatio);
     return vec3(cos(azimuth)*sin(zenithAngle),
                 sin(azimuth)*sin(zenithAngle),
                 cos(zenithAngle));

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/1/aerosols/compute-eclipsed-single-scattering.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/1/aerosols/compute-eclipsed-single-scattering.frag
@@ -1,7 +1,21 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
 
-#line 1 1 // const.h.glsl
+
+
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 6 0 // compute-eclipsed-single-scattering.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,8 +48,8 @@ const vec4 lightPollutionRelativeRadiance=vec4(2.15e-06,1.11400004e-06,3.8580001
 const vec4 wavelengths=vec4(485.333344,516.666687,548,579.333313);
 const int wlSetIndex=1;
 #endif
-#line 5 0 // compute-eclipsed-single-scattering.frag
-#line 1 2 // texture-coordinates.h.glsl
+#line 7 0 // compute-eclipsed-single-scattering.frag
+#line 1 3 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -104,11 +118,11 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 6 0 // compute-eclipsed-single-scattering.frag
-#line 1 3 // radiance-to-luminance.h.glsl
+#line 8 0 // compute-eclipsed-single-scattering.frag
+#line 1 4 // radiance-to-luminance.h.glsl
 const mat4 radianceToLuminance=mat4(1196.74268,3672.67432,12945.498,45528.7344,  835.02478,13767.5205,2120.37939,51317.4727,  8632.59277,21193.416,222.095078,27381.1602,  19410,18758.1973,35.7829971,6712.12158);
-#line 7 0 // compute-eclipsed-single-scattering.frag
-#line 1 4 // single-scattering-eclipsed.h.glsl
+#line 9 0 // compute-eclipsed-single-scattering.frag
+#line 1 5 // single-scattering-eclipsed.h.glsl
 #ifndef INCLUDE_ONCE_050024D2_BD56_434E_8D40_2055DA0B78EC
 #define INCLUDE_ONCE_050024D2_BD56_434E_8D40_2055DA0B78EC
 
@@ -116,7 +130,7 @@ vec4 computeSingleScatteringEclipsed(const vec3 camera, const vec3 viewDir, cons
                                      const bool viewRayIntersectsGround);
 
 #endif
-#line 8 0 // compute-eclipsed-single-scattering.frag
+#line 10 0 // compute-eclipsed-single-scattering.frag
 
 in vec3 position;
 out vec4 scatteringTextureOutput;
@@ -132,16 +146,16 @@ vec4 solarRadiance()
 
 void main()
 {
-    const EclipseScatteringTexVars texVars=eclipseTexCoordsToTexVars(gl_FragCoord.xy/eclipsedSingleScatteringTextureSize, altitude);
-    const float sinViewZenithAngle=sqrt(1-sqr(texVars.cosViewZenithAngle));
-    const vec3 viewDir=vec3(cos(texVars.azimuthRelativeToSun)*sinViewZenithAngle,
+    CONST EclipseScatteringTexVars texVars=eclipseTexCoordsToTexVars(gl_FragCoord.xy/eclipsedSingleScatteringTextureSize, altitude);
+    CONST float sinViewZenithAngle=sqrt(1-sqr(texVars.cosViewZenithAngle));
+    CONST vec3 viewDir=vec3(cos(texVars.azimuthRelativeToSun)*sinViewZenithAngle,
                             sin(texVars.azimuthRelativeToSun)*sinViewZenithAngle,
                             texVars.cosViewZenithAngle);
-    const vec3 cameraPosition=vec3(0,0,altitude);
-    const vec3 sunDirection=vec3(sin(sunZenithAngle), 0, cos(sunZenithAngle));
-    const vec4 radiance=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPositionRelativeToSunAzimuth,
+    CONST vec3 cameraPosition=vec3(0,0,altitude);
+    CONST vec3 sunDirection=vec3(sin(sunZenithAngle), 0, cos(sunZenithAngle));
+    CONST vec4 radiance=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPositionRelativeToSunAzimuth,
                                                         texVars.viewRayIntersectsGround);
-#if COMPUTE_RADIANCE
+#if 0 /*COMPUTE_RADIANCE*/
     scatteringTextureOutput=radiance;
 #elif 1 /*COMPUTE_LUMINANCE*/
     scatteringTextureOutput=radianceToLuminance*radiance;

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/1/aerosols/densities.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/1/aerosols/densities.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // densities.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,20 +45,20 @@ const vec4 lightPollutionRelativeRadiance=vec4(2.15e-06,1.11400004e-06,3.8580001
 const vec4 wavelengths=vec4(485.333344,516.666687,548,579.333313);
 const int wlSetIndex=1;
 #endif
-#line 5 0 // densities.frag
+#line 4 0 // densities.frag
 float scattererNumberDensity_molecules(float altitude)
 {
-        const float rayleighScaleHeight=8*km;
+        CONST float rayleighScaleHeight=8*km;
         return 3.08458e25*exp(-1/rayleighScaleHeight * altitude);
 }
 float scattererNumberDensity_aerosols(float altitude)
 {
-        const float mieScaleHeight=1.2*km;
+        CONST float mieScaleHeight=1.2*km;
         return 1.03333e8*exp(-1/mieScaleHeight*altitude);
 }
 float absorberNumberDensity_ozone(float altitude)
 {
-        const float totalOzoneAmount=370*dobsonUnit;
+        CONST float totalOzoneAmount=370*dobsonUnit;
 
         float density;
 

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/1/aerosols/phase-functions.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/1/aerosols/phase-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // phase-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(2.15e-06,1.11400004e-06,3.8580001
 const vec4 wavelengths=vec4(485.333344,516.666687,548,579.333313);
 const int wlSetIndex=1;
 #endif
-#line 5 0 // phase-functions.frag
+#line 4 0 // phase-functions.frag
 
 vec4 phaseFunction_molecules(float dotViewSun)
 {
@@ -42,9 +53,9 @@ vec4 phaseFunction_molecules(float dotViewSun)
 }
 vec4 phaseFunction_aerosols(float dotViewSun)
 {
-        const float g=0.76;
-        const float g2=g*g;
-        const float k = 3/(8*PI)*(1-g2)/(2+g2);
+        CONST float g=0.76;
+        CONST float g2=g*g;
+        CONST float k = 3/(8*PI)*(1-g2)/(2+g2);
         return vec4(k * (1+sqr(dotViewSun)) / pow(1+g2 - 2*g*dotViewSun, 1.5) + 1/((1-dotViewSun)*600+0.05))*0.904;
 }
 vec4 currentPhaseFunction(float dotViewSun) { return phaseFunction_aerosols(dotViewSun); }

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/1/aerosols/single-scattering-eclipsed.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/1/aerosols/single-scattering-eclipsed.frag
@@ -1,7 +1,21 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
 
-#line 1 1 // const.h.glsl
+
+
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 6 0 // single-scattering-eclipsed.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,15 +48,15 @@ const vec4 lightPollutionRelativeRadiance=vec4(2.15e-06,1.11400004e-06,3.8580001
 const vec4 wavelengths=vec4(485.333344,516.666687,548,579.333313);
 const int wlSetIndex=1;
 #endif
-#line 5 0 // single-scattering-eclipsed.frag
-#line 1 2 // densities.h.glsl
+#line 7 0 // single-scattering-eclipsed.frag
+#line 1 3 // densities.h.glsl
 float scattererNumberDensity_molecules(float altitude);
 float scattererNumberDensity_aerosols(float altitude);
 float absorberNumberDensity_ozone(float altitude);
 vec4 scatteringCrossSection();
 float scattererDensity(float altitude);
-#line 6 0 // single-scattering-eclipsed.frag
-#line 1 3 // common-functions.h.glsl
+#line 8 0 // single-scattering-eclipsed.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -74,8 +88,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // single-scattering-eclipsed.frag
-#line 1 4 // texture-sampling-functions.h.glsl
+#line 9 0 // single-scattering-eclipsed.frag
+#line 1 5 // texture-sampling-functions.h.glsl
 #ifndef INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 #define INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float altitude);
@@ -87,7 +101,7 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                 const int scatteringOrder);
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 #endif
-#line 8 0 // single-scattering-eclipsed.frag
+#line 10 0 // single-scattering-eclipsed.frag
 
 
 float cosZenithAngle(vec3 origin, vec3 direction)
@@ -101,13 +115,13 @@ vec4 computeSingleScatteringIntegrandEclipsed(const float cosSunZenithAngle, con
                                               const float dist, const bool viewRayIntersectsGround,
                                               const vec3 scatterer, const vec3 sunDir, const vec3 moonPos)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle here the case when the
     // endpoint of the view ray intentionally appears in outer space.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosSunZenithAngleAtDist=clampCosine((r*cosSunZenithAngle+dist*dotViewSun)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosSunZenithAngleAtDist=clampCosine((r*cosSunZenithAngle+dist*dotViewSun)/(earthRadius+altAtDist));
 
-    const vec4 xmittance=transmittance(cosViewZenithAngle, altitude, dist, viewRayIntersectsGround)
+    CONST vec4 xmittance=transmittance(cosViewZenithAngle, altitude, dist, viewRayIntersectsGround)
                                                     *
                          transmittanceToAtmosphereBorder(cosSunZenithAngleAtDist, altAtDist)
                                                     *
@@ -115,7 +129,7 @@ vec4 computeSingleScatteringIntegrandEclipsed(const float cosSunZenithAngle, con
                                                     *
                             // FIXME: this ignores orientation of the crescent of eclipsed Sun WRT horizon
                                     sunVisibility(cosSunZenithAngleAtDist, altAtDist);
-#if ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION
+#if 0 /*ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION*/
     COMPUTE_TOTAL_SCATTERING_COEFFICIENT;
     return xmittance * totalScatteringCoefficient;
 #else
@@ -126,26 +140,26 @@ vec4 computeSingleScatteringIntegrandEclipsed(const float cosSunZenithAngle, con
 vec4 computeSingleScatteringEclipsed(const vec3 camera, const vec3 viewDir, const vec3 sunDir, const vec3 moonPos,
                                      const bool viewRayIntersectsGround)
 {
-    const float cosViewZenithAngle=cosZenithAngle(camera,viewDir);
-    const float cosSunZenithAngle=cosZenithAngle(camera,sunDir);
-    const float altitude=pointAltitude(camera);
-    const float dotViewSun=dot(viewDir,sunDir);
-    const float integrInterval=distanceToNearestAtmosphereBoundary(cosViewZenithAngle, altitude,
+    CONST float cosViewZenithAngle=cosZenithAngle(camera,viewDir);
+    CONST float cosSunZenithAngle=cosZenithAngle(camera,sunDir);
+    CONST float altitude=pointAltitude(camera);
+    CONST float dotViewSun=dot(viewDir,sunDir);
+    CONST float integrInterval=distanceToNearestAtmosphereBoundary(cosViewZenithAngle, altitude,
                                                                    viewRayIntersectsGround);
 
     // Using the midpoint rule for quadrature
     vec4 spectrum=vec4(0);
-    const float dl=integrInterval/radialIntegrationPoints;
+    CONST float dl=integrInterval/radialIntegrationPoints;
     for(int n=0; n<radialIntegrationPoints; ++n)
     {
-        const float dist=(n+0.5)*dl;
+        CONST float dist=(n+0.5)*dl;
         spectrum += computeSingleScatteringIntegrandEclipsed(cosSunZenithAngle, cosViewZenithAngle, dotViewSun,
                                                              altitude, dist, viewRayIntersectsGround,
                                                              camera+viewDir*dist, sunDir, moonPos);
     }
 
     spectrum *= dl*solarIrradianceAtTOA
-#if ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION
+#if 0 /*ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION*/
                                 // the multiplier is already included
 #else
                                         * scatteringCrossSection()

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/1/aerosols/texture-coordinates.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/1/aerosols/texture-coordinates.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-coordinates.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,8 +45,8 @@ const vec4 lightPollutionRelativeRadiance=vec4(2.15e-06,1.11400004e-06,3.8580001
 const vec4 wavelengths=vec4(485.333344,516.666687,548,579.333313);
 const int wlSetIndex=1;
 #endif
-#line 5 0 // texture-coordinates.frag
-#line 1 2 // texture-coordinates.h.glsl
+#line 4 0 // texture-coordinates.frag
+#line 1 3 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -104,8 +115,8 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 6 0 // texture-coordinates.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-coordinates.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -137,7 +148,7 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-coordinates.frag
+#line 6 0 // texture-coordinates.frag
 
 const float LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA=sqrt(atmosphereHeight*(atmosphereHeight+2*earthRadius));
 
@@ -205,18 +216,18 @@ vec3 indicesToTexCoords(const vec3 indices, const vec3 texSizes)
 
 TransmittanceTexVars transmittanceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
+    CONST float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
                                 texCoordToUnitRange(texCoord.t,transmittanceTextureSize.t);
     // Distance from Earth center to camera
-    const float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
-    const float altitude=r-earthRadius;
+    CONST float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
+    CONST float altitude=r-earthRadius;
 
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
     // distance to border of visible atmosphere from the view point
-    const float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
+    CONST float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
     // d==0 can happen when altitude==atmosphereHeight
-    const float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
+    CONST float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
     return TransmittanceTexVars(cosVZA,altitude);
 }
 
@@ -235,53 +246,53 @@ vec2 transmittanceTexVarsToTexCoord(const float cosVZA, float altitude)
     if(altitude<0)
         altitude=0;
 
-    const float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
+    CONST float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
                                       transmittanceTextureSize.t);
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
-    const float d=distanceToAtmosphereBorder(cosVZA,altitude);
-    const float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float d=distanceToAtmosphereBorder(cosVZA,altitude);
+    CONST float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
     return vec2(s,t);
 }
 
 // Output: vec2(cos(sunZenithAngle), altitude)
 IrradianceTexVars irradianceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
-    const float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
+    CONST float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
+    CONST float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
     return IrradianceTexVars(cosSZA,alt);
 }
 
 vec2 irradianceTexVarsToTexCoord(const float cosSunZenithAngle, const float altitude)
 {
-    const float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
-    const float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
+    CONST float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
+    CONST float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
     return vec2(s,t);
 }
 
 float cosSZAToUnitRangeTexCoord(const float cosSunZenithAngle)
 {
     // Distance to top atmosphere border along the ray groundUnderCamera-sun: (altitude, cosSunZenithAngle)
-    const float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name
-    const float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
+    CONST float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
     // TODO: choose a more descriptive name
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     return max(0.,1-a/A)/(a+1);
 }
 
 float unitRangeTexCoordToCosSZA(const float texCoord)
 {
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float a=(A-A*texCoord)/(1+A*texCoord);
-    const float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
+    CONST float a=(A-A*texCoord)/(1+A*texCoord);
+    CONST float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
     return distFromGroundToTopAtmoBorder==0 ? 1 :
         clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distFromGroundToTopAtmoBorder)) /
                     (2*earthRadius*distFromGroundToTopAtmoBorder));
@@ -292,24 +303,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
                                                const float dotViewSun, const float altitude,
                                                const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -317,24 +328,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float dotVSCoord=(dotViewSun+1)/2;
+    CONST float dotVSCoord=(dotViewSun+1)/2;
 
     // ------------------------------------
-    const float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
+    CONST float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
 
     return Scattering4DCoords(cosSZACoord, cosVZACoord, dotVSCoord, altCoord, viewRayIntersectsGround);
 }
 
 TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
@@ -342,16 +353,16 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture coordinates we combine into a single sampler3D coordinate.
-    const float texW = scatteringTextureSize[1];
-    const float texH = scatteringTextureSize[2];
-    const float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
-    const vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
+    CONST float texW = scatteringTextureSize[1];
+    CONST float texH = scatteringTextureSize[2];
+    CONST float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
+    CONST vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
                                         ceil (cosSZAIndex)*texW+coords.dotViewSun*(texW-1)) / (texW*texH-1);
-    const vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
+    CONST vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
 
-    const float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
+    CONST float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
 
-    const float alphaUpper=fract(cosSZAIndex);
+    CONST float alphaUpper=fract(cosSZAIndex);
     return TexCoordPair(vec3(cosVZAtc, combinedCoord.x, altitude), float(1-alphaUpper),
                         vec3(cosVZAtc, combinedCoord.y, altitude), float(alphaUpper));
 }
@@ -359,9 +370,9 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
+    CONST TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
     return texture(tex, texCoords.lower) * texCoords.alphaLower +
            texture(tex, texCoords.upper) * texCoords.alphaUpper;
 }
@@ -369,17 +380,17 @@ vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const f
 // 3D texture is the 3D single-altitude slice of a 4D texture
 vec3 scattering4DCoordsToTex3DCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2);
 
-    const float dvsSize = scatteringTextureSize[1];
-    const float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
+    CONST float dvsSize = scatteringTextureSize[1];
+    CONST float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
 
-    const float cszaSize = scatteringTextureSize[2];
-    const float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
+    CONST float cszaSize = scatteringTextureSize[2];
+    CONST float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
 
     return vec3(cosVZAtc, dotVStc, cosSZAtc);
 }
@@ -394,39 +405,39 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along dotViewSun coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[1];
-    const float posOfRow = indices[1];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[1];
+    CONST float posOfRow = indices[1];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         indexToTexCoord(currRow, numRows-1),
                                                         texCoordVerbatim));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               indexToTexCoord(currRow, numRows-1),
                                                               texCoordVerbatim));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          indexToTexCoord(currRow, numRows-1),
                                          texCoordVerbatim));
@@ -434,14 +445,14 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
 vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolationGuides01Tex,
                                  const vec3 indices)
 {
-    const float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
+    CONST float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
 
-    const float cosVZAIndex = indices[0];
-    const float dotVSIndex = indices[1];
-    const float currRow = floor(dotVSIndex);
-    const float posBetweenRows = dotVSIndex - currRow;
-    const float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cosVZAIndex = indices[0];
+    CONST float dotVSIndex = indices[1];
+    CONST float currRow = floor(dotVSIndex);
+    CONST float posBetweenRows = dotVSIndex - currRow;
+    CONST float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -449,14 +460,14 @@ vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolat
     indicesCurrRow[1] =     currRow;
     indicesNextRow[1] = min(currRow+1, scatteringTextureSize[1]-1.);
 
-    const vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
-    const vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
+    CONST vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
+    CONST vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
 
-    const vec4 valueCurrRow = texture(tex, coordsCurrRow);
-    const vec4 valueNextRow = texture(tex, coordsNextRow);
-    const float epsilon = 1e-37; // Prevents passing zero to log
-    const vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
-    const vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
+    CONST vec4 valueCurrRow = texture(tex, coordsCurrRow);
+    CONST vec4 valueNextRow = texture(tex, coordsNextRow);
+    CONST float epsilon = 1e-37; // Prevents passing zero to log
+    CONST vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
+    CONST vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
     return (logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow;
 }
 
@@ -465,37 +476,37 @@ float findGuide02Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along SZA coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[2];
-    const float posOfRow = indices[2];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[2];
+    CONST float posOfRow = indices[2];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
 }
@@ -505,19 +516,19 @@ vec4 sample3DTextureGuided(const sampler3D tex,
                            const float cosSunZenithAngle, const float cosViewZenithAngle,
                            const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
                                                                     dotViewSun, altitude, viewRayIntersectsGround);
     // Handle the external interpolation guides: the guides between a pair of VZA-dotViewSun 2D "pictures".
-    const vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
-    const vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
-    const float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
+    CONST vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
+    CONST float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
 
-    const float cvzaIndex = indices[0];
-    const float cszaIndex = indices[2];
-    const float currRow = floor(cszaIndex);
-    const float posBetweenRows = cszaIndex - currRow;
-    const float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cvzaIndex = indices[0];
+    CONST float cszaIndex = indices[2];
+    CONST float currRow = floor(cszaIndex);
+    CONST float posBetweenRows = cszaIndex - currRow;
+    CONST float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -526,58 +537,58 @@ vec4 sample3DTextureGuided(const sampler3D tex,
     indicesNextRow[2] = min(currRow+1, scatteringTextureSize[2]-1);
 
     // The caller will handle the internal interpolation guides: the ones between rows in each 2D "picture".
-    const vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
-    const vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
+    CONST vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
+    CONST vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
     return exp((logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow);
 }
 
 vec4 sample3DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
     return texture(tex, texCoords);
 }
 
 ScatteringTexVars scatteringTex4DCoordsToTexVars(const Scattering4DCoords coords)
 {
-    const float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
     // ------------------------------------
     float cosViewZenithAngle;
     if(coords.viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
     // ------------------------------------
-    const float dotViewSun=coords.dotViewSun*2-1;
+    CONST float dotViewSun=coords.dotViewSun*2-1;
 
     // ------------------------------------
-    const float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
+    CONST float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
 
     return ScatteringTexVars(cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, coords.viewRayIntersectsGround);
 }
 
 Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 {
-    const vec4 indexMax=scatteringTextureSize-vec4(1);
+    CONST vec4 indexMax=scatteringTextureSize-vec4(1);
     Scattering4DCoords coords4d;
     coords4d.viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
     // The following formulas assume that scatteringTextureSize[0] is even. For odd sizes they would change.
@@ -593,8 +604,8 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture indices we combine into a single sampler3D coordinate.
-    const float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
-    const float combinedIndex=texIndices[1];
+    CONST float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
+    CONST float combinedIndex=texIndices[1];
     coords4d.dotViewSun=mod(combinedIndex,texW)/(texW-1);
     coords4d.cosSunZenithAngle=floor(combinedIndex/texW)/(texH-1);
 
@@ -608,11 +619,11 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
 ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 {
-    const Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
+    CONST Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
     ScatteringTexVars vars=scatteringTex4DCoordsToTexVars(coords4d);
     // Clamp dotViewSun to its valid range of values, given cosViewZenithAngle and cosSunZenithAngle. This is
     // needed to prevent NaNs when computing the scattering texture.
-    const float cosVZA=vars.cosViewZenithAngle,
+    CONST float cosVZA=vars.cosViewZenithAngle,
                 cosSZA=vars.cosSunZenithAngle;
     vars.dotViewSun=clamp(vars.dotViewSun,
                           cosVZA*cosSZA-safeSqrt((1-sqr(cosVZA))*(1-sqr(cosSZA))),
@@ -622,54 +633,54 @@ ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 
 EclipseScatteringTexVars eclipseTexCoordsToTexVars(const vec2 texCoords, const float altitude)
 {
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
-    const bool viewRayIntersectsGround = texCoords.t<0.5;
+    CONST bool viewRayIntersectsGround = texCoords.t<0.5;
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
-    const float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
+    CONST float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
     return EclipseScatteringTexVars(azimuthRelativeToSun, cosViewZenithAngle, viewRayIntersectsGround);
 }
 
 EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                                    const float altitude, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -677,13 +688,13 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
-    const float azimuthCoord = azimuthRelativeToSun/(2*PI);
+    CONST float azimuthCoord = azimuthRelativeToSun/(2*PI);
 
     return EclipseScattering2DCoords(azimuthCoord, cosVZACoord);
 }
@@ -691,14 +702,14 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
 vec2 eclipseTexVarsToTexCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                const float altitude, const bool viewRayIntersectsGround, const vec2 texSize)
 {
-    const EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+    CONST EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                                     viewRayIntersectsGround);
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2);
-    const float azimuthTC = coords.azimuth + 1/(2*texSize.s);
+    CONST float azimuthTC = coords.azimuth + 1/(2*texSize.s);
 
     return vec2(azimuthTC, cosVZAtc);
 }
@@ -707,42 +718,42 @@ vec4 sampleEclipseDoubleScattering3DTexture(const sampler3D tex, const float cos
                                             const float cosViewZenithAngle, const float azimuthRelativeToSun,
                                             const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
+    CONST vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
                                                   eclipsedDoubleScatteringTextureSize.st);
-    const float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
-    const vec3 texCoords=vec3(coords2d, cosSZACoord);
+    CONST float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
+    CONST vec3 texCoords=vec3(coords2d, cosSZACoord);
 
     return texture(tex, texCoords);
 }
 
 LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 texIndices)
 {
-    const vec2 indexMax=lightPollutionTextureSize-vec2(1);
+    CONST vec2 indexMax=lightPollutionTextureSize-vec2(1);
 
-    const float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
-    const float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
+    CONST float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
-    const bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
-    const float cosViewZenithAngleCoord = viewRayIntersectsGround ?
+    CONST bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
+    CONST float cosViewZenithAngleCoord = viewRayIntersectsGround ?
                                    1-2*texIndices[0]/(indexMax[0]-1) :
                                    2*(texIndices[0]-1)/(indexMax[0]-1)-1;
     // ------------------------------------
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
@@ -753,23 +764,23 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 
 LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -777,27 +788,27 @@ LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, con
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     return LightPollution2DCoords(cosVZACoord, altCoord);
 }
 
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
-    const vec2 texSize = lightPollutionTextureSize;
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 texSize = lightPollutionTextureSize;
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2);
-    const float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
+    CONST float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
     return vec2(cosVZAtc, altitudeTC);
 }

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/1/aerosols/texture-sampling-functions.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/1/aerosols/texture-sampling-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-sampling-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,13 +45,13 @@ const vec4 lightPollutionRelativeRadiance=vec4(2.15e-06,1.11400004e-06,3.8580001
 const vec4 wavelengths=vec4(485.333344,516.666687,548,579.333313);
 const int wlSetIndex=1;
 #endif
-#line 5 0 // texture-sampling-functions.frag
-#line 1 2 // phase-functions.h.glsl
+#line 4 0 // texture-sampling-functions.frag
+#line 1 3 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 6 0 // texture-sampling-functions.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-sampling-functions.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -72,8 +83,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-sampling-functions.frag
-#line 1 4 // texture-coordinates.h.glsl
+#line 6 0 // texture-sampling-functions.frag
+#line 1 5 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -142,7 +153,7 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 8 0 // texture-sampling-functions.frag
+#line 7 0 // texture-sampling-functions.frag
 
 uniform sampler2D transmittanceTexture;
 uniform sampler2D irradianceTexture;
@@ -154,13 +165,13 @@ uniform sampler2D lightPollutionScatteringTexture;
 
 vec4 irradiance(const float cosSunZenithAngle, const float altitude)
 {
-    const vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
+    CONST vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
     return texture(irradianceTexture, texCoords);
 }
 
 vec4 opticalDepthToAtmosphereBorder(const float cosViewZenithAngle, const float altitude)
 {
-    const vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
+    CONST vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact when looking into nadir from TOA at some values of texture sizes (in particular, size of
     // transmittance texture for altitude being 4096). This happens when I simply call texture(eclipsedScatteringTexture,
@@ -178,11 +189,11 @@ vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float
 vec4 transmittance(const float cosViewZenithAngle, const float altitude, const float dist,
                    const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle view ray endpoint
     // in space here.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
 
     vec4 depth;
     if(viewRayIntersectsGround)
@@ -201,7 +212,7 @@ vec4 transmittance(const float cosViewZenithAngle, const float altitude, const f
 vec4 calcFirstScattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                          const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
+    CONST vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
                                           dotViewSun, altitude, viewRayIntersectsGround);
     return scattering*currentPhaseFunction(dotViewSun);
 }
@@ -220,6 +231,6 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
 
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     return texture(lightPollutionScatteringTexture, coords);
 }

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/1/molecules/common-functions.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/1/molecules/common-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // common-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(2.15e-06,1.11400004e-06,3.8580001
 const vec4 wavelengths=vec4(485.333344,516.666687,548,579.333313);
 const int wlSetIndex=1;
 #endif
-#line 5 0 // common-functions.frag
+#line 4 0 // common-functions.frag
 
 bool dbgDataPresent=false;
 bool debugDataPresent()
@@ -69,7 +80,7 @@ void setDebugData(float a,float b, float c, float d)
 
 void swap(inout float x, inout float y)
 {
-    const float t = x;
+    CONST float t = x;
     x = y;
     y = t;
 }
@@ -83,7 +94,7 @@ float safeSqrt(const float x)
 
 float safeAtan(const float y, const float x)
 {
-    const float a = atan(y,x);
+    CONST float a = atan(y,x);
     return x==0 && y==0 ? 0 : a;
 }
 
@@ -116,23 +127,23 @@ float pointAltitude(vec3 point)
 
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float Ratm=earthRadius+atmosphereHeight;
-    const float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float Ratm=earthRadius+atmosphereHeight;
+    CONST float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float distanceToGround(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(-safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float cosZenithAngleOfHorizon(const float altitude)
 {
-    const float R=earthRadius;
-    const float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
+    CONST float R=earthRadius;
+    CONST float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
     return -sqrt(2*h*R+sqr(h))/(R+h);
 }
 
@@ -151,8 +162,8 @@ float distanceToNearestAtmosphereBoundary(const float cosZenithAngle, const floa
 float sunVisibility(const float cosSunZenithAngle, float altitude)
 {
     if(altitude<0) altitude=0;
-    const float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
-    const float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
+    CONST float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
+    CONST float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
     /* Approximating visible fraction of solar disk by smoothstep between the position of the Sun
      * touching the horizon by its upper part and the position with lower part touching the horizon.
      * The calculation assumes that solar angular radius is small and thus approximately equals its sine.
@@ -182,13 +193,13 @@ float circlesIntersectionArea(float R1, float R2, float d)
 
 float angleBetween(const vec3 a, const vec3 b)
 {
-    const float d=dot(a,b);
-    const float c=length(cross(a,b));
+    CONST float d=dot(a,b);
+    CONST float c=length(cross(a,b));
     // To avoid loss of precision, don't use dot product near the singularity
     // of acos, and cross product near the singularity of asin
     if(abs(d) < abs(c))
         return acos(d/(length(a)*length(b)));
-    const float smallerAngle = asin(c/(length(a)*length(b)));
+    CONST float smallerAngle = asin(c/(length(a)*length(b)));
     if(d<0) return PI-smallerAngle;
     return smallerAngle;
 }
@@ -205,11 +216,11 @@ float moonAngularRadius(const vec3 cameraPosition, const vec3 moonPosition)
 
 float visibleSolidAngleOfSun(const vec3 camera, const vec3 sunDir, const vec3 moonPos)
 {
-    const float Rs=sunAngularRadius;
-    const float Rm=moonAngularRadius(camera,moonPos);
+    CONST float Rs=sunAngularRadius;
+    CONST float Rm=moonAngularRadius(camera,moonPos);
     float visibleSolidAngle=PI*sqr(Rs);
 
-    const float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
+    CONST float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
     if(dSM<Rs+Rm)
     {
         visibleSolidAngle -= circlesIntersectionArea(Rm,Rs,dSM);
@@ -229,12 +240,12 @@ float sphereIntegrationSolidAngleDifferential(const int pointCountOnSphere)
 }
 vec3 sphereIntegrationSampleDir(const int index, const int pointCountOnSphere)
 {
-    const float goldenRatio=1.6180339887499;
+    CONST float goldenRatio=1.6180339887499;
     // The range of n is 0.5, 1.5, ..., pointCountOnSphere-0.5
-    const float n=index+0.5;
+    CONST float n=index+0.5;
     // Explanation of the Fibonacci grid generation can be seen at https://stackoverflow.com/a/44164075/673852
-    const float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
-    const float azimuth=n*(2*PI*goldenRatio);
+    CONST float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
+    CONST float azimuth=n*(2*PI*goldenRatio);
     return vec3(cos(azimuth)*sin(zenithAngle),
                 sin(azimuth)*sin(zenithAngle),
                 cos(zenithAngle));

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/1/molecules/compute-eclipsed-single-scattering.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/1/molecules/compute-eclipsed-single-scattering.frag
@@ -1,7 +1,21 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
 
-#line 1 1 // const.h.glsl
+
+
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 6 0 // compute-eclipsed-single-scattering.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,8 +48,8 @@ const vec4 lightPollutionRelativeRadiance=vec4(2.15e-06,1.11400004e-06,3.8580001
 const vec4 wavelengths=vec4(485.333344,516.666687,548,579.333313);
 const int wlSetIndex=1;
 #endif
-#line 5 0 // compute-eclipsed-single-scattering.frag
-#line 1 2 // texture-coordinates.h.glsl
+#line 7 0 // compute-eclipsed-single-scattering.frag
+#line 1 3 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -104,11 +118,11 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 6 0 // compute-eclipsed-single-scattering.frag
-#line 1 3 // radiance-to-luminance.h.glsl
+#line 8 0 // compute-eclipsed-single-scattering.frag
+#line 1 4 // radiance-to-luminance.h.glsl
 const mat4 radianceToLuminance=mat4(1196.74268,3672.67432,12945.498,45528.7344,  835.02478,13767.5205,2120.37939,51317.4727,  8632.59277,21193.416,222.095078,27381.1602,  19410,18758.1973,35.7829971,6712.12158);
-#line 7 0 // compute-eclipsed-single-scattering.frag
-#line 1 4 // single-scattering-eclipsed.h.glsl
+#line 9 0 // compute-eclipsed-single-scattering.frag
+#line 1 5 // single-scattering-eclipsed.h.glsl
 #ifndef INCLUDE_ONCE_050024D2_BD56_434E_8D40_2055DA0B78EC
 #define INCLUDE_ONCE_050024D2_BD56_434E_8D40_2055DA0B78EC
 
@@ -116,7 +130,7 @@ vec4 computeSingleScatteringEclipsed(const vec3 camera, const vec3 viewDir, cons
                                      const bool viewRayIntersectsGround);
 
 #endif
-#line 8 0 // compute-eclipsed-single-scattering.frag
+#line 10 0 // compute-eclipsed-single-scattering.frag
 
 in vec3 position;
 out vec4 scatteringTextureOutput;
@@ -132,16 +146,16 @@ vec4 solarRadiance()
 
 void main()
 {
-    const EclipseScatteringTexVars texVars=eclipseTexCoordsToTexVars(gl_FragCoord.xy/eclipsedSingleScatteringTextureSize, altitude);
-    const float sinViewZenithAngle=sqrt(1-sqr(texVars.cosViewZenithAngle));
-    const vec3 viewDir=vec3(cos(texVars.azimuthRelativeToSun)*sinViewZenithAngle,
+    CONST EclipseScatteringTexVars texVars=eclipseTexCoordsToTexVars(gl_FragCoord.xy/eclipsedSingleScatteringTextureSize, altitude);
+    CONST float sinViewZenithAngle=sqrt(1-sqr(texVars.cosViewZenithAngle));
+    CONST vec3 viewDir=vec3(cos(texVars.azimuthRelativeToSun)*sinViewZenithAngle,
                             sin(texVars.azimuthRelativeToSun)*sinViewZenithAngle,
                             texVars.cosViewZenithAngle);
-    const vec3 cameraPosition=vec3(0,0,altitude);
-    const vec3 sunDirection=vec3(sin(sunZenithAngle), 0, cos(sunZenithAngle));
-    const vec4 radiance=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPositionRelativeToSunAzimuth,
+    CONST vec3 cameraPosition=vec3(0,0,altitude);
+    CONST vec3 sunDirection=vec3(sin(sunZenithAngle), 0, cos(sunZenithAngle));
+    CONST vec4 radiance=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPositionRelativeToSunAzimuth,
                                                         texVars.viewRayIntersectsGround);
-#if COMPUTE_RADIANCE
+#if 0 /*COMPUTE_RADIANCE*/
     scatteringTextureOutput=radiance;
 #elif 1 /*COMPUTE_LUMINANCE*/
     scatteringTextureOutput=radianceToLuminance*radiance;

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/1/molecules/densities.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/1/molecules/densities.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // densities.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,20 +45,20 @@ const vec4 lightPollutionRelativeRadiance=vec4(2.15e-06,1.11400004e-06,3.8580001
 const vec4 wavelengths=vec4(485.333344,516.666687,548,579.333313);
 const int wlSetIndex=1;
 #endif
-#line 5 0 // densities.frag
+#line 4 0 // densities.frag
 float scattererNumberDensity_molecules(float altitude)
 {
-        const float rayleighScaleHeight=8*km;
+        CONST float rayleighScaleHeight=8*km;
         return 3.08458e25*exp(-1/rayleighScaleHeight * altitude);
 }
 float scattererNumberDensity_aerosols(float altitude)
 {
-        const float mieScaleHeight=1.2*km;
+        CONST float mieScaleHeight=1.2*km;
         return 1.03333e8*exp(-1/mieScaleHeight*altitude);
 }
 float absorberNumberDensity_ozone(float altitude)
 {
-        const float totalOzoneAmount=370*dobsonUnit;
+        CONST float totalOzoneAmount=370*dobsonUnit;
 
         float density;
 

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/1/molecules/phase-functions.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/1/molecules/phase-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // phase-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(2.15e-06,1.11400004e-06,3.8580001
 const vec4 wavelengths=vec4(485.333344,516.666687,548,579.333313);
 const int wlSetIndex=1;
 #endif
-#line 5 0 // phase-functions.frag
+#line 4 0 // phase-functions.frag
 
 vec4 phaseFunction_molecules(float dotViewSun)
 {
@@ -42,9 +53,9 @@ vec4 phaseFunction_molecules(float dotViewSun)
 }
 vec4 phaseFunction_aerosols(float dotViewSun)
 {
-        const float g=0.76;
-        const float g2=g*g;
-        const float k = 3/(8*PI)*(1-g2)/(2+g2);
+        CONST float g=0.76;
+        CONST float g2=g*g;
+        CONST float k = 3/(8*PI)*(1-g2)/(2+g2);
         return vec4(k * (1+sqr(dotViewSun)) / pow(1+g2 - 2*g*dotViewSun, 1.5) + 1/((1-dotViewSun)*600+0.05))*0.904;
 }
 vec4 currentPhaseFunction(float dotViewSun) { return phaseFunction_molecules(dotViewSun); }

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/1/molecules/single-scattering-eclipsed.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/1/molecules/single-scattering-eclipsed.frag
@@ -1,7 +1,21 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
 
-#line 1 1 // const.h.glsl
+
+
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 6 0 // single-scattering-eclipsed.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,15 +48,15 @@ const vec4 lightPollutionRelativeRadiance=vec4(2.15e-06,1.11400004e-06,3.8580001
 const vec4 wavelengths=vec4(485.333344,516.666687,548,579.333313);
 const int wlSetIndex=1;
 #endif
-#line 5 0 // single-scattering-eclipsed.frag
-#line 1 2 // densities.h.glsl
+#line 7 0 // single-scattering-eclipsed.frag
+#line 1 3 // densities.h.glsl
 float scattererNumberDensity_molecules(float altitude);
 float scattererNumberDensity_aerosols(float altitude);
 float absorberNumberDensity_ozone(float altitude);
 vec4 scatteringCrossSection();
 float scattererDensity(float altitude);
-#line 6 0 // single-scattering-eclipsed.frag
-#line 1 3 // common-functions.h.glsl
+#line 8 0 // single-scattering-eclipsed.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -74,8 +88,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // single-scattering-eclipsed.frag
-#line 1 4 // texture-sampling-functions.h.glsl
+#line 9 0 // single-scattering-eclipsed.frag
+#line 1 5 // texture-sampling-functions.h.glsl
 #ifndef INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 #define INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float altitude);
@@ -87,7 +101,7 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                 const int scatteringOrder);
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 #endif
-#line 8 0 // single-scattering-eclipsed.frag
+#line 10 0 // single-scattering-eclipsed.frag
 
 
 float cosZenithAngle(vec3 origin, vec3 direction)
@@ -101,13 +115,13 @@ vec4 computeSingleScatteringIntegrandEclipsed(const float cosSunZenithAngle, con
                                               const float dist, const bool viewRayIntersectsGround,
                                               const vec3 scatterer, const vec3 sunDir, const vec3 moonPos)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle here the case when the
     // endpoint of the view ray intentionally appears in outer space.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosSunZenithAngleAtDist=clampCosine((r*cosSunZenithAngle+dist*dotViewSun)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosSunZenithAngleAtDist=clampCosine((r*cosSunZenithAngle+dist*dotViewSun)/(earthRadius+altAtDist));
 
-    const vec4 xmittance=transmittance(cosViewZenithAngle, altitude, dist, viewRayIntersectsGround)
+    CONST vec4 xmittance=transmittance(cosViewZenithAngle, altitude, dist, viewRayIntersectsGround)
                                                     *
                          transmittanceToAtmosphereBorder(cosSunZenithAngleAtDist, altAtDist)
                                                     *
@@ -115,7 +129,7 @@ vec4 computeSingleScatteringIntegrandEclipsed(const float cosSunZenithAngle, con
                                                     *
                             // FIXME: this ignores orientation of the crescent of eclipsed Sun WRT horizon
                                     sunVisibility(cosSunZenithAngleAtDist, altAtDist);
-#if ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION
+#if 0 /*ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION*/
     COMPUTE_TOTAL_SCATTERING_COEFFICIENT;
     return xmittance * totalScatteringCoefficient;
 #else
@@ -126,26 +140,26 @@ vec4 computeSingleScatteringIntegrandEclipsed(const float cosSunZenithAngle, con
 vec4 computeSingleScatteringEclipsed(const vec3 camera, const vec3 viewDir, const vec3 sunDir, const vec3 moonPos,
                                      const bool viewRayIntersectsGround)
 {
-    const float cosViewZenithAngle=cosZenithAngle(camera,viewDir);
-    const float cosSunZenithAngle=cosZenithAngle(camera,sunDir);
-    const float altitude=pointAltitude(camera);
-    const float dotViewSun=dot(viewDir,sunDir);
-    const float integrInterval=distanceToNearestAtmosphereBoundary(cosViewZenithAngle, altitude,
+    CONST float cosViewZenithAngle=cosZenithAngle(camera,viewDir);
+    CONST float cosSunZenithAngle=cosZenithAngle(camera,sunDir);
+    CONST float altitude=pointAltitude(camera);
+    CONST float dotViewSun=dot(viewDir,sunDir);
+    CONST float integrInterval=distanceToNearestAtmosphereBoundary(cosViewZenithAngle, altitude,
                                                                    viewRayIntersectsGround);
 
     // Using the midpoint rule for quadrature
     vec4 spectrum=vec4(0);
-    const float dl=integrInterval/radialIntegrationPoints;
+    CONST float dl=integrInterval/radialIntegrationPoints;
     for(int n=0; n<radialIntegrationPoints; ++n)
     {
-        const float dist=(n+0.5)*dl;
+        CONST float dist=(n+0.5)*dl;
         spectrum += computeSingleScatteringIntegrandEclipsed(cosSunZenithAngle, cosViewZenithAngle, dotViewSun,
                                                              altitude, dist, viewRayIntersectsGround,
                                                              camera+viewDir*dist, sunDir, moonPos);
     }
 
     spectrum *= dl*solarIrradianceAtTOA
-#if ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION
+#if 0 /*ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION*/
                                 // the multiplier is already included
 #else
                                         * scatteringCrossSection()

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/1/molecules/texture-coordinates.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/1/molecules/texture-coordinates.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-coordinates.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,8 +45,8 @@ const vec4 lightPollutionRelativeRadiance=vec4(2.15e-06,1.11400004e-06,3.8580001
 const vec4 wavelengths=vec4(485.333344,516.666687,548,579.333313);
 const int wlSetIndex=1;
 #endif
-#line 5 0 // texture-coordinates.frag
-#line 1 2 // texture-coordinates.h.glsl
+#line 4 0 // texture-coordinates.frag
+#line 1 3 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -104,8 +115,8 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 6 0 // texture-coordinates.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-coordinates.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -137,7 +148,7 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-coordinates.frag
+#line 6 0 // texture-coordinates.frag
 
 const float LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA=sqrt(atmosphereHeight*(atmosphereHeight+2*earthRadius));
 
@@ -205,18 +216,18 @@ vec3 indicesToTexCoords(const vec3 indices, const vec3 texSizes)
 
 TransmittanceTexVars transmittanceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
+    CONST float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
                                 texCoordToUnitRange(texCoord.t,transmittanceTextureSize.t);
     // Distance from Earth center to camera
-    const float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
-    const float altitude=r-earthRadius;
+    CONST float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
+    CONST float altitude=r-earthRadius;
 
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
     // distance to border of visible atmosphere from the view point
-    const float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
+    CONST float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
     // d==0 can happen when altitude==atmosphereHeight
-    const float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
+    CONST float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
     return TransmittanceTexVars(cosVZA,altitude);
 }
 
@@ -235,53 +246,53 @@ vec2 transmittanceTexVarsToTexCoord(const float cosVZA, float altitude)
     if(altitude<0)
         altitude=0;
 
-    const float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
+    CONST float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
                                       transmittanceTextureSize.t);
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
-    const float d=distanceToAtmosphereBorder(cosVZA,altitude);
-    const float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float d=distanceToAtmosphereBorder(cosVZA,altitude);
+    CONST float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
     return vec2(s,t);
 }
 
 // Output: vec2(cos(sunZenithAngle), altitude)
 IrradianceTexVars irradianceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
-    const float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
+    CONST float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
+    CONST float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
     return IrradianceTexVars(cosSZA,alt);
 }
 
 vec2 irradianceTexVarsToTexCoord(const float cosSunZenithAngle, const float altitude)
 {
-    const float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
-    const float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
+    CONST float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
+    CONST float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
     return vec2(s,t);
 }
 
 float cosSZAToUnitRangeTexCoord(const float cosSunZenithAngle)
 {
     // Distance to top atmosphere border along the ray groundUnderCamera-sun: (altitude, cosSunZenithAngle)
-    const float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name
-    const float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
+    CONST float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
     // TODO: choose a more descriptive name
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     return max(0.,1-a/A)/(a+1);
 }
 
 float unitRangeTexCoordToCosSZA(const float texCoord)
 {
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float a=(A-A*texCoord)/(1+A*texCoord);
-    const float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
+    CONST float a=(A-A*texCoord)/(1+A*texCoord);
+    CONST float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
     return distFromGroundToTopAtmoBorder==0 ? 1 :
         clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distFromGroundToTopAtmoBorder)) /
                     (2*earthRadius*distFromGroundToTopAtmoBorder));
@@ -292,24 +303,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
                                                const float dotViewSun, const float altitude,
                                                const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -317,24 +328,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float dotVSCoord=(dotViewSun+1)/2;
+    CONST float dotVSCoord=(dotViewSun+1)/2;
 
     // ------------------------------------
-    const float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
+    CONST float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
 
     return Scattering4DCoords(cosSZACoord, cosVZACoord, dotVSCoord, altCoord, viewRayIntersectsGround);
 }
 
 TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
@@ -342,16 +353,16 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture coordinates we combine into a single sampler3D coordinate.
-    const float texW = scatteringTextureSize[1];
-    const float texH = scatteringTextureSize[2];
-    const float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
-    const vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
+    CONST float texW = scatteringTextureSize[1];
+    CONST float texH = scatteringTextureSize[2];
+    CONST float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
+    CONST vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
                                         ceil (cosSZAIndex)*texW+coords.dotViewSun*(texW-1)) / (texW*texH-1);
-    const vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
+    CONST vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
 
-    const float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
+    CONST float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
 
-    const float alphaUpper=fract(cosSZAIndex);
+    CONST float alphaUpper=fract(cosSZAIndex);
     return TexCoordPair(vec3(cosVZAtc, combinedCoord.x, altitude), float(1-alphaUpper),
                         vec3(cosVZAtc, combinedCoord.y, altitude), float(alphaUpper));
 }
@@ -359,9 +370,9 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
+    CONST TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
     return texture(tex, texCoords.lower) * texCoords.alphaLower +
            texture(tex, texCoords.upper) * texCoords.alphaUpper;
 }
@@ -369,17 +380,17 @@ vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const f
 // 3D texture is the 3D single-altitude slice of a 4D texture
 vec3 scattering4DCoordsToTex3DCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2);
 
-    const float dvsSize = scatteringTextureSize[1];
-    const float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
+    CONST float dvsSize = scatteringTextureSize[1];
+    CONST float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
 
-    const float cszaSize = scatteringTextureSize[2];
-    const float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
+    CONST float cszaSize = scatteringTextureSize[2];
+    CONST float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
 
     return vec3(cosVZAtc, dotVStc, cosSZAtc);
 }
@@ -394,39 +405,39 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along dotViewSun coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[1];
-    const float posOfRow = indices[1];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[1];
+    CONST float posOfRow = indices[1];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         indexToTexCoord(currRow, numRows-1),
                                                         texCoordVerbatim));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               indexToTexCoord(currRow, numRows-1),
                                                               texCoordVerbatim));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          indexToTexCoord(currRow, numRows-1),
                                          texCoordVerbatim));
@@ -434,14 +445,14 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
 vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolationGuides01Tex,
                                  const vec3 indices)
 {
-    const float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
+    CONST float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
 
-    const float cosVZAIndex = indices[0];
-    const float dotVSIndex = indices[1];
-    const float currRow = floor(dotVSIndex);
-    const float posBetweenRows = dotVSIndex - currRow;
-    const float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cosVZAIndex = indices[0];
+    CONST float dotVSIndex = indices[1];
+    CONST float currRow = floor(dotVSIndex);
+    CONST float posBetweenRows = dotVSIndex - currRow;
+    CONST float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -449,14 +460,14 @@ vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolat
     indicesCurrRow[1] =     currRow;
     indicesNextRow[1] = min(currRow+1, scatteringTextureSize[1]-1.);
 
-    const vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
-    const vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
+    CONST vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
+    CONST vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
 
-    const vec4 valueCurrRow = texture(tex, coordsCurrRow);
-    const vec4 valueNextRow = texture(tex, coordsNextRow);
-    const float epsilon = 1e-37; // Prevents passing zero to log
-    const vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
-    const vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
+    CONST vec4 valueCurrRow = texture(tex, coordsCurrRow);
+    CONST vec4 valueNextRow = texture(tex, coordsNextRow);
+    CONST float epsilon = 1e-37; // Prevents passing zero to log
+    CONST vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
+    CONST vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
     return (logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow;
 }
 
@@ -465,37 +476,37 @@ float findGuide02Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along SZA coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[2];
-    const float posOfRow = indices[2];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[2];
+    CONST float posOfRow = indices[2];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
 }
@@ -505,19 +516,19 @@ vec4 sample3DTextureGuided(const sampler3D tex,
                            const float cosSunZenithAngle, const float cosViewZenithAngle,
                            const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
                                                                     dotViewSun, altitude, viewRayIntersectsGround);
     // Handle the external interpolation guides: the guides between a pair of VZA-dotViewSun 2D "pictures".
-    const vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
-    const vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
-    const float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
+    CONST vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
+    CONST float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
 
-    const float cvzaIndex = indices[0];
-    const float cszaIndex = indices[2];
-    const float currRow = floor(cszaIndex);
-    const float posBetweenRows = cszaIndex - currRow;
-    const float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cvzaIndex = indices[0];
+    CONST float cszaIndex = indices[2];
+    CONST float currRow = floor(cszaIndex);
+    CONST float posBetweenRows = cszaIndex - currRow;
+    CONST float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -526,58 +537,58 @@ vec4 sample3DTextureGuided(const sampler3D tex,
     indicesNextRow[2] = min(currRow+1, scatteringTextureSize[2]-1);
 
     // The caller will handle the internal interpolation guides: the ones between rows in each 2D "picture".
-    const vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
-    const vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
+    CONST vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
+    CONST vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
     return exp((logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow);
 }
 
 vec4 sample3DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
     return texture(tex, texCoords);
 }
 
 ScatteringTexVars scatteringTex4DCoordsToTexVars(const Scattering4DCoords coords)
 {
-    const float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
     // ------------------------------------
     float cosViewZenithAngle;
     if(coords.viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
     // ------------------------------------
-    const float dotViewSun=coords.dotViewSun*2-1;
+    CONST float dotViewSun=coords.dotViewSun*2-1;
 
     // ------------------------------------
-    const float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
+    CONST float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
 
     return ScatteringTexVars(cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, coords.viewRayIntersectsGround);
 }
 
 Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 {
-    const vec4 indexMax=scatteringTextureSize-vec4(1);
+    CONST vec4 indexMax=scatteringTextureSize-vec4(1);
     Scattering4DCoords coords4d;
     coords4d.viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
     // The following formulas assume that scatteringTextureSize[0] is even. For odd sizes they would change.
@@ -593,8 +604,8 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture indices we combine into a single sampler3D coordinate.
-    const float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
-    const float combinedIndex=texIndices[1];
+    CONST float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
+    CONST float combinedIndex=texIndices[1];
     coords4d.dotViewSun=mod(combinedIndex,texW)/(texW-1);
     coords4d.cosSunZenithAngle=floor(combinedIndex/texW)/(texH-1);
 
@@ -608,11 +619,11 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
 ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 {
-    const Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
+    CONST Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
     ScatteringTexVars vars=scatteringTex4DCoordsToTexVars(coords4d);
     // Clamp dotViewSun to its valid range of values, given cosViewZenithAngle and cosSunZenithAngle. This is
     // needed to prevent NaNs when computing the scattering texture.
-    const float cosVZA=vars.cosViewZenithAngle,
+    CONST float cosVZA=vars.cosViewZenithAngle,
                 cosSZA=vars.cosSunZenithAngle;
     vars.dotViewSun=clamp(vars.dotViewSun,
                           cosVZA*cosSZA-safeSqrt((1-sqr(cosVZA))*(1-sqr(cosSZA))),
@@ -622,54 +633,54 @@ ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 
 EclipseScatteringTexVars eclipseTexCoordsToTexVars(const vec2 texCoords, const float altitude)
 {
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
-    const bool viewRayIntersectsGround = texCoords.t<0.5;
+    CONST bool viewRayIntersectsGround = texCoords.t<0.5;
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
-    const float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
+    CONST float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
     return EclipseScatteringTexVars(azimuthRelativeToSun, cosViewZenithAngle, viewRayIntersectsGround);
 }
 
 EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                                    const float altitude, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -677,13 +688,13 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
-    const float azimuthCoord = azimuthRelativeToSun/(2*PI);
+    CONST float azimuthCoord = azimuthRelativeToSun/(2*PI);
 
     return EclipseScattering2DCoords(azimuthCoord, cosVZACoord);
 }
@@ -691,14 +702,14 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
 vec2 eclipseTexVarsToTexCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                const float altitude, const bool viewRayIntersectsGround, const vec2 texSize)
 {
-    const EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+    CONST EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                                     viewRayIntersectsGround);
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2);
-    const float azimuthTC = coords.azimuth + 1/(2*texSize.s);
+    CONST float azimuthTC = coords.azimuth + 1/(2*texSize.s);
 
     return vec2(azimuthTC, cosVZAtc);
 }
@@ -707,42 +718,42 @@ vec4 sampleEclipseDoubleScattering3DTexture(const sampler3D tex, const float cos
                                             const float cosViewZenithAngle, const float azimuthRelativeToSun,
                                             const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
+    CONST vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
                                                   eclipsedDoubleScatteringTextureSize.st);
-    const float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
-    const vec3 texCoords=vec3(coords2d, cosSZACoord);
+    CONST float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
+    CONST vec3 texCoords=vec3(coords2d, cosSZACoord);
 
     return texture(tex, texCoords);
 }
 
 LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 texIndices)
 {
-    const vec2 indexMax=lightPollutionTextureSize-vec2(1);
+    CONST vec2 indexMax=lightPollutionTextureSize-vec2(1);
 
-    const float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
-    const float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
+    CONST float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
-    const bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
-    const float cosViewZenithAngleCoord = viewRayIntersectsGround ?
+    CONST bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
+    CONST float cosViewZenithAngleCoord = viewRayIntersectsGround ?
                                    1-2*texIndices[0]/(indexMax[0]-1) :
                                    2*(texIndices[0]-1)/(indexMax[0]-1)-1;
     // ------------------------------------
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
@@ -753,23 +764,23 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 
 LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -777,27 +788,27 @@ LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, con
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     return LightPollution2DCoords(cosVZACoord, altCoord);
 }
 
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
-    const vec2 texSize = lightPollutionTextureSize;
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 texSize = lightPollutionTextureSize;
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2);
-    const float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
+    CONST float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
     return vec2(cosVZAtc, altitudeTC);
 }

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/1/molecules/texture-sampling-functions.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/1/molecules/texture-sampling-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-sampling-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,13 +45,13 @@ const vec4 lightPollutionRelativeRadiance=vec4(2.15e-06,1.11400004e-06,3.8580001
 const vec4 wavelengths=vec4(485.333344,516.666687,548,579.333313);
 const int wlSetIndex=1;
 #endif
-#line 5 0 // texture-sampling-functions.frag
-#line 1 2 // phase-functions.h.glsl
+#line 4 0 // texture-sampling-functions.frag
+#line 1 3 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 6 0 // texture-sampling-functions.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-sampling-functions.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -72,8 +83,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-sampling-functions.frag
-#line 1 4 // texture-coordinates.h.glsl
+#line 6 0 // texture-sampling-functions.frag
+#line 1 5 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -142,7 +153,7 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 8 0 // texture-sampling-functions.frag
+#line 7 0 // texture-sampling-functions.frag
 
 uniform sampler2D transmittanceTexture;
 uniform sampler2D irradianceTexture;
@@ -154,13 +165,13 @@ uniform sampler2D lightPollutionScatteringTexture;
 
 vec4 irradiance(const float cosSunZenithAngle, const float altitude)
 {
-    const vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
+    CONST vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
     return texture(irradianceTexture, texCoords);
 }
 
 vec4 opticalDepthToAtmosphereBorder(const float cosViewZenithAngle, const float altitude)
 {
-    const vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
+    CONST vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact when looking into nadir from TOA at some values of texture sizes (in particular, size of
     // transmittance texture for altitude being 4096). This happens when I simply call texture(eclipsedScatteringTexture,
@@ -178,11 +189,11 @@ vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float
 vec4 transmittance(const float cosViewZenithAngle, const float altitude, const float dist,
                    const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle view ray endpoint
     // in space here.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
 
     vec4 depth;
     if(viewRayIntersectsGround)
@@ -201,7 +212,7 @@ vec4 transmittance(const float cosViewZenithAngle, const float altitude, const f
 vec4 calcFirstScattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                          const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
+    CONST vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
                                           dotViewSun, altitude, viewRayIntersectsGround);
     return scattering*currentPhaseFunction(dotViewSun);
 }
@@ -220,6 +231,6 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
 
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     return texture(lightPollutionScatteringTexture, coords);
 }

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/2/aerosols/common-functions.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/2/aerosols/common-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // common-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.35000004e-05,1.33100002e-05,9.4
 const vec4 wavelengths=vec4(610.666687,642,673.333313,704.666687);
 const int wlSetIndex=2;
 #endif
-#line 5 0 // common-functions.frag
+#line 4 0 // common-functions.frag
 
 bool dbgDataPresent=false;
 bool debugDataPresent()
@@ -69,7 +80,7 @@ void setDebugData(float a,float b, float c, float d)
 
 void swap(inout float x, inout float y)
 {
-    const float t = x;
+    CONST float t = x;
     x = y;
     y = t;
 }
@@ -83,7 +94,7 @@ float safeSqrt(const float x)
 
 float safeAtan(const float y, const float x)
 {
-    const float a = atan(y,x);
+    CONST float a = atan(y,x);
     return x==0 && y==0 ? 0 : a;
 }
 
@@ -116,23 +127,23 @@ float pointAltitude(vec3 point)
 
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float Ratm=earthRadius+atmosphereHeight;
-    const float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float Ratm=earthRadius+atmosphereHeight;
+    CONST float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float distanceToGround(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(-safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float cosZenithAngleOfHorizon(const float altitude)
 {
-    const float R=earthRadius;
-    const float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
+    CONST float R=earthRadius;
+    CONST float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
     return -sqrt(2*h*R+sqr(h))/(R+h);
 }
 
@@ -151,8 +162,8 @@ float distanceToNearestAtmosphereBoundary(const float cosZenithAngle, const floa
 float sunVisibility(const float cosSunZenithAngle, float altitude)
 {
     if(altitude<0) altitude=0;
-    const float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
-    const float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
+    CONST float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
+    CONST float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
     /* Approximating visible fraction of solar disk by smoothstep between the position of the Sun
      * touching the horizon by its upper part and the position with lower part touching the horizon.
      * The calculation assumes that solar angular radius is small and thus approximately equals its sine.
@@ -182,13 +193,13 @@ float circlesIntersectionArea(float R1, float R2, float d)
 
 float angleBetween(const vec3 a, const vec3 b)
 {
-    const float d=dot(a,b);
-    const float c=length(cross(a,b));
+    CONST float d=dot(a,b);
+    CONST float c=length(cross(a,b));
     // To avoid loss of precision, don't use dot product near the singularity
     // of acos, and cross product near the singularity of asin
     if(abs(d) < abs(c))
         return acos(d/(length(a)*length(b)));
-    const float smallerAngle = asin(c/(length(a)*length(b)));
+    CONST float smallerAngle = asin(c/(length(a)*length(b)));
     if(d<0) return PI-smallerAngle;
     return smallerAngle;
 }
@@ -205,11 +216,11 @@ float moonAngularRadius(const vec3 cameraPosition, const vec3 moonPosition)
 
 float visibleSolidAngleOfSun(const vec3 camera, const vec3 sunDir, const vec3 moonPos)
 {
-    const float Rs=sunAngularRadius;
-    const float Rm=moonAngularRadius(camera,moonPos);
+    CONST float Rs=sunAngularRadius;
+    CONST float Rm=moonAngularRadius(camera,moonPos);
     float visibleSolidAngle=PI*sqr(Rs);
 
-    const float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
+    CONST float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
     if(dSM<Rs+Rm)
     {
         visibleSolidAngle -= circlesIntersectionArea(Rm,Rs,dSM);
@@ -229,12 +240,12 @@ float sphereIntegrationSolidAngleDifferential(const int pointCountOnSphere)
 }
 vec3 sphereIntegrationSampleDir(const int index, const int pointCountOnSphere)
 {
-    const float goldenRatio=1.6180339887499;
+    CONST float goldenRatio=1.6180339887499;
     // The range of n is 0.5, 1.5, ..., pointCountOnSphere-0.5
-    const float n=index+0.5;
+    CONST float n=index+0.5;
     // Explanation of the Fibonacci grid generation can be seen at https://stackoverflow.com/a/44164075/673852
-    const float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
-    const float azimuth=n*(2*PI*goldenRatio);
+    CONST float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
+    CONST float azimuth=n*(2*PI*goldenRatio);
     return vec3(cos(azimuth)*sin(zenithAngle),
                 sin(azimuth)*sin(zenithAngle),
                 cos(zenithAngle));

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/2/aerosols/compute-eclipsed-single-scattering.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/2/aerosols/compute-eclipsed-single-scattering.frag
@@ -1,7 +1,21 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
 
-#line 1 1 // const.h.glsl
+
+
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 6 0 // compute-eclipsed-single-scattering.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,8 +48,8 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.35000004e-05,1.33100002e-05,9.4
 const vec4 wavelengths=vec4(610.666687,642,673.333313,704.666687);
 const int wlSetIndex=2;
 #endif
-#line 5 0 // compute-eclipsed-single-scattering.frag
-#line 1 2 // texture-coordinates.h.glsl
+#line 7 0 // compute-eclipsed-single-scattering.frag
+#line 1 3 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -104,11 +118,11 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 6 0 // compute-eclipsed-single-scattering.frag
-#line 1 3 // radiance-to-luminance.h.glsl
+#line 8 0 // compute-eclipsed-single-scattering.frag
+#line 1 4 // radiance-to-luminance.h.glsl
 const mat4 radianceToLuminance=mat4(21296.1113,10585.7773,6.80903196,807.40564,  8819.19727,3416.5498,0.346691847,67.973465,  1511.18506,551.902527,0,6.17586422,  177.630722,64.1456985,0,0.693584085);
-#line 7 0 // compute-eclipsed-single-scattering.frag
-#line 1 4 // single-scattering-eclipsed.h.glsl
+#line 9 0 // compute-eclipsed-single-scattering.frag
+#line 1 5 // single-scattering-eclipsed.h.glsl
 #ifndef INCLUDE_ONCE_050024D2_BD56_434E_8D40_2055DA0B78EC
 #define INCLUDE_ONCE_050024D2_BD56_434E_8D40_2055DA0B78EC
 
@@ -116,7 +130,7 @@ vec4 computeSingleScatteringEclipsed(const vec3 camera, const vec3 viewDir, cons
                                      const bool viewRayIntersectsGround);
 
 #endif
-#line 8 0 // compute-eclipsed-single-scattering.frag
+#line 10 0 // compute-eclipsed-single-scattering.frag
 
 in vec3 position;
 out vec4 scatteringTextureOutput;
@@ -132,16 +146,16 @@ vec4 solarRadiance()
 
 void main()
 {
-    const EclipseScatteringTexVars texVars=eclipseTexCoordsToTexVars(gl_FragCoord.xy/eclipsedSingleScatteringTextureSize, altitude);
-    const float sinViewZenithAngle=sqrt(1-sqr(texVars.cosViewZenithAngle));
-    const vec3 viewDir=vec3(cos(texVars.azimuthRelativeToSun)*sinViewZenithAngle,
+    CONST EclipseScatteringTexVars texVars=eclipseTexCoordsToTexVars(gl_FragCoord.xy/eclipsedSingleScatteringTextureSize, altitude);
+    CONST float sinViewZenithAngle=sqrt(1-sqr(texVars.cosViewZenithAngle));
+    CONST vec3 viewDir=vec3(cos(texVars.azimuthRelativeToSun)*sinViewZenithAngle,
                             sin(texVars.azimuthRelativeToSun)*sinViewZenithAngle,
                             texVars.cosViewZenithAngle);
-    const vec3 cameraPosition=vec3(0,0,altitude);
-    const vec3 sunDirection=vec3(sin(sunZenithAngle), 0, cos(sunZenithAngle));
-    const vec4 radiance=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPositionRelativeToSunAzimuth,
+    CONST vec3 cameraPosition=vec3(0,0,altitude);
+    CONST vec3 sunDirection=vec3(sin(sunZenithAngle), 0, cos(sunZenithAngle));
+    CONST vec4 radiance=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPositionRelativeToSunAzimuth,
                                                         texVars.viewRayIntersectsGround);
-#if COMPUTE_RADIANCE
+#if 0 /*COMPUTE_RADIANCE*/
     scatteringTextureOutput=radiance;
 #elif 1 /*COMPUTE_LUMINANCE*/
     scatteringTextureOutput=radianceToLuminance*radiance;

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/2/aerosols/densities.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/2/aerosols/densities.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // densities.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,20 +45,20 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.35000004e-05,1.33100002e-05,9.4
 const vec4 wavelengths=vec4(610.666687,642,673.333313,704.666687);
 const int wlSetIndex=2;
 #endif
-#line 5 0 // densities.frag
+#line 4 0 // densities.frag
 float scattererNumberDensity_molecules(float altitude)
 {
-        const float rayleighScaleHeight=8*km;
+        CONST float rayleighScaleHeight=8*km;
         return 3.08458e25*exp(-1/rayleighScaleHeight * altitude);
 }
 float scattererNumberDensity_aerosols(float altitude)
 {
-        const float mieScaleHeight=1.2*km;
+        CONST float mieScaleHeight=1.2*km;
         return 1.03333e8*exp(-1/mieScaleHeight*altitude);
 }
 float absorberNumberDensity_ozone(float altitude)
 {
-        const float totalOzoneAmount=370*dobsonUnit;
+        CONST float totalOzoneAmount=370*dobsonUnit;
 
         float density;
 

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/2/aerosols/phase-functions.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/2/aerosols/phase-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // phase-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.35000004e-05,1.33100002e-05,9.4
 const vec4 wavelengths=vec4(610.666687,642,673.333313,704.666687);
 const int wlSetIndex=2;
 #endif
-#line 5 0 // phase-functions.frag
+#line 4 0 // phase-functions.frag
 
 vec4 phaseFunction_molecules(float dotViewSun)
 {
@@ -42,9 +53,9 @@ vec4 phaseFunction_molecules(float dotViewSun)
 }
 vec4 phaseFunction_aerosols(float dotViewSun)
 {
-        const float g=0.76;
-        const float g2=g*g;
-        const float k = 3/(8*PI)*(1-g2)/(2+g2);
+        CONST float g=0.76;
+        CONST float g2=g*g;
+        CONST float k = 3/(8*PI)*(1-g2)/(2+g2);
         return vec4(k * (1+sqr(dotViewSun)) / pow(1+g2 - 2*g*dotViewSun, 1.5) + 1/((1-dotViewSun)*600+0.05))*0.904;
 }
 vec4 currentPhaseFunction(float dotViewSun) { return phaseFunction_aerosols(dotViewSun); }

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/2/aerosols/single-scattering-eclipsed.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/2/aerosols/single-scattering-eclipsed.frag
@@ -1,7 +1,21 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
 
-#line 1 1 // const.h.glsl
+
+
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 6 0 // single-scattering-eclipsed.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,15 +48,15 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.35000004e-05,1.33100002e-05,9.4
 const vec4 wavelengths=vec4(610.666687,642,673.333313,704.666687);
 const int wlSetIndex=2;
 #endif
-#line 5 0 // single-scattering-eclipsed.frag
-#line 1 2 // densities.h.glsl
+#line 7 0 // single-scattering-eclipsed.frag
+#line 1 3 // densities.h.glsl
 float scattererNumberDensity_molecules(float altitude);
 float scattererNumberDensity_aerosols(float altitude);
 float absorberNumberDensity_ozone(float altitude);
 vec4 scatteringCrossSection();
 float scattererDensity(float altitude);
-#line 6 0 // single-scattering-eclipsed.frag
-#line 1 3 // common-functions.h.glsl
+#line 8 0 // single-scattering-eclipsed.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -74,8 +88,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // single-scattering-eclipsed.frag
-#line 1 4 // texture-sampling-functions.h.glsl
+#line 9 0 // single-scattering-eclipsed.frag
+#line 1 5 // texture-sampling-functions.h.glsl
 #ifndef INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 #define INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float altitude);
@@ -87,7 +101,7 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                 const int scatteringOrder);
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 #endif
-#line 8 0 // single-scattering-eclipsed.frag
+#line 10 0 // single-scattering-eclipsed.frag
 
 
 float cosZenithAngle(vec3 origin, vec3 direction)
@@ -101,13 +115,13 @@ vec4 computeSingleScatteringIntegrandEclipsed(const float cosSunZenithAngle, con
                                               const float dist, const bool viewRayIntersectsGround,
                                               const vec3 scatterer, const vec3 sunDir, const vec3 moonPos)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle here the case when the
     // endpoint of the view ray intentionally appears in outer space.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosSunZenithAngleAtDist=clampCosine((r*cosSunZenithAngle+dist*dotViewSun)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosSunZenithAngleAtDist=clampCosine((r*cosSunZenithAngle+dist*dotViewSun)/(earthRadius+altAtDist));
 
-    const vec4 xmittance=transmittance(cosViewZenithAngle, altitude, dist, viewRayIntersectsGround)
+    CONST vec4 xmittance=transmittance(cosViewZenithAngle, altitude, dist, viewRayIntersectsGround)
                                                     *
                          transmittanceToAtmosphereBorder(cosSunZenithAngleAtDist, altAtDist)
                                                     *
@@ -115,7 +129,7 @@ vec4 computeSingleScatteringIntegrandEclipsed(const float cosSunZenithAngle, con
                                                     *
                             // FIXME: this ignores orientation of the crescent of eclipsed Sun WRT horizon
                                     sunVisibility(cosSunZenithAngleAtDist, altAtDist);
-#if ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION
+#if 0 /*ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION*/
     COMPUTE_TOTAL_SCATTERING_COEFFICIENT;
     return xmittance * totalScatteringCoefficient;
 #else
@@ -126,26 +140,26 @@ vec4 computeSingleScatteringIntegrandEclipsed(const float cosSunZenithAngle, con
 vec4 computeSingleScatteringEclipsed(const vec3 camera, const vec3 viewDir, const vec3 sunDir, const vec3 moonPos,
                                      const bool viewRayIntersectsGround)
 {
-    const float cosViewZenithAngle=cosZenithAngle(camera,viewDir);
-    const float cosSunZenithAngle=cosZenithAngle(camera,sunDir);
-    const float altitude=pointAltitude(camera);
-    const float dotViewSun=dot(viewDir,sunDir);
-    const float integrInterval=distanceToNearestAtmosphereBoundary(cosViewZenithAngle, altitude,
+    CONST float cosViewZenithAngle=cosZenithAngle(camera,viewDir);
+    CONST float cosSunZenithAngle=cosZenithAngle(camera,sunDir);
+    CONST float altitude=pointAltitude(camera);
+    CONST float dotViewSun=dot(viewDir,sunDir);
+    CONST float integrInterval=distanceToNearestAtmosphereBoundary(cosViewZenithAngle, altitude,
                                                                    viewRayIntersectsGround);
 
     // Using the midpoint rule for quadrature
     vec4 spectrum=vec4(0);
-    const float dl=integrInterval/radialIntegrationPoints;
+    CONST float dl=integrInterval/radialIntegrationPoints;
     for(int n=0; n<radialIntegrationPoints; ++n)
     {
-        const float dist=(n+0.5)*dl;
+        CONST float dist=(n+0.5)*dl;
         spectrum += computeSingleScatteringIntegrandEclipsed(cosSunZenithAngle, cosViewZenithAngle, dotViewSun,
                                                              altitude, dist, viewRayIntersectsGround,
                                                              camera+viewDir*dist, sunDir, moonPos);
     }
 
     spectrum *= dl*solarIrradianceAtTOA
-#if ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION
+#if 0 /*ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION*/
                                 // the multiplier is already included
 #else
                                         * scatteringCrossSection()

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/2/aerosols/texture-coordinates.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/2/aerosols/texture-coordinates.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-coordinates.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,8 +45,8 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.35000004e-05,1.33100002e-05,9.4
 const vec4 wavelengths=vec4(610.666687,642,673.333313,704.666687);
 const int wlSetIndex=2;
 #endif
-#line 5 0 // texture-coordinates.frag
-#line 1 2 // texture-coordinates.h.glsl
+#line 4 0 // texture-coordinates.frag
+#line 1 3 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -104,8 +115,8 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 6 0 // texture-coordinates.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-coordinates.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -137,7 +148,7 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-coordinates.frag
+#line 6 0 // texture-coordinates.frag
 
 const float LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA=sqrt(atmosphereHeight*(atmosphereHeight+2*earthRadius));
 
@@ -205,18 +216,18 @@ vec3 indicesToTexCoords(const vec3 indices, const vec3 texSizes)
 
 TransmittanceTexVars transmittanceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
+    CONST float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
                                 texCoordToUnitRange(texCoord.t,transmittanceTextureSize.t);
     // Distance from Earth center to camera
-    const float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
-    const float altitude=r-earthRadius;
+    CONST float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
+    CONST float altitude=r-earthRadius;
 
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
     // distance to border of visible atmosphere from the view point
-    const float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
+    CONST float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
     // d==0 can happen when altitude==atmosphereHeight
-    const float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
+    CONST float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
     return TransmittanceTexVars(cosVZA,altitude);
 }
 
@@ -235,53 +246,53 @@ vec2 transmittanceTexVarsToTexCoord(const float cosVZA, float altitude)
     if(altitude<0)
         altitude=0;
 
-    const float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
+    CONST float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
                                       transmittanceTextureSize.t);
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
-    const float d=distanceToAtmosphereBorder(cosVZA,altitude);
-    const float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float d=distanceToAtmosphereBorder(cosVZA,altitude);
+    CONST float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
     return vec2(s,t);
 }
 
 // Output: vec2(cos(sunZenithAngle), altitude)
 IrradianceTexVars irradianceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
-    const float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
+    CONST float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
+    CONST float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
     return IrradianceTexVars(cosSZA,alt);
 }
 
 vec2 irradianceTexVarsToTexCoord(const float cosSunZenithAngle, const float altitude)
 {
-    const float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
-    const float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
+    CONST float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
+    CONST float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
     return vec2(s,t);
 }
 
 float cosSZAToUnitRangeTexCoord(const float cosSunZenithAngle)
 {
     // Distance to top atmosphere border along the ray groundUnderCamera-sun: (altitude, cosSunZenithAngle)
-    const float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name
-    const float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
+    CONST float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
     // TODO: choose a more descriptive name
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     return max(0.,1-a/A)/(a+1);
 }
 
 float unitRangeTexCoordToCosSZA(const float texCoord)
 {
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float a=(A-A*texCoord)/(1+A*texCoord);
-    const float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
+    CONST float a=(A-A*texCoord)/(1+A*texCoord);
+    CONST float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
     return distFromGroundToTopAtmoBorder==0 ? 1 :
         clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distFromGroundToTopAtmoBorder)) /
                     (2*earthRadius*distFromGroundToTopAtmoBorder));
@@ -292,24 +303,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
                                                const float dotViewSun, const float altitude,
                                                const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -317,24 +328,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float dotVSCoord=(dotViewSun+1)/2;
+    CONST float dotVSCoord=(dotViewSun+1)/2;
 
     // ------------------------------------
-    const float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
+    CONST float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
 
     return Scattering4DCoords(cosSZACoord, cosVZACoord, dotVSCoord, altCoord, viewRayIntersectsGround);
 }
 
 TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
@@ -342,16 +353,16 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture coordinates we combine into a single sampler3D coordinate.
-    const float texW = scatteringTextureSize[1];
-    const float texH = scatteringTextureSize[2];
-    const float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
-    const vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
+    CONST float texW = scatteringTextureSize[1];
+    CONST float texH = scatteringTextureSize[2];
+    CONST float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
+    CONST vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
                                         ceil (cosSZAIndex)*texW+coords.dotViewSun*(texW-1)) / (texW*texH-1);
-    const vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
+    CONST vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
 
-    const float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
+    CONST float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
 
-    const float alphaUpper=fract(cosSZAIndex);
+    CONST float alphaUpper=fract(cosSZAIndex);
     return TexCoordPair(vec3(cosVZAtc, combinedCoord.x, altitude), float(1-alphaUpper),
                         vec3(cosVZAtc, combinedCoord.y, altitude), float(alphaUpper));
 }
@@ -359,9 +370,9 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
+    CONST TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
     return texture(tex, texCoords.lower) * texCoords.alphaLower +
            texture(tex, texCoords.upper) * texCoords.alphaUpper;
 }
@@ -369,17 +380,17 @@ vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const f
 // 3D texture is the 3D single-altitude slice of a 4D texture
 vec3 scattering4DCoordsToTex3DCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2);
 
-    const float dvsSize = scatteringTextureSize[1];
-    const float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
+    CONST float dvsSize = scatteringTextureSize[1];
+    CONST float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
 
-    const float cszaSize = scatteringTextureSize[2];
-    const float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
+    CONST float cszaSize = scatteringTextureSize[2];
+    CONST float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
 
     return vec3(cosVZAtc, dotVStc, cosSZAtc);
 }
@@ -394,39 +405,39 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along dotViewSun coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[1];
-    const float posOfRow = indices[1];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[1];
+    CONST float posOfRow = indices[1];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         indexToTexCoord(currRow, numRows-1),
                                                         texCoordVerbatim));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               indexToTexCoord(currRow, numRows-1),
                                                               texCoordVerbatim));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          indexToTexCoord(currRow, numRows-1),
                                          texCoordVerbatim));
@@ -434,14 +445,14 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
 vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolationGuides01Tex,
                                  const vec3 indices)
 {
-    const float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
+    CONST float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
 
-    const float cosVZAIndex = indices[0];
-    const float dotVSIndex = indices[1];
-    const float currRow = floor(dotVSIndex);
-    const float posBetweenRows = dotVSIndex - currRow;
-    const float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cosVZAIndex = indices[0];
+    CONST float dotVSIndex = indices[1];
+    CONST float currRow = floor(dotVSIndex);
+    CONST float posBetweenRows = dotVSIndex - currRow;
+    CONST float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -449,14 +460,14 @@ vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolat
     indicesCurrRow[1] =     currRow;
     indicesNextRow[1] = min(currRow+1, scatteringTextureSize[1]-1.);
 
-    const vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
-    const vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
+    CONST vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
+    CONST vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
 
-    const vec4 valueCurrRow = texture(tex, coordsCurrRow);
-    const vec4 valueNextRow = texture(tex, coordsNextRow);
-    const float epsilon = 1e-37; // Prevents passing zero to log
-    const vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
-    const vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
+    CONST vec4 valueCurrRow = texture(tex, coordsCurrRow);
+    CONST vec4 valueNextRow = texture(tex, coordsNextRow);
+    CONST float epsilon = 1e-37; // Prevents passing zero to log
+    CONST vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
+    CONST vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
     return (logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow;
 }
 
@@ -465,37 +476,37 @@ float findGuide02Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along SZA coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[2];
-    const float posOfRow = indices[2];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[2];
+    CONST float posOfRow = indices[2];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
 }
@@ -505,19 +516,19 @@ vec4 sample3DTextureGuided(const sampler3D tex,
                            const float cosSunZenithAngle, const float cosViewZenithAngle,
                            const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
                                                                     dotViewSun, altitude, viewRayIntersectsGround);
     // Handle the external interpolation guides: the guides between a pair of VZA-dotViewSun 2D "pictures".
-    const vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
-    const vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
-    const float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
+    CONST vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
+    CONST float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
 
-    const float cvzaIndex = indices[0];
-    const float cszaIndex = indices[2];
-    const float currRow = floor(cszaIndex);
-    const float posBetweenRows = cszaIndex - currRow;
-    const float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cvzaIndex = indices[0];
+    CONST float cszaIndex = indices[2];
+    CONST float currRow = floor(cszaIndex);
+    CONST float posBetweenRows = cszaIndex - currRow;
+    CONST float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -526,58 +537,58 @@ vec4 sample3DTextureGuided(const sampler3D tex,
     indicesNextRow[2] = min(currRow+1, scatteringTextureSize[2]-1);
 
     // The caller will handle the internal interpolation guides: the ones between rows in each 2D "picture".
-    const vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
-    const vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
+    CONST vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
+    CONST vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
     return exp((logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow);
 }
 
 vec4 sample3DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
     return texture(tex, texCoords);
 }
 
 ScatteringTexVars scatteringTex4DCoordsToTexVars(const Scattering4DCoords coords)
 {
-    const float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
     // ------------------------------------
     float cosViewZenithAngle;
     if(coords.viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
     // ------------------------------------
-    const float dotViewSun=coords.dotViewSun*2-1;
+    CONST float dotViewSun=coords.dotViewSun*2-1;
 
     // ------------------------------------
-    const float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
+    CONST float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
 
     return ScatteringTexVars(cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, coords.viewRayIntersectsGround);
 }
 
 Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 {
-    const vec4 indexMax=scatteringTextureSize-vec4(1);
+    CONST vec4 indexMax=scatteringTextureSize-vec4(1);
     Scattering4DCoords coords4d;
     coords4d.viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
     // The following formulas assume that scatteringTextureSize[0] is even. For odd sizes they would change.
@@ -593,8 +604,8 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture indices we combine into a single sampler3D coordinate.
-    const float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
-    const float combinedIndex=texIndices[1];
+    CONST float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
+    CONST float combinedIndex=texIndices[1];
     coords4d.dotViewSun=mod(combinedIndex,texW)/(texW-1);
     coords4d.cosSunZenithAngle=floor(combinedIndex/texW)/(texH-1);
 
@@ -608,11 +619,11 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
 ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 {
-    const Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
+    CONST Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
     ScatteringTexVars vars=scatteringTex4DCoordsToTexVars(coords4d);
     // Clamp dotViewSun to its valid range of values, given cosViewZenithAngle and cosSunZenithAngle. This is
     // needed to prevent NaNs when computing the scattering texture.
-    const float cosVZA=vars.cosViewZenithAngle,
+    CONST float cosVZA=vars.cosViewZenithAngle,
                 cosSZA=vars.cosSunZenithAngle;
     vars.dotViewSun=clamp(vars.dotViewSun,
                           cosVZA*cosSZA-safeSqrt((1-sqr(cosVZA))*(1-sqr(cosSZA))),
@@ -622,54 +633,54 @@ ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 
 EclipseScatteringTexVars eclipseTexCoordsToTexVars(const vec2 texCoords, const float altitude)
 {
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
-    const bool viewRayIntersectsGround = texCoords.t<0.5;
+    CONST bool viewRayIntersectsGround = texCoords.t<0.5;
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
-    const float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
+    CONST float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
     return EclipseScatteringTexVars(azimuthRelativeToSun, cosViewZenithAngle, viewRayIntersectsGround);
 }
 
 EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                                    const float altitude, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -677,13 +688,13 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
-    const float azimuthCoord = azimuthRelativeToSun/(2*PI);
+    CONST float azimuthCoord = azimuthRelativeToSun/(2*PI);
 
     return EclipseScattering2DCoords(azimuthCoord, cosVZACoord);
 }
@@ -691,14 +702,14 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
 vec2 eclipseTexVarsToTexCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                const float altitude, const bool viewRayIntersectsGround, const vec2 texSize)
 {
-    const EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+    CONST EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                                     viewRayIntersectsGround);
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2);
-    const float azimuthTC = coords.azimuth + 1/(2*texSize.s);
+    CONST float azimuthTC = coords.azimuth + 1/(2*texSize.s);
 
     return vec2(azimuthTC, cosVZAtc);
 }
@@ -707,42 +718,42 @@ vec4 sampleEclipseDoubleScattering3DTexture(const sampler3D tex, const float cos
                                             const float cosViewZenithAngle, const float azimuthRelativeToSun,
                                             const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
+    CONST vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
                                                   eclipsedDoubleScatteringTextureSize.st);
-    const float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
-    const vec3 texCoords=vec3(coords2d, cosSZACoord);
+    CONST float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
+    CONST vec3 texCoords=vec3(coords2d, cosSZACoord);
 
     return texture(tex, texCoords);
 }
 
 LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 texIndices)
 {
-    const vec2 indexMax=lightPollutionTextureSize-vec2(1);
+    CONST vec2 indexMax=lightPollutionTextureSize-vec2(1);
 
-    const float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
-    const float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
+    CONST float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
-    const bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
-    const float cosViewZenithAngleCoord = viewRayIntersectsGround ?
+    CONST bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
+    CONST float cosViewZenithAngleCoord = viewRayIntersectsGround ?
                                    1-2*texIndices[0]/(indexMax[0]-1) :
                                    2*(texIndices[0]-1)/(indexMax[0]-1)-1;
     // ------------------------------------
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
@@ -753,23 +764,23 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 
 LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -777,27 +788,27 @@ LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, con
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     return LightPollution2DCoords(cosVZACoord, altCoord);
 }
 
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
-    const vec2 texSize = lightPollutionTextureSize;
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 texSize = lightPollutionTextureSize;
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2);
-    const float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
+    CONST float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
     return vec2(cosVZAtc, altitudeTC);
 }

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/2/aerosols/texture-sampling-functions.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/2/aerosols/texture-sampling-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-sampling-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,13 +45,13 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.35000004e-05,1.33100002e-05,9.4
 const vec4 wavelengths=vec4(610.666687,642,673.333313,704.666687);
 const int wlSetIndex=2;
 #endif
-#line 5 0 // texture-sampling-functions.frag
-#line 1 2 // phase-functions.h.glsl
+#line 4 0 // texture-sampling-functions.frag
+#line 1 3 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 6 0 // texture-sampling-functions.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-sampling-functions.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -72,8 +83,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-sampling-functions.frag
-#line 1 4 // texture-coordinates.h.glsl
+#line 6 0 // texture-sampling-functions.frag
+#line 1 5 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -142,7 +153,7 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 8 0 // texture-sampling-functions.frag
+#line 7 0 // texture-sampling-functions.frag
 
 uniform sampler2D transmittanceTexture;
 uniform sampler2D irradianceTexture;
@@ -154,13 +165,13 @@ uniform sampler2D lightPollutionScatteringTexture;
 
 vec4 irradiance(const float cosSunZenithAngle, const float altitude)
 {
-    const vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
+    CONST vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
     return texture(irradianceTexture, texCoords);
 }
 
 vec4 opticalDepthToAtmosphereBorder(const float cosViewZenithAngle, const float altitude)
 {
-    const vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
+    CONST vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact when looking into nadir from TOA at some values of texture sizes (in particular, size of
     // transmittance texture for altitude being 4096). This happens when I simply call texture(eclipsedScatteringTexture,
@@ -178,11 +189,11 @@ vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float
 vec4 transmittance(const float cosViewZenithAngle, const float altitude, const float dist,
                    const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle view ray endpoint
     // in space here.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
 
     vec4 depth;
     if(viewRayIntersectsGround)
@@ -201,7 +212,7 @@ vec4 transmittance(const float cosViewZenithAngle, const float altitude, const f
 vec4 calcFirstScattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                          const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
+    CONST vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
                                           dotViewSun, altitude, viewRayIntersectsGround);
     return scattering*currentPhaseFunction(dotViewSun);
 }
@@ -220,6 +231,6 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
 
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     return texture(lightPollutionScatteringTexture, coords);
 }

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/2/molecules/common-functions.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/2/molecules/common-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // common-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.35000004e-05,1.33100002e-05,9.4
 const vec4 wavelengths=vec4(610.666687,642,673.333313,704.666687);
 const int wlSetIndex=2;
 #endif
-#line 5 0 // common-functions.frag
+#line 4 0 // common-functions.frag
 
 bool dbgDataPresent=false;
 bool debugDataPresent()
@@ -69,7 +80,7 @@ void setDebugData(float a,float b, float c, float d)
 
 void swap(inout float x, inout float y)
 {
-    const float t = x;
+    CONST float t = x;
     x = y;
     y = t;
 }
@@ -83,7 +94,7 @@ float safeSqrt(const float x)
 
 float safeAtan(const float y, const float x)
 {
-    const float a = atan(y,x);
+    CONST float a = atan(y,x);
     return x==0 && y==0 ? 0 : a;
 }
 
@@ -116,23 +127,23 @@ float pointAltitude(vec3 point)
 
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float Ratm=earthRadius+atmosphereHeight;
-    const float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float Ratm=earthRadius+atmosphereHeight;
+    CONST float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float distanceToGround(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(-safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float cosZenithAngleOfHorizon(const float altitude)
 {
-    const float R=earthRadius;
-    const float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
+    CONST float R=earthRadius;
+    CONST float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
     return -sqrt(2*h*R+sqr(h))/(R+h);
 }
 
@@ -151,8 +162,8 @@ float distanceToNearestAtmosphereBoundary(const float cosZenithAngle, const floa
 float sunVisibility(const float cosSunZenithAngle, float altitude)
 {
     if(altitude<0) altitude=0;
-    const float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
-    const float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
+    CONST float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
+    CONST float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
     /* Approximating visible fraction of solar disk by smoothstep between the position of the Sun
      * touching the horizon by its upper part and the position with lower part touching the horizon.
      * The calculation assumes that solar angular radius is small and thus approximately equals its sine.
@@ -182,13 +193,13 @@ float circlesIntersectionArea(float R1, float R2, float d)
 
 float angleBetween(const vec3 a, const vec3 b)
 {
-    const float d=dot(a,b);
-    const float c=length(cross(a,b));
+    CONST float d=dot(a,b);
+    CONST float c=length(cross(a,b));
     // To avoid loss of precision, don't use dot product near the singularity
     // of acos, and cross product near the singularity of asin
     if(abs(d) < abs(c))
         return acos(d/(length(a)*length(b)));
-    const float smallerAngle = asin(c/(length(a)*length(b)));
+    CONST float smallerAngle = asin(c/(length(a)*length(b)));
     if(d<0) return PI-smallerAngle;
     return smallerAngle;
 }
@@ -205,11 +216,11 @@ float moonAngularRadius(const vec3 cameraPosition, const vec3 moonPosition)
 
 float visibleSolidAngleOfSun(const vec3 camera, const vec3 sunDir, const vec3 moonPos)
 {
-    const float Rs=sunAngularRadius;
-    const float Rm=moonAngularRadius(camera,moonPos);
+    CONST float Rs=sunAngularRadius;
+    CONST float Rm=moonAngularRadius(camera,moonPos);
     float visibleSolidAngle=PI*sqr(Rs);
 
-    const float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
+    CONST float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
     if(dSM<Rs+Rm)
     {
         visibleSolidAngle -= circlesIntersectionArea(Rm,Rs,dSM);
@@ -229,12 +240,12 @@ float sphereIntegrationSolidAngleDifferential(const int pointCountOnSphere)
 }
 vec3 sphereIntegrationSampleDir(const int index, const int pointCountOnSphere)
 {
-    const float goldenRatio=1.6180339887499;
+    CONST float goldenRatio=1.6180339887499;
     // The range of n is 0.5, 1.5, ..., pointCountOnSphere-0.5
-    const float n=index+0.5;
+    CONST float n=index+0.5;
     // Explanation of the Fibonacci grid generation can be seen at https://stackoverflow.com/a/44164075/673852
-    const float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
-    const float azimuth=n*(2*PI*goldenRatio);
+    CONST float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
+    CONST float azimuth=n*(2*PI*goldenRatio);
     return vec3(cos(azimuth)*sin(zenithAngle),
                 sin(azimuth)*sin(zenithAngle),
                 cos(zenithAngle));

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/2/molecules/compute-eclipsed-single-scattering.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/2/molecules/compute-eclipsed-single-scattering.frag
@@ -1,7 +1,21 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
 
-#line 1 1 // const.h.glsl
+
+
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 6 0 // compute-eclipsed-single-scattering.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,8 +48,8 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.35000004e-05,1.33100002e-05,9.4
 const vec4 wavelengths=vec4(610.666687,642,673.333313,704.666687);
 const int wlSetIndex=2;
 #endif
-#line 5 0 // compute-eclipsed-single-scattering.frag
-#line 1 2 // texture-coordinates.h.glsl
+#line 7 0 // compute-eclipsed-single-scattering.frag
+#line 1 3 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -104,11 +118,11 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 6 0 // compute-eclipsed-single-scattering.frag
-#line 1 3 // radiance-to-luminance.h.glsl
+#line 8 0 // compute-eclipsed-single-scattering.frag
+#line 1 4 // radiance-to-luminance.h.glsl
 const mat4 radianceToLuminance=mat4(21296.1113,10585.7773,6.80903196,807.40564,  8819.19727,3416.5498,0.346691847,67.973465,  1511.18506,551.902527,0,6.17586422,  177.630722,64.1456985,0,0.693584085);
-#line 7 0 // compute-eclipsed-single-scattering.frag
-#line 1 4 // single-scattering-eclipsed.h.glsl
+#line 9 0 // compute-eclipsed-single-scattering.frag
+#line 1 5 // single-scattering-eclipsed.h.glsl
 #ifndef INCLUDE_ONCE_050024D2_BD56_434E_8D40_2055DA0B78EC
 #define INCLUDE_ONCE_050024D2_BD56_434E_8D40_2055DA0B78EC
 
@@ -116,7 +130,7 @@ vec4 computeSingleScatteringEclipsed(const vec3 camera, const vec3 viewDir, cons
                                      const bool viewRayIntersectsGround);
 
 #endif
-#line 8 0 // compute-eclipsed-single-scattering.frag
+#line 10 0 // compute-eclipsed-single-scattering.frag
 
 in vec3 position;
 out vec4 scatteringTextureOutput;
@@ -132,16 +146,16 @@ vec4 solarRadiance()
 
 void main()
 {
-    const EclipseScatteringTexVars texVars=eclipseTexCoordsToTexVars(gl_FragCoord.xy/eclipsedSingleScatteringTextureSize, altitude);
-    const float sinViewZenithAngle=sqrt(1-sqr(texVars.cosViewZenithAngle));
-    const vec3 viewDir=vec3(cos(texVars.azimuthRelativeToSun)*sinViewZenithAngle,
+    CONST EclipseScatteringTexVars texVars=eclipseTexCoordsToTexVars(gl_FragCoord.xy/eclipsedSingleScatteringTextureSize, altitude);
+    CONST float sinViewZenithAngle=sqrt(1-sqr(texVars.cosViewZenithAngle));
+    CONST vec3 viewDir=vec3(cos(texVars.azimuthRelativeToSun)*sinViewZenithAngle,
                             sin(texVars.azimuthRelativeToSun)*sinViewZenithAngle,
                             texVars.cosViewZenithAngle);
-    const vec3 cameraPosition=vec3(0,0,altitude);
-    const vec3 sunDirection=vec3(sin(sunZenithAngle), 0, cos(sunZenithAngle));
-    const vec4 radiance=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPositionRelativeToSunAzimuth,
+    CONST vec3 cameraPosition=vec3(0,0,altitude);
+    CONST vec3 sunDirection=vec3(sin(sunZenithAngle), 0, cos(sunZenithAngle));
+    CONST vec4 radiance=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPositionRelativeToSunAzimuth,
                                                         texVars.viewRayIntersectsGround);
-#if COMPUTE_RADIANCE
+#if 0 /*COMPUTE_RADIANCE*/
     scatteringTextureOutput=radiance;
 #elif 1 /*COMPUTE_LUMINANCE*/
     scatteringTextureOutput=radianceToLuminance*radiance;

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/2/molecules/densities.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/2/molecules/densities.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // densities.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,20 +45,20 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.35000004e-05,1.33100002e-05,9.4
 const vec4 wavelengths=vec4(610.666687,642,673.333313,704.666687);
 const int wlSetIndex=2;
 #endif
-#line 5 0 // densities.frag
+#line 4 0 // densities.frag
 float scattererNumberDensity_molecules(float altitude)
 {
-        const float rayleighScaleHeight=8*km;
+        CONST float rayleighScaleHeight=8*km;
         return 3.08458e25*exp(-1/rayleighScaleHeight * altitude);
 }
 float scattererNumberDensity_aerosols(float altitude)
 {
-        const float mieScaleHeight=1.2*km;
+        CONST float mieScaleHeight=1.2*km;
         return 1.03333e8*exp(-1/mieScaleHeight*altitude);
 }
 float absorberNumberDensity_ozone(float altitude)
 {
-        const float totalOzoneAmount=370*dobsonUnit;
+        CONST float totalOzoneAmount=370*dobsonUnit;
 
         float density;
 

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/2/molecules/phase-functions.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/2/molecules/phase-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // phase-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.35000004e-05,1.33100002e-05,9.4
 const vec4 wavelengths=vec4(610.666687,642,673.333313,704.666687);
 const int wlSetIndex=2;
 #endif
-#line 5 0 // phase-functions.frag
+#line 4 0 // phase-functions.frag
 
 vec4 phaseFunction_molecules(float dotViewSun)
 {
@@ -42,9 +53,9 @@ vec4 phaseFunction_molecules(float dotViewSun)
 }
 vec4 phaseFunction_aerosols(float dotViewSun)
 {
-        const float g=0.76;
-        const float g2=g*g;
-        const float k = 3/(8*PI)*(1-g2)/(2+g2);
+        CONST float g=0.76;
+        CONST float g2=g*g;
+        CONST float k = 3/(8*PI)*(1-g2)/(2+g2);
         return vec4(k * (1+sqr(dotViewSun)) / pow(1+g2 - 2*g*dotViewSun, 1.5) + 1/((1-dotViewSun)*600+0.05))*0.904;
 }
 vec4 currentPhaseFunction(float dotViewSun) { return phaseFunction_molecules(dotViewSun); }

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/2/molecules/single-scattering-eclipsed.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/2/molecules/single-scattering-eclipsed.frag
@@ -1,7 +1,21 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
 
-#line 1 1 // const.h.glsl
+
+
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 6 0 // single-scattering-eclipsed.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,15 +48,15 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.35000004e-05,1.33100002e-05,9.4
 const vec4 wavelengths=vec4(610.666687,642,673.333313,704.666687);
 const int wlSetIndex=2;
 #endif
-#line 5 0 // single-scattering-eclipsed.frag
-#line 1 2 // densities.h.glsl
+#line 7 0 // single-scattering-eclipsed.frag
+#line 1 3 // densities.h.glsl
 float scattererNumberDensity_molecules(float altitude);
 float scattererNumberDensity_aerosols(float altitude);
 float absorberNumberDensity_ozone(float altitude);
 vec4 scatteringCrossSection();
 float scattererDensity(float altitude);
-#line 6 0 // single-scattering-eclipsed.frag
-#line 1 3 // common-functions.h.glsl
+#line 8 0 // single-scattering-eclipsed.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -74,8 +88,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // single-scattering-eclipsed.frag
-#line 1 4 // texture-sampling-functions.h.glsl
+#line 9 0 // single-scattering-eclipsed.frag
+#line 1 5 // texture-sampling-functions.h.glsl
 #ifndef INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 #define INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float altitude);
@@ -87,7 +101,7 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                 const int scatteringOrder);
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 #endif
-#line 8 0 // single-scattering-eclipsed.frag
+#line 10 0 // single-scattering-eclipsed.frag
 
 
 float cosZenithAngle(vec3 origin, vec3 direction)
@@ -101,13 +115,13 @@ vec4 computeSingleScatteringIntegrandEclipsed(const float cosSunZenithAngle, con
                                               const float dist, const bool viewRayIntersectsGround,
                                               const vec3 scatterer, const vec3 sunDir, const vec3 moonPos)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle here the case when the
     // endpoint of the view ray intentionally appears in outer space.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosSunZenithAngleAtDist=clampCosine((r*cosSunZenithAngle+dist*dotViewSun)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosSunZenithAngleAtDist=clampCosine((r*cosSunZenithAngle+dist*dotViewSun)/(earthRadius+altAtDist));
 
-    const vec4 xmittance=transmittance(cosViewZenithAngle, altitude, dist, viewRayIntersectsGround)
+    CONST vec4 xmittance=transmittance(cosViewZenithAngle, altitude, dist, viewRayIntersectsGround)
                                                     *
                          transmittanceToAtmosphereBorder(cosSunZenithAngleAtDist, altAtDist)
                                                     *
@@ -115,7 +129,7 @@ vec4 computeSingleScatteringIntegrandEclipsed(const float cosSunZenithAngle, con
                                                     *
                             // FIXME: this ignores orientation of the crescent of eclipsed Sun WRT horizon
                                     sunVisibility(cosSunZenithAngleAtDist, altAtDist);
-#if ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION
+#if 0 /*ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION*/
     COMPUTE_TOTAL_SCATTERING_COEFFICIENT;
     return xmittance * totalScatteringCoefficient;
 #else
@@ -126,26 +140,26 @@ vec4 computeSingleScatteringIntegrandEclipsed(const float cosSunZenithAngle, con
 vec4 computeSingleScatteringEclipsed(const vec3 camera, const vec3 viewDir, const vec3 sunDir, const vec3 moonPos,
                                      const bool viewRayIntersectsGround)
 {
-    const float cosViewZenithAngle=cosZenithAngle(camera,viewDir);
-    const float cosSunZenithAngle=cosZenithAngle(camera,sunDir);
-    const float altitude=pointAltitude(camera);
-    const float dotViewSun=dot(viewDir,sunDir);
-    const float integrInterval=distanceToNearestAtmosphereBoundary(cosViewZenithAngle, altitude,
+    CONST float cosViewZenithAngle=cosZenithAngle(camera,viewDir);
+    CONST float cosSunZenithAngle=cosZenithAngle(camera,sunDir);
+    CONST float altitude=pointAltitude(camera);
+    CONST float dotViewSun=dot(viewDir,sunDir);
+    CONST float integrInterval=distanceToNearestAtmosphereBoundary(cosViewZenithAngle, altitude,
                                                                    viewRayIntersectsGround);
 
     // Using the midpoint rule for quadrature
     vec4 spectrum=vec4(0);
-    const float dl=integrInterval/radialIntegrationPoints;
+    CONST float dl=integrInterval/radialIntegrationPoints;
     for(int n=0; n<radialIntegrationPoints; ++n)
     {
-        const float dist=(n+0.5)*dl;
+        CONST float dist=(n+0.5)*dl;
         spectrum += computeSingleScatteringIntegrandEclipsed(cosSunZenithAngle, cosViewZenithAngle, dotViewSun,
                                                              altitude, dist, viewRayIntersectsGround,
                                                              camera+viewDir*dist, sunDir, moonPos);
     }
 
     spectrum *= dl*solarIrradianceAtTOA
-#if ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION
+#if 0 /*ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION*/
                                 // the multiplier is already included
 #else
                                         * scatteringCrossSection()

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/2/molecules/texture-coordinates.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/2/molecules/texture-coordinates.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-coordinates.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,8 +45,8 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.35000004e-05,1.33100002e-05,9.4
 const vec4 wavelengths=vec4(610.666687,642,673.333313,704.666687);
 const int wlSetIndex=2;
 #endif
-#line 5 0 // texture-coordinates.frag
-#line 1 2 // texture-coordinates.h.glsl
+#line 4 0 // texture-coordinates.frag
+#line 1 3 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -104,8 +115,8 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 6 0 // texture-coordinates.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-coordinates.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -137,7 +148,7 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-coordinates.frag
+#line 6 0 // texture-coordinates.frag
 
 const float LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA=sqrt(atmosphereHeight*(atmosphereHeight+2*earthRadius));
 
@@ -205,18 +216,18 @@ vec3 indicesToTexCoords(const vec3 indices, const vec3 texSizes)
 
 TransmittanceTexVars transmittanceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
+    CONST float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
                                 texCoordToUnitRange(texCoord.t,transmittanceTextureSize.t);
     // Distance from Earth center to camera
-    const float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
-    const float altitude=r-earthRadius;
+    CONST float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
+    CONST float altitude=r-earthRadius;
 
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
     // distance to border of visible atmosphere from the view point
-    const float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
+    CONST float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
     // d==0 can happen when altitude==atmosphereHeight
-    const float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
+    CONST float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
     return TransmittanceTexVars(cosVZA,altitude);
 }
 
@@ -235,53 +246,53 @@ vec2 transmittanceTexVarsToTexCoord(const float cosVZA, float altitude)
     if(altitude<0)
         altitude=0;
 
-    const float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
+    CONST float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
                                       transmittanceTextureSize.t);
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
-    const float d=distanceToAtmosphereBorder(cosVZA,altitude);
-    const float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float d=distanceToAtmosphereBorder(cosVZA,altitude);
+    CONST float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
     return vec2(s,t);
 }
 
 // Output: vec2(cos(sunZenithAngle), altitude)
 IrradianceTexVars irradianceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
-    const float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
+    CONST float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
+    CONST float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
     return IrradianceTexVars(cosSZA,alt);
 }
 
 vec2 irradianceTexVarsToTexCoord(const float cosSunZenithAngle, const float altitude)
 {
-    const float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
-    const float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
+    CONST float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
+    CONST float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
     return vec2(s,t);
 }
 
 float cosSZAToUnitRangeTexCoord(const float cosSunZenithAngle)
 {
     // Distance to top atmosphere border along the ray groundUnderCamera-sun: (altitude, cosSunZenithAngle)
-    const float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name
-    const float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
+    CONST float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
     // TODO: choose a more descriptive name
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     return max(0.,1-a/A)/(a+1);
 }
 
 float unitRangeTexCoordToCosSZA(const float texCoord)
 {
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float a=(A-A*texCoord)/(1+A*texCoord);
-    const float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
+    CONST float a=(A-A*texCoord)/(1+A*texCoord);
+    CONST float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
     return distFromGroundToTopAtmoBorder==0 ? 1 :
         clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distFromGroundToTopAtmoBorder)) /
                     (2*earthRadius*distFromGroundToTopAtmoBorder));
@@ -292,24 +303,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
                                                const float dotViewSun, const float altitude,
                                                const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -317,24 +328,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float dotVSCoord=(dotViewSun+1)/2;
+    CONST float dotVSCoord=(dotViewSun+1)/2;
 
     // ------------------------------------
-    const float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
+    CONST float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
 
     return Scattering4DCoords(cosSZACoord, cosVZACoord, dotVSCoord, altCoord, viewRayIntersectsGround);
 }
 
 TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
@@ -342,16 +353,16 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture coordinates we combine into a single sampler3D coordinate.
-    const float texW = scatteringTextureSize[1];
-    const float texH = scatteringTextureSize[2];
-    const float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
-    const vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
+    CONST float texW = scatteringTextureSize[1];
+    CONST float texH = scatteringTextureSize[2];
+    CONST float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
+    CONST vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
                                         ceil (cosSZAIndex)*texW+coords.dotViewSun*(texW-1)) / (texW*texH-1);
-    const vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
+    CONST vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
 
-    const float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
+    CONST float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
 
-    const float alphaUpper=fract(cosSZAIndex);
+    CONST float alphaUpper=fract(cosSZAIndex);
     return TexCoordPair(vec3(cosVZAtc, combinedCoord.x, altitude), float(1-alphaUpper),
                         vec3(cosVZAtc, combinedCoord.y, altitude), float(alphaUpper));
 }
@@ -359,9 +370,9 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
+    CONST TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
     return texture(tex, texCoords.lower) * texCoords.alphaLower +
            texture(tex, texCoords.upper) * texCoords.alphaUpper;
 }
@@ -369,17 +380,17 @@ vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const f
 // 3D texture is the 3D single-altitude slice of a 4D texture
 vec3 scattering4DCoordsToTex3DCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2);
 
-    const float dvsSize = scatteringTextureSize[1];
-    const float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
+    CONST float dvsSize = scatteringTextureSize[1];
+    CONST float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
 
-    const float cszaSize = scatteringTextureSize[2];
-    const float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
+    CONST float cszaSize = scatteringTextureSize[2];
+    CONST float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
 
     return vec3(cosVZAtc, dotVStc, cosSZAtc);
 }
@@ -394,39 +405,39 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along dotViewSun coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[1];
-    const float posOfRow = indices[1];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[1];
+    CONST float posOfRow = indices[1];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         indexToTexCoord(currRow, numRows-1),
                                                         texCoordVerbatim));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               indexToTexCoord(currRow, numRows-1),
                                                               texCoordVerbatim));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          indexToTexCoord(currRow, numRows-1),
                                          texCoordVerbatim));
@@ -434,14 +445,14 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
 vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolationGuides01Tex,
                                  const vec3 indices)
 {
-    const float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
+    CONST float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
 
-    const float cosVZAIndex = indices[0];
-    const float dotVSIndex = indices[1];
-    const float currRow = floor(dotVSIndex);
-    const float posBetweenRows = dotVSIndex - currRow;
-    const float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cosVZAIndex = indices[0];
+    CONST float dotVSIndex = indices[1];
+    CONST float currRow = floor(dotVSIndex);
+    CONST float posBetweenRows = dotVSIndex - currRow;
+    CONST float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -449,14 +460,14 @@ vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolat
     indicesCurrRow[1] =     currRow;
     indicesNextRow[1] = min(currRow+1, scatteringTextureSize[1]-1.);
 
-    const vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
-    const vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
+    CONST vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
+    CONST vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
 
-    const vec4 valueCurrRow = texture(tex, coordsCurrRow);
-    const vec4 valueNextRow = texture(tex, coordsNextRow);
-    const float epsilon = 1e-37; // Prevents passing zero to log
-    const vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
-    const vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
+    CONST vec4 valueCurrRow = texture(tex, coordsCurrRow);
+    CONST vec4 valueNextRow = texture(tex, coordsNextRow);
+    CONST float epsilon = 1e-37; // Prevents passing zero to log
+    CONST vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
+    CONST vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
     return (logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow;
 }
 
@@ -465,37 +476,37 @@ float findGuide02Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along SZA coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[2];
-    const float posOfRow = indices[2];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[2];
+    CONST float posOfRow = indices[2];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
 }
@@ -505,19 +516,19 @@ vec4 sample3DTextureGuided(const sampler3D tex,
                            const float cosSunZenithAngle, const float cosViewZenithAngle,
                            const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
                                                                     dotViewSun, altitude, viewRayIntersectsGround);
     // Handle the external interpolation guides: the guides between a pair of VZA-dotViewSun 2D "pictures".
-    const vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
-    const vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
-    const float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
+    CONST vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
+    CONST float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
 
-    const float cvzaIndex = indices[0];
-    const float cszaIndex = indices[2];
-    const float currRow = floor(cszaIndex);
-    const float posBetweenRows = cszaIndex - currRow;
-    const float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cvzaIndex = indices[0];
+    CONST float cszaIndex = indices[2];
+    CONST float currRow = floor(cszaIndex);
+    CONST float posBetweenRows = cszaIndex - currRow;
+    CONST float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -526,58 +537,58 @@ vec4 sample3DTextureGuided(const sampler3D tex,
     indicesNextRow[2] = min(currRow+1, scatteringTextureSize[2]-1);
 
     // The caller will handle the internal interpolation guides: the ones between rows in each 2D "picture".
-    const vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
-    const vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
+    CONST vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
+    CONST vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
     return exp((logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow);
 }
 
 vec4 sample3DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
     return texture(tex, texCoords);
 }
 
 ScatteringTexVars scatteringTex4DCoordsToTexVars(const Scattering4DCoords coords)
 {
-    const float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
     // ------------------------------------
     float cosViewZenithAngle;
     if(coords.viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
     // ------------------------------------
-    const float dotViewSun=coords.dotViewSun*2-1;
+    CONST float dotViewSun=coords.dotViewSun*2-1;
 
     // ------------------------------------
-    const float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
+    CONST float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
 
     return ScatteringTexVars(cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, coords.viewRayIntersectsGround);
 }
 
 Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 {
-    const vec4 indexMax=scatteringTextureSize-vec4(1);
+    CONST vec4 indexMax=scatteringTextureSize-vec4(1);
     Scattering4DCoords coords4d;
     coords4d.viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
     // The following formulas assume that scatteringTextureSize[0] is even. For odd sizes they would change.
@@ -593,8 +604,8 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture indices we combine into a single sampler3D coordinate.
-    const float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
-    const float combinedIndex=texIndices[1];
+    CONST float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
+    CONST float combinedIndex=texIndices[1];
     coords4d.dotViewSun=mod(combinedIndex,texW)/(texW-1);
     coords4d.cosSunZenithAngle=floor(combinedIndex/texW)/(texH-1);
 
@@ -608,11 +619,11 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
 ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 {
-    const Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
+    CONST Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
     ScatteringTexVars vars=scatteringTex4DCoordsToTexVars(coords4d);
     // Clamp dotViewSun to its valid range of values, given cosViewZenithAngle and cosSunZenithAngle. This is
     // needed to prevent NaNs when computing the scattering texture.
-    const float cosVZA=vars.cosViewZenithAngle,
+    CONST float cosVZA=vars.cosViewZenithAngle,
                 cosSZA=vars.cosSunZenithAngle;
     vars.dotViewSun=clamp(vars.dotViewSun,
                           cosVZA*cosSZA-safeSqrt((1-sqr(cosVZA))*(1-sqr(cosSZA))),
@@ -622,54 +633,54 @@ ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 
 EclipseScatteringTexVars eclipseTexCoordsToTexVars(const vec2 texCoords, const float altitude)
 {
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
-    const bool viewRayIntersectsGround = texCoords.t<0.5;
+    CONST bool viewRayIntersectsGround = texCoords.t<0.5;
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
-    const float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
+    CONST float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
     return EclipseScatteringTexVars(azimuthRelativeToSun, cosViewZenithAngle, viewRayIntersectsGround);
 }
 
 EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                                    const float altitude, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -677,13 +688,13 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
-    const float azimuthCoord = azimuthRelativeToSun/(2*PI);
+    CONST float azimuthCoord = azimuthRelativeToSun/(2*PI);
 
     return EclipseScattering2DCoords(azimuthCoord, cosVZACoord);
 }
@@ -691,14 +702,14 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
 vec2 eclipseTexVarsToTexCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                const float altitude, const bool viewRayIntersectsGround, const vec2 texSize)
 {
-    const EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+    CONST EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                                     viewRayIntersectsGround);
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2);
-    const float azimuthTC = coords.azimuth + 1/(2*texSize.s);
+    CONST float azimuthTC = coords.azimuth + 1/(2*texSize.s);
 
     return vec2(azimuthTC, cosVZAtc);
 }
@@ -707,42 +718,42 @@ vec4 sampleEclipseDoubleScattering3DTexture(const sampler3D tex, const float cos
                                             const float cosViewZenithAngle, const float azimuthRelativeToSun,
                                             const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
+    CONST vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
                                                   eclipsedDoubleScatteringTextureSize.st);
-    const float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
-    const vec3 texCoords=vec3(coords2d, cosSZACoord);
+    CONST float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
+    CONST vec3 texCoords=vec3(coords2d, cosSZACoord);
 
     return texture(tex, texCoords);
 }
 
 LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 texIndices)
 {
-    const vec2 indexMax=lightPollutionTextureSize-vec2(1);
+    CONST vec2 indexMax=lightPollutionTextureSize-vec2(1);
 
-    const float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
-    const float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
+    CONST float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
-    const bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
-    const float cosViewZenithAngleCoord = viewRayIntersectsGround ?
+    CONST bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
+    CONST float cosViewZenithAngleCoord = viewRayIntersectsGround ?
                                    1-2*texIndices[0]/(indexMax[0]-1) :
                                    2*(texIndices[0]-1)/(indexMax[0]-1)-1;
     // ------------------------------------
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
@@ -753,23 +764,23 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 
 LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -777,27 +788,27 @@ LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, con
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     return LightPollution2DCoords(cosVZACoord, altCoord);
 }
 
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
-    const vec2 texSize = lightPollutionTextureSize;
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 texSize = lightPollutionTextureSize;
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2);
-    const float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
+    CONST float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
     return vec2(cosVZAtc, altitudeTC);
 }

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/2/molecules/texture-sampling-functions.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/2/molecules/texture-sampling-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-sampling-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,13 +45,13 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.35000004e-05,1.33100002e-05,9.4
 const vec4 wavelengths=vec4(610.666687,642,673.333313,704.666687);
 const int wlSetIndex=2;
 #endif
-#line 5 0 // texture-sampling-functions.frag
-#line 1 2 // phase-functions.h.glsl
+#line 4 0 // texture-sampling-functions.frag
+#line 1 3 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 6 0 // texture-sampling-functions.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-sampling-functions.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -72,8 +83,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-sampling-functions.frag
-#line 1 4 // texture-coordinates.h.glsl
+#line 6 0 // texture-sampling-functions.frag
+#line 1 5 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -142,7 +153,7 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 8 0 // texture-sampling-functions.frag
+#line 7 0 // texture-sampling-functions.frag
 
 uniform sampler2D transmittanceTexture;
 uniform sampler2D irradianceTexture;
@@ -154,13 +165,13 @@ uniform sampler2D lightPollutionScatteringTexture;
 
 vec4 irradiance(const float cosSunZenithAngle, const float altitude)
 {
-    const vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
+    CONST vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
     return texture(irradianceTexture, texCoords);
 }
 
 vec4 opticalDepthToAtmosphereBorder(const float cosViewZenithAngle, const float altitude)
 {
-    const vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
+    CONST vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact when looking into nadir from TOA at some values of texture sizes (in particular, size of
     // transmittance texture for altitude being 4096). This happens when I simply call texture(eclipsedScatteringTexture,
@@ -178,11 +189,11 @@ vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float
 vec4 transmittance(const float cosViewZenithAngle, const float altitude, const float dist,
                    const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle view ray endpoint
     // in space here.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
 
     vec4 depth;
     if(viewRayIntersectsGround)
@@ -201,7 +212,7 @@ vec4 transmittance(const float cosViewZenithAngle, const float altitude, const f
 vec4 calcFirstScattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                          const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
+    CONST vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
                                           dotViewSun, altitude, viewRayIntersectsGround);
     return scattering*currentPhaseFunction(dotViewSun);
 }
@@ -220,6 +231,6 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
 
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     return texture(lightPollutionScatteringTexture, coords);
 }

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/3/aerosols/common-functions.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/3/aerosols/common-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // common-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // common-functions.frag
+#line 4 0 // common-functions.frag
 
 bool dbgDataPresent=false;
 bool debugDataPresent()
@@ -69,7 +80,7 @@ void setDebugData(float a,float b, float c, float d)
 
 void swap(inout float x, inout float y)
 {
-    const float t = x;
+    CONST float t = x;
     x = y;
     y = t;
 }
@@ -83,7 +94,7 @@ float safeSqrt(const float x)
 
 float safeAtan(const float y, const float x)
 {
-    const float a = atan(y,x);
+    CONST float a = atan(y,x);
     return x==0 && y==0 ? 0 : a;
 }
 
@@ -116,23 +127,23 @@ float pointAltitude(vec3 point)
 
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float Ratm=earthRadius+atmosphereHeight;
-    const float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float Ratm=earthRadius+atmosphereHeight;
+    CONST float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float distanceToGround(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(-safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float cosZenithAngleOfHorizon(const float altitude)
 {
-    const float R=earthRadius;
-    const float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
+    CONST float R=earthRadius;
+    CONST float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
     return -sqrt(2*h*R+sqr(h))/(R+h);
 }
 
@@ -151,8 +162,8 @@ float distanceToNearestAtmosphereBoundary(const float cosZenithAngle, const floa
 float sunVisibility(const float cosSunZenithAngle, float altitude)
 {
     if(altitude<0) altitude=0;
-    const float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
-    const float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
+    CONST float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
+    CONST float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
     /* Approximating visible fraction of solar disk by smoothstep between the position of the Sun
      * touching the horizon by its upper part and the position with lower part touching the horizon.
      * The calculation assumes that solar angular radius is small and thus approximately equals its sine.
@@ -182,13 +193,13 @@ float circlesIntersectionArea(float R1, float R2, float d)
 
 float angleBetween(const vec3 a, const vec3 b)
 {
-    const float d=dot(a,b);
-    const float c=length(cross(a,b));
+    CONST float d=dot(a,b);
+    CONST float c=length(cross(a,b));
     // To avoid loss of precision, don't use dot product near the singularity
     // of acos, and cross product near the singularity of asin
     if(abs(d) < abs(c))
         return acos(d/(length(a)*length(b)));
-    const float smallerAngle = asin(c/(length(a)*length(b)));
+    CONST float smallerAngle = asin(c/(length(a)*length(b)));
     if(d<0) return PI-smallerAngle;
     return smallerAngle;
 }
@@ -205,11 +216,11 @@ float moonAngularRadius(const vec3 cameraPosition, const vec3 moonPosition)
 
 float visibleSolidAngleOfSun(const vec3 camera, const vec3 sunDir, const vec3 moonPos)
 {
-    const float Rs=sunAngularRadius;
-    const float Rm=moonAngularRadius(camera,moonPos);
+    CONST float Rs=sunAngularRadius;
+    CONST float Rm=moonAngularRadius(camera,moonPos);
     float visibleSolidAngle=PI*sqr(Rs);
 
-    const float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
+    CONST float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
     if(dSM<Rs+Rm)
     {
         visibleSolidAngle -= circlesIntersectionArea(Rm,Rs,dSM);
@@ -229,12 +240,12 @@ float sphereIntegrationSolidAngleDifferential(const int pointCountOnSphere)
 }
 vec3 sphereIntegrationSampleDir(const int index, const int pointCountOnSphere)
 {
-    const float goldenRatio=1.6180339887499;
+    CONST float goldenRatio=1.6180339887499;
     // The range of n is 0.5, 1.5, ..., pointCountOnSphere-0.5
-    const float n=index+0.5;
+    CONST float n=index+0.5;
     // Explanation of the Fibonacci grid generation can be seen at https://stackoverflow.com/a/44164075/673852
-    const float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
-    const float azimuth=n*(2*PI*goldenRatio);
+    CONST float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
+    CONST float azimuth=n*(2*PI*goldenRatio);
     return vec3(cos(azimuth)*sin(zenithAngle),
                 sin(azimuth)*sin(zenithAngle),
                 cos(zenithAngle));

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/3/aerosols/compute-eclipsed-single-scattering.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/3/aerosols/compute-eclipsed-single-scattering.frag
@@ -1,7 +1,21 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
 
-#line 1 1 // const.h.glsl
+
+
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 6 0 // compute-eclipsed-single-scattering.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,8 +48,8 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // compute-eclipsed-single-scattering.frag
-#line 1 2 // texture-coordinates.h.glsl
+#line 7 0 // compute-eclipsed-single-scattering.frag
+#line 1 3 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -104,11 +118,11 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 6 0 // compute-eclipsed-single-scattering.frag
-#line 1 3 // radiance-to-luminance.h.glsl
+#line 8 0 // compute-eclipsed-single-scattering.frag
+#line 1 4 // radiance-to-luminance.h.glsl
 const mat4 radianceToLuminance=mat4(19.8756237,7.17745161,0,0.0937032327,  2.13895917,0.772417068,0,0.0149318045,  0.241072536,0.0870557055,0,0,  0.0133876652,0.00483453181,0,0);
-#line 7 0 // compute-eclipsed-single-scattering.frag
-#line 1 4 // single-scattering-eclipsed.h.glsl
+#line 9 0 // compute-eclipsed-single-scattering.frag
+#line 1 5 // single-scattering-eclipsed.h.glsl
 #ifndef INCLUDE_ONCE_050024D2_BD56_434E_8D40_2055DA0B78EC
 #define INCLUDE_ONCE_050024D2_BD56_434E_8D40_2055DA0B78EC
 
@@ -116,7 +130,7 @@ vec4 computeSingleScatteringEclipsed(const vec3 camera, const vec3 viewDir, cons
                                      const bool viewRayIntersectsGround);
 
 #endif
-#line 8 0 // compute-eclipsed-single-scattering.frag
+#line 10 0 // compute-eclipsed-single-scattering.frag
 
 in vec3 position;
 out vec4 scatteringTextureOutput;
@@ -132,16 +146,16 @@ vec4 solarRadiance()
 
 void main()
 {
-    const EclipseScatteringTexVars texVars=eclipseTexCoordsToTexVars(gl_FragCoord.xy/eclipsedSingleScatteringTextureSize, altitude);
-    const float sinViewZenithAngle=sqrt(1-sqr(texVars.cosViewZenithAngle));
-    const vec3 viewDir=vec3(cos(texVars.azimuthRelativeToSun)*sinViewZenithAngle,
+    CONST EclipseScatteringTexVars texVars=eclipseTexCoordsToTexVars(gl_FragCoord.xy/eclipsedSingleScatteringTextureSize, altitude);
+    CONST float sinViewZenithAngle=sqrt(1-sqr(texVars.cosViewZenithAngle));
+    CONST vec3 viewDir=vec3(cos(texVars.azimuthRelativeToSun)*sinViewZenithAngle,
                             sin(texVars.azimuthRelativeToSun)*sinViewZenithAngle,
                             texVars.cosViewZenithAngle);
-    const vec3 cameraPosition=vec3(0,0,altitude);
-    const vec3 sunDirection=vec3(sin(sunZenithAngle), 0, cos(sunZenithAngle));
-    const vec4 radiance=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPositionRelativeToSunAzimuth,
+    CONST vec3 cameraPosition=vec3(0,0,altitude);
+    CONST vec3 sunDirection=vec3(sin(sunZenithAngle), 0, cos(sunZenithAngle));
+    CONST vec4 radiance=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPositionRelativeToSunAzimuth,
                                                         texVars.viewRayIntersectsGround);
-#if COMPUTE_RADIANCE
+#if 0 /*COMPUTE_RADIANCE*/
     scatteringTextureOutput=radiance;
 #elif 1 /*COMPUTE_LUMINANCE*/
     scatteringTextureOutput=radianceToLuminance*radiance;

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/3/aerosols/densities.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/3/aerosols/densities.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // densities.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,20 +45,20 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // densities.frag
+#line 4 0 // densities.frag
 float scattererNumberDensity_molecules(float altitude)
 {
-        const float rayleighScaleHeight=8*km;
+        CONST float rayleighScaleHeight=8*km;
         return 3.08458e25*exp(-1/rayleighScaleHeight * altitude);
 }
 float scattererNumberDensity_aerosols(float altitude)
 {
-        const float mieScaleHeight=1.2*km;
+        CONST float mieScaleHeight=1.2*km;
         return 1.03333e8*exp(-1/mieScaleHeight*altitude);
 }
 float absorberNumberDensity_ozone(float altitude)
 {
-        const float totalOzoneAmount=370*dobsonUnit;
+        CONST float totalOzoneAmount=370*dobsonUnit;
 
         float density;
 

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/3/aerosols/phase-functions.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/3/aerosols/phase-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // phase-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // phase-functions.frag
+#line 4 0 // phase-functions.frag
 
 vec4 phaseFunction_molecules(float dotViewSun)
 {
@@ -42,9 +53,9 @@ vec4 phaseFunction_molecules(float dotViewSun)
 }
 vec4 phaseFunction_aerosols(float dotViewSun)
 {
-        const float g=0.76;
-        const float g2=g*g;
-        const float k = 3/(8*PI)*(1-g2)/(2+g2);
+        CONST float g=0.76;
+        CONST float g2=g*g;
+        CONST float k = 3/(8*PI)*(1-g2)/(2+g2);
         return vec4(k * (1+sqr(dotViewSun)) / pow(1+g2 - 2*g*dotViewSun, 1.5) + 1/((1-dotViewSun)*600+0.05))*0.904;
 }
 vec4 currentPhaseFunction(float dotViewSun) { return phaseFunction_aerosols(dotViewSun); }

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/3/aerosols/single-scattering-eclipsed.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/3/aerosols/single-scattering-eclipsed.frag
@@ -1,7 +1,21 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
 
-#line 1 1 // const.h.glsl
+
+
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 6 0 // single-scattering-eclipsed.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,15 +48,15 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // single-scattering-eclipsed.frag
-#line 1 2 // densities.h.glsl
+#line 7 0 // single-scattering-eclipsed.frag
+#line 1 3 // densities.h.glsl
 float scattererNumberDensity_molecules(float altitude);
 float scattererNumberDensity_aerosols(float altitude);
 float absorberNumberDensity_ozone(float altitude);
 vec4 scatteringCrossSection();
 float scattererDensity(float altitude);
-#line 6 0 // single-scattering-eclipsed.frag
-#line 1 3 // common-functions.h.glsl
+#line 8 0 // single-scattering-eclipsed.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -74,8 +88,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // single-scattering-eclipsed.frag
-#line 1 4 // texture-sampling-functions.h.glsl
+#line 9 0 // single-scattering-eclipsed.frag
+#line 1 5 // texture-sampling-functions.h.glsl
 #ifndef INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 #define INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float altitude);
@@ -87,7 +101,7 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                 const int scatteringOrder);
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 #endif
-#line 8 0 // single-scattering-eclipsed.frag
+#line 10 0 // single-scattering-eclipsed.frag
 
 
 float cosZenithAngle(vec3 origin, vec3 direction)
@@ -101,13 +115,13 @@ vec4 computeSingleScatteringIntegrandEclipsed(const float cosSunZenithAngle, con
                                               const float dist, const bool viewRayIntersectsGround,
                                               const vec3 scatterer, const vec3 sunDir, const vec3 moonPos)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle here the case when the
     // endpoint of the view ray intentionally appears in outer space.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosSunZenithAngleAtDist=clampCosine((r*cosSunZenithAngle+dist*dotViewSun)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosSunZenithAngleAtDist=clampCosine((r*cosSunZenithAngle+dist*dotViewSun)/(earthRadius+altAtDist));
 
-    const vec4 xmittance=transmittance(cosViewZenithAngle, altitude, dist, viewRayIntersectsGround)
+    CONST vec4 xmittance=transmittance(cosViewZenithAngle, altitude, dist, viewRayIntersectsGround)
                                                     *
                          transmittanceToAtmosphereBorder(cosSunZenithAngleAtDist, altAtDist)
                                                     *
@@ -115,7 +129,7 @@ vec4 computeSingleScatteringIntegrandEclipsed(const float cosSunZenithAngle, con
                                                     *
                             // FIXME: this ignores orientation of the crescent of eclipsed Sun WRT horizon
                                     sunVisibility(cosSunZenithAngleAtDist, altAtDist);
-#if ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION
+#if 0 /*ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION*/
     COMPUTE_TOTAL_SCATTERING_COEFFICIENT;
     return xmittance * totalScatteringCoefficient;
 #else
@@ -126,26 +140,26 @@ vec4 computeSingleScatteringIntegrandEclipsed(const float cosSunZenithAngle, con
 vec4 computeSingleScatteringEclipsed(const vec3 camera, const vec3 viewDir, const vec3 sunDir, const vec3 moonPos,
                                      const bool viewRayIntersectsGround)
 {
-    const float cosViewZenithAngle=cosZenithAngle(camera,viewDir);
-    const float cosSunZenithAngle=cosZenithAngle(camera,sunDir);
-    const float altitude=pointAltitude(camera);
-    const float dotViewSun=dot(viewDir,sunDir);
-    const float integrInterval=distanceToNearestAtmosphereBoundary(cosViewZenithAngle, altitude,
+    CONST float cosViewZenithAngle=cosZenithAngle(camera,viewDir);
+    CONST float cosSunZenithAngle=cosZenithAngle(camera,sunDir);
+    CONST float altitude=pointAltitude(camera);
+    CONST float dotViewSun=dot(viewDir,sunDir);
+    CONST float integrInterval=distanceToNearestAtmosphereBoundary(cosViewZenithAngle, altitude,
                                                                    viewRayIntersectsGround);
 
     // Using the midpoint rule for quadrature
     vec4 spectrum=vec4(0);
-    const float dl=integrInterval/radialIntegrationPoints;
+    CONST float dl=integrInterval/radialIntegrationPoints;
     for(int n=0; n<radialIntegrationPoints; ++n)
     {
-        const float dist=(n+0.5)*dl;
+        CONST float dist=(n+0.5)*dl;
         spectrum += computeSingleScatteringIntegrandEclipsed(cosSunZenithAngle, cosViewZenithAngle, dotViewSun,
                                                              altitude, dist, viewRayIntersectsGround,
                                                              camera+viewDir*dist, sunDir, moonPos);
     }
 
     spectrum *= dl*solarIrradianceAtTOA
-#if ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION
+#if 0 /*ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION*/
                                 // the multiplier is already included
 #else
                                         * scatteringCrossSection()

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/3/aerosols/texture-coordinates.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/3/aerosols/texture-coordinates.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-coordinates.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,8 +45,8 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // texture-coordinates.frag
-#line 1 2 // texture-coordinates.h.glsl
+#line 4 0 // texture-coordinates.frag
+#line 1 3 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -104,8 +115,8 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 6 0 // texture-coordinates.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-coordinates.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -137,7 +148,7 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-coordinates.frag
+#line 6 0 // texture-coordinates.frag
 
 const float LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA=sqrt(atmosphereHeight*(atmosphereHeight+2*earthRadius));
 
@@ -205,18 +216,18 @@ vec3 indicesToTexCoords(const vec3 indices, const vec3 texSizes)
 
 TransmittanceTexVars transmittanceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
+    CONST float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
                                 texCoordToUnitRange(texCoord.t,transmittanceTextureSize.t);
     // Distance from Earth center to camera
-    const float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
-    const float altitude=r-earthRadius;
+    CONST float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
+    CONST float altitude=r-earthRadius;
 
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
     // distance to border of visible atmosphere from the view point
-    const float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
+    CONST float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
     // d==0 can happen when altitude==atmosphereHeight
-    const float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
+    CONST float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
     return TransmittanceTexVars(cosVZA,altitude);
 }
 
@@ -235,53 +246,53 @@ vec2 transmittanceTexVarsToTexCoord(const float cosVZA, float altitude)
     if(altitude<0)
         altitude=0;
 
-    const float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
+    CONST float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
                                       transmittanceTextureSize.t);
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
-    const float d=distanceToAtmosphereBorder(cosVZA,altitude);
-    const float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float d=distanceToAtmosphereBorder(cosVZA,altitude);
+    CONST float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
     return vec2(s,t);
 }
 
 // Output: vec2(cos(sunZenithAngle), altitude)
 IrradianceTexVars irradianceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
-    const float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
+    CONST float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
+    CONST float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
     return IrradianceTexVars(cosSZA,alt);
 }
 
 vec2 irradianceTexVarsToTexCoord(const float cosSunZenithAngle, const float altitude)
 {
-    const float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
-    const float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
+    CONST float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
+    CONST float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
     return vec2(s,t);
 }
 
 float cosSZAToUnitRangeTexCoord(const float cosSunZenithAngle)
 {
     // Distance to top atmosphere border along the ray groundUnderCamera-sun: (altitude, cosSunZenithAngle)
-    const float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name
-    const float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
+    CONST float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
     // TODO: choose a more descriptive name
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     return max(0.,1-a/A)/(a+1);
 }
 
 float unitRangeTexCoordToCosSZA(const float texCoord)
 {
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float a=(A-A*texCoord)/(1+A*texCoord);
-    const float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
+    CONST float a=(A-A*texCoord)/(1+A*texCoord);
+    CONST float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
     return distFromGroundToTopAtmoBorder==0 ? 1 :
         clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distFromGroundToTopAtmoBorder)) /
                     (2*earthRadius*distFromGroundToTopAtmoBorder));
@@ -292,24 +303,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
                                                const float dotViewSun, const float altitude,
                                                const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -317,24 +328,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float dotVSCoord=(dotViewSun+1)/2;
+    CONST float dotVSCoord=(dotViewSun+1)/2;
 
     // ------------------------------------
-    const float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
+    CONST float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
 
     return Scattering4DCoords(cosSZACoord, cosVZACoord, dotVSCoord, altCoord, viewRayIntersectsGround);
 }
 
 TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
@@ -342,16 +353,16 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture coordinates we combine into a single sampler3D coordinate.
-    const float texW = scatteringTextureSize[1];
-    const float texH = scatteringTextureSize[2];
-    const float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
-    const vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
+    CONST float texW = scatteringTextureSize[1];
+    CONST float texH = scatteringTextureSize[2];
+    CONST float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
+    CONST vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
                                         ceil (cosSZAIndex)*texW+coords.dotViewSun*(texW-1)) / (texW*texH-1);
-    const vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
+    CONST vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
 
-    const float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
+    CONST float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
 
-    const float alphaUpper=fract(cosSZAIndex);
+    CONST float alphaUpper=fract(cosSZAIndex);
     return TexCoordPair(vec3(cosVZAtc, combinedCoord.x, altitude), float(1-alphaUpper),
                         vec3(cosVZAtc, combinedCoord.y, altitude), float(alphaUpper));
 }
@@ -359,9 +370,9 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
+    CONST TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
     return texture(tex, texCoords.lower) * texCoords.alphaLower +
            texture(tex, texCoords.upper) * texCoords.alphaUpper;
 }
@@ -369,17 +380,17 @@ vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const f
 // 3D texture is the 3D single-altitude slice of a 4D texture
 vec3 scattering4DCoordsToTex3DCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2);
 
-    const float dvsSize = scatteringTextureSize[1];
-    const float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
+    CONST float dvsSize = scatteringTextureSize[1];
+    CONST float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
 
-    const float cszaSize = scatteringTextureSize[2];
-    const float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
+    CONST float cszaSize = scatteringTextureSize[2];
+    CONST float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
 
     return vec3(cosVZAtc, dotVStc, cosSZAtc);
 }
@@ -394,39 +405,39 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along dotViewSun coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[1];
-    const float posOfRow = indices[1];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[1];
+    CONST float posOfRow = indices[1];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         indexToTexCoord(currRow, numRows-1),
                                                         texCoordVerbatim));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               indexToTexCoord(currRow, numRows-1),
                                                               texCoordVerbatim));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          indexToTexCoord(currRow, numRows-1),
                                          texCoordVerbatim));
@@ -434,14 +445,14 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
 vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolationGuides01Tex,
                                  const vec3 indices)
 {
-    const float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
+    CONST float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
 
-    const float cosVZAIndex = indices[0];
-    const float dotVSIndex = indices[1];
-    const float currRow = floor(dotVSIndex);
-    const float posBetweenRows = dotVSIndex - currRow;
-    const float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cosVZAIndex = indices[0];
+    CONST float dotVSIndex = indices[1];
+    CONST float currRow = floor(dotVSIndex);
+    CONST float posBetweenRows = dotVSIndex - currRow;
+    CONST float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -449,14 +460,14 @@ vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolat
     indicesCurrRow[1] =     currRow;
     indicesNextRow[1] = min(currRow+1, scatteringTextureSize[1]-1.);
 
-    const vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
-    const vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
+    CONST vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
+    CONST vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
 
-    const vec4 valueCurrRow = texture(tex, coordsCurrRow);
-    const vec4 valueNextRow = texture(tex, coordsNextRow);
-    const float epsilon = 1e-37; // Prevents passing zero to log
-    const vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
-    const vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
+    CONST vec4 valueCurrRow = texture(tex, coordsCurrRow);
+    CONST vec4 valueNextRow = texture(tex, coordsNextRow);
+    CONST float epsilon = 1e-37; // Prevents passing zero to log
+    CONST vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
+    CONST vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
     return (logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow;
 }
 
@@ -465,37 +476,37 @@ float findGuide02Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along SZA coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[2];
-    const float posOfRow = indices[2];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[2];
+    CONST float posOfRow = indices[2];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
 }
@@ -505,19 +516,19 @@ vec4 sample3DTextureGuided(const sampler3D tex,
                            const float cosSunZenithAngle, const float cosViewZenithAngle,
                            const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
                                                                     dotViewSun, altitude, viewRayIntersectsGround);
     // Handle the external interpolation guides: the guides between a pair of VZA-dotViewSun 2D "pictures".
-    const vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
-    const vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
-    const float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
+    CONST vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
+    CONST float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
 
-    const float cvzaIndex = indices[0];
-    const float cszaIndex = indices[2];
-    const float currRow = floor(cszaIndex);
-    const float posBetweenRows = cszaIndex - currRow;
-    const float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cvzaIndex = indices[0];
+    CONST float cszaIndex = indices[2];
+    CONST float currRow = floor(cszaIndex);
+    CONST float posBetweenRows = cszaIndex - currRow;
+    CONST float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -526,58 +537,58 @@ vec4 sample3DTextureGuided(const sampler3D tex,
     indicesNextRow[2] = min(currRow+1, scatteringTextureSize[2]-1);
 
     // The caller will handle the internal interpolation guides: the ones between rows in each 2D "picture".
-    const vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
-    const vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
+    CONST vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
+    CONST vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
     return exp((logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow);
 }
 
 vec4 sample3DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
     return texture(tex, texCoords);
 }
 
 ScatteringTexVars scatteringTex4DCoordsToTexVars(const Scattering4DCoords coords)
 {
-    const float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
     // ------------------------------------
     float cosViewZenithAngle;
     if(coords.viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
     // ------------------------------------
-    const float dotViewSun=coords.dotViewSun*2-1;
+    CONST float dotViewSun=coords.dotViewSun*2-1;
 
     // ------------------------------------
-    const float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
+    CONST float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
 
     return ScatteringTexVars(cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, coords.viewRayIntersectsGround);
 }
 
 Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 {
-    const vec4 indexMax=scatteringTextureSize-vec4(1);
+    CONST vec4 indexMax=scatteringTextureSize-vec4(1);
     Scattering4DCoords coords4d;
     coords4d.viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
     // The following formulas assume that scatteringTextureSize[0] is even. For odd sizes they would change.
@@ -593,8 +604,8 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture indices we combine into a single sampler3D coordinate.
-    const float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
-    const float combinedIndex=texIndices[1];
+    CONST float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
+    CONST float combinedIndex=texIndices[1];
     coords4d.dotViewSun=mod(combinedIndex,texW)/(texW-1);
     coords4d.cosSunZenithAngle=floor(combinedIndex/texW)/(texH-1);
 
@@ -608,11 +619,11 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
 ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 {
-    const Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
+    CONST Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
     ScatteringTexVars vars=scatteringTex4DCoordsToTexVars(coords4d);
     // Clamp dotViewSun to its valid range of values, given cosViewZenithAngle and cosSunZenithAngle. This is
     // needed to prevent NaNs when computing the scattering texture.
-    const float cosVZA=vars.cosViewZenithAngle,
+    CONST float cosVZA=vars.cosViewZenithAngle,
                 cosSZA=vars.cosSunZenithAngle;
     vars.dotViewSun=clamp(vars.dotViewSun,
                           cosVZA*cosSZA-safeSqrt((1-sqr(cosVZA))*(1-sqr(cosSZA))),
@@ -622,54 +633,54 @@ ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 
 EclipseScatteringTexVars eclipseTexCoordsToTexVars(const vec2 texCoords, const float altitude)
 {
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
-    const bool viewRayIntersectsGround = texCoords.t<0.5;
+    CONST bool viewRayIntersectsGround = texCoords.t<0.5;
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
-    const float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
+    CONST float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
     return EclipseScatteringTexVars(azimuthRelativeToSun, cosViewZenithAngle, viewRayIntersectsGround);
 }
 
 EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                                    const float altitude, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -677,13 +688,13 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
-    const float azimuthCoord = azimuthRelativeToSun/(2*PI);
+    CONST float azimuthCoord = azimuthRelativeToSun/(2*PI);
 
     return EclipseScattering2DCoords(azimuthCoord, cosVZACoord);
 }
@@ -691,14 +702,14 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
 vec2 eclipseTexVarsToTexCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                const float altitude, const bool viewRayIntersectsGround, const vec2 texSize)
 {
-    const EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+    CONST EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                                     viewRayIntersectsGround);
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2);
-    const float azimuthTC = coords.azimuth + 1/(2*texSize.s);
+    CONST float azimuthTC = coords.azimuth + 1/(2*texSize.s);
 
     return vec2(azimuthTC, cosVZAtc);
 }
@@ -707,42 +718,42 @@ vec4 sampleEclipseDoubleScattering3DTexture(const sampler3D tex, const float cos
                                             const float cosViewZenithAngle, const float azimuthRelativeToSun,
                                             const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
+    CONST vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
                                                   eclipsedDoubleScatteringTextureSize.st);
-    const float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
-    const vec3 texCoords=vec3(coords2d, cosSZACoord);
+    CONST float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
+    CONST vec3 texCoords=vec3(coords2d, cosSZACoord);
 
     return texture(tex, texCoords);
 }
 
 LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 texIndices)
 {
-    const vec2 indexMax=lightPollutionTextureSize-vec2(1);
+    CONST vec2 indexMax=lightPollutionTextureSize-vec2(1);
 
-    const float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
-    const float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
+    CONST float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
-    const bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
-    const float cosViewZenithAngleCoord = viewRayIntersectsGround ?
+    CONST bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
+    CONST float cosViewZenithAngleCoord = viewRayIntersectsGround ?
                                    1-2*texIndices[0]/(indexMax[0]-1) :
                                    2*(texIndices[0]-1)/(indexMax[0]-1)-1;
     // ------------------------------------
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
@@ -753,23 +764,23 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 
 LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -777,27 +788,27 @@ LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, con
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     return LightPollution2DCoords(cosVZACoord, altCoord);
 }
 
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
-    const vec2 texSize = lightPollutionTextureSize;
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 texSize = lightPollutionTextureSize;
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2);
-    const float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
+    CONST float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
     return vec2(cosVZAtc, altitudeTC);
 }

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/3/aerosols/texture-sampling-functions.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/3/aerosols/texture-sampling-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-sampling-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,13 +45,13 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // texture-sampling-functions.frag
-#line 1 2 // phase-functions.h.glsl
+#line 4 0 // texture-sampling-functions.frag
+#line 1 3 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 6 0 // texture-sampling-functions.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-sampling-functions.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -72,8 +83,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-sampling-functions.frag
-#line 1 4 // texture-coordinates.h.glsl
+#line 6 0 // texture-sampling-functions.frag
+#line 1 5 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -142,7 +153,7 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 8 0 // texture-sampling-functions.frag
+#line 7 0 // texture-sampling-functions.frag
 
 uniform sampler2D transmittanceTexture;
 uniform sampler2D irradianceTexture;
@@ -154,13 +165,13 @@ uniform sampler2D lightPollutionScatteringTexture;
 
 vec4 irradiance(const float cosSunZenithAngle, const float altitude)
 {
-    const vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
+    CONST vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
     return texture(irradianceTexture, texCoords);
 }
 
 vec4 opticalDepthToAtmosphereBorder(const float cosViewZenithAngle, const float altitude)
 {
-    const vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
+    CONST vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact when looking into nadir from TOA at some values of texture sizes (in particular, size of
     // transmittance texture for altitude being 4096). This happens when I simply call texture(eclipsedScatteringTexture,
@@ -178,11 +189,11 @@ vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float
 vec4 transmittance(const float cosViewZenithAngle, const float altitude, const float dist,
                    const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle view ray endpoint
     // in space here.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
 
     vec4 depth;
     if(viewRayIntersectsGround)
@@ -201,7 +212,7 @@ vec4 transmittance(const float cosViewZenithAngle, const float altitude, const f
 vec4 calcFirstScattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                          const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
+    CONST vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
                                           dotViewSun, altitude, viewRayIntersectsGround);
     return scattering*currentPhaseFunction(dotViewSun);
 }
@@ -220,6 +231,6 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
 
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     return texture(lightPollutionScatteringTexture, coords);
 }

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/3/molecules/common-functions.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/3/molecules/common-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // common-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // common-functions.frag
+#line 4 0 // common-functions.frag
 
 bool dbgDataPresent=false;
 bool debugDataPresent()
@@ -69,7 +80,7 @@ void setDebugData(float a,float b, float c, float d)
 
 void swap(inout float x, inout float y)
 {
-    const float t = x;
+    CONST float t = x;
     x = y;
     y = t;
 }
@@ -83,7 +94,7 @@ float safeSqrt(const float x)
 
 float safeAtan(const float y, const float x)
 {
-    const float a = atan(y,x);
+    CONST float a = atan(y,x);
     return x==0 && y==0 ? 0 : a;
 }
 
@@ -116,23 +127,23 @@ float pointAltitude(vec3 point)
 
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float Ratm=earthRadius+atmosphereHeight;
-    const float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float Ratm=earthRadius+atmosphereHeight;
+    CONST float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float distanceToGround(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(-safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float cosZenithAngleOfHorizon(const float altitude)
 {
-    const float R=earthRadius;
-    const float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
+    CONST float R=earthRadius;
+    CONST float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
     return -sqrt(2*h*R+sqr(h))/(R+h);
 }
 
@@ -151,8 +162,8 @@ float distanceToNearestAtmosphereBoundary(const float cosZenithAngle, const floa
 float sunVisibility(const float cosSunZenithAngle, float altitude)
 {
     if(altitude<0) altitude=0;
-    const float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
-    const float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
+    CONST float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
+    CONST float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
     /* Approximating visible fraction of solar disk by smoothstep between the position of the Sun
      * touching the horizon by its upper part and the position with lower part touching the horizon.
      * The calculation assumes that solar angular radius is small and thus approximately equals its sine.
@@ -182,13 +193,13 @@ float circlesIntersectionArea(float R1, float R2, float d)
 
 float angleBetween(const vec3 a, const vec3 b)
 {
-    const float d=dot(a,b);
-    const float c=length(cross(a,b));
+    CONST float d=dot(a,b);
+    CONST float c=length(cross(a,b));
     // To avoid loss of precision, don't use dot product near the singularity
     // of acos, and cross product near the singularity of asin
     if(abs(d) < abs(c))
         return acos(d/(length(a)*length(b)));
-    const float smallerAngle = asin(c/(length(a)*length(b)));
+    CONST float smallerAngle = asin(c/(length(a)*length(b)));
     if(d<0) return PI-smallerAngle;
     return smallerAngle;
 }
@@ -205,11 +216,11 @@ float moonAngularRadius(const vec3 cameraPosition, const vec3 moonPosition)
 
 float visibleSolidAngleOfSun(const vec3 camera, const vec3 sunDir, const vec3 moonPos)
 {
-    const float Rs=sunAngularRadius;
-    const float Rm=moonAngularRadius(camera,moonPos);
+    CONST float Rs=sunAngularRadius;
+    CONST float Rm=moonAngularRadius(camera,moonPos);
     float visibleSolidAngle=PI*sqr(Rs);
 
-    const float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
+    CONST float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
     if(dSM<Rs+Rm)
     {
         visibleSolidAngle -= circlesIntersectionArea(Rm,Rs,dSM);
@@ -229,12 +240,12 @@ float sphereIntegrationSolidAngleDifferential(const int pointCountOnSphere)
 }
 vec3 sphereIntegrationSampleDir(const int index, const int pointCountOnSphere)
 {
-    const float goldenRatio=1.6180339887499;
+    CONST float goldenRatio=1.6180339887499;
     // The range of n is 0.5, 1.5, ..., pointCountOnSphere-0.5
-    const float n=index+0.5;
+    CONST float n=index+0.5;
     // Explanation of the Fibonacci grid generation can be seen at https://stackoverflow.com/a/44164075/673852
-    const float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
-    const float azimuth=n*(2*PI*goldenRatio);
+    CONST float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
+    CONST float azimuth=n*(2*PI*goldenRatio);
     return vec3(cos(azimuth)*sin(zenithAngle),
                 sin(azimuth)*sin(zenithAngle),
                 cos(zenithAngle));

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/3/molecules/compute-eclipsed-single-scattering.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/3/molecules/compute-eclipsed-single-scattering.frag
@@ -1,7 +1,21 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
 
-#line 1 1 // const.h.glsl
+
+
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 6 0 // compute-eclipsed-single-scattering.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,8 +48,8 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // compute-eclipsed-single-scattering.frag
-#line 1 2 // texture-coordinates.h.glsl
+#line 7 0 // compute-eclipsed-single-scattering.frag
+#line 1 3 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -104,11 +118,11 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 6 0 // compute-eclipsed-single-scattering.frag
-#line 1 3 // radiance-to-luminance.h.glsl
+#line 8 0 // compute-eclipsed-single-scattering.frag
+#line 1 4 // radiance-to-luminance.h.glsl
 const mat4 radianceToLuminance=mat4(19.8756237,7.17745161,0,0.0937032327,  2.13895917,0.772417068,0,0.0149318045,  0.241072536,0.0870557055,0,0,  0.0133876652,0.00483453181,0,0);
-#line 7 0 // compute-eclipsed-single-scattering.frag
-#line 1 4 // single-scattering-eclipsed.h.glsl
+#line 9 0 // compute-eclipsed-single-scattering.frag
+#line 1 5 // single-scattering-eclipsed.h.glsl
 #ifndef INCLUDE_ONCE_050024D2_BD56_434E_8D40_2055DA0B78EC
 #define INCLUDE_ONCE_050024D2_BD56_434E_8D40_2055DA0B78EC
 
@@ -116,7 +130,7 @@ vec4 computeSingleScatteringEclipsed(const vec3 camera, const vec3 viewDir, cons
                                      const bool viewRayIntersectsGround);
 
 #endif
-#line 8 0 // compute-eclipsed-single-scattering.frag
+#line 10 0 // compute-eclipsed-single-scattering.frag
 
 in vec3 position;
 out vec4 scatteringTextureOutput;
@@ -132,16 +146,16 @@ vec4 solarRadiance()
 
 void main()
 {
-    const EclipseScatteringTexVars texVars=eclipseTexCoordsToTexVars(gl_FragCoord.xy/eclipsedSingleScatteringTextureSize, altitude);
-    const float sinViewZenithAngle=sqrt(1-sqr(texVars.cosViewZenithAngle));
-    const vec3 viewDir=vec3(cos(texVars.azimuthRelativeToSun)*sinViewZenithAngle,
+    CONST EclipseScatteringTexVars texVars=eclipseTexCoordsToTexVars(gl_FragCoord.xy/eclipsedSingleScatteringTextureSize, altitude);
+    CONST float sinViewZenithAngle=sqrt(1-sqr(texVars.cosViewZenithAngle));
+    CONST vec3 viewDir=vec3(cos(texVars.azimuthRelativeToSun)*sinViewZenithAngle,
                             sin(texVars.azimuthRelativeToSun)*sinViewZenithAngle,
                             texVars.cosViewZenithAngle);
-    const vec3 cameraPosition=vec3(0,0,altitude);
-    const vec3 sunDirection=vec3(sin(sunZenithAngle), 0, cos(sunZenithAngle));
-    const vec4 radiance=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPositionRelativeToSunAzimuth,
+    CONST vec3 cameraPosition=vec3(0,0,altitude);
+    CONST vec3 sunDirection=vec3(sin(sunZenithAngle), 0, cos(sunZenithAngle));
+    CONST vec4 radiance=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPositionRelativeToSunAzimuth,
                                                         texVars.viewRayIntersectsGround);
-#if COMPUTE_RADIANCE
+#if 0 /*COMPUTE_RADIANCE*/
     scatteringTextureOutput=radiance;
 #elif 1 /*COMPUTE_LUMINANCE*/
     scatteringTextureOutput=radianceToLuminance*radiance;

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/3/molecules/densities.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/3/molecules/densities.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // densities.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,20 +45,20 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // densities.frag
+#line 4 0 // densities.frag
 float scattererNumberDensity_molecules(float altitude)
 {
-        const float rayleighScaleHeight=8*km;
+        CONST float rayleighScaleHeight=8*km;
         return 3.08458e25*exp(-1/rayleighScaleHeight * altitude);
 }
 float scattererNumberDensity_aerosols(float altitude)
 {
-        const float mieScaleHeight=1.2*km;
+        CONST float mieScaleHeight=1.2*km;
         return 1.03333e8*exp(-1/mieScaleHeight*altitude);
 }
 float absorberNumberDensity_ozone(float altitude)
 {
-        const float totalOzoneAmount=370*dobsonUnit;
+        CONST float totalOzoneAmount=370*dobsonUnit;
 
         float density;
 

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/3/molecules/phase-functions.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/3/molecules/phase-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // phase-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // phase-functions.frag
+#line 4 0 // phase-functions.frag
 
 vec4 phaseFunction_molecules(float dotViewSun)
 {
@@ -42,9 +53,9 @@ vec4 phaseFunction_molecules(float dotViewSun)
 }
 vec4 phaseFunction_aerosols(float dotViewSun)
 {
-        const float g=0.76;
-        const float g2=g*g;
-        const float k = 3/(8*PI)*(1-g2)/(2+g2);
+        CONST float g=0.76;
+        CONST float g2=g*g;
+        CONST float k = 3/(8*PI)*(1-g2)/(2+g2);
         return vec4(k * (1+sqr(dotViewSun)) / pow(1+g2 - 2*g*dotViewSun, 1.5) + 1/((1-dotViewSun)*600+0.05))*0.904;
 }
 vec4 currentPhaseFunction(float dotViewSun) { return phaseFunction_molecules(dotViewSun); }

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/3/molecules/single-scattering-eclipsed.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/3/molecules/single-scattering-eclipsed.frag
@@ -1,7 +1,21 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
 
-#line 1 1 // const.h.glsl
+
+
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 6 0 // single-scattering-eclipsed.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,15 +48,15 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // single-scattering-eclipsed.frag
-#line 1 2 // densities.h.glsl
+#line 7 0 // single-scattering-eclipsed.frag
+#line 1 3 // densities.h.glsl
 float scattererNumberDensity_molecules(float altitude);
 float scattererNumberDensity_aerosols(float altitude);
 float absorberNumberDensity_ozone(float altitude);
 vec4 scatteringCrossSection();
 float scattererDensity(float altitude);
-#line 6 0 // single-scattering-eclipsed.frag
-#line 1 3 // common-functions.h.glsl
+#line 8 0 // single-scattering-eclipsed.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -74,8 +88,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // single-scattering-eclipsed.frag
-#line 1 4 // texture-sampling-functions.h.glsl
+#line 9 0 // single-scattering-eclipsed.frag
+#line 1 5 // texture-sampling-functions.h.glsl
 #ifndef INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 #define INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float altitude);
@@ -87,7 +101,7 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                 const int scatteringOrder);
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 #endif
-#line 8 0 // single-scattering-eclipsed.frag
+#line 10 0 // single-scattering-eclipsed.frag
 
 
 float cosZenithAngle(vec3 origin, vec3 direction)
@@ -101,13 +115,13 @@ vec4 computeSingleScatteringIntegrandEclipsed(const float cosSunZenithAngle, con
                                               const float dist, const bool viewRayIntersectsGround,
                                               const vec3 scatterer, const vec3 sunDir, const vec3 moonPos)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle here the case when the
     // endpoint of the view ray intentionally appears in outer space.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosSunZenithAngleAtDist=clampCosine((r*cosSunZenithAngle+dist*dotViewSun)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosSunZenithAngleAtDist=clampCosine((r*cosSunZenithAngle+dist*dotViewSun)/(earthRadius+altAtDist));
 
-    const vec4 xmittance=transmittance(cosViewZenithAngle, altitude, dist, viewRayIntersectsGround)
+    CONST vec4 xmittance=transmittance(cosViewZenithAngle, altitude, dist, viewRayIntersectsGround)
                                                     *
                          transmittanceToAtmosphereBorder(cosSunZenithAngleAtDist, altAtDist)
                                                     *
@@ -115,7 +129,7 @@ vec4 computeSingleScatteringIntegrandEclipsed(const float cosSunZenithAngle, con
                                                     *
                             // FIXME: this ignores orientation of the crescent of eclipsed Sun WRT horizon
                                     sunVisibility(cosSunZenithAngleAtDist, altAtDist);
-#if ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION
+#if 0 /*ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION*/
     COMPUTE_TOTAL_SCATTERING_COEFFICIENT;
     return xmittance * totalScatteringCoefficient;
 #else
@@ -126,26 +140,26 @@ vec4 computeSingleScatteringIntegrandEclipsed(const float cosSunZenithAngle, con
 vec4 computeSingleScatteringEclipsed(const vec3 camera, const vec3 viewDir, const vec3 sunDir, const vec3 moonPos,
                                      const bool viewRayIntersectsGround)
 {
-    const float cosViewZenithAngle=cosZenithAngle(camera,viewDir);
-    const float cosSunZenithAngle=cosZenithAngle(camera,sunDir);
-    const float altitude=pointAltitude(camera);
-    const float dotViewSun=dot(viewDir,sunDir);
-    const float integrInterval=distanceToNearestAtmosphereBoundary(cosViewZenithAngle, altitude,
+    CONST float cosViewZenithAngle=cosZenithAngle(camera,viewDir);
+    CONST float cosSunZenithAngle=cosZenithAngle(camera,sunDir);
+    CONST float altitude=pointAltitude(camera);
+    CONST float dotViewSun=dot(viewDir,sunDir);
+    CONST float integrInterval=distanceToNearestAtmosphereBoundary(cosViewZenithAngle, altitude,
                                                                    viewRayIntersectsGround);
 
     // Using the midpoint rule for quadrature
     vec4 spectrum=vec4(0);
-    const float dl=integrInterval/radialIntegrationPoints;
+    CONST float dl=integrInterval/radialIntegrationPoints;
     for(int n=0; n<radialIntegrationPoints; ++n)
     {
-        const float dist=(n+0.5)*dl;
+        CONST float dist=(n+0.5)*dl;
         spectrum += computeSingleScatteringIntegrandEclipsed(cosSunZenithAngle, cosViewZenithAngle, dotViewSun,
                                                              altitude, dist, viewRayIntersectsGround,
                                                              camera+viewDir*dist, sunDir, moonPos);
     }
 
     spectrum *= dl*solarIrradianceAtTOA
-#if ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION
+#if 0 /*ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION*/
                                 // the multiplier is already included
 #else
                                         * scatteringCrossSection()

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/3/molecules/texture-coordinates.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/3/molecules/texture-coordinates.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-coordinates.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,8 +45,8 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // texture-coordinates.frag
-#line 1 2 // texture-coordinates.h.glsl
+#line 4 0 // texture-coordinates.frag
+#line 1 3 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -104,8 +115,8 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 6 0 // texture-coordinates.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-coordinates.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -137,7 +148,7 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-coordinates.frag
+#line 6 0 // texture-coordinates.frag
 
 const float LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA=sqrt(atmosphereHeight*(atmosphereHeight+2*earthRadius));
 
@@ -205,18 +216,18 @@ vec3 indicesToTexCoords(const vec3 indices, const vec3 texSizes)
 
 TransmittanceTexVars transmittanceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
+    CONST float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
                                 texCoordToUnitRange(texCoord.t,transmittanceTextureSize.t);
     // Distance from Earth center to camera
-    const float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
-    const float altitude=r-earthRadius;
+    CONST float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
+    CONST float altitude=r-earthRadius;
 
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
     // distance to border of visible atmosphere from the view point
-    const float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
+    CONST float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
     // d==0 can happen when altitude==atmosphereHeight
-    const float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
+    CONST float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
     return TransmittanceTexVars(cosVZA,altitude);
 }
 
@@ -235,53 +246,53 @@ vec2 transmittanceTexVarsToTexCoord(const float cosVZA, float altitude)
     if(altitude<0)
         altitude=0;
 
-    const float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
+    CONST float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
                                       transmittanceTextureSize.t);
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
-    const float d=distanceToAtmosphereBorder(cosVZA,altitude);
-    const float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float d=distanceToAtmosphereBorder(cosVZA,altitude);
+    CONST float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
     return vec2(s,t);
 }
 
 // Output: vec2(cos(sunZenithAngle), altitude)
 IrradianceTexVars irradianceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
-    const float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
+    CONST float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
+    CONST float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
     return IrradianceTexVars(cosSZA,alt);
 }
 
 vec2 irradianceTexVarsToTexCoord(const float cosSunZenithAngle, const float altitude)
 {
-    const float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
-    const float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
+    CONST float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
+    CONST float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
     return vec2(s,t);
 }
 
 float cosSZAToUnitRangeTexCoord(const float cosSunZenithAngle)
 {
     // Distance to top atmosphere border along the ray groundUnderCamera-sun: (altitude, cosSunZenithAngle)
-    const float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name
-    const float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
+    CONST float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
     // TODO: choose a more descriptive name
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     return max(0.,1-a/A)/(a+1);
 }
 
 float unitRangeTexCoordToCosSZA(const float texCoord)
 {
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float a=(A-A*texCoord)/(1+A*texCoord);
-    const float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
+    CONST float a=(A-A*texCoord)/(1+A*texCoord);
+    CONST float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
     return distFromGroundToTopAtmoBorder==0 ? 1 :
         clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distFromGroundToTopAtmoBorder)) /
                     (2*earthRadius*distFromGroundToTopAtmoBorder));
@@ -292,24 +303,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
                                                const float dotViewSun, const float altitude,
                                                const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -317,24 +328,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float dotVSCoord=(dotViewSun+1)/2;
+    CONST float dotVSCoord=(dotViewSun+1)/2;
 
     // ------------------------------------
-    const float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
+    CONST float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
 
     return Scattering4DCoords(cosSZACoord, cosVZACoord, dotVSCoord, altCoord, viewRayIntersectsGround);
 }
 
 TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
@@ -342,16 +353,16 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture coordinates we combine into a single sampler3D coordinate.
-    const float texW = scatteringTextureSize[1];
-    const float texH = scatteringTextureSize[2];
-    const float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
-    const vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
+    CONST float texW = scatteringTextureSize[1];
+    CONST float texH = scatteringTextureSize[2];
+    CONST float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
+    CONST vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
                                         ceil (cosSZAIndex)*texW+coords.dotViewSun*(texW-1)) / (texW*texH-1);
-    const vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
+    CONST vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
 
-    const float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
+    CONST float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
 
-    const float alphaUpper=fract(cosSZAIndex);
+    CONST float alphaUpper=fract(cosSZAIndex);
     return TexCoordPair(vec3(cosVZAtc, combinedCoord.x, altitude), float(1-alphaUpper),
                         vec3(cosVZAtc, combinedCoord.y, altitude), float(alphaUpper));
 }
@@ -359,9 +370,9 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
+    CONST TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
     return texture(tex, texCoords.lower) * texCoords.alphaLower +
            texture(tex, texCoords.upper) * texCoords.alphaUpper;
 }
@@ -369,17 +380,17 @@ vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const f
 // 3D texture is the 3D single-altitude slice of a 4D texture
 vec3 scattering4DCoordsToTex3DCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2);
 
-    const float dvsSize = scatteringTextureSize[1];
-    const float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
+    CONST float dvsSize = scatteringTextureSize[1];
+    CONST float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
 
-    const float cszaSize = scatteringTextureSize[2];
-    const float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
+    CONST float cszaSize = scatteringTextureSize[2];
+    CONST float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
 
     return vec3(cosVZAtc, dotVStc, cosSZAtc);
 }
@@ -394,39 +405,39 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along dotViewSun coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[1];
-    const float posOfRow = indices[1];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[1];
+    CONST float posOfRow = indices[1];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         indexToTexCoord(currRow, numRows-1),
                                                         texCoordVerbatim));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               indexToTexCoord(currRow, numRows-1),
                                                               texCoordVerbatim));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          indexToTexCoord(currRow, numRows-1),
                                          texCoordVerbatim));
@@ -434,14 +445,14 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
 vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolationGuides01Tex,
                                  const vec3 indices)
 {
-    const float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
+    CONST float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
 
-    const float cosVZAIndex = indices[0];
-    const float dotVSIndex = indices[1];
-    const float currRow = floor(dotVSIndex);
-    const float posBetweenRows = dotVSIndex - currRow;
-    const float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cosVZAIndex = indices[0];
+    CONST float dotVSIndex = indices[1];
+    CONST float currRow = floor(dotVSIndex);
+    CONST float posBetweenRows = dotVSIndex - currRow;
+    CONST float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -449,14 +460,14 @@ vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolat
     indicesCurrRow[1] =     currRow;
     indicesNextRow[1] = min(currRow+1, scatteringTextureSize[1]-1.);
 
-    const vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
-    const vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
+    CONST vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
+    CONST vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
 
-    const vec4 valueCurrRow = texture(tex, coordsCurrRow);
-    const vec4 valueNextRow = texture(tex, coordsNextRow);
-    const float epsilon = 1e-37; // Prevents passing zero to log
-    const vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
-    const vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
+    CONST vec4 valueCurrRow = texture(tex, coordsCurrRow);
+    CONST vec4 valueNextRow = texture(tex, coordsNextRow);
+    CONST float epsilon = 1e-37; // Prevents passing zero to log
+    CONST vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
+    CONST vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
     return (logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow;
 }
 
@@ -465,37 +476,37 @@ float findGuide02Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along SZA coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[2];
-    const float posOfRow = indices[2];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[2];
+    CONST float posOfRow = indices[2];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
 }
@@ -505,19 +516,19 @@ vec4 sample3DTextureGuided(const sampler3D tex,
                            const float cosSunZenithAngle, const float cosViewZenithAngle,
                            const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
                                                                     dotViewSun, altitude, viewRayIntersectsGround);
     // Handle the external interpolation guides: the guides between a pair of VZA-dotViewSun 2D "pictures".
-    const vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
-    const vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
-    const float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
+    CONST vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
+    CONST float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
 
-    const float cvzaIndex = indices[0];
-    const float cszaIndex = indices[2];
-    const float currRow = floor(cszaIndex);
-    const float posBetweenRows = cszaIndex - currRow;
-    const float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cvzaIndex = indices[0];
+    CONST float cszaIndex = indices[2];
+    CONST float currRow = floor(cszaIndex);
+    CONST float posBetweenRows = cszaIndex - currRow;
+    CONST float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -526,58 +537,58 @@ vec4 sample3DTextureGuided(const sampler3D tex,
     indicesNextRow[2] = min(currRow+1, scatteringTextureSize[2]-1);
 
     // The caller will handle the internal interpolation guides: the ones between rows in each 2D "picture".
-    const vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
-    const vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
+    CONST vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
+    CONST vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
     return exp((logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow);
 }
 
 vec4 sample3DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
     return texture(tex, texCoords);
 }
 
 ScatteringTexVars scatteringTex4DCoordsToTexVars(const Scattering4DCoords coords)
 {
-    const float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
     // ------------------------------------
     float cosViewZenithAngle;
     if(coords.viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
     // ------------------------------------
-    const float dotViewSun=coords.dotViewSun*2-1;
+    CONST float dotViewSun=coords.dotViewSun*2-1;
 
     // ------------------------------------
-    const float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
+    CONST float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
 
     return ScatteringTexVars(cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, coords.viewRayIntersectsGround);
 }
 
 Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 {
-    const vec4 indexMax=scatteringTextureSize-vec4(1);
+    CONST vec4 indexMax=scatteringTextureSize-vec4(1);
     Scattering4DCoords coords4d;
     coords4d.viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
     // The following formulas assume that scatteringTextureSize[0] is even. For odd sizes they would change.
@@ -593,8 +604,8 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture indices we combine into a single sampler3D coordinate.
-    const float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
-    const float combinedIndex=texIndices[1];
+    CONST float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
+    CONST float combinedIndex=texIndices[1];
     coords4d.dotViewSun=mod(combinedIndex,texW)/(texW-1);
     coords4d.cosSunZenithAngle=floor(combinedIndex/texW)/(texH-1);
 
@@ -608,11 +619,11 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
 ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 {
-    const Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
+    CONST Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
     ScatteringTexVars vars=scatteringTex4DCoordsToTexVars(coords4d);
     // Clamp dotViewSun to its valid range of values, given cosViewZenithAngle and cosSunZenithAngle. This is
     // needed to prevent NaNs when computing the scattering texture.
-    const float cosVZA=vars.cosViewZenithAngle,
+    CONST float cosVZA=vars.cosViewZenithAngle,
                 cosSZA=vars.cosSunZenithAngle;
     vars.dotViewSun=clamp(vars.dotViewSun,
                           cosVZA*cosSZA-safeSqrt((1-sqr(cosVZA))*(1-sqr(cosSZA))),
@@ -622,54 +633,54 @@ ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 
 EclipseScatteringTexVars eclipseTexCoordsToTexVars(const vec2 texCoords, const float altitude)
 {
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
-    const bool viewRayIntersectsGround = texCoords.t<0.5;
+    CONST bool viewRayIntersectsGround = texCoords.t<0.5;
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
-    const float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
+    CONST float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
     return EclipseScatteringTexVars(azimuthRelativeToSun, cosViewZenithAngle, viewRayIntersectsGround);
 }
 
 EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                                    const float altitude, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -677,13 +688,13 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
-    const float azimuthCoord = azimuthRelativeToSun/(2*PI);
+    CONST float azimuthCoord = azimuthRelativeToSun/(2*PI);
 
     return EclipseScattering2DCoords(azimuthCoord, cosVZACoord);
 }
@@ -691,14 +702,14 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
 vec2 eclipseTexVarsToTexCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                const float altitude, const bool viewRayIntersectsGround, const vec2 texSize)
 {
-    const EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+    CONST EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                                     viewRayIntersectsGround);
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2);
-    const float azimuthTC = coords.azimuth + 1/(2*texSize.s);
+    CONST float azimuthTC = coords.azimuth + 1/(2*texSize.s);
 
     return vec2(azimuthTC, cosVZAtc);
 }
@@ -707,42 +718,42 @@ vec4 sampleEclipseDoubleScattering3DTexture(const sampler3D tex, const float cos
                                             const float cosViewZenithAngle, const float azimuthRelativeToSun,
                                             const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
+    CONST vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
                                                   eclipsedDoubleScatteringTextureSize.st);
-    const float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
-    const vec3 texCoords=vec3(coords2d, cosSZACoord);
+    CONST float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
+    CONST vec3 texCoords=vec3(coords2d, cosSZACoord);
 
     return texture(tex, texCoords);
 }
 
 LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 texIndices)
 {
-    const vec2 indexMax=lightPollutionTextureSize-vec2(1);
+    CONST vec2 indexMax=lightPollutionTextureSize-vec2(1);
 
-    const float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
-    const float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
+    CONST float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
-    const bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
-    const float cosViewZenithAngleCoord = viewRayIntersectsGround ?
+    CONST bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
+    CONST float cosViewZenithAngleCoord = viewRayIntersectsGround ?
                                    1-2*texIndices[0]/(indexMax[0]-1) :
                                    2*(texIndices[0]-1)/(indexMax[0]-1)-1;
     // ------------------------------------
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
@@ -753,23 +764,23 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 
 LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -777,27 +788,27 @@ LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, con
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     return LightPollution2DCoords(cosVZACoord, altCoord);
 }
 
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
-    const vec2 texSize = lightPollutionTextureSize;
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 texSize = lightPollutionTextureSize;
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2);
-    const float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
+    CONST float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
     return vec2(cosVZAtc, altitudeTC);
 }

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/3/molecules/texture-sampling-functions.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputation/3/molecules/texture-sampling-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-sampling-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,13 +45,13 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // texture-sampling-functions.frag
-#line 1 2 // phase-functions.h.glsl
+#line 4 0 // texture-sampling-functions.frag
+#line 1 3 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 6 0 // texture-sampling-functions.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-sampling-functions.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -72,8 +83,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-sampling-functions.frag
-#line 1 4 // texture-coordinates.h.glsl
+#line 6 0 // texture-sampling-functions.frag
+#line 1 5 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -142,7 +153,7 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 8 0 // texture-sampling-functions.frag
+#line 7 0 // texture-sampling-functions.frag
 
 uniform sampler2D transmittanceTexture;
 uniform sampler2D irradianceTexture;
@@ -154,13 +165,13 @@ uniform sampler2D lightPollutionScatteringTexture;
 
 vec4 irradiance(const float cosSunZenithAngle, const float altitude)
 {
-    const vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
+    CONST vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
     return texture(irradianceTexture, texCoords);
 }
 
 vec4 opticalDepthToAtmosphereBorder(const float cosViewZenithAngle, const float altitude)
 {
-    const vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
+    CONST vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact when looking into nadir from TOA at some values of texture sizes (in particular, size of
     // transmittance texture for altitude being 4096). This happens when I simply call texture(eclipsedScatteringTexture,
@@ -178,11 +189,11 @@ vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float
 vec4 transmittance(const float cosViewZenithAngle, const float altitude, const float dist,
                    const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle view ray endpoint
     // in space here.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
 
     vec4 depth;
     if(viewRayIntersectsGround)
@@ -201,7 +212,7 @@ vec4 transmittance(const float cosViewZenithAngle, const float altitude, const f
 vec4 calcFirstScattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                          const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
+    CONST vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
                                           dotViewSun, altitude, viewRayIntersectsGround);
     return scattering*currentPhaseFunction(dotViewSun);
 }
@@ -220,6 +231,6 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
 
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     return texture(lightPollutionScatteringTexture, coords);
 }

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputed/aerosols/common-functions.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputed/aerosols/common-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // common-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // common-functions.frag
+#line 4 0 // common-functions.frag
 
 bool dbgDataPresent=false;
 bool debugDataPresent()
@@ -69,7 +80,7 @@ void setDebugData(float a,float b, float c, float d)
 
 void swap(inout float x, inout float y)
 {
-    const float t = x;
+    CONST float t = x;
     x = y;
     y = t;
 }
@@ -83,7 +94,7 @@ float safeSqrt(const float x)
 
 float safeAtan(const float y, const float x)
 {
-    const float a = atan(y,x);
+    CONST float a = atan(y,x);
     return x==0 && y==0 ? 0 : a;
 }
 
@@ -116,23 +127,23 @@ float pointAltitude(vec3 point)
 
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float Ratm=earthRadius+atmosphereHeight;
-    const float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float Ratm=earthRadius+atmosphereHeight;
+    CONST float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float distanceToGround(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(-safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float cosZenithAngleOfHorizon(const float altitude)
 {
-    const float R=earthRadius;
-    const float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
+    CONST float R=earthRadius;
+    CONST float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
     return -sqrt(2*h*R+sqr(h))/(R+h);
 }
 
@@ -151,8 +162,8 @@ float distanceToNearestAtmosphereBoundary(const float cosZenithAngle, const floa
 float sunVisibility(const float cosSunZenithAngle, float altitude)
 {
     if(altitude<0) altitude=0;
-    const float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
-    const float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
+    CONST float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
+    CONST float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
     /* Approximating visible fraction of solar disk by smoothstep between the position of the Sun
      * touching the horizon by its upper part and the position with lower part touching the horizon.
      * The calculation assumes that solar angular radius is small and thus approximately equals its sine.
@@ -182,13 +193,13 @@ float circlesIntersectionArea(float R1, float R2, float d)
 
 float angleBetween(const vec3 a, const vec3 b)
 {
-    const float d=dot(a,b);
-    const float c=length(cross(a,b));
+    CONST float d=dot(a,b);
+    CONST float c=length(cross(a,b));
     // To avoid loss of precision, don't use dot product near the singularity
     // of acos, and cross product near the singularity of asin
     if(abs(d) < abs(c))
         return acos(d/(length(a)*length(b)));
-    const float smallerAngle = asin(c/(length(a)*length(b)));
+    CONST float smallerAngle = asin(c/(length(a)*length(b)));
     if(d<0) return PI-smallerAngle;
     return smallerAngle;
 }
@@ -205,11 +216,11 @@ float moonAngularRadius(const vec3 cameraPosition, const vec3 moonPosition)
 
 float visibleSolidAngleOfSun(const vec3 camera, const vec3 sunDir, const vec3 moonPos)
 {
-    const float Rs=sunAngularRadius;
-    const float Rm=moonAngularRadius(camera,moonPos);
+    CONST float Rs=sunAngularRadius;
+    CONST float Rm=moonAngularRadius(camera,moonPos);
     float visibleSolidAngle=PI*sqr(Rs);
 
-    const float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
+    CONST float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
     if(dSM<Rs+Rm)
     {
         visibleSolidAngle -= circlesIntersectionArea(Rm,Rs,dSM);
@@ -229,12 +240,12 @@ float sphereIntegrationSolidAngleDifferential(const int pointCountOnSphere)
 }
 vec3 sphereIntegrationSampleDir(const int index, const int pointCountOnSphere)
 {
-    const float goldenRatio=1.6180339887499;
+    CONST float goldenRatio=1.6180339887499;
     // The range of n is 0.5, 1.5, ..., pointCountOnSphere-0.5
-    const float n=index+0.5;
+    CONST float n=index+0.5;
     // Explanation of the Fibonacci grid generation can be seen at https://stackoverflow.com/a/44164075/673852
-    const float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
-    const float azimuth=n*(2*PI*goldenRatio);
+    CONST float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
+    CONST float azimuth=n*(2*PI*goldenRatio);
     return vec3(cos(azimuth)*sin(zenithAngle),
                 sin(azimuth)*sin(zenithAngle),
                 cos(zenithAngle));

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputed/aerosols/densities.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputed/aerosols/densities.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // densities.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,20 +45,20 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // densities.frag
+#line 4 0 // densities.frag
 float scattererNumberDensity_molecules(float altitude)
 {
-        const float rayleighScaleHeight=8*km;
+        CONST float rayleighScaleHeight=8*km;
         return 3.08458e25*exp(-1/rayleighScaleHeight * altitude);
 }
 float scattererNumberDensity_aerosols(float altitude)
 {
-        const float mieScaleHeight=1.2*km;
+        CONST float mieScaleHeight=1.2*km;
         return 1.03333e8*exp(-1/mieScaleHeight*altitude);
 }
 float absorberNumberDensity_ozone(float altitude)
 {
-        const float totalOzoneAmount=370*dobsonUnit;
+        CONST float totalOzoneAmount=370*dobsonUnit;
 
         float density;
 

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputed/aerosols/phase-functions.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputed/aerosols/phase-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // phase-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // phase-functions.frag
+#line 4 0 // phase-functions.frag
 
 vec4 phaseFunction_molecules(float dotViewSun)
 {
@@ -42,9 +53,9 @@ vec4 phaseFunction_molecules(float dotViewSun)
 }
 vec4 phaseFunction_aerosols(float dotViewSun)
 {
-        const float g=0.76;
-        const float g2=g*g;
-        const float k = 3/(8*PI)*(1-g2)/(2+g2);
+        CONST float g=0.76;
+        CONST float g2=g*g;
+        CONST float k = 3/(8*PI)*(1-g2)/(2+g2);
         return vec4(k * (1+sqr(dotViewSun)) / pow(1+g2 - 2*g*dotViewSun, 1.5) + 1/((1-dotViewSun)*600+0.05))*0.904;
 }
 vec4 currentPhaseFunction(float dotViewSun) { return phaseFunction_aerosols(dotViewSun); }

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputed/aerosols/render.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputed/aerosols/render.frag
@@ -1,7 +1,21 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
 
-#line 1 1 // const.h.glsl
+
+
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 6 0 // render.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,11 +48,11 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // render.frag
-#line 1 2 // calc-view-dir.h.glsl
+#line 7 0 // render.frag
+#line 1 3 // calc-view-dir.h.glsl
 vec3 calcViewDir();
-#line 6 0 // render.frag
-#line 1 3 // common-functions.h.glsl
+#line 8 0 // render.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -70,14 +84,14 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // render.frag
-#line 1 4 // phase-functions.h.glsl
+#line 9 0 // render.frag
+#line 1 5 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 8 0 // render.frag
+#line 10 0 // render.frag
 
-#line 1 5 // single-scattering-eclipsed.h.glsl
+#line 1 6 // single-scattering-eclipsed.h.glsl
 #ifndef INCLUDE_ONCE_050024D2_BD56_434E_8D40_2055DA0B78EC
 #define INCLUDE_ONCE_050024D2_BD56_434E_8D40_2055DA0B78EC
 
@@ -85,8 +99,8 @@ vec4 computeSingleScatteringEclipsed(const vec3 camera, const vec3 viewDir, cons
                                      const bool viewRayIntersectsGround);
 
 #endif
-#line 10 0 // render.frag
-#line 1 6 // texture-coordinates.h.glsl
+#line 12 0 // render.frag
+#line 1 7 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -155,10 +169,10 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 11 0 // render.frag
-#line 1 7 // radiance-to-luminance.h.glsl
+#line 13 0 // render.frag
+#line 1 8 // radiance-to-luminance.h.glsl
 const mat4 radianceToLuminance=mat4(19.8756237,7.17745161,0,0.0937032327,  2.13895917,0.772417068,0,0.0149318045,  0.241072536,0.0870557055,0,0,  0.0133876652,0.00483453181,0,0);
-#line 12 0 // render.frag
+#line 14 0 // render.frag
 
 
 
@@ -195,18 +209,18 @@ void main()
     // this approximation has the same order of magnitude as the assumption that the Earth and its atmosphere
     // are spherical.
     float altitude = max(cameraPosition.z, 0.);
-    const vec3 oldCamPos=cameraPosition;
+    CONST vec3 oldCamPos=cameraPosition;
     // Hide the uniform with this name, thus effectively modifying it for the following code
     vec3 cameraPosition=vec3(oldCamPos.xy, altitude);
 
     bool lookingIntoAtmosphere=true;
     if(altitude>atmosphereHeight)
     {
-        const vec3 p = cameraPosition - earthCenter;
-        const float p_dot_v = dot(p, viewDir);
-        const float p_dot_p = dot(p, p);
-        const float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
-        const float distanceToTOA = -p_dot_v - sqrt(sqr(earthRadius+atmosphereHeight) - squaredDistBetweenViewRayAndEarthCenter);
+        CONST vec3 p = cameraPosition - earthCenter;
+        CONST float p_dot_v = dot(p, viewDir);
+        CONST float p_dot_p = dot(p, p);
+        CONST float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
+        CONST float distanceToTOA = -p_dot_v - sqrt(sqr(earthRadius+atmosphereHeight) - squaredDistBetweenViewRayAndEarthCenter);
         if(distanceToTOA>=0)
         {
             cameraPosition += viewDir*distanceToTOA;
@@ -214,7 +228,7 @@ void main()
         }
         else
         {
-#if RENDERING_ANY_ZERO_SCATTERING
+#if 0 /*RENDERING_ANY_ZERO_SCATTERING*/
             lookingIntoAtmosphere=false;
 #else
             luminance=vec4(0);
@@ -224,16 +238,16 @@ void main()
         }
     }
 
-    const vec3 zenith=normalize(cameraPosition-earthCenter);
+    CONST vec3 zenith=normalize(cameraPosition-earthCenter);
     float cosViewZenithAngle=dot(zenith,viewDir);
 
     bool viewRayIntersectsGround=false;
     {
-        const vec3 p = cameraPosition - earthCenter;
-        const float p_dot_v = dot(p, viewDir);
-        const float p_dot_p = dot(p, p);
-        const float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
-        const float distanceToIntersection = -p_dot_v - sqrt(sqr(earthRadius) - squaredDistBetweenViewRayAndEarthCenter);
+        CONST vec3 p = cameraPosition - earthCenter;
+        CONST float p_dot_v = dot(p, viewDir);
+        CONST float p_dot_p = dot(p, p);
+        CONST float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
+        CONST float distanceToIntersection = -p_dot_v - sqrt(sqr(earthRadius) - squaredDistBetweenViewRayAndEarthCenter);
         // altitude==0 is a special case where distance to intersection calculation
         // is unreliable (has a lot of noise in its sign), so check it separately
         if(distanceToIntersection>0 || (altitude==0 && cosViewZenithAngle<0))
@@ -244,11 +258,11 @@ void main()
     // Aside from aesthetics, this affects brightness input to Stellarium's tone mapper.
     if(pseudoMirrorSkyBelowHorizon && viewRayIntersectsGround)
     {
-        const float horizonCZA = cosZenithAngleOfHorizon(altitude);
-        const float viewElev  = asin(clampCosine(cosViewZenithAngle));
-        const float horizElev = asin(clampCosine(horizonCZA));
-        const float newViewElev = 2*horizElev - viewElev;
-        const float viewDirXYnorm = length(viewDir-zenith*cosViewZenithAngle);
+        CONST float horizonCZA = cosZenithAngleOfHorizon(altitude);
+        CONST float viewElev  = asin(clampCosine(cosViewZenithAngle));
+        CONST float horizElev = asin(clampCosine(horizonCZA));
+        CONST float newViewElev = 2*horizElev - viewElev;
+        CONST float viewDirXYnorm = length(viewDir-zenith*cosViewZenithAngle);
         if(viewDirXYnorm == 0)
         {
             viewDir = zenith;
@@ -267,27 +281,27 @@ void main()
         viewRayIntersectsGround = false;
     }
 
-    const float cosSunZenithAngle =dot(zenith,sunDirection);
-    const float dotViewSun=dot(viewDir,sunDirection);
+    CONST float cosSunZenithAngle =dot(zenith,sunDirection);
+    CONST float dotViewSun=dot(viewDir,sunDirection);
 
-    const vec3 sunXYunnorm=sunDirection-dot(sunDirection,zenith)*zenith;
-    const vec3 viewXYunnorm=viewDir-dot(viewDir,zenith)*zenith;
-    const vec3 sunXY = sunXYunnorm.x!=0 || sunXYunnorm.y!=0 || sunXYunnorm.z!=0 ? normalize(sunXYunnorm) : vec3(0);
-    const vec3 viewXY = viewXYunnorm.x!=0 || viewXYunnorm.y!=0 || viewXYunnorm.z!=0 ? normalize(viewXYunnorm) : vec3(0);
-    const float azimuthRelativeToSun=safeAtan(dot(cross(sunXY, viewXY), zenith), dot(sunXY, viewXY));
+    CONST vec3 sunXYunnorm=sunDirection-dot(sunDirection,zenith)*zenith;
+    CONST vec3 viewXYunnorm=viewDir-dot(viewDir,zenith)*zenith;
+    CONST vec3 sunXY = sunXYunnorm.x!=0 || sunXYunnorm.y!=0 || sunXYunnorm.z!=0 ? normalize(sunXYunnorm) : vec3(0);
+    CONST vec3 viewXY = viewXYunnorm.x!=0 || viewXYunnorm.y!=0 || viewXYunnorm.z!=0 ? normalize(viewXYunnorm) : vec3(0);
+    CONST float azimuthRelativeToSun=safeAtan(dot(cross(sunXY, viewXY), zenith), dot(sunXY, viewXY));
 
-#if RENDERING_ZERO_SCATTERING
+#if 0 /*RENDERING_ZERO_SCATTERING*/
     vec4 radiance;
     if(viewRayIntersectsGround)
     {
         // XXX: keep in sync with the same code in computeScatteringDensity(), but don't forget about
         //      the difference in the usage of viewDir vs incDir.
-        const float distToGround = distanceToGround(cosViewZenithAngle, altitude);
-        const vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
-        const vec3 groundNormal = normalize(zenith*(earthRadius+altitude)+viewDir*distToGround);
-        const vec4 groundIrradiance = irradiance(dot(groundNormal, sunDirection), 0);
+        CONST float distToGround = distanceToGround(cosViewZenithAngle, altitude);
+        CONST vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
+        CONST vec3 groundNormal = normalize(zenith*(earthRadius+altitude)+viewDir*distToGround);
+        CONST vec4 groundIrradiance = irradiance(dot(groundNormal, sunDirection), 0);
         // Radiation scattered by the ground
-        const float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
+        CONST float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
         radiance = transmittanceToGround*groundAlbedo*groundIrradiance*solarIrradianceFixup*groundBRDF
                  + lightPollutionGroundLuminance*lightPollutionRelativeRadiance;
     }
@@ -304,22 +318,22 @@ void main()
     }
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_ZERO_SCATTERING
+#elif 0 /*RENDERING_ECLIPSED_ZERO_SCATTERING*/
     vec4 radiance;
-    const float dotViewMoon=dot(viewDir,normalize(moonPosition-cameraPosition));
+    CONST float dotViewMoon=dot(viewDir,normalize(moonPosition-cameraPosition));
     if(viewRayIntersectsGround)
     {
         // XXX: keep in sync with the similar code in non-eclipsed zero scattering rendering.
-        const float distToGround = distanceToGround(cosViewZenithAngle, altitude);
-        const vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
-        const vec3 pointOnGround = cameraPosition+viewDir*distToGround;
-        const vec4 directGroundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDirection, moonPosition);
+        CONST float distToGround = distanceToGround(cosViewZenithAngle, altitude);
+        CONST vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
+        CONST vec3 pointOnGround = cameraPosition+viewDir*distToGround;
+        CONST vec4 directGroundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDirection, moonPosition);
         // FIXME: add first-order indirect irradiance too: it's done in non-eclipsed irradiance (in the same
         // conditions: when limited to 2 orders). This should be calculated at the same time when second order
         // is: all the infrastructure is already there.
-        const vec4 groundIrradiance = directGroundIrradiance;
+        CONST vec4 groundIrradiance = directGroundIrradiance;
         // Radiation scattered by the ground
-        const float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
+        CONST float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
         radiance = transmittanceToGround*groundAlbedo*groundIrradiance*solarIrradianceFixup*groundBRDF
                  + lightPollutionGroundLuminance*lightPollutionRelativeRadiance;
     }
@@ -336,53 +350,53 @@ void main()
     }
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_ON_THE_FLY
-    const vec4 scattering=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPosition,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_ON_THE_FLY*/
+    CONST vec4 scattering=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPosition,
                                                           viewRayIntersectsGround);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE
-    const vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE*/
+    CONST vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                      viewRayIntersectsGround, eclipsedSingleScatteringTextureSize);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact at the point where azimuth texture coordinate changes from 1 to 0 (at azimuthRelativeToSun crossing
     // 0). This happens when I simply call texture(eclipsedScatteringTexture, texCoords) without specifying LOD.
     // Apparently, the driver uses the derivative for some reason, even though it shouldn't.
-    const vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
+    CONST vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
 #elif 1 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
-    const vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+    CONST vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                      viewRayIntersectsGround, eclipsedSingleScatteringTextureSize);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact at the point where azimuth texture coordinate changes from 1 to 0 (at azimuthRelativeToSun crossing
     // 0). This happens when I simply call texture(eclipsedScatteringTexture, texCoords) without specifying LOD.
     // Apparently, the driver uses the derivative for some reason, even though it shouldn't.
-    const vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
+    CONST vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
     luminance=scattering*currentPhaseFunction(dotViewSun);
-#elif RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_RADIANCE
+#elif 0 /*RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_RADIANCE*/
     vec4 radiance=exp(sampleEclipseDoubleScattering3DTexture(eclipsedDoubleScatteringTexture,
                                                              cosSunZenithAngle, cosViewZenithAngle, azimuthRelativeToSun,
                                                              altitude, viewRayIntersectsGround));
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_LUMINANCE
+#elif 0 /*RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
     luminance=exp(sampleEclipseDoubleScattering3DTexture(eclipsedDoubleScatteringTexture,
                                                          cosSunZenithAngle, cosViewZenithAngle, azimuthRelativeToSun,
                                                          altitude, viewRayIntersectsGround));
-#elif RENDERING_SINGLE_SCATTERING_ON_THE_FLY
-    const vec4 scattering=computeSingleScattering(cosSunZenithAngle,cosViewZenithAngle,dotViewSun,
+#elif 0 /*RENDERING_SINGLE_SCATTERING_ON_THE_FLY*/
+    CONST vec4 scattering=computeSingleScattering(cosSunZenithAngle,cosViewZenithAngle,dotViewSun,
                                                   altitude,viewRayIntersectsGround);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE
+#elif 0 /*RENDERING_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE*/
     vec4 scattering;
     if(useInterpolationGuides)
     {
@@ -399,7 +413,7 @@ void main()
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE
+#elif 0 /*RENDERING_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
     vec4 scattering;
     if(useInterpolationGuides)
     {
@@ -413,18 +427,18 @@ void main()
                                      dotViewSun, altitude, viewRayIntersectsGround);
     }
     luminance=scattering * (bool(PHASE_FUNCTION_IS_EMBEDDED) ? vec4(1) : currentPhaseFunction(dotViewSun));
-#elif RENDERING_MULTIPLE_SCATTERING_LUMINANCE
+#elif 0 /*RENDERING_MULTIPLE_SCATTERING_LUMINANCE*/
     luminance=sample3DTexture(scatteringTexture, cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, viewRayIntersectsGround);
-#elif RENDERING_MULTIPLE_SCATTERING_RADIANCE
+#elif 0 /*RENDERING_MULTIPLE_SCATTERING_RADIANCE*/
     vec4 radiance=sample3DTexture(scatteringTexture, cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, viewRayIntersectsGround);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_LIGHT_POLLUTION_RADIANCE
+#elif 0 /*RENDERING_LIGHT_POLLUTION_RADIANCE*/
     vec4 radiance=lightPollutionGroundLuminance*lightPollutionScattering(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_LIGHT_POLLUTION_LUMINANCE
+#elif 0 /*RENDERING_LIGHT_POLLUTION_LUMINANCE*/
     luminance=lightPollutionGroundLuminance*lightPollutionScattering(altitude, cosViewZenithAngle, viewRayIntersectsGround);
 #else
 #error What to render?

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputed/aerosols/single-scattering-eclipsed.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputed/aerosols/single-scattering-eclipsed.frag
@@ -1,7 +1,21 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
 
-#line 1 1 // const.h.glsl
+
+
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 6 0 // single-scattering-eclipsed.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,15 +48,15 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // single-scattering-eclipsed.frag
-#line 1 2 // densities.h.glsl
+#line 7 0 // single-scattering-eclipsed.frag
+#line 1 3 // densities.h.glsl
 float scattererNumberDensity_molecules(float altitude);
 float scattererNumberDensity_aerosols(float altitude);
 float absorberNumberDensity_ozone(float altitude);
 vec4 scatteringCrossSection();
 float scattererDensity(float altitude);
-#line 6 0 // single-scattering-eclipsed.frag
-#line 1 3 // common-functions.h.glsl
+#line 8 0 // single-scattering-eclipsed.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -74,8 +88,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // single-scattering-eclipsed.frag
-#line 1 4 // texture-sampling-functions.h.glsl
+#line 9 0 // single-scattering-eclipsed.frag
+#line 1 5 // texture-sampling-functions.h.glsl
 #ifndef INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 #define INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float altitude);
@@ -87,7 +101,7 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                 const int scatteringOrder);
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 #endif
-#line 8 0 // single-scattering-eclipsed.frag
+#line 10 0 // single-scattering-eclipsed.frag
 
 
 float cosZenithAngle(vec3 origin, vec3 direction)
@@ -101,13 +115,13 @@ vec4 computeSingleScatteringIntegrandEclipsed(const float cosSunZenithAngle, con
                                               const float dist, const bool viewRayIntersectsGround,
                                               const vec3 scatterer, const vec3 sunDir, const vec3 moonPos)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle here the case when the
     // endpoint of the view ray intentionally appears in outer space.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosSunZenithAngleAtDist=clampCosine((r*cosSunZenithAngle+dist*dotViewSun)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosSunZenithAngleAtDist=clampCosine((r*cosSunZenithAngle+dist*dotViewSun)/(earthRadius+altAtDist));
 
-    const vec4 xmittance=transmittance(cosViewZenithAngle, altitude, dist, viewRayIntersectsGround)
+    CONST vec4 xmittance=transmittance(cosViewZenithAngle, altitude, dist, viewRayIntersectsGround)
                                                     *
                          transmittanceToAtmosphereBorder(cosSunZenithAngleAtDist, altAtDist)
                                                     *
@@ -115,7 +129,7 @@ vec4 computeSingleScatteringIntegrandEclipsed(const float cosSunZenithAngle, con
                                                     *
                             // FIXME: this ignores orientation of the crescent of eclipsed Sun WRT horizon
                                     sunVisibility(cosSunZenithAngleAtDist, altAtDist);
-#if ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION
+#if 0 /*ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION*/
     COMPUTE_TOTAL_SCATTERING_COEFFICIENT;
     return xmittance * totalScatteringCoefficient;
 #else
@@ -126,26 +140,26 @@ vec4 computeSingleScatteringIntegrandEclipsed(const float cosSunZenithAngle, con
 vec4 computeSingleScatteringEclipsed(const vec3 camera, const vec3 viewDir, const vec3 sunDir, const vec3 moonPos,
                                      const bool viewRayIntersectsGround)
 {
-    const float cosViewZenithAngle=cosZenithAngle(camera,viewDir);
-    const float cosSunZenithAngle=cosZenithAngle(camera,sunDir);
-    const float altitude=pointAltitude(camera);
-    const float dotViewSun=dot(viewDir,sunDir);
-    const float integrInterval=distanceToNearestAtmosphereBoundary(cosViewZenithAngle, altitude,
+    CONST float cosViewZenithAngle=cosZenithAngle(camera,viewDir);
+    CONST float cosSunZenithAngle=cosZenithAngle(camera,sunDir);
+    CONST float altitude=pointAltitude(camera);
+    CONST float dotViewSun=dot(viewDir,sunDir);
+    CONST float integrInterval=distanceToNearestAtmosphereBoundary(cosViewZenithAngle, altitude,
                                                                    viewRayIntersectsGround);
 
     // Using the midpoint rule for quadrature
     vec4 spectrum=vec4(0);
-    const float dl=integrInterval/radialIntegrationPoints;
+    CONST float dl=integrInterval/radialIntegrationPoints;
     for(int n=0; n<radialIntegrationPoints; ++n)
     {
-        const float dist=(n+0.5)*dl;
+        CONST float dist=(n+0.5)*dl;
         spectrum += computeSingleScatteringIntegrandEclipsed(cosSunZenithAngle, cosViewZenithAngle, dotViewSun,
                                                              altitude, dist, viewRayIntersectsGround,
                                                              camera+viewDir*dist, sunDir, moonPos);
     }
 
     spectrum *= dl*solarIrradianceAtTOA
-#if ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION
+#if 0 /*ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION*/
                                 // the multiplier is already included
 #else
                                         * scatteringCrossSection()

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputed/aerosols/texture-coordinates.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputed/aerosols/texture-coordinates.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-coordinates.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,8 +45,8 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // texture-coordinates.frag
-#line 1 2 // texture-coordinates.h.glsl
+#line 4 0 // texture-coordinates.frag
+#line 1 3 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -104,8 +115,8 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 6 0 // texture-coordinates.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-coordinates.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -137,7 +148,7 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-coordinates.frag
+#line 6 0 // texture-coordinates.frag
 
 const float LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA=sqrt(atmosphereHeight*(atmosphereHeight+2*earthRadius));
 
@@ -205,18 +216,18 @@ vec3 indicesToTexCoords(const vec3 indices, const vec3 texSizes)
 
 TransmittanceTexVars transmittanceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
+    CONST float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
                                 texCoordToUnitRange(texCoord.t,transmittanceTextureSize.t);
     // Distance from Earth center to camera
-    const float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
-    const float altitude=r-earthRadius;
+    CONST float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
+    CONST float altitude=r-earthRadius;
 
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
     // distance to border of visible atmosphere from the view point
-    const float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
+    CONST float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
     // d==0 can happen when altitude==atmosphereHeight
-    const float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
+    CONST float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
     return TransmittanceTexVars(cosVZA,altitude);
 }
 
@@ -235,53 +246,53 @@ vec2 transmittanceTexVarsToTexCoord(const float cosVZA, float altitude)
     if(altitude<0)
         altitude=0;
 
-    const float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
+    CONST float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
                                       transmittanceTextureSize.t);
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
-    const float d=distanceToAtmosphereBorder(cosVZA,altitude);
-    const float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float d=distanceToAtmosphereBorder(cosVZA,altitude);
+    CONST float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
     return vec2(s,t);
 }
 
 // Output: vec2(cos(sunZenithAngle), altitude)
 IrradianceTexVars irradianceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
-    const float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
+    CONST float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
+    CONST float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
     return IrradianceTexVars(cosSZA,alt);
 }
 
 vec2 irradianceTexVarsToTexCoord(const float cosSunZenithAngle, const float altitude)
 {
-    const float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
-    const float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
+    CONST float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
+    CONST float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
     return vec2(s,t);
 }
 
 float cosSZAToUnitRangeTexCoord(const float cosSunZenithAngle)
 {
     // Distance to top atmosphere border along the ray groundUnderCamera-sun: (altitude, cosSunZenithAngle)
-    const float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name
-    const float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
+    CONST float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
     // TODO: choose a more descriptive name
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     return max(0.,1-a/A)/(a+1);
 }
 
 float unitRangeTexCoordToCosSZA(const float texCoord)
 {
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float a=(A-A*texCoord)/(1+A*texCoord);
-    const float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
+    CONST float a=(A-A*texCoord)/(1+A*texCoord);
+    CONST float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
     return distFromGroundToTopAtmoBorder==0 ? 1 :
         clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distFromGroundToTopAtmoBorder)) /
                     (2*earthRadius*distFromGroundToTopAtmoBorder));
@@ -292,24 +303,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
                                                const float dotViewSun, const float altitude,
                                                const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -317,24 +328,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float dotVSCoord=(dotViewSun+1)/2;
+    CONST float dotVSCoord=(dotViewSun+1)/2;
 
     // ------------------------------------
-    const float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
+    CONST float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
 
     return Scattering4DCoords(cosSZACoord, cosVZACoord, dotVSCoord, altCoord, viewRayIntersectsGround);
 }
 
 TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
@@ -342,16 +353,16 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture coordinates we combine into a single sampler3D coordinate.
-    const float texW = scatteringTextureSize[1];
-    const float texH = scatteringTextureSize[2];
-    const float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
-    const vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
+    CONST float texW = scatteringTextureSize[1];
+    CONST float texH = scatteringTextureSize[2];
+    CONST float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
+    CONST vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
                                         ceil (cosSZAIndex)*texW+coords.dotViewSun*(texW-1)) / (texW*texH-1);
-    const vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
+    CONST vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
 
-    const float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
+    CONST float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
 
-    const float alphaUpper=fract(cosSZAIndex);
+    CONST float alphaUpper=fract(cosSZAIndex);
     return TexCoordPair(vec3(cosVZAtc, combinedCoord.x, altitude), float(1-alphaUpper),
                         vec3(cosVZAtc, combinedCoord.y, altitude), float(alphaUpper));
 }
@@ -359,9 +370,9 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
+    CONST TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
     return texture(tex, texCoords.lower) * texCoords.alphaLower +
            texture(tex, texCoords.upper) * texCoords.alphaUpper;
 }
@@ -369,17 +380,17 @@ vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const f
 // 3D texture is the 3D single-altitude slice of a 4D texture
 vec3 scattering4DCoordsToTex3DCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2);
 
-    const float dvsSize = scatteringTextureSize[1];
-    const float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
+    CONST float dvsSize = scatteringTextureSize[1];
+    CONST float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
 
-    const float cszaSize = scatteringTextureSize[2];
-    const float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
+    CONST float cszaSize = scatteringTextureSize[2];
+    CONST float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
 
     return vec3(cosVZAtc, dotVStc, cosSZAtc);
 }
@@ -394,39 +405,39 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along dotViewSun coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[1];
-    const float posOfRow = indices[1];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[1];
+    CONST float posOfRow = indices[1];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         indexToTexCoord(currRow, numRows-1),
                                                         texCoordVerbatim));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               indexToTexCoord(currRow, numRows-1),
                                                               texCoordVerbatim));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          indexToTexCoord(currRow, numRows-1),
                                          texCoordVerbatim));
@@ -434,14 +445,14 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
 vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolationGuides01Tex,
                                  const vec3 indices)
 {
-    const float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
+    CONST float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
 
-    const float cosVZAIndex = indices[0];
-    const float dotVSIndex = indices[1];
-    const float currRow = floor(dotVSIndex);
-    const float posBetweenRows = dotVSIndex - currRow;
-    const float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cosVZAIndex = indices[0];
+    CONST float dotVSIndex = indices[1];
+    CONST float currRow = floor(dotVSIndex);
+    CONST float posBetweenRows = dotVSIndex - currRow;
+    CONST float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -449,14 +460,14 @@ vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolat
     indicesCurrRow[1] =     currRow;
     indicesNextRow[1] = min(currRow+1, scatteringTextureSize[1]-1.);
 
-    const vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
-    const vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
+    CONST vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
+    CONST vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
 
-    const vec4 valueCurrRow = texture(tex, coordsCurrRow);
-    const vec4 valueNextRow = texture(tex, coordsNextRow);
-    const float epsilon = 1e-37; // Prevents passing zero to log
-    const vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
-    const vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
+    CONST vec4 valueCurrRow = texture(tex, coordsCurrRow);
+    CONST vec4 valueNextRow = texture(tex, coordsNextRow);
+    CONST float epsilon = 1e-37; // Prevents passing zero to log
+    CONST vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
+    CONST vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
     return (logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow;
 }
 
@@ -465,37 +476,37 @@ float findGuide02Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along SZA coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[2];
-    const float posOfRow = indices[2];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[2];
+    CONST float posOfRow = indices[2];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
 }
@@ -505,19 +516,19 @@ vec4 sample3DTextureGuided(const sampler3D tex,
                            const float cosSunZenithAngle, const float cosViewZenithAngle,
                            const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
                                                                     dotViewSun, altitude, viewRayIntersectsGround);
     // Handle the external interpolation guides: the guides between a pair of VZA-dotViewSun 2D "pictures".
-    const vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
-    const vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
-    const float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
+    CONST vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
+    CONST float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
 
-    const float cvzaIndex = indices[0];
-    const float cszaIndex = indices[2];
-    const float currRow = floor(cszaIndex);
-    const float posBetweenRows = cszaIndex - currRow;
-    const float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cvzaIndex = indices[0];
+    CONST float cszaIndex = indices[2];
+    CONST float currRow = floor(cszaIndex);
+    CONST float posBetweenRows = cszaIndex - currRow;
+    CONST float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -526,58 +537,58 @@ vec4 sample3DTextureGuided(const sampler3D tex,
     indicesNextRow[2] = min(currRow+1, scatteringTextureSize[2]-1);
 
     // The caller will handle the internal interpolation guides: the ones between rows in each 2D "picture".
-    const vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
-    const vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
+    CONST vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
+    CONST vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
     return exp((logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow);
 }
 
 vec4 sample3DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
     return texture(tex, texCoords);
 }
 
 ScatteringTexVars scatteringTex4DCoordsToTexVars(const Scattering4DCoords coords)
 {
-    const float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
     // ------------------------------------
     float cosViewZenithAngle;
     if(coords.viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
     // ------------------------------------
-    const float dotViewSun=coords.dotViewSun*2-1;
+    CONST float dotViewSun=coords.dotViewSun*2-1;
 
     // ------------------------------------
-    const float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
+    CONST float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
 
     return ScatteringTexVars(cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, coords.viewRayIntersectsGround);
 }
 
 Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 {
-    const vec4 indexMax=scatteringTextureSize-vec4(1);
+    CONST vec4 indexMax=scatteringTextureSize-vec4(1);
     Scattering4DCoords coords4d;
     coords4d.viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
     // The following formulas assume that scatteringTextureSize[0] is even. For odd sizes they would change.
@@ -593,8 +604,8 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture indices we combine into a single sampler3D coordinate.
-    const float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
-    const float combinedIndex=texIndices[1];
+    CONST float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
+    CONST float combinedIndex=texIndices[1];
     coords4d.dotViewSun=mod(combinedIndex,texW)/(texW-1);
     coords4d.cosSunZenithAngle=floor(combinedIndex/texW)/(texH-1);
 
@@ -608,11 +619,11 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
 ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 {
-    const Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
+    CONST Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
     ScatteringTexVars vars=scatteringTex4DCoordsToTexVars(coords4d);
     // Clamp dotViewSun to its valid range of values, given cosViewZenithAngle and cosSunZenithAngle. This is
     // needed to prevent NaNs when computing the scattering texture.
-    const float cosVZA=vars.cosViewZenithAngle,
+    CONST float cosVZA=vars.cosViewZenithAngle,
                 cosSZA=vars.cosSunZenithAngle;
     vars.dotViewSun=clamp(vars.dotViewSun,
                           cosVZA*cosSZA-safeSqrt((1-sqr(cosVZA))*(1-sqr(cosSZA))),
@@ -622,54 +633,54 @@ ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 
 EclipseScatteringTexVars eclipseTexCoordsToTexVars(const vec2 texCoords, const float altitude)
 {
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
-    const bool viewRayIntersectsGround = texCoords.t<0.5;
+    CONST bool viewRayIntersectsGround = texCoords.t<0.5;
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
-    const float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
+    CONST float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
     return EclipseScatteringTexVars(azimuthRelativeToSun, cosViewZenithAngle, viewRayIntersectsGround);
 }
 
 EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                                    const float altitude, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -677,13 +688,13 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
-    const float azimuthCoord = azimuthRelativeToSun/(2*PI);
+    CONST float azimuthCoord = azimuthRelativeToSun/(2*PI);
 
     return EclipseScattering2DCoords(azimuthCoord, cosVZACoord);
 }
@@ -691,14 +702,14 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
 vec2 eclipseTexVarsToTexCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                const float altitude, const bool viewRayIntersectsGround, const vec2 texSize)
 {
-    const EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+    CONST EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                                     viewRayIntersectsGround);
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2);
-    const float azimuthTC = coords.azimuth + 1/(2*texSize.s);
+    CONST float azimuthTC = coords.azimuth + 1/(2*texSize.s);
 
     return vec2(azimuthTC, cosVZAtc);
 }
@@ -707,42 +718,42 @@ vec4 sampleEclipseDoubleScattering3DTexture(const sampler3D tex, const float cos
                                             const float cosViewZenithAngle, const float azimuthRelativeToSun,
                                             const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
+    CONST vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
                                                   eclipsedDoubleScatteringTextureSize.st);
-    const float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
-    const vec3 texCoords=vec3(coords2d, cosSZACoord);
+    CONST float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
+    CONST vec3 texCoords=vec3(coords2d, cosSZACoord);
 
     return texture(tex, texCoords);
 }
 
 LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 texIndices)
 {
-    const vec2 indexMax=lightPollutionTextureSize-vec2(1);
+    CONST vec2 indexMax=lightPollutionTextureSize-vec2(1);
 
-    const float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
-    const float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
+    CONST float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
-    const bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
-    const float cosViewZenithAngleCoord = viewRayIntersectsGround ?
+    CONST bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
+    CONST float cosViewZenithAngleCoord = viewRayIntersectsGround ?
                                    1-2*texIndices[0]/(indexMax[0]-1) :
                                    2*(texIndices[0]-1)/(indexMax[0]-1)-1;
     // ------------------------------------
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
@@ -753,23 +764,23 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 
 LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -777,27 +788,27 @@ LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, con
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     return LightPollution2DCoords(cosVZACoord, altCoord);
 }
 
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
-    const vec2 texSize = lightPollutionTextureSize;
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 texSize = lightPollutionTextureSize;
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2);
-    const float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
+    CONST float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
     return vec2(cosVZAtc, altitudeTC);
 }

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputed/aerosols/texture-sampling-functions.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputed/aerosols/texture-sampling-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-sampling-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,13 +45,13 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // texture-sampling-functions.frag
-#line 1 2 // phase-functions.h.glsl
+#line 4 0 // texture-sampling-functions.frag
+#line 1 3 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 6 0 // texture-sampling-functions.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-sampling-functions.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -72,8 +83,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-sampling-functions.frag
-#line 1 4 // texture-coordinates.h.glsl
+#line 6 0 // texture-sampling-functions.frag
+#line 1 5 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -142,7 +153,7 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 8 0 // texture-sampling-functions.frag
+#line 7 0 // texture-sampling-functions.frag
 
 uniform sampler2D transmittanceTexture;
 uniform sampler2D irradianceTexture;
@@ -154,13 +165,13 @@ uniform sampler2D lightPollutionScatteringTexture;
 
 vec4 irradiance(const float cosSunZenithAngle, const float altitude)
 {
-    const vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
+    CONST vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
     return texture(irradianceTexture, texCoords);
 }
 
 vec4 opticalDepthToAtmosphereBorder(const float cosViewZenithAngle, const float altitude)
 {
-    const vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
+    CONST vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact when looking into nadir from TOA at some values of texture sizes (in particular, size of
     // transmittance texture for altitude being 4096). This happens when I simply call texture(eclipsedScatteringTexture,
@@ -178,11 +189,11 @@ vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float
 vec4 transmittance(const float cosViewZenithAngle, const float altitude, const float dist,
                    const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle view ray endpoint
     // in space here.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
 
     vec4 depth;
     if(viewRayIntersectsGround)
@@ -201,7 +212,7 @@ vec4 transmittance(const float cosViewZenithAngle, const float altitude, const f
 vec4 calcFirstScattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                          const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
+    CONST vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
                                           dotViewSun, altitude, viewRayIntersectsGround);
     return scattering*currentPhaseFunction(dotViewSun);
 }
@@ -220,6 +231,6 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
 
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     return texture(lightPollutionScatteringTexture, coords);
 }

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputed/molecules/common-functions.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputed/molecules/common-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // common-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // common-functions.frag
+#line 4 0 // common-functions.frag
 
 bool dbgDataPresent=false;
 bool debugDataPresent()
@@ -69,7 +80,7 @@ void setDebugData(float a,float b, float c, float d)
 
 void swap(inout float x, inout float y)
 {
-    const float t = x;
+    CONST float t = x;
     x = y;
     y = t;
 }
@@ -83,7 +94,7 @@ float safeSqrt(const float x)
 
 float safeAtan(const float y, const float x)
 {
-    const float a = atan(y,x);
+    CONST float a = atan(y,x);
     return x==0 && y==0 ? 0 : a;
 }
 
@@ -116,23 +127,23 @@ float pointAltitude(vec3 point)
 
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float Ratm=earthRadius+atmosphereHeight;
-    const float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float Ratm=earthRadius+atmosphereHeight;
+    CONST float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float distanceToGround(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(-safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float cosZenithAngleOfHorizon(const float altitude)
 {
-    const float R=earthRadius;
-    const float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
+    CONST float R=earthRadius;
+    CONST float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
     return -sqrt(2*h*R+sqr(h))/(R+h);
 }
 
@@ -151,8 +162,8 @@ float distanceToNearestAtmosphereBoundary(const float cosZenithAngle, const floa
 float sunVisibility(const float cosSunZenithAngle, float altitude)
 {
     if(altitude<0) altitude=0;
-    const float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
-    const float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
+    CONST float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
+    CONST float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
     /* Approximating visible fraction of solar disk by smoothstep between the position of the Sun
      * touching the horizon by its upper part and the position with lower part touching the horizon.
      * The calculation assumes that solar angular radius is small and thus approximately equals its sine.
@@ -182,13 +193,13 @@ float circlesIntersectionArea(float R1, float R2, float d)
 
 float angleBetween(const vec3 a, const vec3 b)
 {
-    const float d=dot(a,b);
-    const float c=length(cross(a,b));
+    CONST float d=dot(a,b);
+    CONST float c=length(cross(a,b));
     // To avoid loss of precision, don't use dot product near the singularity
     // of acos, and cross product near the singularity of asin
     if(abs(d) < abs(c))
         return acos(d/(length(a)*length(b)));
-    const float smallerAngle = asin(c/(length(a)*length(b)));
+    CONST float smallerAngle = asin(c/(length(a)*length(b)));
     if(d<0) return PI-smallerAngle;
     return smallerAngle;
 }
@@ -205,11 +216,11 @@ float moonAngularRadius(const vec3 cameraPosition, const vec3 moonPosition)
 
 float visibleSolidAngleOfSun(const vec3 camera, const vec3 sunDir, const vec3 moonPos)
 {
-    const float Rs=sunAngularRadius;
-    const float Rm=moonAngularRadius(camera,moonPos);
+    CONST float Rs=sunAngularRadius;
+    CONST float Rm=moonAngularRadius(camera,moonPos);
     float visibleSolidAngle=PI*sqr(Rs);
 
-    const float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
+    CONST float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
     if(dSM<Rs+Rm)
     {
         visibleSolidAngle -= circlesIntersectionArea(Rm,Rs,dSM);
@@ -229,12 +240,12 @@ float sphereIntegrationSolidAngleDifferential(const int pointCountOnSphere)
 }
 vec3 sphereIntegrationSampleDir(const int index, const int pointCountOnSphere)
 {
-    const float goldenRatio=1.6180339887499;
+    CONST float goldenRatio=1.6180339887499;
     // The range of n is 0.5, 1.5, ..., pointCountOnSphere-0.5
-    const float n=index+0.5;
+    CONST float n=index+0.5;
     // Explanation of the Fibonacci grid generation can be seen at https://stackoverflow.com/a/44164075/673852
-    const float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
-    const float azimuth=n*(2*PI*goldenRatio);
+    CONST float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
+    CONST float azimuth=n*(2*PI*goldenRatio);
     return vec3(cos(azimuth)*sin(zenithAngle),
                 sin(azimuth)*sin(zenithAngle),
                 cos(zenithAngle));

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputed/molecules/densities.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputed/molecules/densities.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // densities.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,20 +45,20 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // densities.frag
+#line 4 0 // densities.frag
 float scattererNumberDensity_molecules(float altitude)
 {
-        const float rayleighScaleHeight=8*km;
+        CONST float rayleighScaleHeight=8*km;
         return 3.08458e25*exp(-1/rayleighScaleHeight * altitude);
 }
 float scattererNumberDensity_aerosols(float altitude)
 {
-        const float mieScaleHeight=1.2*km;
+        CONST float mieScaleHeight=1.2*km;
         return 1.03333e8*exp(-1/mieScaleHeight*altitude);
 }
 float absorberNumberDensity_ozone(float altitude)
 {
-        const float totalOzoneAmount=370*dobsonUnit;
+        CONST float totalOzoneAmount=370*dobsonUnit;
 
         float density;
 

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputed/molecules/phase-functions.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputed/molecules/phase-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // phase-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // phase-functions.frag
+#line 4 0 // phase-functions.frag
 
 vec4 phaseFunction_molecules(float dotViewSun)
 {
@@ -42,9 +53,9 @@ vec4 phaseFunction_molecules(float dotViewSun)
 }
 vec4 phaseFunction_aerosols(float dotViewSun)
 {
-        const float g=0.76;
-        const float g2=g*g;
-        const float k = 3/(8*PI)*(1-g2)/(2+g2);
+        CONST float g=0.76;
+        CONST float g2=g*g;
+        CONST float k = 3/(8*PI)*(1-g2)/(2+g2);
         return vec4(k * (1+sqr(dotViewSun)) / pow(1+g2 - 2*g*dotViewSun, 1.5) + 1/((1-dotViewSun)*600+0.05))*0.904;
 }
 vec4 currentPhaseFunction(float dotViewSun) { return phaseFunction_molecules(dotViewSun); }

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputed/molecules/render.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputed/molecules/render.frag
@@ -1,7 +1,21 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
 
-#line 1 1 // const.h.glsl
+
+
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 6 0 // render.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,11 +48,11 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // render.frag
-#line 1 2 // calc-view-dir.h.glsl
+#line 7 0 // render.frag
+#line 1 3 // calc-view-dir.h.glsl
 vec3 calcViewDir();
-#line 6 0 // render.frag
-#line 1 3 // common-functions.h.glsl
+#line 8 0 // render.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -70,14 +84,14 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // render.frag
-#line 1 4 // phase-functions.h.glsl
+#line 9 0 // render.frag
+#line 1 5 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 8 0 // render.frag
+#line 10 0 // render.frag
 
-#line 1 5 // single-scattering-eclipsed.h.glsl
+#line 1 6 // single-scattering-eclipsed.h.glsl
 #ifndef INCLUDE_ONCE_050024D2_BD56_434E_8D40_2055DA0B78EC
 #define INCLUDE_ONCE_050024D2_BD56_434E_8D40_2055DA0B78EC
 
@@ -85,8 +99,8 @@ vec4 computeSingleScatteringEclipsed(const vec3 camera, const vec3 viewDir, cons
                                      const bool viewRayIntersectsGround);
 
 #endif
-#line 10 0 // render.frag
-#line 1 6 // texture-coordinates.h.glsl
+#line 12 0 // render.frag
+#line 1 7 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -155,10 +169,10 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 11 0 // render.frag
-#line 1 7 // radiance-to-luminance.h.glsl
+#line 13 0 // render.frag
+#line 1 8 // radiance-to-luminance.h.glsl
 const mat4 radianceToLuminance=mat4(19.8756237,7.17745161,0,0.0937032327,  2.13895917,0.772417068,0,0.0149318045,  0.241072536,0.0870557055,0,0,  0.0133876652,0.00483453181,0,0);
-#line 12 0 // render.frag
+#line 14 0 // render.frag
 
 
 
@@ -195,18 +209,18 @@ void main()
     // this approximation has the same order of magnitude as the assumption that the Earth and its atmosphere
     // are spherical.
     float altitude = max(cameraPosition.z, 0.);
-    const vec3 oldCamPos=cameraPosition;
+    CONST vec3 oldCamPos=cameraPosition;
     // Hide the uniform with this name, thus effectively modifying it for the following code
     vec3 cameraPosition=vec3(oldCamPos.xy, altitude);
 
     bool lookingIntoAtmosphere=true;
     if(altitude>atmosphereHeight)
     {
-        const vec3 p = cameraPosition - earthCenter;
-        const float p_dot_v = dot(p, viewDir);
-        const float p_dot_p = dot(p, p);
-        const float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
-        const float distanceToTOA = -p_dot_v - sqrt(sqr(earthRadius+atmosphereHeight) - squaredDistBetweenViewRayAndEarthCenter);
+        CONST vec3 p = cameraPosition - earthCenter;
+        CONST float p_dot_v = dot(p, viewDir);
+        CONST float p_dot_p = dot(p, p);
+        CONST float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
+        CONST float distanceToTOA = -p_dot_v - sqrt(sqr(earthRadius+atmosphereHeight) - squaredDistBetweenViewRayAndEarthCenter);
         if(distanceToTOA>=0)
         {
             cameraPosition += viewDir*distanceToTOA;
@@ -214,7 +228,7 @@ void main()
         }
         else
         {
-#if RENDERING_ANY_ZERO_SCATTERING
+#if 0 /*RENDERING_ANY_ZERO_SCATTERING*/
             lookingIntoAtmosphere=false;
 #else
             luminance=vec4(0);
@@ -224,16 +238,16 @@ void main()
         }
     }
 
-    const vec3 zenith=normalize(cameraPosition-earthCenter);
+    CONST vec3 zenith=normalize(cameraPosition-earthCenter);
     float cosViewZenithAngle=dot(zenith,viewDir);
 
     bool viewRayIntersectsGround=false;
     {
-        const vec3 p = cameraPosition - earthCenter;
-        const float p_dot_v = dot(p, viewDir);
-        const float p_dot_p = dot(p, p);
-        const float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
-        const float distanceToIntersection = -p_dot_v - sqrt(sqr(earthRadius) - squaredDistBetweenViewRayAndEarthCenter);
+        CONST vec3 p = cameraPosition - earthCenter;
+        CONST float p_dot_v = dot(p, viewDir);
+        CONST float p_dot_p = dot(p, p);
+        CONST float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
+        CONST float distanceToIntersection = -p_dot_v - sqrt(sqr(earthRadius) - squaredDistBetweenViewRayAndEarthCenter);
         // altitude==0 is a special case where distance to intersection calculation
         // is unreliable (has a lot of noise in its sign), so check it separately
         if(distanceToIntersection>0 || (altitude==0 && cosViewZenithAngle<0))
@@ -244,11 +258,11 @@ void main()
     // Aside from aesthetics, this affects brightness input to Stellarium's tone mapper.
     if(pseudoMirrorSkyBelowHorizon && viewRayIntersectsGround)
     {
-        const float horizonCZA = cosZenithAngleOfHorizon(altitude);
-        const float viewElev  = asin(clampCosine(cosViewZenithAngle));
-        const float horizElev = asin(clampCosine(horizonCZA));
-        const float newViewElev = 2*horizElev - viewElev;
-        const float viewDirXYnorm = length(viewDir-zenith*cosViewZenithAngle);
+        CONST float horizonCZA = cosZenithAngleOfHorizon(altitude);
+        CONST float viewElev  = asin(clampCosine(cosViewZenithAngle));
+        CONST float horizElev = asin(clampCosine(horizonCZA));
+        CONST float newViewElev = 2*horizElev - viewElev;
+        CONST float viewDirXYnorm = length(viewDir-zenith*cosViewZenithAngle);
         if(viewDirXYnorm == 0)
         {
             viewDir = zenith;
@@ -267,27 +281,27 @@ void main()
         viewRayIntersectsGround = false;
     }
 
-    const float cosSunZenithAngle =dot(zenith,sunDirection);
-    const float dotViewSun=dot(viewDir,sunDirection);
+    CONST float cosSunZenithAngle =dot(zenith,sunDirection);
+    CONST float dotViewSun=dot(viewDir,sunDirection);
 
-    const vec3 sunXYunnorm=sunDirection-dot(sunDirection,zenith)*zenith;
-    const vec3 viewXYunnorm=viewDir-dot(viewDir,zenith)*zenith;
-    const vec3 sunXY = sunXYunnorm.x!=0 || sunXYunnorm.y!=0 || sunXYunnorm.z!=0 ? normalize(sunXYunnorm) : vec3(0);
-    const vec3 viewXY = viewXYunnorm.x!=0 || viewXYunnorm.y!=0 || viewXYunnorm.z!=0 ? normalize(viewXYunnorm) : vec3(0);
-    const float azimuthRelativeToSun=safeAtan(dot(cross(sunXY, viewXY), zenith), dot(sunXY, viewXY));
+    CONST vec3 sunXYunnorm=sunDirection-dot(sunDirection,zenith)*zenith;
+    CONST vec3 viewXYunnorm=viewDir-dot(viewDir,zenith)*zenith;
+    CONST vec3 sunXY = sunXYunnorm.x!=0 || sunXYunnorm.y!=0 || sunXYunnorm.z!=0 ? normalize(sunXYunnorm) : vec3(0);
+    CONST vec3 viewXY = viewXYunnorm.x!=0 || viewXYunnorm.y!=0 || viewXYunnorm.z!=0 ? normalize(viewXYunnorm) : vec3(0);
+    CONST float azimuthRelativeToSun=safeAtan(dot(cross(sunXY, viewXY), zenith), dot(sunXY, viewXY));
 
-#if RENDERING_ZERO_SCATTERING
+#if 0 /*RENDERING_ZERO_SCATTERING*/
     vec4 radiance;
     if(viewRayIntersectsGround)
     {
         // XXX: keep in sync with the same code in computeScatteringDensity(), but don't forget about
         //      the difference in the usage of viewDir vs incDir.
-        const float distToGround = distanceToGround(cosViewZenithAngle, altitude);
-        const vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
-        const vec3 groundNormal = normalize(zenith*(earthRadius+altitude)+viewDir*distToGround);
-        const vec4 groundIrradiance = irradiance(dot(groundNormal, sunDirection), 0);
+        CONST float distToGround = distanceToGround(cosViewZenithAngle, altitude);
+        CONST vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
+        CONST vec3 groundNormal = normalize(zenith*(earthRadius+altitude)+viewDir*distToGround);
+        CONST vec4 groundIrradiance = irradiance(dot(groundNormal, sunDirection), 0);
         // Radiation scattered by the ground
-        const float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
+        CONST float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
         radiance = transmittanceToGround*groundAlbedo*groundIrradiance*solarIrradianceFixup*groundBRDF
                  + lightPollutionGroundLuminance*lightPollutionRelativeRadiance;
     }
@@ -304,22 +318,22 @@ void main()
     }
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_ZERO_SCATTERING
+#elif 0 /*RENDERING_ECLIPSED_ZERO_SCATTERING*/
     vec4 radiance;
-    const float dotViewMoon=dot(viewDir,normalize(moonPosition-cameraPosition));
+    CONST float dotViewMoon=dot(viewDir,normalize(moonPosition-cameraPosition));
     if(viewRayIntersectsGround)
     {
         // XXX: keep in sync with the similar code in non-eclipsed zero scattering rendering.
-        const float distToGround = distanceToGround(cosViewZenithAngle, altitude);
-        const vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
-        const vec3 pointOnGround = cameraPosition+viewDir*distToGround;
-        const vec4 directGroundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDirection, moonPosition);
+        CONST float distToGround = distanceToGround(cosViewZenithAngle, altitude);
+        CONST vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
+        CONST vec3 pointOnGround = cameraPosition+viewDir*distToGround;
+        CONST vec4 directGroundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDirection, moonPosition);
         // FIXME: add first-order indirect irradiance too: it's done in non-eclipsed irradiance (in the same
         // conditions: when limited to 2 orders). This should be calculated at the same time when second order
         // is: all the infrastructure is already there.
-        const vec4 groundIrradiance = directGroundIrradiance;
+        CONST vec4 groundIrradiance = directGroundIrradiance;
         // Radiation scattered by the ground
-        const float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
+        CONST float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
         radiance = transmittanceToGround*groundAlbedo*groundIrradiance*solarIrradianceFixup*groundBRDF
                  + lightPollutionGroundLuminance*lightPollutionRelativeRadiance;
     }
@@ -336,53 +350,53 @@ void main()
     }
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_ON_THE_FLY
-    const vec4 scattering=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPosition,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_ON_THE_FLY*/
+    CONST vec4 scattering=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPosition,
                                                           viewRayIntersectsGround);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE
-    const vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE*/
+    CONST vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                      viewRayIntersectsGround, eclipsedSingleScatteringTextureSize);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact at the point where azimuth texture coordinate changes from 1 to 0 (at azimuthRelativeToSun crossing
     // 0). This happens when I simply call texture(eclipsedScatteringTexture, texCoords) without specifying LOD.
     // Apparently, the driver uses the derivative for some reason, even though it shouldn't.
-    const vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
+    CONST vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
 #elif 1 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
-    const vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+    CONST vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                      viewRayIntersectsGround, eclipsedSingleScatteringTextureSize);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact at the point where azimuth texture coordinate changes from 1 to 0 (at azimuthRelativeToSun crossing
     // 0). This happens when I simply call texture(eclipsedScatteringTexture, texCoords) without specifying LOD.
     // Apparently, the driver uses the derivative for some reason, even though it shouldn't.
-    const vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
+    CONST vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
     luminance=scattering*currentPhaseFunction(dotViewSun);
-#elif RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_RADIANCE
+#elif 0 /*RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_RADIANCE*/
     vec4 radiance=exp(sampleEclipseDoubleScattering3DTexture(eclipsedDoubleScatteringTexture,
                                                              cosSunZenithAngle, cosViewZenithAngle, azimuthRelativeToSun,
                                                              altitude, viewRayIntersectsGround));
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_LUMINANCE
+#elif 0 /*RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
     luminance=exp(sampleEclipseDoubleScattering3DTexture(eclipsedDoubleScatteringTexture,
                                                          cosSunZenithAngle, cosViewZenithAngle, azimuthRelativeToSun,
                                                          altitude, viewRayIntersectsGround));
-#elif RENDERING_SINGLE_SCATTERING_ON_THE_FLY
-    const vec4 scattering=computeSingleScattering(cosSunZenithAngle,cosViewZenithAngle,dotViewSun,
+#elif 0 /*RENDERING_SINGLE_SCATTERING_ON_THE_FLY*/
+    CONST vec4 scattering=computeSingleScattering(cosSunZenithAngle,cosViewZenithAngle,dotViewSun,
                                                   altitude,viewRayIntersectsGround);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE
+#elif 0 /*RENDERING_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE*/
     vec4 scattering;
     if(useInterpolationGuides)
     {
@@ -399,7 +413,7 @@ void main()
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE
+#elif 0 /*RENDERING_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
     vec4 scattering;
     if(useInterpolationGuides)
     {
@@ -413,18 +427,18 @@ void main()
                                      dotViewSun, altitude, viewRayIntersectsGround);
     }
     luminance=scattering * (bool(PHASE_FUNCTION_IS_EMBEDDED) ? vec4(1) : currentPhaseFunction(dotViewSun));
-#elif RENDERING_MULTIPLE_SCATTERING_LUMINANCE
+#elif 0 /*RENDERING_MULTIPLE_SCATTERING_LUMINANCE*/
     luminance=sample3DTexture(scatteringTexture, cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, viewRayIntersectsGround);
-#elif RENDERING_MULTIPLE_SCATTERING_RADIANCE
+#elif 0 /*RENDERING_MULTIPLE_SCATTERING_RADIANCE*/
     vec4 radiance=sample3DTexture(scatteringTexture, cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, viewRayIntersectsGround);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_LIGHT_POLLUTION_RADIANCE
+#elif 0 /*RENDERING_LIGHT_POLLUTION_RADIANCE*/
     vec4 radiance=lightPollutionGroundLuminance*lightPollutionScattering(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_LIGHT_POLLUTION_LUMINANCE
+#elif 0 /*RENDERING_LIGHT_POLLUTION_LUMINANCE*/
     luminance=lightPollutionGroundLuminance*lightPollutionScattering(altitude, cosViewZenithAngle, viewRayIntersectsGround);
 #else
 #error What to render?

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputed/molecules/single-scattering-eclipsed.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputed/molecules/single-scattering-eclipsed.frag
@@ -1,7 +1,21 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
 
-#line 1 1 // const.h.glsl
+
+
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 6 0 // single-scattering-eclipsed.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,15 +48,15 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // single-scattering-eclipsed.frag
-#line 1 2 // densities.h.glsl
+#line 7 0 // single-scattering-eclipsed.frag
+#line 1 3 // densities.h.glsl
 float scattererNumberDensity_molecules(float altitude);
 float scattererNumberDensity_aerosols(float altitude);
 float absorberNumberDensity_ozone(float altitude);
 vec4 scatteringCrossSection();
 float scattererDensity(float altitude);
-#line 6 0 // single-scattering-eclipsed.frag
-#line 1 3 // common-functions.h.glsl
+#line 8 0 // single-scattering-eclipsed.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -74,8 +88,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // single-scattering-eclipsed.frag
-#line 1 4 // texture-sampling-functions.h.glsl
+#line 9 0 // single-scattering-eclipsed.frag
+#line 1 5 // texture-sampling-functions.h.glsl
 #ifndef INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 #define INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float altitude);
@@ -87,7 +101,7 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                 const int scatteringOrder);
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 #endif
-#line 8 0 // single-scattering-eclipsed.frag
+#line 10 0 // single-scattering-eclipsed.frag
 
 
 float cosZenithAngle(vec3 origin, vec3 direction)
@@ -101,13 +115,13 @@ vec4 computeSingleScatteringIntegrandEclipsed(const float cosSunZenithAngle, con
                                               const float dist, const bool viewRayIntersectsGround,
                                               const vec3 scatterer, const vec3 sunDir, const vec3 moonPos)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle here the case when the
     // endpoint of the view ray intentionally appears in outer space.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosSunZenithAngleAtDist=clampCosine((r*cosSunZenithAngle+dist*dotViewSun)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosSunZenithAngleAtDist=clampCosine((r*cosSunZenithAngle+dist*dotViewSun)/(earthRadius+altAtDist));
 
-    const vec4 xmittance=transmittance(cosViewZenithAngle, altitude, dist, viewRayIntersectsGround)
+    CONST vec4 xmittance=transmittance(cosViewZenithAngle, altitude, dist, viewRayIntersectsGround)
                                                     *
                          transmittanceToAtmosphereBorder(cosSunZenithAngleAtDist, altAtDist)
                                                     *
@@ -115,7 +129,7 @@ vec4 computeSingleScatteringIntegrandEclipsed(const float cosSunZenithAngle, con
                                                     *
                             // FIXME: this ignores orientation of the crescent of eclipsed Sun WRT horizon
                                     sunVisibility(cosSunZenithAngleAtDist, altAtDist);
-#if ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION
+#if 0 /*ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION*/
     COMPUTE_TOTAL_SCATTERING_COEFFICIENT;
     return xmittance * totalScatteringCoefficient;
 #else
@@ -126,26 +140,26 @@ vec4 computeSingleScatteringIntegrandEclipsed(const float cosSunZenithAngle, con
 vec4 computeSingleScatteringEclipsed(const vec3 camera, const vec3 viewDir, const vec3 sunDir, const vec3 moonPos,
                                      const bool viewRayIntersectsGround)
 {
-    const float cosViewZenithAngle=cosZenithAngle(camera,viewDir);
-    const float cosSunZenithAngle=cosZenithAngle(camera,sunDir);
-    const float altitude=pointAltitude(camera);
-    const float dotViewSun=dot(viewDir,sunDir);
-    const float integrInterval=distanceToNearestAtmosphereBoundary(cosViewZenithAngle, altitude,
+    CONST float cosViewZenithAngle=cosZenithAngle(camera,viewDir);
+    CONST float cosSunZenithAngle=cosZenithAngle(camera,sunDir);
+    CONST float altitude=pointAltitude(camera);
+    CONST float dotViewSun=dot(viewDir,sunDir);
+    CONST float integrInterval=distanceToNearestAtmosphereBoundary(cosViewZenithAngle, altitude,
                                                                    viewRayIntersectsGround);
 
     // Using the midpoint rule for quadrature
     vec4 spectrum=vec4(0);
-    const float dl=integrInterval/radialIntegrationPoints;
+    CONST float dl=integrInterval/radialIntegrationPoints;
     for(int n=0; n<radialIntegrationPoints; ++n)
     {
-        const float dist=(n+0.5)*dl;
+        CONST float dist=(n+0.5)*dl;
         spectrum += computeSingleScatteringIntegrandEclipsed(cosSunZenithAngle, cosViewZenithAngle, dotViewSun,
                                                              altitude, dist, viewRayIntersectsGround,
                                                              camera+viewDir*dist, sunDir, moonPos);
     }
 
     spectrum *= dl*solarIrradianceAtTOA
-#if ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION
+#if 0 /*ALL_SCATTERERS_AT_ONCE_WITH_PHASE_FUNCTION*/
                                 // the multiplier is already included
 #else
                                         * scatteringCrossSection()

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputed/molecules/texture-coordinates.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputed/molecules/texture-coordinates.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-coordinates.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,8 +45,8 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // texture-coordinates.frag
-#line 1 2 // texture-coordinates.h.glsl
+#line 4 0 // texture-coordinates.frag
+#line 1 3 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -104,8 +115,8 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 6 0 // texture-coordinates.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-coordinates.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -137,7 +148,7 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-coordinates.frag
+#line 6 0 // texture-coordinates.frag
 
 const float LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA=sqrt(atmosphereHeight*(atmosphereHeight+2*earthRadius));
 
@@ -205,18 +216,18 @@ vec3 indicesToTexCoords(const vec3 indices, const vec3 texSizes)
 
 TransmittanceTexVars transmittanceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
+    CONST float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
                                 texCoordToUnitRange(texCoord.t,transmittanceTextureSize.t);
     // Distance from Earth center to camera
-    const float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
-    const float altitude=r-earthRadius;
+    CONST float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
+    CONST float altitude=r-earthRadius;
 
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
     // distance to border of visible atmosphere from the view point
-    const float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
+    CONST float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
     // d==0 can happen when altitude==atmosphereHeight
-    const float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
+    CONST float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
     return TransmittanceTexVars(cosVZA,altitude);
 }
 
@@ -235,53 +246,53 @@ vec2 transmittanceTexVarsToTexCoord(const float cosVZA, float altitude)
     if(altitude<0)
         altitude=0;
 
-    const float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
+    CONST float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
                                       transmittanceTextureSize.t);
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
-    const float d=distanceToAtmosphereBorder(cosVZA,altitude);
-    const float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float d=distanceToAtmosphereBorder(cosVZA,altitude);
+    CONST float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
     return vec2(s,t);
 }
 
 // Output: vec2(cos(sunZenithAngle), altitude)
 IrradianceTexVars irradianceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
-    const float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
+    CONST float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
+    CONST float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
     return IrradianceTexVars(cosSZA,alt);
 }
 
 vec2 irradianceTexVarsToTexCoord(const float cosSunZenithAngle, const float altitude)
 {
-    const float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
-    const float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
+    CONST float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
+    CONST float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
     return vec2(s,t);
 }
 
 float cosSZAToUnitRangeTexCoord(const float cosSunZenithAngle)
 {
     // Distance to top atmosphere border along the ray groundUnderCamera-sun: (altitude, cosSunZenithAngle)
-    const float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name
-    const float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
+    CONST float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
     // TODO: choose a more descriptive name
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     return max(0.,1-a/A)/(a+1);
 }
 
 float unitRangeTexCoordToCosSZA(const float texCoord)
 {
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float a=(A-A*texCoord)/(1+A*texCoord);
-    const float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
+    CONST float a=(A-A*texCoord)/(1+A*texCoord);
+    CONST float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
     return distFromGroundToTopAtmoBorder==0 ? 1 :
         clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distFromGroundToTopAtmoBorder)) /
                     (2*earthRadius*distFromGroundToTopAtmoBorder));
@@ -292,24 +303,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
                                                const float dotViewSun, const float altitude,
                                                const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -317,24 +328,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float dotVSCoord=(dotViewSun+1)/2;
+    CONST float dotVSCoord=(dotViewSun+1)/2;
 
     // ------------------------------------
-    const float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
+    CONST float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
 
     return Scattering4DCoords(cosSZACoord, cosVZACoord, dotVSCoord, altCoord, viewRayIntersectsGround);
 }
 
 TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
@@ -342,16 +353,16 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture coordinates we combine into a single sampler3D coordinate.
-    const float texW = scatteringTextureSize[1];
-    const float texH = scatteringTextureSize[2];
-    const float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
-    const vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
+    CONST float texW = scatteringTextureSize[1];
+    CONST float texH = scatteringTextureSize[2];
+    CONST float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
+    CONST vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
                                         ceil (cosSZAIndex)*texW+coords.dotViewSun*(texW-1)) / (texW*texH-1);
-    const vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
+    CONST vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
 
-    const float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
+    CONST float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
 
-    const float alphaUpper=fract(cosSZAIndex);
+    CONST float alphaUpper=fract(cosSZAIndex);
     return TexCoordPair(vec3(cosVZAtc, combinedCoord.x, altitude), float(1-alphaUpper),
                         vec3(cosVZAtc, combinedCoord.y, altitude), float(alphaUpper));
 }
@@ -359,9 +370,9 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
+    CONST TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
     return texture(tex, texCoords.lower) * texCoords.alphaLower +
            texture(tex, texCoords.upper) * texCoords.alphaUpper;
 }
@@ -369,17 +380,17 @@ vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const f
 // 3D texture is the 3D single-altitude slice of a 4D texture
 vec3 scattering4DCoordsToTex3DCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2);
 
-    const float dvsSize = scatteringTextureSize[1];
-    const float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
+    CONST float dvsSize = scatteringTextureSize[1];
+    CONST float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
 
-    const float cszaSize = scatteringTextureSize[2];
-    const float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
+    CONST float cszaSize = scatteringTextureSize[2];
+    CONST float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
 
     return vec3(cosVZAtc, dotVStc, cosSZAtc);
 }
@@ -394,39 +405,39 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along dotViewSun coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[1];
-    const float posOfRow = indices[1];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[1];
+    CONST float posOfRow = indices[1];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         indexToTexCoord(currRow, numRows-1),
                                                         texCoordVerbatim));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               indexToTexCoord(currRow, numRows-1),
                                                               texCoordVerbatim));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          indexToTexCoord(currRow, numRows-1),
                                          texCoordVerbatim));
@@ -434,14 +445,14 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
 vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolationGuides01Tex,
                                  const vec3 indices)
 {
-    const float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
+    CONST float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
 
-    const float cosVZAIndex = indices[0];
-    const float dotVSIndex = indices[1];
-    const float currRow = floor(dotVSIndex);
-    const float posBetweenRows = dotVSIndex - currRow;
-    const float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cosVZAIndex = indices[0];
+    CONST float dotVSIndex = indices[1];
+    CONST float currRow = floor(dotVSIndex);
+    CONST float posBetweenRows = dotVSIndex - currRow;
+    CONST float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -449,14 +460,14 @@ vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolat
     indicesCurrRow[1] =     currRow;
     indicesNextRow[1] = min(currRow+1, scatteringTextureSize[1]-1.);
 
-    const vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
-    const vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
+    CONST vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
+    CONST vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
 
-    const vec4 valueCurrRow = texture(tex, coordsCurrRow);
-    const vec4 valueNextRow = texture(tex, coordsNextRow);
-    const float epsilon = 1e-37; // Prevents passing zero to log
-    const vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
-    const vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
+    CONST vec4 valueCurrRow = texture(tex, coordsCurrRow);
+    CONST vec4 valueNextRow = texture(tex, coordsNextRow);
+    CONST float epsilon = 1e-37; // Prevents passing zero to log
+    CONST vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
+    CONST vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
     return (logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow;
 }
 
@@ -465,37 +476,37 @@ float findGuide02Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along SZA coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[2];
-    const float posOfRow = indices[2];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[2];
+    CONST float posOfRow = indices[2];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
 }
@@ -505,19 +516,19 @@ vec4 sample3DTextureGuided(const sampler3D tex,
                            const float cosSunZenithAngle, const float cosViewZenithAngle,
                            const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
                                                                     dotViewSun, altitude, viewRayIntersectsGround);
     // Handle the external interpolation guides: the guides between a pair of VZA-dotViewSun 2D "pictures".
-    const vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
-    const vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
-    const float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
+    CONST vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
+    CONST float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
 
-    const float cvzaIndex = indices[0];
-    const float cszaIndex = indices[2];
-    const float currRow = floor(cszaIndex);
-    const float posBetweenRows = cszaIndex - currRow;
-    const float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cvzaIndex = indices[0];
+    CONST float cszaIndex = indices[2];
+    CONST float currRow = floor(cszaIndex);
+    CONST float posBetweenRows = cszaIndex - currRow;
+    CONST float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -526,58 +537,58 @@ vec4 sample3DTextureGuided(const sampler3D tex,
     indicesNextRow[2] = min(currRow+1, scatteringTextureSize[2]-1);
 
     // The caller will handle the internal interpolation guides: the ones between rows in each 2D "picture".
-    const vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
-    const vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
+    CONST vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
+    CONST vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
     return exp((logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow);
 }
 
 vec4 sample3DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
     return texture(tex, texCoords);
 }
 
 ScatteringTexVars scatteringTex4DCoordsToTexVars(const Scattering4DCoords coords)
 {
-    const float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
     // ------------------------------------
     float cosViewZenithAngle;
     if(coords.viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
     // ------------------------------------
-    const float dotViewSun=coords.dotViewSun*2-1;
+    CONST float dotViewSun=coords.dotViewSun*2-1;
 
     // ------------------------------------
-    const float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
+    CONST float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
 
     return ScatteringTexVars(cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, coords.viewRayIntersectsGround);
 }
 
 Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 {
-    const vec4 indexMax=scatteringTextureSize-vec4(1);
+    CONST vec4 indexMax=scatteringTextureSize-vec4(1);
     Scattering4DCoords coords4d;
     coords4d.viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
     // The following formulas assume that scatteringTextureSize[0] is even. For odd sizes they would change.
@@ -593,8 +604,8 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture indices we combine into a single sampler3D coordinate.
-    const float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
-    const float combinedIndex=texIndices[1];
+    CONST float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
+    CONST float combinedIndex=texIndices[1];
     coords4d.dotViewSun=mod(combinedIndex,texW)/(texW-1);
     coords4d.cosSunZenithAngle=floor(combinedIndex/texW)/(texH-1);
 
@@ -608,11 +619,11 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
 ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 {
-    const Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
+    CONST Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
     ScatteringTexVars vars=scatteringTex4DCoordsToTexVars(coords4d);
     // Clamp dotViewSun to its valid range of values, given cosViewZenithAngle and cosSunZenithAngle. This is
     // needed to prevent NaNs when computing the scattering texture.
-    const float cosVZA=vars.cosViewZenithAngle,
+    CONST float cosVZA=vars.cosViewZenithAngle,
                 cosSZA=vars.cosSunZenithAngle;
     vars.dotViewSun=clamp(vars.dotViewSun,
                           cosVZA*cosSZA-safeSqrt((1-sqr(cosVZA))*(1-sqr(cosSZA))),
@@ -622,54 +633,54 @@ ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 
 EclipseScatteringTexVars eclipseTexCoordsToTexVars(const vec2 texCoords, const float altitude)
 {
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
-    const bool viewRayIntersectsGround = texCoords.t<0.5;
+    CONST bool viewRayIntersectsGround = texCoords.t<0.5;
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
-    const float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
+    CONST float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
     return EclipseScatteringTexVars(azimuthRelativeToSun, cosViewZenithAngle, viewRayIntersectsGround);
 }
 
 EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                                    const float altitude, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -677,13 +688,13 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
-    const float azimuthCoord = azimuthRelativeToSun/(2*PI);
+    CONST float azimuthCoord = azimuthRelativeToSun/(2*PI);
 
     return EclipseScattering2DCoords(azimuthCoord, cosVZACoord);
 }
@@ -691,14 +702,14 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
 vec2 eclipseTexVarsToTexCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                const float altitude, const bool viewRayIntersectsGround, const vec2 texSize)
 {
-    const EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+    CONST EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                                     viewRayIntersectsGround);
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2);
-    const float azimuthTC = coords.azimuth + 1/(2*texSize.s);
+    CONST float azimuthTC = coords.azimuth + 1/(2*texSize.s);
 
     return vec2(azimuthTC, cosVZAtc);
 }
@@ -707,42 +718,42 @@ vec4 sampleEclipseDoubleScattering3DTexture(const sampler3D tex, const float cos
                                             const float cosViewZenithAngle, const float azimuthRelativeToSun,
                                             const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
+    CONST vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
                                                   eclipsedDoubleScatteringTextureSize.st);
-    const float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
-    const vec3 texCoords=vec3(coords2d, cosSZACoord);
+    CONST float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
+    CONST vec3 texCoords=vec3(coords2d, cosSZACoord);
 
     return texture(tex, texCoords);
 }
 
 LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 texIndices)
 {
-    const vec2 indexMax=lightPollutionTextureSize-vec2(1);
+    CONST vec2 indexMax=lightPollutionTextureSize-vec2(1);
 
-    const float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
-    const float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
+    CONST float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
-    const bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
-    const float cosViewZenithAngleCoord = viewRayIntersectsGround ?
+    CONST bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
+    CONST float cosViewZenithAngleCoord = viewRayIntersectsGround ?
                                    1-2*texIndices[0]/(indexMax[0]-1) :
                                    2*(texIndices[0]-1)/(indexMax[0]-1)-1;
     // ------------------------------------
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
@@ -753,23 +764,23 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 
 LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -777,27 +788,27 @@ LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, con
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     return LightPollution2DCoords(cosVZACoord, altCoord);
 }
 
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
-    const vec2 texSize = lightPollutionTextureSize;
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 texSize = lightPollutionTextureSize;
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2);
-    const float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
+    CONST float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
     return vec2(cosVZAtc, altitudeTC);
 }

--- a/atmosphere/default/shaders/single-scattering-eclipsed/precomputed/molecules/texture-sampling-functions.frag
+++ b/atmosphere/default/shaders/single-scattering-eclipsed/precomputed/molecules/texture-sampling-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-sampling-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,13 +45,13 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // texture-sampling-functions.frag
-#line 1 2 // phase-functions.h.glsl
+#line 4 0 // texture-sampling-functions.frag
+#line 1 3 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 6 0 // texture-sampling-functions.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-sampling-functions.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -72,8 +83,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-sampling-functions.frag
-#line 1 4 // texture-coordinates.h.glsl
+#line 6 0 // texture-sampling-functions.frag
+#line 1 5 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -142,7 +153,7 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 8 0 // texture-sampling-functions.frag
+#line 7 0 // texture-sampling-functions.frag
 
 uniform sampler2D transmittanceTexture;
 uniform sampler2D irradianceTexture;
@@ -154,13 +165,13 @@ uniform sampler2D lightPollutionScatteringTexture;
 
 vec4 irradiance(const float cosSunZenithAngle, const float altitude)
 {
-    const vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
+    CONST vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
     return texture(irradianceTexture, texCoords);
 }
 
 vec4 opticalDepthToAtmosphereBorder(const float cosViewZenithAngle, const float altitude)
 {
-    const vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
+    CONST vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact when looking into nadir from TOA at some values of texture sizes (in particular, size of
     // transmittance texture for altitude being 4096). This happens when I simply call texture(eclipsedScatteringTexture,
@@ -178,11 +189,11 @@ vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float
 vec4 transmittance(const float cosViewZenithAngle, const float altitude, const float dist,
                    const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle view ray endpoint
     // in space here.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
 
     vec4 depth;
     if(viewRayIntersectsGround)
@@ -201,7 +212,7 @@ vec4 transmittance(const float cosViewZenithAngle, const float altitude, const f
 vec4 calcFirstScattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                          const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
+    CONST vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
                                           dotViewSun, altitude, viewRayIntersectsGround);
     return scattering*currentPhaseFunction(dotViewSun);
 }
@@ -220,6 +231,6 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
 
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     return texture(lightPollutionScatteringTexture, coords);
 }

--- a/atmosphere/default/shaders/single-scattering/on-the-fly/0/aerosols/common-functions.frag
+++ b/atmosphere/default/shaders/single-scattering/on-the-fly/0/aerosols/common-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // common-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // common-functions.frag
+#line 4 0 // common-functions.frag
 
 bool dbgDataPresent=false;
 bool debugDataPresent()
@@ -69,7 +80,7 @@ void setDebugData(float a,float b, float c, float d)
 
 void swap(inout float x, inout float y)
 {
-    const float t = x;
+    CONST float t = x;
     x = y;
     y = t;
 }
@@ -83,7 +94,7 @@ float safeSqrt(const float x)
 
 float safeAtan(const float y, const float x)
 {
-    const float a = atan(y,x);
+    CONST float a = atan(y,x);
     return x==0 && y==0 ? 0 : a;
 }
 
@@ -116,23 +127,23 @@ float pointAltitude(vec3 point)
 
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float Ratm=earthRadius+atmosphereHeight;
-    const float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float Ratm=earthRadius+atmosphereHeight;
+    CONST float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float distanceToGround(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(-safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float cosZenithAngleOfHorizon(const float altitude)
 {
-    const float R=earthRadius;
-    const float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
+    CONST float R=earthRadius;
+    CONST float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
     return -sqrt(2*h*R+sqr(h))/(R+h);
 }
 
@@ -151,8 +162,8 @@ float distanceToNearestAtmosphereBoundary(const float cosZenithAngle, const floa
 float sunVisibility(const float cosSunZenithAngle, float altitude)
 {
     if(altitude<0) altitude=0;
-    const float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
-    const float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
+    CONST float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
+    CONST float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
     /* Approximating visible fraction of solar disk by smoothstep between the position of the Sun
      * touching the horizon by its upper part and the position with lower part touching the horizon.
      * The calculation assumes that solar angular radius is small and thus approximately equals its sine.
@@ -182,13 +193,13 @@ float circlesIntersectionArea(float R1, float R2, float d)
 
 float angleBetween(const vec3 a, const vec3 b)
 {
-    const float d=dot(a,b);
-    const float c=length(cross(a,b));
+    CONST float d=dot(a,b);
+    CONST float c=length(cross(a,b));
     // To avoid loss of precision, don't use dot product near the singularity
     // of acos, and cross product near the singularity of asin
     if(abs(d) < abs(c))
         return acos(d/(length(a)*length(b)));
-    const float smallerAngle = asin(c/(length(a)*length(b)));
+    CONST float smallerAngle = asin(c/(length(a)*length(b)));
     if(d<0) return PI-smallerAngle;
     return smallerAngle;
 }
@@ -205,11 +216,11 @@ float moonAngularRadius(const vec3 cameraPosition, const vec3 moonPosition)
 
 float visibleSolidAngleOfSun(const vec3 camera, const vec3 sunDir, const vec3 moonPos)
 {
-    const float Rs=sunAngularRadius;
-    const float Rm=moonAngularRadius(camera,moonPos);
+    CONST float Rs=sunAngularRadius;
+    CONST float Rm=moonAngularRadius(camera,moonPos);
     float visibleSolidAngle=PI*sqr(Rs);
 
-    const float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
+    CONST float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
     if(dSM<Rs+Rm)
     {
         visibleSolidAngle -= circlesIntersectionArea(Rm,Rs,dSM);
@@ -229,12 +240,12 @@ float sphereIntegrationSolidAngleDifferential(const int pointCountOnSphere)
 }
 vec3 sphereIntegrationSampleDir(const int index, const int pointCountOnSphere)
 {
-    const float goldenRatio=1.6180339887499;
+    CONST float goldenRatio=1.6180339887499;
     // The range of n is 0.5, 1.5, ..., pointCountOnSphere-0.5
-    const float n=index+0.5;
+    CONST float n=index+0.5;
     // Explanation of the Fibonacci grid generation can be seen at https://stackoverflow.com/a/44164075/673852
-    const float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
-    const float azimuth=n*(2*PI*goldenRatio);
+    CONST float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
+    CONST float azimuth=n*(2*PI*goldenRatio);
     return vec3(cos(azimuth)*sin(zenithAngle),
                 sin(azimuth)*sin(zenithAngle),
                 cos(zenithAngle));

--- a/atmosphere/default/shaders/single-scattering/on-the-fly/0/aerosols/densities.frag
+++ b/atmosphere/default/shaders/single-scattering/on-the-fly/0/aerosols/densities.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // densities.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,20 +45,20 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // densities.frag
+#line 4 0 // densities.frag
 float scattererNumberDensity_molecules(float altitude)
 {
-        const float rayleighScaleHeight=8*km;
+        CONST float rayleighScaleHeight=8*km;
         return 3.08458e25*exp(-1/rayleighScaleHeight * altitude);
 }
 float scattererNumberDensity_aerosols(float altitude)
 {
-        const float mieScaleHeight=1.2*km;
+        CONST float mieScaleHeight=1.2*km;
         return 1.03333e8*exp(-1/mieScaleHeight*altitude);
 }
 float absorberNumberDensity_ozone(float altitude)
 {
-        const float totalOzoneAmount=370*dobsonUnit;
+        CONST float totalOzoneAmount=370*dobsonUnit;
 
         float density;
 

--- a/atmosphere/default/shaders/single-scattering/on-the-fly/0/aerosols/phase-functions.frag
+++ b/atmosphere/default/shaders/single-scattering/on-the-fly/0/aerosols/phase-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // phase-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // phase-functions.frag
+#line 4 0 // phase-functions.frag
 
 vec4 phaseFunction_molecules(float dotViewSun)
 {
@@ -42,9 +53,9 @@ vec4 phaseFunction_molecules(float dotViewSun)
 }
 vec4 phaseFunction_aerosols(float dotViewSun)
 {
-        const float g=0.76;
-        const float g2=g*g;
-        const float k = 3/(8*PI)*(1-g2)/(2+g2);
+        CONST float g=0.76;
+        CONST float g2=g*g;
+        CONST float k = 3/(8*PI)*(1-g2)/(2+g2);
         return vec4(k * (1+sqr(dotViewSun)) / pow(1+g2 - 2*g*dotViewSun, 1.5) + 1/((1-dotViewSun)*600+0.05))*0.904;
 }
 vec4 currentPhaseFunction(float dotViewSun) { return phaseFunction_aerosols(dotViewSun); }

--- a/atmosphere/default/shaders/single-scattering/on-the-fly/0/aerosols/render.frag
+++ b/atmosphere/default/shaders/single-scattering/on-the-fly/0/aerosols/render.frag
@@ -1,7 +1,21 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
 
-#line 1 1 // const.h.glsl
+
+
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 6 0 // render.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,11 +48,11 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // render.frag
-#line 1 2 // calc-view-dir.h.glsl
+#line 7 0 // render.frag
+#line 1 3 // calc-view-dir.h.glsl
 vec3 calcViewDir();
-#line 6 0 // render.frag
-#line 1 3 // common-functions.h.glsl
+#line 8 0 // render.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -70,13 +84,13 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // render.frag
-#line 1 4 // phase-functions.h.glsl
+#line 9 0 // render.frag
+#line 1 5 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 8 0 // render.frag
-#line 1 5 // single-scattering.h.glsl
+#line 10 0 // render.frag
+#line 1 6 // single-scattering.h.glsl
 #ifndef INCLUDE_ONCE_1DB2EDC1_C687_4FFA_BFF4_D18A54BA651B
 #define INCLUDE_ONCE_1DB2EDC1_C687_4FFA_BFF4_D18A54BA651B
 
@@ -84,9 +98,9 @@ vec4 computeSingleScattering(const float cosSunZenithAngle, const float cosViewZ
                              const float dotViewSun, const float altitude,
                              const bool viewRayIntersectsGround);
 #endif
-#line 9 0 // render.frag
+#line 11 0 // render.frag
 
-#line 1 6 // texture-coordinates.h.glsl
+#line 1 7 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -155,10 +169,10 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 11 0 // render.frag
-#line 1 7 // radiance-to-luminance.h.glsl
+#line 13 0 // render.frag
+#line 1 8 // radiance-to-luminance.h.glsl
 const mat4 radianceToLuminance=mat4(1.38997746,0.0419133306,6.48549128,0,  105.968163,3.00652099,500.960266,142.641495,  3776.24023,119.971481,18207.7598,6412.0166,  6910.01318,981.06665,37504.0586,26741.9102);
-#line 12 0 // render.frag
+#line 14 0 // render.frag
 
 
 
@@ -195,18 +209,18 @@ void main()
     // this approximation has the same order of magnitude as the assumption that the Earth and its atmosphere
     // are spherical.
     float altitude = max(cameraPosition.z, 0.);
-    const vec3 oldCamPos=cameraPosition;
+    CONST vec3 oldCamPos=cameraPosition;
     // Hide the uniform with this name, thus effectively modifying it for the following code
     vec3 cameraPosition=vec3(oldCamPos.xy, altitude);
 
     bool lookingIntoAtmosphere=true;
     if(altitude>atmosphereHeight)
     {
-        const vec3 p = cameraPosition - earthCenter;
-        const float p_dot_v = dot(p, viewDir);
-        const float p_dot_p = dot(p, p);
-        const float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
-        const float distanceToTOA = -p_dot_v - sqrt(sqr(earthRadius+atmosphereHeight) - squaredDistBetweenViewRayAndEarthCenter);
+        CONST vec3 p = cameraPosition - earthCenter;
+        CONST float p_dot_v = dot(p, viewDir);
+        CONST float p_dot_p = dot(p, p);
+        CONST float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
+        CONST float distanceToTOA = -p_dot_v - sqrt(sqr(earthRadius+atmosphereHeight) - squaredDistBetweenViewRayAndEarthCenter);
         if(distanceToTOA>=0)
         {
             cameraPosition += viewDir*distanceToTOA;
@@ -214,7 +228,7 @@ void main()
         }
         else
         {
-#if RENDERING_ANY_ZERO_SCATTERING
+#if 0 /*RENDERING_ANY_ZERO_SCATTERING*/
             lookingIntoAtmosphere=false;
 #else
             luminance=vec4(0);
@@ -224,16 +238,16 @@ void main()
         }
     }
 
-    const vec3 zenith=normalize(cameraPosition-earthCenter);
+    CONST vec3 zenith=normalize(cameraPosition-earthCenter);
     float cosViewZenithAngle=dot(zenith,viewDir);
 
     bool viewRayIntersectsGround=false;
     {
-        const vec3 p = cameraPosition - earthCenter;
-        const float p_dot_v = dot(p, viewDir);
-        const float p_dot_p = dot(p, p);
-        const float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
-        const float distanceToIntersection = -p_dot_v - sqrt(sqr(earthRadius) - squaredDistBetweenViewRayAndEarthCenter);
+        CONST vec3 p = cameraPosition - earthCenter;
+        CONST float p_dot_v = dot(p, viewDir);
+        CONST float p_dot_p = dot(p, p);
+        CONST float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
+        CONST float distanceToIntersection = -p_dot_v - sqrt(sqr(earthRadius) - squaredDistBetweenViewRayAndEarthCenter);
         // altitude==0 is a special case where distance to intersection calculation
         // is unreliable (has a lot of noise in its sign), so check it separately
         if(distanceToIntersection>0 || (altitude==0 && cosViewZenithAngle<0))
@@ -244,11 +258,11 @@ void main()
     // Aside from aesthetics, this affects brightness input to Stellarium's tone mapper.
     if(pseudoMirrorSkyBelowHorizon && viewRayIntersectsGround)
     {
-        const float horizonCZA = cosZenithAngleOfHorizon(altitude);
-        const float viewElev  = asin(clampCosine(cosViewZenithAngle));
-        const float horizElev = asin(clampCosine(horizonCZA));
-        const float newViewElev = 2*horizElev - viewElev;
-        const float viewDirXYnorm = length(viewDir-zenith*cosViewZenithAngle);
+        CONST float horizonCZA = cosZenithAngleOfHorizon(altitude);
+        CONST float viewElev  = asin(clampCosine(cosViewZenithAngle));
+        CONST float horizElev = asin(clampCosine(horizonCZA));
+        CONST float newViewElev = 2*horizElev - viewElev;
+        CONST float viewDirXYnorm = length(viewDir-zenith*cosViewZenithAngle);
         if(viewDirXYnorm == 0)
         {
             viewDir = zenith;
@@ -267,27 +281,27 @@ void main()
         viewRayIntersectsGround = false;
     }
 
-    const float cosSunZenithAngle =dot(zenith,sunDirection);
-    const float dotViewSun=dot(viewDir,sunDirection);
+    CONST float cosSunZenithAngle =dot(zenith,sunDirection);
+    CONST float dotViewSun=dot(viewDir,sunDirection);
 
-    const vec3 sunXYunnorm=sunDirection-dot(sunDirection,zenith)*zenith;
-    const vec3 viewXYunnorm=viewDir-dot(viewDir,zenith)*zenith;
-    const vec3 sunXY = sunXYunnorm.x!=0 || sunXYunnorm.y!=0 || sunXYunnorm.z!=0 ? normalize(sunXYunnorm) : vec3(0);
-    const vec3 viewXY = viewXYunnorm.x!=0 || viewXYunnorm.y!=0 || viewXYunnorm.z!=0 ? normalize(viewXYunnorm) : vec3(0);
-    const float azimuthRelativeToSun=safeAtan(dot(cross(sunXY, viewXY), zenith), dot(sunXY, viewXY));
+    CONST vec3 sunXYunnorm=sunDirection-dot(sunDirection,zenith)*zenith;
+    CONST vec3 viewXYunnorm=viewDir-dot(viewDir,zenith)*zenith;
+    CONST vec3 sunXY = sunXYunnorm.x!=0 || sunXYunnorm.y!=0 || sunXYunnorm.z!=0 ? normalize(sunXYunnorm) : vec3(0);
+    CONST vec3 viewXY = viewXYunnorm.x!=0 || viewXYunnorm.y!=0 || viewXYunnorm.z!=0 ? normalize(viewXYunnorm) : vec3(0);
+    CONST float azimuthRelativeToSun=safeAtan(dot(cross(sunXY, viewXY), zenith), dot(sunXY, viewXY));
 
-#if RENDERING_ZERO_SCATTERING
+#if 0 /*RENDERING_ZERO_SCATTERING*/
     vec4 radiance;
     if(viewRayIntersectsGround)
     {
         // XXX: keep in sync with the same code in computeScatteringDensity(), but don't forget about
         //      the difference in the usage of viewDir vs incDir.
-        const float distToGround = distanceToGround(cosViewZenithAngle, altitude);
-        const vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
-        const vec3 groundNormal = normalize(zenith*(earthRadius+altitude)+viewDir*distToGround);
-        const vec4 groundIrradiance = irradiance(dot(groundNormal, sunDirection), 0);
+        CONST float distToGround = distanceToGround(cosViewZenithAngle, altitude);
+        CONST vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
+        CONST vec3 groundNormal = normalize(zenith*(earthRadius+altitude)+viewDir*distToGround);
+        CONST vec4 groundIrradiance = irradiance(dot(groundNormal, sunDirection), 0);
         // Radiation scattered by the ground
-        const float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
+        CONST float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
         radiance = transmittanceToGround*groundAlbedo*groundIrradiance*solarIrradianceFixup*groundBRDF
                  + lightPollutionGroundLuminance*lightPollutionRelativeRadiance;
     }
@@ -304,22 +318,22 @@ void main()
     }
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_ZERO_SCATTERING
+#elif 0 /*RENDERING_ECLIPSED_ZERO_SCATTERING*/
     vec4 radiance;
-    const float dotViewMoon=dot(viewDir,normalize(moonPosition-cameraPosition));
+    CONST float dotViewMoon=dot(viewDir,normalize(moonPosition-cameraPosition));
     if(viewRayIntersectsGround)
     {
         // XXX: keep in sync with the similar code in non-eclipsed zero scattering rendering.
-        const float distToGround = distanceToGround(cosViewZenithAngle, altitude);
-        const vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
-        const vec3 pointOnGround = cameraPosition+viewDir*distToGround;
-        const vec4 directGroundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDirection, moonPosition);
+        CONST float distToGround = distanceToGround(cosViewZenithAngle, altitude);
+        CONST vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
+        CONST vec3 pointOnGround = cameraPosition+viewDir*distToGround;
+        CONST vec4 directGroundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDirection, moonPosition);
         // FIXME: add first-order indirect irradiance too: it's done in non-eclipsed irradiance (in the same
         // conditions: when limited to 2 orders). This should be calculated at the same time when second order
         // is: all the infrastructure is already there.
-        const vec4 groundIrradiance = directGroundIrradiance;
+        CONST vec4 groundIrradiance = directGroundIrradiance;
         // Radiation scattered by the ground
-        const float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
+        CONST float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
         radiance = transmittanceToGround*groundAlbedo*groundIrradiance*solarIrradianceFixup*groundBRDF
                  + lightPollutionGroundLuminance*lightPollutionRelativeRadiance;
     }
@@ -336,53 +350,53 @@ void main()
     }
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_ON_THE_FLY
-    const vec4 scattering=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPosition,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_ON_THE_FLY*/
+    CONST vec4 scattering=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPosition,
                                                           viewRayIntersectsGround);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE
-    const vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE*/
+    CONST vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                      viewRayIntersectsGround, eclipsedSingleScatteringTextureSize);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact at the point where azimuth texture coordinate changes from 1 to 0 (at azimuthRelativeToSun crossing
     // 0). This happens when I simply call texture(eclipsedScatteringTexture, texCoords) without specifying LOD.
     // Apparently, the driver uses the derivative for some reason, even though it shouldn't.
-    const vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
+    CONST vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE
-    const vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
+    CONST vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                      viewRayIntersectsGround, eclipsedSingleScatteringTextureSize);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact at the point where azimuth texture coordinate changes from 1 to 0 (at azimuthRelativeToSun crossing
     // 0). This happens when I simply call texture(eclipsedScatteringTexture, texCoords) without specifying LOD.
     // Apparently, the driver uses the derivative for some reason, even though it shouldn't.
-    const vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
+    CONST vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
     luminance=scattering*currentPhaseFunction(dotViewSun);
-#elif RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_RADIANCE
+#elif 0 /*RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_RADIANCE*/
     vec4 radiance=exp(sampleEclipseDoubleScattering3DTexture(eclipsedDoubleScatteringTexture,
                                                              cosSunZenithAngle, cosViewZenithAngle, azimuthRelativeToSun,
                                                              altitude, viewRayIntersectsGround));
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_LUMINANCE
+#elif 0 /*RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
     luminance=exp(sampleEclipseDoubleScattering3DTexture(eclipsedDoubleScatteringTexture,
                                                          cosSunZenithAngle, cosViewZenithAngle, azimuthRelativeToSun,
                                                          altitude, viewRayIntersectsGround));
 #elif 1 /*RENDERING_SINGLE_SCATTERING_ON_THE_FLY*/
-    const vec4 scattering=computeSingleScattering(cosSunZenithAngle,cosViewZenithAngle,dotViewSun,
+    CONST vec4 scattering=computeSingleScattering(cosSunZenithAngle,cosViewZenithAngle,dotViewSun,
                                                   altitude,viewRayIntersectsGround);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE
+#elif 0 /*RENDERING_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE*/
     vec4 scattering;
     if(useInterpolationGuides)
     {
@@ -399,7 +413,7 @@ void main()
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE
+#elif 0 /*RENDERING_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
     vec4 scattering;
     if(useInterpolationGuides)
     {
@@ -413,18 +427,18 @@ void main()
                                      dotViewSun, altitude, viewRayIntersectsGround);
     }
     luminance=scattering * (bool(0) ? vec4(1) : currentPhaseFunction(dotViewSun));
-#elif RENDERING_MULTIPLE_SCATTERING_LUMINANCE
+#elif 0 /*RENDERING_MULTIPLE_SCATTERING_LUMINANCE*/
     luminance=sample3DTexture(scatteringTexture, cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, viewRayIntersectsGround);
-#elif RENDERING_MULTIPLE_SCATTERING_RADIANCE
+#elif 0 /*RENDERING_MULTIPLE_SCATTERING_RADIANCE*/
     vec4 radiance=sample3DTexture(scatteringTexture, cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, viewRayIntersectsGround);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_LIGHT_POLLUTION_RADIANCE
+#elif 0 /*RENDERING_LIGHT_POLLUTION_RADIANCE*/
     vec4 radiance=lightPollutionGroundLuminance*lightPollutionScattering(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_LIGHT_POLLUTION_LUMINANCE
+#elif 0 /*RENDERING_LIGHT_POLLUTION_LUMINANCE*/
     luminance=lightPollutionGroundLuminance*lightPollutionScattering(altitude, cosViewZenithAngle, viewRayIntersectsGround);
 #else
 #error What to render?

--- a/atmosphere/default/shaders/single-scattering/on-the-fly/0/aerosols/single-scattering.frag
+++ b/atmosphere/default/shaders/single-scattering/on-the-fly/0/aerosols/single-scattering.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // single-scattering.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,15 +45,15 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // single-scattering.frag
-#line 1 2 // densities.h.glsl
+#line 4 0 // single-scattering.frag
+#line 1 3 // densities.h.glsl
 float scattererNumberDensity_molecules(float altitude);
 float scattererNumberDensity_aerosols(float altitude);
 float absorberNumberDensity_ozone(float altitude);
 vec4 scatteringCrossSection();
 float scattererDensity(float altitude);
-#line 6 0 // single-scattering.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // single-scattering.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -74,8 +85,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // single-scattering.frag
-#line 1 4 // single-scattering.h.glsl
+#line 6 0 // single-scattering.frag
+#line 1 5 // single-scattering.h.glsl
 #ifndef INCLUDE_ONCE_1DB2EDC1_C687_4FFA_BFF4_D18A54BA651B
 #define INCLUDE_ONCE_1DB2EDC1_C687_4FFA_BFF4_D18A54BA651B
 
@@ -83,8 +94,8 @@ vec4 computeSingleScattering(const float cosSunZenithAngle, const float cosViewZ
                              const float dotViewSun, const float altitude,
                              const bool viewRayIntersectsGround);
 #endif
-#line 8 0 // single-scattering.frag
-#line 1 5 // texture-sampling-functions.h.glsl
+#line 7 0 // single-scattering.frag
+#line 1 6 // texture-sampling-functions.h.glsl
 #ifndef INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 #define INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float altitude);
@@ -96,20 +107,20 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                 const int scatteringOrder);
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 #endif
-#line 9 0 // single-scattering.frag
+#line 8 0 // single-scattering.frag
 
 // This function omits phase function and solar irradiance: these are to be applied somewhere in the calling code.
 vec4 computeSingleScatteringIntegrand(const float cosSunZenithAngle, const float cosViewZenithAngle,
                                       const float dotViewSun, const float altitude,
                                       const float dist, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle here the case when the
     // endpoint of the view ray intentionally appears in outer space.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosSunZenithAngleAtDist=clampCosine((r*cosSunZenithAngle+dist*dotViewSun)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosSunZenithAngleAtDist=clampCosine((r*cosSunZenithAngle+dist*dotViewSun)/(earthRadius+altAtDist));
 
-    const vec4 xmittance=transmittance(cosViewZenithAngle, altitude, dist, viewRayIntersectsGround)
+    CONST vec4 xmittance=transmittance(cosViewZenithAngle, altitude, dist, viewRayIntersectsGround)
                                                     *
                          transmittanceToAtmosphereBorder(cosSunZenithAngleAtDist, altAtDist)
                                                     *
@@ -121,14 +132,14 @@ vec4 computeSingleScattering(const float cosSunZenithAngle, const float cosViewZ
                              const float dotViewSun, const float altitude,
                              const bool viewRayIntersectsGround)
 {
-    const float integrInterval=distanceToNearestAtmosphereBoundary(cosViewZenithAngle, altitude,
+    CONST float integrInterval=distanceToNearestAtmosphereBoundary(cosViewZenithAngle, altitude,
                                                                    viewRayIntersectsGround);
     // Using the midpoint rule for quadrature
     vec4 spectrum=vec4(0);
-    const float dl=integrInterval/radialIntegrationPoints;
+    CONST float dl=integrInterval/radialIntegrationPoints;
     for(int n=0; n<radialIntegrationPoints; ++n)
     {
-        const float dist=(n+0.5)*dl;
+        CONST float dist=(n+0.5)*dl;
         spectrum += computeSingleScatteringIntegrand(cosSunZenithAngle, cosViewZenithAngle, dotViewSun,
                                                      altitude, dist, viewRayIntersectsGround);
     }

--- a/atmosphere/default/shaders/single-scattering/on-the-fly/0/aerosols/texture-coordinates.frag
+++ b/atmosphere/default/shaders/single-scattering/on-the-fly/0/aerosols/texture-coordinates.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-coordinates.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,8 +45,8 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // texture-coordinates.frag
-#line 1 2 // texture-coordinates.h.glsl
+#line 4 0 // texture-coordinates.frag
+#line 1 3 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -104,8 +115,8 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 6 0 // texture-coordinates.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-coordinates.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -137,7 +148,7 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-coordinates.frag
+#line 6 0 // texture-coordinates.frag
 
 const float LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA=sqrt(atmosphereHeight*(atmosphereHeight+2*earthRadius));
 
@@ -205,18 +216,18 @@ vec3 indicesToTexCoords(const vec3 indices, const vec3 texSizes)
 
 TransmittanceTexVars transmittanceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
+    CONST float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
                                 texCoordToUnitRange(texCoord.t,transmittanceTextureSize.t);
     // Distance from Earth center to camera
-    const float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
-    const float altitude=r-earthRadius;
+    CONST float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
+    CONST float altitude=r-earthRadius;
 
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
     // distance to border of visible atmosphere from the view point
-    const float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
+    CONST float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
     // d==0 can happen when altitude==atmosphereHeight
-    const float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
+    CONST float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
     return TransmittanceTexVars(cosVZA,altitude);
 }
 
@@ -235,53 +246,53 @@ vec2 transmittanceTexVarsToTexCoord(const float cosVZA, float altitude)
     if(altitude<0)
         altitude=0;
 
-    const float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
+    CONST float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
                                       transmittanceTextureSize.t);
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
-    const float d=distanceToAtmosphereBorder(cosVZA,altitude);
-    const float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float d=distanceToAtmosphereBorder(cosVZA,altitude);
+    CONST float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
     return vec2(s,t);
 }
 
 // Output: vec2(cos(sunZenithAngle), altitude)
 IrradianceTexVars irradianceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
-    const float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
+    CONST float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
+    CONST float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
     return IrradianceTexVars(cosSZA,alt);
 }
 
 vec2 irradianceTexVarsToTexCoord(const float cosSunZenithAngle, const float altitude)
 {
-    const float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
-    const float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
+    CONST float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
+    CONST float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
     return vec2(s,t);
 }
 
 float cosSZAToUnitRangeTexCoord(const float cosSunZenithAngle)
 {
     // Distance to top atmosphere border along the ray groundUnderCamera-sun: (altitude, cosSunZenithAngle)
-    const float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name
-    const float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
+    CONST float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
     // TODO: choose a more descriptive name
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     return max(0.,1-a/A)/(a+1);
 }
 
 float unitRangeTexCoordToCosSZA(const float texCoord)
 {
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float a=(A-A*texCoord)/(1+A*texCoord);
-    const float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
+    CONST float a=(A-A*texCoord)/(1+A*texCoord);
+    CONST float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
     return distFromGroundToTopAtmoBorder==0 ? 1 :
         clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distFromGroundToTopAtmoBorder)) /
                     (2*earthRadius*distFromGroundToTopAtmoBorder));
@@ -292,24 +303,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
                                                const float dotViewSun, const float altitude,
                                                const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -317,24 +328,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float dotVSCoord=(dotViewSun+1)/2;
+    CONST float dotVSCoord=(dotViewSun+1)/2;
 
     // ------------------------------------
-    const float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
+    CONST float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
 
     return Scattering4DCoords(cosSZACoord, cosVZACoord, dotVSCoord, altCoord, viewRayIntersectsGround);
 }
 
 TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
@@ -342,16 +353,16 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture coordinates we combine into a single sampler3D coordinate.
-    const float texW = scatteringTextureSize[1];
-    const float texH = scatteringTextureSize[2];
-    const float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
-    const vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
+    CONST float texW = scatteringTextureSize[1];
+    CONST float texH = scatteringTextureSize[2];
+    CONST float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
+    CONST vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
                                         ceil (cosSZAIndex)*texW+coords.dotViewSun*(texW-1)) / (texW*texH-1);
-    const vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
+    CONST vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
 
-    const float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
+    CONST float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
 
-    const float alphaUpper=fract(cosSZAIndex);
+    CONST float alphaUpper=fract(cosSZAIndex);
     return TexCoordPair(vec3(cosVZAtc, combinedCoord.x, altitude), float(1-alphaUpper),
                         vec3(cosVZAtc, combinedCoord.y, altitude), float(alphaUpper));
 }
@@ -359,9 +370,9 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
+    CONST TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
     return texture(tex, texCoords.lower) * texCoords.alphaLower +
            texture(tex, texCoords.upper) * texCoords.alphaUpper;
 }
@@ -369,17 +380,17 @@ vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const f
 // 3D texture is the 3D single-altitude slice of a 4D texture
 vec3 scattering4DCoordsToTex3DCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2);
 
-    const float dvsSize = scatteringTextureSize[1];
-    const float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
+    CONST float dvsSize = scatteringTextureSize[1];
+    CONST float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
 
-    const float cszaSize = scatteringTextureSize[2];
-    const float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
+    CONST float cszaSize = scatteringTextureSize[2];
+    CONST float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
 
     return vec3(cosVZAtc, dotVStc, cosSZAtc);
 }
@@ -394,39 +405,39 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along dotViewSun coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[1];
-    const float posOfRow = indices[1];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[1];
+    CONST float posOfRow = indices[1];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         indexToTexCoord(currRow, numRows-1),
                                                         texCoordVerbatim));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               indexToTexCoord(currRow, numRows-1),
                                                               texCoordVerbatim));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          indexToTexCoord(currRow, numRows-1),
                                          texCoordVerbatim));
@@ -434,14 +445,14 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
 vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolationGuides01Tex,
                                  const vec3 indices)
 {
-    const float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
+    CONST float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
 
-    const float cosVZAIndex = indices[0];
-    const float dotVSIndex = indices[1];
-    const float currRow = floor(dotVSIndex);
-    const float posBetweenRows = dotVSIndex - currRow;
-    const float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cosVZAIndex = indices[0];
+    CONST float dotVSIndex = indices[1];
+    CONST float currRow = floor(dotVSIndex);
+    CONST float posBetweenRows = dotVSIndex - currRow;
+    CONST float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -449,14 +460,14 @@ vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolat
     indicesCurrRow[1] =     currRow;
     indicesNextRow[1] = min(currRow+1, scatteringTextureSize[1]-1.);
 
-    const vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
-    const vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
+    CONST vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
+    CONST vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
 
-    const vec4 valueCurrRow = texture(tex, coordsCurrRow);
-    const vec4 valueNextRow = texture(tex, coordsNextRow);
-    const float epsilon = 1e-37; // Prevents passing zero to log
-    const vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
-    const vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
+    CONST vec4 valueCurrRow = texture(tex, coordsCurrRow);
+    CONST vec4 valueNextRow = texture(tex, coordsNextRow);
+    CONST float epsilon = 1e-37; // Prevents passing zero to log
+    CONST vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
+    CONST vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
     return (logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow;
 }
 
@@ -465,37 +476,37 @@ float findGuide02Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along SZA coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[2];
-    const float posOfRow = indices[2];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[2];
+    CONST float posOfRow = indices[2];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
 }
@@ -505,19 +516,19 @@ vec4 sample3DTextureGuided(const sampler3D tex,
                            const float cosSunZenithAngle, const float cosViewZenithAngle,
                            const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
                                                                     dotViewSun, altitude, viewRayIntersectsGround);
     // Handle the external interpolation guides: the guides between a pair of VZA-dotViewSun 2D "pictures".
-    const vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
-    const vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
-    const float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
+    CONST vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
+    CONST float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
 
-    const float cvzaIndex = indices[0];
-    const float cszaIndex = indices[2];
-    const float currRow = floor(cszaIndex);
-    const float posBetweenRows = cszaIndex - currRow;
-    const float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cvzaIndex = indices[0];
+    CONST float cszaIndex = indices[2];
+    CONST float currRow = floor(cszaIndex);
+    CONST float posBetweenRows = cszaIndex - currRow;
+    CONST float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -526,58 +537,58 @@ vec4 sample3DTextureGuided(const sampler3D tex,
     indicesNextRow[2] = min(currRow+1, scatteringTextureSize[2]-1);
 
     // The caller will handle the internal interpolation guides: the ones between rows in each 2D "picture".
-    const vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
-    const vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
+    CONST vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
+    CONST vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
     return exp((logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow);
 }
 
 vec4 sample3DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
     return texture(tex, texCoords);
 }
 
 ScatteringTexVars scatteringTex4DCoordsToTexVars(const Scattering4DCoords coords)
 {
-    const float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
     // ------------------------------------
     float cosViewZenithAngle;
     if(coords.viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
     // ------------------------------------
-    const float dotViewSun=coords.dotViewSun*2-1;
+    CONST float dotViewSun=coords.dotViewSun*2-1;
 
     // ------------------------------------
-    const float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
+    CONST float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
 
     return ScatteringTexVars(cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, coords.viewRayIntersectsGround);
 }
 
 Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 {
-    const vec4 indexMax=scatteringTextureSize-vec4(1);
+    CONST vec4 indexMax=scatteringTextureSize-vec4(1);
     Scattering4DCoords coords4d;
     coords4d.viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
     // The following formulas assume that scatteringTextureSize[0] is even. For odd sizes they would change.
@@ -593,8 +604,8 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture indices we combine into a single sampler3D coordinate.
-    const float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
-    const float combinedIndex=texIndices[1];
+    CONST float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
+    CONST float combinedIndex=texIndices[1];
     coords4d.dotViewSun=mod(combinedIndex,texW)/(texW-1);
     coords4d.cosSunZenithAngle=floor(combinedIndex/texW)/(texH-1);
 
@@ -608,11 +619,11 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
 ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 {
-    const Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
+    CONST Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
     ScatteringTexVars vars=scatteringTex4DCoordsToTexVars(coords4d);
     // Clamp dotViewSun to its valid range of values, given cosViewZenithAngle and cosSunZenithAngle. This is
     // needed to prevent NaNs when computing the scattering texture.
-    const float cosVZA=vars.cosViewZenithAngle,
+    CONST float cosVZA=vars.cosViewZenithAngle,
                 cosSZA=vars.cosSunZenithAngle;
     vars.dotViewSun=clamp(vars.dotViewSun,
                           cosVZA*cosSZA-safeSqrt((1-sqr(cosVZA))*(1-sqr(cosSZA))),
@@ -622,54 +633,54 @@ ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 
 EclipseScatteringTexVars eclipseTexCoordsToTexVars(const vec2 texCoords, const float altitude)
 {
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
-    const bool viewRayIntersectsGround = texCoords.t<0.5;
+    CONST bool viewRayIntersectsGround = texCoords.t<0.5;
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
-    const float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
+    CONST float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
     return EclipseScatteringTexVars(azimuthRelativeToSun, cosViewZenithAngle, viewRayIntersectsGround);
 }
 
 EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                                    const float altitude, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -677,13 +688,13 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
-    const float azimuthCoord = azimuthRelativeToSun/(2*PI);
+    CONST float azimuthCoord = azimuthRelativeToSun/(2*PI);
 
     return EclipseScattering2DCoords(azimuthCoord, cosVZACoord);
 }
@@ -691,14 +702,14 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
 vec2 eclipseTexVarsToTexCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                const float altitude, const bool viewRayIntersectsGround, const vec2 texSize)
 {
-    const EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+    CONST EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                                     viewRayIntersectsGround);
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2);
-    const float azimuthTC = coords.azimuth + 1/(2*texSize.s);
+    CONST float azimuthTC = coords.azimuth + 1/(2*texSize.s);
 
     return vec2(azimuthTC, cosVZAtc);
 }
@@ -707,42 +718,42 @@ vec4 sampleEclipseDoubleScattering3DTexture(const sampler3D tex, const float cos
                                             const float cosViewZenithAngle, const float azimuthRelativeToSun,
                                             const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
+    CONST vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
                                                   eclipsedDoubleScatteringTextureSize.st);
-    const float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
-    const vec3 texCoords=vec3(coords2d, cosSZACoord);
+    CONST float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
+    CONST vec3 texCoords=vec3(coords2d, cosSZACoord);
 
     return texture(tex, texCoords);
 }
 
 LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 texIndices)
 {
-    const vec2 indexMax=lightPollutionTextureSize-vec2(1);
+    CONST vec2 indexMax=lightPollutionTextureSize-vec2(1);
 
-    const float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
-    const float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
+    CONST float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
-    const bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
-    const float cosViewZenithAngleCoord = viewRayIntersectsGround ?
+    CONST bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
+    CONST float cosViewZenithAngleCoord = viewRayIntersectsGround ?
                                    1-2*texIndices[0]/(indexMax[0]-1) :
                                    2*(texIndices[0]-1)/(indexMax[0]-1)-1;
     // ------------------------------------
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
@@ -753,23 +764,23 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 
 LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -777,27 +788,27 @@ LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, con
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     return LightPollution2DCoords(cosVZACoord, altCoord);
 }
 
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
-    const vec2 texSize = lightPollutionTextureSize;
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 texSize = lightPollutionTextureSize;
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2);
-    const float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
+    CONST float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
     return vec2(cosVZAtc, altitudeTC);
 }

--- a/atmosphere/default/shaders/single-scattering/on-the-fly/0/aerosols/texture-sampling-functions.frag
+++ b/atmosphere/default/shaders/single-scattering/on-the-fly/0/aerosols/texture-sampling-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-sampling-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,13 +45,13 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // texture-sampling-functions.frag
-#line 1 2 // phase-functions.h.glsl
+#line 4 0 // texture-sampling-functions.frag
+#line 1 3 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 6 0 // texture-sampling-functions.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-sampling-functions.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -72,8 +83,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-sampling-functions.frag
-#line 1 4 // texture-coordinates.h.glsl
+#line 6 0 // texture-sampling-functions.frag
+#line 1 5 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -142,7 +153,7 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 8 0 // texture-sampling-functions.frag
+#line 7 0 // texture-sampling-functions.frag
 
 uniform sampler2D transmittanceTexture;
 uniform sampler2D irradianceTexture;
@@ -154,13 +165,13 @@ uniform sampler2D lightPollutionScatteringTexture;
 
 vec4 irradiance(const float cosSunZenithAngle, const float altitude)
 {
-    const vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
+    CONST vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
     return texture(irradianceTexture, texCoords);
 }
 
 vec4 opticalDepthToAtmosphereBorder(const float cosViewZenithAngle, const float altitude)
 {
-    const vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
+    CONST vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact when looking into nadir from TOA at some values of texture sizes (in particular, size of
     // transmittance texture for altitude being 4096). This happens when I simply call texture(eclipsedScatteringTexture,
@@ -178,11 +189,11 @@ vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float
 vec4 transmittance(const float cosViewZenithAngle, const float altitude, const float dist,
                    const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle view ray endpoint
     // in space here.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
 
     vec4 depth;
     if(viewRayIntersectsGround)
@@ -201,7 +212,7 @@ vec4 transmittance(const float cosViewZenithAngle, const float altitude, const f
 vec4 calcFirstScattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                          const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
+    CONST vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
                                           dotViewSun, altitude, viewRayIntersectsGround);
     return scattering*currentPhaseFunction(dotViewSun);
 }
@@ -220,6 +231,6 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
 
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     return texture(lightPollutionScatteringTexture, coords);
 }

--- a/atmosphere/default/shaders/single-scattering/on-the-fly/0/molecules/common-functions.frag
+++ b/atmosphere/default/shaders/single-scattering/on-the-fly/0/molecules/common-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // common-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // common-functions.frag
+#line 4 0 // common-functions.frag
 
 bool dbgDataPresent=false;
 bool debugDataPresent()
@@ -69,7 +80,7 @@ void setDebugData(float a,float b, float c, float d)
 
 void swap(inout float x, inout float y)
 {
-    const float t = x;
+    CONST float t = x;
     x = y;
     y = t;
 }
@@ -83,7 +94,7 @@ float safeSqrt(const float x)
 
 float safeAtan(const float y, const float x)
 {
-    const float a = atan(y,x);
+    CONST float a = atan(y,x);
     return x==0 && y==0 ? 0 : a;
 }
 
@@ -116,23 +127,23 @@ float pointAltitude(vec3 point)
 
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float Ratm=earthRadius+atmosphereHeight;
-    const float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float Ratm=earthRadius+atmosphereHeight;
+    CONST float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float distanceToGround(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(-safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float cosZenithAngleOfHorizon(const float altitude)
 {
-    const float R=earthRadius;
-    const float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
+    CONST float R=earthRadius;
+    CONST float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
     return -sqrt(2*h*R+sqr(h))/(R+h);
 }
 
@@ -151,8 +162,8 @@ float distanceToNearestAtmosphereBoundary(const float cosZenithAngle, const floa
 float sunVisibility(const float cosSunZenithAngle, float altitude)
 {
     if(altitude<0) altitude=0;
-    const float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
-    const float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
+    CONST float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
+    CONST float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
     /* Approximating visible fraction of solar disk by smoothstep between the position of the Sun
      * touching the horizon by its upper part and the position with lower part touching the horizon.
      * The calculation assumes that solar angular radius is small and thus approximately equals its sine.
@@ -182,13 +193,13 @@ float circlesIntersectionArea(float R1, float R2, float d)
 
 float angleBetween(const vec3 a, const vec3 b)
 {
-    const float d=dot(a,b);
-    const float c=length(cross(a,b));
+    CONST float d=dot(a,b);
+    CONST float c=length(cross(a,b));
     // To avoid loss of precision, don't use dot product near the singularity
     // of acos, and cross product near the singularity of asin
     if(abs(d) < abs(c))
         return acos(d/(length(a)*length(b)));
-    const float smallerAngle = asin(c/(length(a)*length(b)));
+    CONST float smallerAngle = asin(c/(length(a)*length(b)));
     if(d<0) return PI-smallerAngle;
     return smallerAngle;
 }
@@ -205,11 +216,11 @@ float moonAngularRadius(const vec3 cameraPosition, const vec3 moonPosition)
 
 float visibleSolidAngleOfSun(const vec3 camera, const vec3 sunDir, const vec3 moonPos)
 {
-    const float Rs=sunAngularRadius;
-    const float Rm=moonAngularRadius(camera,moonPos);
+    CONST float Rs=sunAngularRadius;
+    CONST float Rm=moonAngularRadius(camera,moonPos);
     float visibleSolidAngle=PI*sqr(Rs);
 
-    const float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
+    CONST float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
     if(dSM<Rs+Rm)
     {
         visibleSolidAngle -= circlesIntersectionArea(Rm,Rs,dSM);
@@ -229,12 +240,12 @@ float sphereIntegrationSolidAngleDifferential(const int pointCountOnSphere)
 }
 vec3 sphereIntegrationSampleDir(const int index, const int pointCountOnSphere)
 {
-    const float goldenRatio=1.6180339887499;
+    CONST float goldenRatio=1.6180339887499;
     // The range of n is 0.5, 1.5, ..., pointCountOnSphere-0.5
-    const float n=index+0.5;
+    CONST float n=index+0.5;
     // Explanation of the Fibonacci grid generation can be seen at https://stackoverflow.com/a/44164075/673852
-    const float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
-    const float azimuth=n*(2*PI*goldenRatio);
+    CONST float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
+    CONST float azimuth=n*(2*PI*goldenRatio);
     return vec3(cos(azimuth)*sin(zenithAngle),
                 sin(azimuth)*sin(zenithAngle),
                 cos(zenithAngle));

--- a/atmosphere/default/shaders/single-scattering/on-the-fly/0/molecules/densities.frag
+++ b/atmosphere/default/shaders/single-scattering/on-the-fly/0/molecules/densities.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // densities.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,20 +45,20 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // densities.frag
+#line 4 0 // densities.frag
 float scattererNumberDensity_molecules(float altitude)
 {
-        const float rayleighScaleHeight=8*km;
+        CONST float rayleighScaleHeight=8*km;
         return 3.08458e25*exp(-1/rayleighScaleHeight * altitude);
 }
 float scattererNumberDensity_aerosols(float altitude)
 {
-        const float mieScaleHeight=1.2*km;
+        CONST float mieScaleHeight=1.2*km;
         return 1.03333e8*exp(-1/mieScaleHeight*altitude);
 }
 float absorberNumberDensity_ozone(float altitude)
 {
-        const float totalOzoneAmount=370*dobsonUnit;
+        CONST float totalOzoneAmount=370*dobsonUnit;
 
         float density;
 

--- a/atmosphere/default/shaders/single-scattering/on-the-fly/0/molecules/phase-functions.frag
+++ b/atmosphere/default/shaders/single-scattering/on-the-fly/0/molecules/phase-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // phase-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // phase-functions.frag
+#line 4 0 // phase-functions.frag
 
 vec4 phaseFunction_molecules(float dotViewSun)
 {
@@ -42,9 +53,9 @@ vec4 phaseFunction_molecules(float dotViewSun)
 }
 vec4 phaseFunction_aerosols(float dotViewSun)
 {
-        const float g=0.76;
-        const float g2=g*g;
-        const float k = 3/(8*PI)*(1-g2)/(2+g2);
+        CONST float g=0.76;
+        CONST float g2=g*g;
+        CONST float k = 3/(8*PI)*(1-g2)/(2+g2);
         return vec4(k * (1+sqr(dotViewSun)) / pow(1+g2 - 2*g*dotViewSun, 1.5) + 1/((1-dotViewSun)*600+0.05))*0.904;
 }
 vec4 currentPhaseFunction(float dotViewSun) { return phaseFunction_molecules(dotViewSun); }

--- a/atmosphere/default/shaders/single-scattering/on-the-fly/0/molecules/render.frag
+++ b/atmosphere/default/shaders/single-scattering/on-the-fly/0/molecules/render.frag
@@ -1,7 +1,21 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
 
-#line 1 1 // const.h.glsl
+
+
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 6 0 // render.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,11 +48,11 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // render.frag
-#line 1 2 // calc-view-dir.h.glsl
+#line 7 0 // render.frag
+#line 1 3 // calc-view-dir.h.glsl
 vec3 calcViewDir();
-#line 6 0 // render.frag
-#line 1 3 // common-functions.h.glsl
+#line 8 0 // render.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -70,13 +84,13 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // render.frag
-#line 1 4 // phase-functions.h.glsl
+#line 9 0 // render.frag
+#line 1 5 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 8 0 // render.frag
-#line 1 5 // single-scattering.h.glsl
+#line 10 0 // render.frag
+#line 1 6 // single-scattering.h.glsl
 #ifndef INCLUDE_ONCE_1DB2EDC1_C687_4FFA_BFF4_D18A54BA651B
 #define INCLUDE_ONCE_1DB2EDC1_C687_4FFA_BFF4_D18A54BA651B
 
@@ -84,9 +98,9 @@ vec4 computeSingleScattering(const float cosSunZenithAngle, const float cosViewZ
                              const float dotViewSun, const float altitude,
                              const bool viewRayIntersectsGround);
 #endif
-#line 9 0 // render.frag
+#line 11 0 // render.frag
 
-#line 1 6 // texture-coordinates.h.glsl
+#line 1 7 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -155,10 +169,10 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 11 0 // render.frag
-#line 1 7 // radiance-to-luminance.h.glsl
+#line 13 0 // render.frag
+#line 1 8 // radiance-to-luminance.h.glsl
 const mat4 radianceToLuminance=mat4(1.38997746,0.0419133306,6.48549128,0,  105.968163,3.00652099,500.960266,142.641495,  3776.24023,119.971481,18207.7598,6412.0166,  6910.01318,981.06665,37504.0586,26741.9102);
-#line 12 0 // render.frag
+#line 14 0 // render.frag
 
 
 
@@ -195,18 +209,18 @@ void main()
     // this approximation has the same order of magnitude as the assumption that the Earth and its atmosphere
     // are spherical.
     float altitude = max(cameraPosition.z, 0.);
-    const vec3 oldCamPos=cameraPosition;
+    CONST vec3 oldCamPos=cameraPosition;
     // Hide the uniform with this name, thus effectively modifying it for the following code
     vec3 cameraPosition=vec3(oldCamPos.xy, altitude);
 
     bool lookingIntoAtmosphere=true;
     if(altitude>atmosphereHeight)
     {
-        const vec3 p = cameraPosition - earthCenter;
-        const float p_dot_v = dot(p, viewDir);
-        const float p_dot_p = dot(p, p);
-        const float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
-        const float distanceToTOA = -p_dot_v - sqrt(sqr(earthRadius+atmosphereHeight) - squaredDistBetweenViewRayAndEarthCenter);
+        CONST vec3 p = cameraPosition - earthCenter;
+        CONST float p_dot_v = dot(p, viewDir);
+        CONST float p_dot_p = dot(p, p);
+        CONST float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
+        CONST float distanceToTOA = -p_dot_v - sqrt(sqr(earthRadius+atmosphereHeight) - squaredDistBetweenViewRayAndEarthCenter);
         if(distanceToTOA>=0)
         {
             cameraPosition += viewDir*distanceToTOA;
@@ -214,7 +228,7 @@ void main()
         }
         else
         {
-#if RENDERING_ANY_ZERO_SCATTERING
+#if 0 /*RENDERING_ANY_ZERO_SCATTERING*/
             lookingIntoAtmosphere=false;
 #else
             luminance=vec4(0);
@@ -224,16 +238,16 @@ void main()
         }
     }
 
-    const vec3 zenith=normalize(cameraPosition-earthCenter);
+    CONST vec3 zenith=normalize(cameraPosition-earthCenter);
     float cosViewZenithAngle=dot(zenith,viewDir);
 
     bool viewRayIntersectsGround=false;
     {
-        const vec3 p = cameraPosition - earthCenter;
-        const float p_dot_v = dot(p, viewDir);
-        const float p_dot_p = dot(p, p);
-        const float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
-        const float distanceToIntersection = -p_dot_v - sqrt(sqr(earthRadius) - squaredDistBetweenViewRayAndEarthCenter);
+        CONST vec3 p = cameraPosition - earthCenter;
+        CONST float p_dot_v = dot(p, viewDir);
+        CONST float p_dot_p = dot(p, p);
+        CONST float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
+        CONST float distanceToIntersection = -p_dot_v - sqrt(sqr(earthRadius) - squaredDistBetweenViewRayAndEarthCenter);
         // altitude==0 is a special case where distance to intersection calculation
         // is unreliable (has a lot of noise in its sign), so check it separately
         if(distanceToIntersection>0 || (altitude==0 && cosViewZenithAngle<0))
@@ -244,11 +258,11 @@ void main()
     // Aside from aesthetics, this affects brightness input to Stellarium's tone mapper.
     if(pseudoMirrorSkyBelowHorizon && viewRayIntersectsGround)
     {
-        const float horizonCZA = cosZenithAngleOfHorizon(altitude);
-        const float viewElev  = asin(clampCosine(cosViewZenithAngle));
-        const float horizElev = asin(clampCosine(horizonCZA));
-        const float newViewElev = 2*horizElev - viewElev;
-        const float viewDirXYnorm = length(viewDir-zenith*cosViewZenithAngle);
+        CONST float horizonCZA = cosZenithAngleOfHorizon(altitude);
+        CONST float viewElev  = asin(clampCosine(cosViewZenithAngle));
+        CONST float horizElev = asin(clampCosine(horizonCZA));
+        CONST float newViewElev = 2*horizElev - viewElev;
+        CONST float viewDirXYnorm = length(viewDir-zenith*cosViewZenithAngle);
         if(viewDirXYnorm == 0)
         {
             viewDir = zenith;
@@ -267,27 +281,27 @@ void main()
         viewRayIntersectsGround = false;
     }
 
-    const float cosSunZenithAngle =dot(zenith,sunDirection);
-    const float dotViewSun=dot(viewDir,sunDirection);
+    CONST float cosSunZenithAngle =dot(zenith,sunDirection);
+    CONST float dotViewSun=dot(viewDir,sunDirection);
 
-    const vec3 sunXYunnorm=sunDirection-dot(sunDirection,zenith)*zenith;
-    const vec3 viewXYunnorm=viewDir-dot(viewDir,zenith)*zenith;
-    const vec3 sunXY = sunXYunnorm.x!=0 || sunXYunnorm.y!=0 || sunXYunnorm.z!=0 ? normalize(sunXYunnorm) : vec3(0);
-    const vec3 viewXY = viewXYunnorm.x!=0 || viewXYunnorm.y!=0 || viewXYunnorm.z!=0 ? normalize(viewXYunnorm) : vec3(0);
-    const float azimuthRelativeToSun=safeAtan(dot(cross(sunXY, viewXY), zenith), dot(sunXY, viewXY));
+    CONST vec3 sunXYunnorm=sunDirection-dot(sunDirection,zenith)*zenith;
+    CONST vec3 viewXYunnorm=viewDir-dot(viewDir,zenith)*zenith;
+    CONST vec3 sunXY = sunXYunnorm.x!=0 || sunXYunnorm.y!=0 || sunXYunnorm.z!=0 ? normalize(sunXYunnorm) : vec3(0);
+    CONST vec3 viewXY = viewXYunnorm.x!=0 || viewXYunnorm.y!=0 || viewXYunnorm.z!=0 ? normalize(viewXYunnorm) : vec3(0);
+    CONST float azimuthRelativeToSun=safeAtan(dot(cross(sunXY, viewXY), zenith), dot(sunXY, viewXY));
 
-#if RENDERING_ZERO_SCATTERING
+#if 0 /*RENDERING_ZERO_SCATTERING*/
     vec4 radiance;
     if(viewRayIntersectsGround)
     {
         // XXX: keep in sync with the same code in computeScatteringDensity(), but don't forget about
         //      the difference in the usage of viewDir vs incDir.
-        const float distToGround = distanceToGround(cosViewZenithAngle, altitude);
-        const vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
-        const vec3 groundNormal = normalize(zenith*(earthRadius+altitude)+viewDir*distToGround);
-        const vec4 groundIrradiance = irradiance(dot(groundNormal, sunDirection), 0);
+        CONST float distToGround = distanceToGround(cosViewZenithAngle, altitude);
+        CONST vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
+        CONST vec3 groundNormal = normalize(zenith*(earthRadius+altitude)+viewDir*distToGround);
+        CONST vec4 groundIrradiance = irradiance(dot(groundNormal, sunDirection), 0);
         // Radiation scattered by the ground
-        const float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
+        CONST float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
         radiance = transmittanceToGround*groundAlbedo*groundIrradiance*solarIrradianceFixup*groundBRDF
                  + lightPollutionGroundLuminance*lightPollutionRelativeRadiance;
     }
@@ -304,22 +318,22 @@ void main()
     }
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_ZERO_SCATTERING
+#elif 0 /*RENDERING_ECLIPSED_ZERO_SCATTERING*/
     vec4 radiance;
-    const float dotViewMoon=dot(viewDir,normalize(moonPosition-cameraPosition));
+    CONST float dotViewMoon=dot(viewDir,normalize(moonPosition-cameraPosition));
     if(viewRayIntersectsGround)
     {
         // XXX: keep in sync with the similar code in non-eclipsed zero scattering rendering.
-        const float distToGround = distanceToGround(cosViewZenithAngle, altitude);
-        const vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
-        const vec3 pointOnGround = cameraPosition+viewDir*distToGround;
-        const vec4 directGroundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDirection, moonPosition);
+        CONST float distToGround = distanceToGround(cosViewZenithAngle, altitude);
+        CONST vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
+        CONST vec3 pointOnGround = cameraPosition+viewDir*distToGround;
+        CONST vec4 directGroundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDirection, moonPosition);
         // FIXME: add first-order indirect irradiance too: it's done in non-eclipsed irradiance (in the same
         // conditions: when limited to 2 orders). This should be calculated at the same time when second order
         // is: all the infrastructure is already there.
-        const vec4 groundIrradiance = directGroundIrradiance;
+        CONST vec4 groundIrradiance = directGroundIrradiance;
         // Radiation scattered by the ground
-        const float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
+        CONST float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
         radiance = transmittanceToGround*groundAlbedo*groundIrradiance*solarIrradianceFixup*groundBRDF
                  + lightPollutionGroundLuminance*lightPollutionRelativeRadiance;
     }
@@ -336,53 +350,53 @@ void main()
     }
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_ON_THE_FLY
-    const vec4 scattering=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPosition,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_ON_THE_FLY*/
+    CONST vec4 scattering=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPosition,
                                                           viewRayIntersectsGround);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE
-    const vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE*/
+    CONST vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                      viewRayIntersectsGround, eclipsedSingleScatteringTextureSize);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact at the point where azimuth texture coordinate changes from 1 to 0 (at azimuthRelativeToSun crossing
     // 0). This happens when I simply call texture(eclipsedScatteringTexture, texCoords) without specifying LOD.
     // Apparently, the driver uses the derivative for some reason, even though it shouldn't.
-    const vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
+    CONST vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE
-    const vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
+    CONST vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                      viewRayIntersectsGround, eclipsedSingleScatteringTextureSize);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact at the point where azimuth texture coordinate changes from 1 to 0 (at azimuthRelativeToSun crossing
     // 0). This happens when I simply call texture(eclipsedScatteringTexture, texCoords) without specifying LOD.
     // Apparently, the driver uses the derivative for some reason, even though it shouldn't.
-    const vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
+    CONST vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
     luminance=scattering*currentPhaseFunction(dotViewSun);
-#elif RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_RADIANCE
+#elif 0 /*RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_RADIANCE*/
     vec4 radiance=exp(sampleEclipseDoubleScattering3DTexture(eclipsedDoubleScatteringTexture,
                                                              cosSunZenithAngle, cosViewZenithAngle, azimuthRelativeToSun,
                                                              altitude, viewRayIntersectsGround));
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_LUMINANCE
+#elif 0 /*RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
     luminance=exp(sampleEclipseDoubleScattering3DTexture(eclipsedDoubleScatteringTexture,
                                                          cosSunZenithAngle, cosViewZenithAngle, azimuthRelativeToSun,
                                                          altitude, viewRayIntersectsGround));
 #elif 1 /*RENDERING_SINGLE_SCATTERING_ON_THE_FLY*/
-    const vec4 scattering=computeSingleScattering(cosSunZenithAngle,cosViewZenithAngle,dotViewSun,
+    CONST vec4 scattering=computeSingleScattering(cosSunZenithAngle,cosViewZenithAngle,dotViewSun,
                                                   altitude,viewRayIntersectsGround);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE
+#elif 0 /*RENDERING_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE*/
     vec4 scattering;
     if(useInterpolationGuides)
     {
@@ -399,7 +413,7 @@ void main()
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE
+#elif 0 /*RENDERING_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
     vec4 scattering;
     if(useInterpolationGuides)
     {
@@ -413,18 +427,18 @@ void main()
                                      dotViewSun, altitude, viewRayIntersectsGround);
     }
     luminance=scattering * (bool(1) ? vec4(1) : currentPhaseFunction(dotViewSun));
-#elif RENDERING_MULTIPLE_SCATTERING_LUMINANCE
+#elif 0 /*RENDERING_MULTIPLE_SCATTERING_LUMINANCE*/
     luminance=sample3DTexture(scatteringTexture, cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, viewRayIntersectsGround);
-#elif RENDERING_MULTIPLE_SCATTERING_RADIANCE
+#elif 0 /*RENDERING_MULTIPLE_SCATTERING_RADIANCE*/
     vec4 radiance=sample3DTexture(scatteringTexture, cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, viewRayIntersectsGround);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_LIGHT_POLLUTION_RADIANCE
+#elif 0 /*RENDERING_LIGHT_POLLUTION_RADIANCE*/
     vec4 radiance=lightPollutionGroundLuminance*lightPollutionScattering(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_LIGHT_POLLUTION_LUMINANCE
+#elif 0 /*RENDERING_LIGHT_POLLUTION_LUMINANCE*/
     luminance=lightPollutionGroundLuminance*lightPollutionScattering(altitude, cosViewZenithAngle, viewRayIntersectsGround);
 #else
 #error What to render?

--- a/atmosphere/default/shaders/single-scattering/on-the-fly/0/molecules/single-scattering.frag
+++ b/atmosphere/default/shaders/single-scattering/on-the-fly/0/molecules/single-scattering.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // single-scattering.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,15 +45,15 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // single-scattering.frag
-#line 1 2 // densities.h.glsl
+#line 4 0 // single-scattering.frag
+#line 1 3 // densities.h.glsl
 float scattererNumberDensity_molecules(float altitude);
 float scattererNumberDensity_aerosols(float altitude);
 float absorberNumberDensity_ozone(float altitude);
 vec4 scatteringCrossSection();
 float scattererDensity(float altitude);
-#line 6 0 // single-scattering.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // single-scattering.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -74,8 +85,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // single-scattering.frag
-#line 1 4 // single-scattering.h.glsl
+#line 6 0 // single-scattering.frag
+#line 1 5 // single-scattering.h.glsl
 #ifndef INCLUDE_ONCE_1DB2EDC1_C687_4FFA_BFF4_D18A54BA651B
 #define INCLUDE_ONCE_1DB2EDC1_C687_4FFA_BFF4_D18A54BA651B
 
@@ -83,8 +94,8 @@ vec4 computeSingleScattering(const float cosSunZenithAngle, const float cosViewZ
                              const float dotViewSun, const float altitude,
                              const bool viewRayIntersectsGround);
 #endif
-#line 8 0 // single-scattering.frag
-#line 1 5 // texture-sampling-functions.h.glsl
+#line 7 0 // single-scattering.frag
+#line 1 6 // texture-sampling-functions.h.glsl
 #ifndef INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 #define INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float altitude);
@@ -96,20 +107,20 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                 const int scatteringOrder);
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 #endif
-#line 9 0 // single-scattering.frag
+#line 8 0 // single-scattering.frag
 
 // This function omits phase function and solar irradiance: these are to be applied somewhere in the calling code.
 vec4 computeSingleScatteringIntegrand(const float cosSunZenithAngle, const float cosViewZenithAngle,
                                       const float dotViewSun, const float altitude,
                                       const float dist, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle here the case when the
     // endpoint of the view ray intentionally appears in outer space.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosSunZenithAngleAtDist=clampCosine((r*cosSunZenithAngle+dist*dotViewSun)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosSunZenithAngleAtDist=clampCosine((r*cosSunZenithAngle+dist*dotViewSun)/(earthRadius+altAtDist));
 
-    const vec4 xmittance=transmittance(cosViewZenithAngle, altitude, dist, viewRayIntersectsGround)
+    CONST vec4 xmittance=transmittance(cosViewZenithAngle, altitude, dist, viewRayIntersectsGround)
                                                     *
                          transmittanceToAtmosphereBorder(cosSunZenithAngleAtDist, altAtDist)
                                                     *
@@ -121,14 +132,14 @@ vec4 computeSingleScattering(const float cosSunZenithAngle, const float cosViewZ
                              const float dotViewSun, const float altitude,
                              const bool viewRayIntersectsGround)
 {
-    const float integrInterval=distanceToNearestAtmosphereBoundary(cosViewZenithAngle, altitude,
+    CONST float integrInterval=distanceToNearestAtmosphereBoundary(cosViewZenithAngle, altitude,
                                                                    viewRayIntersectsGround);
     // Using the midpoint rule for quadrature
     vec4 spectrum=vec4(0);
-    const float dl=integrInterval/radialIntegrationPoints;
+    CONST float dl=integrInterval/radialIntegrationPoints;
     for(int n=0; n<radialIntegrationPoints; ++n)
     {
-        const float dist=(n+0.5)*dl;
+        CONST float dist=(n+0.5)*dl;
         spectrum += computeSingleScatteringIntegrand(cosSunZenithAngle, cosViewZenithAngle, dotViewSun,
                                                      altitude, dist, viewRayIntersectsGround);
     }

--- a/atmosphere/default/shaders/single-scattering/on-the-fly/0/molecules/texture-coordinates.frag
+++ b/atmosphere/default/shaders/single-scattering/on-the-fly/0/molecules/texture-coordinates.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-coordinates.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,8 +45,8 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // texture-coordinates.frag
-#line 1 2 // texture-coordinates.h.glsl
+#line 4 0 // texture-coordinates.frag
+#line 1 3 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -104,8 +115,8 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 6 0 // texture-coordinates.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-coordinates.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -137,7 +148,7 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-coordinates.frag
+#line 6 0 // texture-coordinates.frag
 
 const float LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA=sqrt(atmosphereHeight*(atmosphereHeight+2*earthRadius));
 
@@ -205,18 +216,18 @@ vec3 indicesToTexCoords(const vec3 indices, const vec3 texSizes)
 
 TransmittanceTexVars transmittanceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
+    CONST float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
                                 texCoordToUnitRange(texCoord.t,transmittanceTextureSize.t);
     // Distance from Earth center to camera
-    const float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
-    const float altitude=r-earthRadius;
+    CONST float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
+    CONST float altitude=r-earthRadius;
 
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
     // distance to border of visible atmosphere from the view point
-    const float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
+    CONST float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
     // d==0 can happen when altitude==atmosphereHeight
-    const float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
+    CONST float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
     return TransmittanceTexVars(cosVZA,altitude);
 }
 
@@ -235,53 +246,53 @@ vec2 transmittanceTexVarsToTexCoord(const float cosVZA, float altitude)
     if(altitude<0)
         altitude=0;
 
-    const float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
+    CONST float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
                                       transmittanceTextureSize.t);
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
-    const float d=distanceToAtmosphereBorder(cosVZA,altitude);
-    const float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float d=distanceToAtmosphereBorder(cosVZA,altitude);
+    CONST float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
     return vec2(s,t);
 }
 
 // Output: vec2(cos(sunZenithAngle), altitude)
 IrradianceTexVars irradianceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
-    const float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
+    CONST float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
+    CONST float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
     return IrradianceTexVars(cosSZA,alt);
 }
 
 vec2 irradianceTexVarsToTexCoord(const float cosSunZenithAngle, const float altitude)
 {
-    const float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
-    const float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
+    CONST float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
+    CONST float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
     return vec2(s,t);
 }
 
 float cosSZAToUnitRangeTexCoord(const float cosSunZenithAngle)
 {
     // Distance to top atmosphere border along the ray groundUnderCamera-sun: (altitude, cosSunZenithAngle)
-    const float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name
-    const float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
+    CONST float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
     // TODO: choose a more descriptive name
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     return max(0.,1-a/A)/(a+1);
 }
 
 float unitRangeTexCoordToCosSZA(const float texCoord)
 {
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float a=(A-A*texCoord)/(1+A*texCoord);
-    const float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
+    CONST float a=(A-A*texCoord)/(1+A*texCoord);
+    CONST float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
     return distFromGroundToTopAtmoBorder==0 ? 1 :
         clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distFromGroundToTopAtmoBorder)) /
                     (2*earthRadius*distFromGroundToTopAtmoBorder));
@@ -292,24 +303,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
                                                const float dotViewSun, const float altitude,
                                                const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -317,24 +328,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float dotVSCoord=(dotViewSun+1)/2;
+    CONST float dotVSCoord=(dotViewSun+1)/2;
 
     // ------------------------------------
-    const float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
+    CONST float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
 
     return Scattering4DCoords(cosSZACoord, cosVZACoord, dotVSCoord, altCoord, viewRayIntersectsGround);
 }
 
 TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
@@ -342,16 +353,16 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture coordinates we combine into a single sampler3D coordinate.
-    const float texW = scatteringTextureSize[1];
-    const float texH = scatteringTextureSize[2];
-    const float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
-    const vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
+    CONST float texW = scatteringTextureSize[1];
+    CONST float texH = scatteringTextureSize[2];
+    CONST float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
+    CONST vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
                                         ceil (cosSZAIndex)*texW+coords.dotViewSun*(texW-1)) / (texW*texH-1);
-    const vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
+    CONST vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
 
-    const float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
+    CONST float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
 
-    const float alphaUpper=fract(cosSZAIndex);
+    CONST float alphaUpper=fract(cosSZAIndex);
     return TexCoordPair(vec3(cosVZAtc, combinedCoord.x, altitude), float(1-alphaUpper),
                         vec3(cosVZAtc, combinedCoord.y, altitude), float(alphaUpper));
 }
@@ -359,9 +370,9 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
+    CONST TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
     return texture(tex, texCoords.lower) * texCoords.alphaLower +
            texture(tex, texCoords.upper) * texCoords.alphaUpper;
 }
@@ -369,17 +380,17 @@ vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const f
 // 3D texture is the 3D single-altitude slice of a 4D texture
 vec3 scattering4DCoordsToTex3DCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2);
 
-    const float dvsSize = scatteringTextureSize[1];
-    const float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
+    CONST float dvsSize = scatteringTextureSize[1];
+    CONST float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
 
-    const float cszaSize = scatteringTextureSize[2];
-    const float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
+    CONST float cszaSize = scatteringTextureSize[2];
+    CONST float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
 
     return vec3(cosVZAtc, dotVStc, cosSZAtc);
 }
@@ -394,39 +405,39 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along dotViewSun coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[1];
-    const float posOfRow = indices[1];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[1];
+    CONST float posOfRow = indices[1];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         indexToTexCoord(currRow, numRows-1),
                                                         texCoordVerbatim));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               indexToTexCoord(currRow, numRows-1),
                                                               texCoordVerbatim));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          indexToTexCoord(currRow, numRows-1),
                                          texCoordVerbatim));
@@ -434,14 +445,14 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
 vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolationGuides01Tex,
                                  const vec3 indices)
 {
-    const float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
+    CONST float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
 
-    const float cosVZAIndex = indices[0];
-    const float dotVSIndex = indices[1];
-    const float currRow = floor(dotVSIndex);
-    const float posBetweenRows = dotVSIndex - currRow;
-    const float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cosVZAIndex = indices[0];
+    CONST float dotVSIndex = indices[1];
+    CONST float currRow = floor(dotVSIndex);
+    CONST float posBetweenRows = dotVSIndex - currRow;
+    CONST float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -449,14 +460,14 @@ vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolat
     indicesCurrRow[1] =     currRow;
     indicesNextRow[1] = min(currRow+1, scatteringTextureSize[1]-1.);
 
-    const vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
-    const vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
+    CONST vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
+    CONST vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
 
-    const vec4 valueCurrRow = texture(tex, coordsCurrRow);
-    const vec4 valueNextRow = texture(tex, coordsNextRow);
-    const float epsilon = 1e-37; // Prevents passing zero to log
-    const vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
-    const vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
+    CONST vec4 valueCurrRow = texture(tex, coordsCurrRow);
+    CONST vec4 valueNextRow = texture(tex, coordsNextRow);
+    CONST float epsilon = 1e-37; // Prevents passing zero to log
+    CONST vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
+    CONST vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
     return (logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow;
 }
 
@@ -465,37 +476,37 @@ float findGuide02Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along SZA coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[2];
-    const float posOfRow = indices[2];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[2];
+    CONST float posOfRow = indices[2];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
 }
@@ -505,19 +516,19 @@ vec4 sample3DTextureGuided(const sampler3D tex,
                            const float cosSunZenithAngle, const float cosViewZenithAngle,
                            const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
                                                                     dotViewSun, altitude, viewRayIntersectsGround);
     // Handle the external interpolation guides: the guides between a pair of VZA-dotViewSun 2D "pictures".
-    const vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
-    const vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
-    const float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
+    CONST vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
+    CONST float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
 
-    const float cvzaIndex = indices[0];
-    const float cszaIndex = indices[2];
-    const float currRow = floor(cszaIndex);
-    const float posBetweenRows = cszaIndex - currRow;
-    const float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cvzaIndex = indices[0];
+    CONST float cszaIndex = indices[2];
+    CONST float currRow = floor(cszaIndex);
+    CONST float posBetweenRows = cszaIndex - currRow;
+    CONST float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -526,58 +537,58 @@ vec4 sample3DTextureGuided(const sampler3D tex,
     indicesNextRow[2] = min(currRow+1, scatteringTextureSize[2]-1);
 
     // The caller will handle the internal interpolation guides: the ones between rows in each 2D "picture".
-    const vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
-    const vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
+    CONST vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
+    CONST vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
     return exp((logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow);
 }
 
 vec4 sample3DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
     return texture(tex, texCoords);
 }
 
 ScatteringTexVars scatteringTex4DCoordsToTexVars(const Scattering4DCoords coords)
 {
-    const float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
     // ------------------------------------
     float cosViewZenithAngle;
     if(coords.viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
     // ------------------------------------
-    const float dotViewSun=coords.dotViewSun*2-1;
+    CONST float dotViewSun=coords.dotViewSun*2-1;
 
     // ------------------------------------
-    const float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
+    CONST float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
 
     return ScatteringTexVars(cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, coords.viewRayIntersectsGround);
 }
 
 Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 {
-    const vec4 indexMax=scatteringTextureSize-vec4(1);
+    CONST vec4 indexMax=scatteringTextureSize-vec4(1);
     Scattering4DCoords coords4d;
     coords4d.viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
     // The following formulas assume that scatteringTextureSize[0] is even. For odd sizes they would change.
@@ -593,8 +604,8 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture indices we combine into a single sampler3D coordinate.
-    const float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
-    const float combinedIndex=texIndices[1];
+    CONST float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
+    CONST float combinedIndex=texIndices[1];
     coords4d.dotViewSun=mod(combinedIndex,texW)/(texW-1);
     coords4d.cosSunZenithAngle=floor(combinedIndex/texW)/(texH-1);
 
@@ -608,11 +619,11 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
 ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 {
-    const Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
+    CONST Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
     ScatteringTexVars vars=scatteringTex4DCoordsToTexVars(coords4d);
     // Clamp dotViewSun to its valid range of values, given cosViewZenithAngle and cosSunZenithAngle. This is
     // needed to prevent NaNs when computing the scattering texture.
-    const float cosVZA=vars.cosViewZenithAngle,
+    CONST float cosVZA=vars.cosViewZenithAngle,
                 cosSZA=vars.cosSunZenithAngle;
     vars.dotViewSun=clamp(vars.dotViewSun,
                           cosVZA*cosSZA-safeSqrt((1-sqr(cosVZA))*(1-sqr(cosSZA))),
@@ -622,54 +633,54 @@ ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 
 EclipseScatteringTexVars eclipseTexCoordsToTexVars(const vec2 texCoords, const float altitude)
 {
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
-    const bool viewRayIntersectsGround = texCoords.t<0.5;
+    CONST bool viewRayIntersectsGround = texCoords.t<0.5;
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
-    const float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
+    CONST float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
     return EclipseScatteringTexVars(azimuthRelativeToSun, cosViewZenithAngle, viewRayIntersectsGround);
 }
 
 EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                                    const float altitude, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -677,13 +688,13 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
-    const float azimuthCoord = azimuthRelativeToSun/(2*PI);
+    CONST float azimuthCoord = azimuthRelativeToSun/(2*PI);
 
     return EclipseScattering2DCoords(azimuthCoord, cosVZACoord);
 }
@@ -691,14 +702,14 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
 vec2 eclipseTexVarsToTexCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                const float altitude, const bool viewRayIntersectsGround, const vec2 texSize)
 {
-    const EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+    CONST EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                                     viewRayIntersectsGround);
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2);
-    const float azimuthTC = coords.azimuth + 1/(2*texSize.s);
+    CONST float azimuthTC = coords.azimuth + 1/(2*texSize.s);
 
     return vec2(azimuthTC, cosVZAtc);
 }
@@ -707,42 +718,42 @@ vec4 sampleEclipseDoubleScattering3DTexture(const sampler3D tex, const float cos
                                             const float cosViewZenithAngle, const float azimuthRelativeToSun,
                                             const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
+    CONST vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
                                                   eclipsedDoubleScatteringTextureSize.st);
-    const float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
-    const vec3 texCoords=vec3(coords2d, cosSZACoord);
+    CONST float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
+    CONST vec3 texCoords=vec3(coords2d, cosSZACoord);
 
     return texture(tex, texCoords);
 }
 
 LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 texIndices)
 {
-    const vec2 indexMax=lightPollutionTextureSize-vec2(1);
+    CONST vec2 indexMax=lightPollutionTextureSize-vec2(1);
 
-    const float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
-    const float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
+    CONST float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
-    const bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
-    const float cosViewZenithAngleCoord = viewRayIntersectsGround ?
+    CONST bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
+    CONST float cosViewZenithAngleCoord = viewRayIntersectsGround ?
                                    1-2*texIndices[0]/(indexMax[0]-1) :
                                    2*(texIndices[0]-1)/(indexMax[0]-1)-1;
     // ------------------------------------
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
@@ -753,23 +764,23 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 
 LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -777,27 +788,27 @@ LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, con
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     return LightPollution2DCoords(cosVZACoord, altCoord);
 }
 
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
-    const vec2 texSize = lightPollutionTextureSize;
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 texSize = lightPollutionTextureSize;
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2);
-    const float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
+    CONST float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
     return vec2(cosVZAtc, altitudeTC);
 }

--- a/atmosphere/default/shaders/single-scattering/on-the-fly/0/molecules/texture-sampling-functions.frag
+++ b/atmosphere/default/shaders/single-scattering/on-the-fly/0/molecules/texture-sampling-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-sampling-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,13 +45,13 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // texture-sampling-functions.frag
-#line 1 2 // phase-functions.h.glsl
+#line 4 0 // texture-sampling-functions.frag
+#line 1 3 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 6 0 // texture-sampling-functions.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-sampling-functions.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -72,8 +83,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-sampling-functions.frag
-#line 1 4 // texture-coordinates.h.glsl
+#line 6 0 // texture-sampling-functions.frag
+#line 1 5 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -142,7 +153,7 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 8 0 // texture-sampling-functions.frag
+#line 7 0 // texture-sampling-functions.frag
 
 uniform sampler2D transmittanceTexture;
 uniform sampler2D irradianceTexture;
@@ -154,13 +165,13 @@ uniform sampler2D lightPollutionScatteringTexture;
 
 vec4 irradiance(const float cosSunZenithAngle, const float altitude)
 {
-    const vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
+    CONST vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
     return texture(irradianceTexture, texCoords);
 }
 
 vec4 opticalDepthToAtmosphereBorder(const float cosViewZenithAngle, const float altitude)
 {
-    const vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
+    CONST vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact when looking into nadir from TOA at some values of texture sizes (in particular, size of
     // transmittance texture for altitude being 4096). This happens when I simply call texture(eclipsedScatteringTexture,
@@ -178,11 +189,11 @@ vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float
 vec4 transmittance(const float cosViewZenithAngle, const float altitude, const float dist,
                    const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle view ray endpoint
     // in space here.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
 
     vec4 depth;
     if(viewRayIntersectsGround)
@@ -201,7 +212,7 @@ vec4 transmittance(const float cosViewZenithAngle, const float altitude, const f
 vec4 calcFirstScattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                          const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
+    CONST vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
                                           dotViewSun, altitude, viewRayIntersectsGround);
     return scattering*currentPhaseFunction(dotViewSun);
 }
@@ -220,6 +231,6 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
 
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     return texture(lightPollutionScatteringTexture, coords);
 }

--- a/atmosphere/default/shaders/single-scattering/on-the-fly/1/aerosols/common-functions.frag
+++ b/atmosphere/default/shaders/single-scattering/on-the-fly/1/aerosols/common-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // common-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(2.15e-06,1.11400004e-06,3.8580001
 const vec4 wavelengths=vec4(485.333344,516.666687,548,579.333313);
 const int wlSetIndex=1;
 #endif
-#line 5 0 // common-functions.frag
+#line 4 0 // common-functions.frag
 
 bool dbgDataPresent=false;
 bool debugDataPresent()
@@ -69,7 +80,7 @@ void setDebugData(float a,float b, float c, float d)
 
 void swap(inout float x, inout float y)
 {
-    const float t = x;
+    CONST float t = x;
     x = y;
     y = t;
 }
@@ -83,7 +94,7 @@ float safeSqrt(const float x)
 
 float safeAtan(const float y, const float x)
 {
-    const float a = atan(y,x);
+    CONST float a = atan(y,x);
     return x==0 && y==0 ? 0 : a;
 }
 
@@ -116,23 +127,23 @@ float pointAltitude(vec3 point)
 
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float Ratm=earthRadius+atmosphereHeight;
-    const float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float Ratm=earthRadius+atmosphereHeight;
+    CONST float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float distanceToGround(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(-safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float cosZenithAngleOfHorizon(const float altitude)
 {
-    const float R=earthRadius;
-    const float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
+    CONST float R=earthRadius;
+    CONST float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
     return -sqrt(2*h*R+sqr(h))/(R+h);
 }
 
@@ -151,8 +162,8 @@ float distanceToNearestAtmosphereBoundary(const float cosZenithAngle, const floa
 float sunVisibility(const float cosSunZenithAngle, float altitude)
 {
     if(altitude<0) altitude=0;
-    const float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
-    const float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
+    CONST float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
+    CONST float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
     /* Approximating visible fraction of solar disk by smoothstep between the position of the Sun
      * touching the horizon by its upper part and the position with lower part touching the horizon.
      * The calculation assumes that solar angular radius is small and thus approximately equals its sine.
@@ -182,13 +193,13 @@ float circlesIntersectionArea(float R1, float R2, float d)
 
 float angleBetween(const vec3 a, const vec3 b)
 {
-    const float d=dot(a,b);
-    const float c=length(cross(a,b));
+    CONST float d=dot(a,b);
+    CONST float c=length(cross(a,b));
     // To avoid loss of precision, don't use dot product near the singularity
     // of acos, and cross product near the singularity of asin
     if(abs(d) < abs(c))
         return acos(d/(length(a)*length(b)));
-    const float smallerAngle = asin(c/(length(a)*length(b)));
+    CONST float smallerAngle = asin(c/(length(a)*length(b)));
     if(d<0) return PI-smallerAngle;
     return smallerAngle;
 }
@@ -205,11 +216,11 @@ float moonAngularRadius(const vec3 cameraPosition, const vec3 moonPosition)
 
 float visibleSolidAngleOfSun(const vec3 camera, const vec3 sunDir, const vec3 moonPos)
 {
-    const float Rs=sunAngularRadius;
-    const float Rm=moonAngularRadius(camera,moonPos);
+    CONST float Rs=sunAngularRadius;
+    CONST float Rm=moonAngularRadius(camera,moonPos);
     float visibleSolidAngle=PI*sqr(Rs);
 
-    const float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
+    CONST float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
     if(dSM<Rs+Rm)
     {
         visibleSolidAngle -= circlesIntersectionArea(Rm,Rs,dSM);
@@ -229,12 +240,12 @@ float sphereIntegrationSolidAngleDifferential(const int pointCountOnSphere)
 }
 vec3 sphereIntegrationSampleDir(const int index, const int pointCountOnSphere)
 {
-    const float goldenRatio=1.6180339887499;
+    CONST float goldenRatio=1.6180339887499;
     // The range of n is 0.5, 1.5, ..., pointCountOnSphere-0.5
-    const float n=index+0.5;
+    CONST float n=index+0.5;
     // Explanation of the Fibonacci grid generation can be seen at https://stackoverflow.com/a/44164075/673852
-    const float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
-    const float azimuth=n*(2*PI*goldenRatio);
+    CONST float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
+    CONST float azimuth=n*(2*PI*goldenRatio);
     return vec3(cos(azimuth)*sin(zenithAngle),
                 sin(azimuth)*sin(zenithAngle),
                 cos(zenithAngle));

--- a/atmosphere/default/shaders/single-scattering/on-the-fly/1/aerosols/densities.frag
+++ b/atmosphere/default/shaders/single-scattering/on-the-fly/1/aerosols/densities.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // densities.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,20 +45,20 @@ const vec4 lightPollutionRelativeRadiance=vec4(2.15e-06,1.11400004e-06,3.8580001
 const vec4 wavelengths=vec4(485.333344,516.666687,548,579.333313);
 const int wlSetIndex=1;
 #endif
-#line 5 0 // densities.frag
+#line 4 0 // densities.frag
 float scattererNumberDensity_molecules(float altitude)
 {
-        const float rayleighScaleHeight=8*km;
+        CONST float rayleighScaleHeight=8*km;
         return 3.08458e25*exp(-1/rayleighScaleHeight * altitude);
 }
 float scattererNumberDensity_aerosols(float altitude)
 {
-        const float mieScaleHeight=1.2*km;
+        CONST float mieScaleHeight=1.2*km;
         return 1.03333e8*exp(-1/mieScaleHeight*altitude);
 }
 float absorberNumberDensity_ozone(float altitude)
 {
-        const float totalOzoneAmount=370*dobsonUnit;
+        CONST float totalOzoneAmount=370*dobsonUnit;
 
         float density;
 

--- a/atmosphere/default/shaders/single-scattering/on-the-fly/1/aerosols/phase-functions.frag
+++ b/atmosphere/default/shaders/single-scattering/on-the-fly/1/aerosols/phase-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // phase-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(2.15e-06,1.11400004e-06,3.8580001
 const vec4 wavelengths=vec4(485.333344,516.666687,548,579.333313);
 const int wlSetIndex=1;
 #endif
-#line 5 0 // phase-functions.frag
+#line 4 0 // phase-functions.frag
 
 vec4 phaseFunction_molecules(float dotViewSun)
 {
@@ -42,9 +53,9 @@ vec4 phaseFunction_molecules(float dotViewSun)
 }
 vec4 phaseFunction_aerosols(float dotViewSun)
 {
-        const float g=0.76;
-        const float g2=g*g;
-        const float k = 3/(8*PI)*(1-g2)/(2+g2);
+        CONST float g=0.76;
+        CONST float g2=g*g;
+        CONST float k = 3/(8*PI)*(1-g2)/(2+g2);
         return vec4(k * (1+sqr(dotViewSun)) / pow(1+g2 - 2*g*dotViewSun, 1.5) + 1/((1-dotViewSun)*600+0.05))*0.904;
 }
 vec4 currentPhaseFunction(float dotViewSun) { return phaseFunction_aerosols(dotViewSun); }

--- a/atmosphere/default/shaders/single-scattering/on-the-fly/1/aerosols/render.frag
+++ b/atmosphere/default/shaders/single-scattering/on-the-fly/1/aerosols/render.frag
@@ -1,7 +1,21 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
 
-#line 1 1 // const.h.glsl
+
+
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 6 0 // render.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,11 +48,11 @@ const vec4 lightPollutionRelativeRadiance=vec4(2.15e-06,1.11400004e-06,3.8580001
 const vec4 wavelengths=vec4(485.333344,516.666687,548,579.333313);
 const int wlSetIndex=1;
 #endif
-#line 5 0 // render.frag
-#line 1 2 // calc-view-dir.h.glsl
+#line 7 0 // render.frag
+#line 1 3 // calc-view-dir.h.glsl
 vec3 calcViewDir();
-#line 6 0 // render.frag
-#line 1 3 // common-functions.h.glsl
+#line 8 0 // render.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -70,13 +84,13 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // render.frag
-#line 1 4 // phase-functions.h.glsl
+#line 9 0 // render.frag
+#line 1 5 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 8 0 // render.frag
-#line 1 5 // single-scattering.h.glsl
+#line 10 0 // render.frag
+#line 1 6 // single-scattering.h.glsl
 #ifndef INCLUDE_ONCE_1DB2EDC1_C687_4FFA_BFF4_D18A54BA651B
 #define INCLUDE_ONCE_1DB2EDC1_C687_4FFA_BFF4_D18A54BA651B
 
@@ -84,9 +98,9 @@ vec4 computeSingleScattering(const float cosSunZenithAngle, const float cosViewZ
                              const float dotViewSun, const float altitude,
                              const bool viewRayIntersectsGround);
 #endif
-#line 9 0 // render.frag
+#line 11 0 // render.frag
 
-#line 1 6 // texture-coordinates.h.glsl
+#line 1 7 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -155,10 +169,10 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 11 0 // render.frag
-#line 1 7 // radiance-to-luminance.h.glsl
+#line 13 0 // render.frag
+#line 1 8 // radiance-to-luminance.h.glsl
 const mat4 radianceToLuminance=mat4(1196.74268,3672.67432,12945.498,45528.7344,  835.02478,13767.5205,2120.37939,51317.4727,  8632.59277,21193.416,222.095078,27381.1602,  19410,18758.1973,35.7829971,6712.12158);
-#line 12 0 // render.frag
+#line 14 0 // render.frag
 
 
 
@@ -195,18 +209,18 @@ void main()
     // this approximation has the same order of magnitude as the assumption that the Earth and its atmosphere
     // are spherical.
     float altitude = max(cameraPosition.z, 0.);
-    const vec3 oldCamPos=cameraPosition;
+    CONST vec3 oldCamPos=cameraPosition;
     // Hide the uniform with this name, thus effectively modifying it for the following code
     vec3 cameraPosition=vec3(oldCamPos.xy, altitude);
 
     bool lookingIntoAtmosphere=true;
     if(altitude>atmosphereHeight)
     {
-        const vec3 p = cameraPosition - earthCenter;
-        const float p_dot_v = dot(p, viewDir);
-        const float p_dot_p = dot(p, p);
-        const float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
-        const float distanceToTOA = -p_dot_v - sqrt(sqr(earthRadius+atmosphereHeight) - squaredDistBetweenViewRayAndEarthCenter);
+        CONST vec3 p = cameraPosition - earthCenter;
+        CONST float p_dot_v = dot(p, viewDir);
+        CONST float p_dot_p = dot(p, p);
+        CONST float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
+        CONST float distanceToTOA = -p_dot_v - sqrt(sqr(earthRadius+atmosphereHeight) - squaredDistBetweenViewRayAndEarthCenter);
         if(distanceToTOA>=0)
         {
             cameraPosition += viewDir*distanceToTOA;
@@ -214,7 +228,7 @@ void main()
         }
         else
         {
-#if RENDERING_ANY_ZERO_SCATTERING
+#if 0 /*RENDERING_ANY_ZERO_SCATTERING*/
             lookingIntoAtmosphere=false;
 #else
             luminance=vec4(0);
@@ -224,16 +238,16 @@ void main()
         }
     }
 
-    const vec3 zenith=normalize(cameraPosition-earthCenter);
+    CONST vec3 zenith=normalize(cameraPosition-earthCenter);
     float cosViewZenithAngle=dot(zenith,viewDir);
 
     bool viewRayIntersectsGround=false;
     {
-        const vec3 p = cameraPosition - earthCenter;
-        const float p_dot_v = dot(p, viewDir);
-        const float p_dot_p = dot(p, p);
-        const float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
-        const float distanceToIntersection = -p_dot_v - sqrt(sqr(earthRadius) - squaredDistBetweenViewRayAndEarthCenter);
+        CONST vec3 p = cameraPosition - earthCenter;
+        CONST float p_dot_v = dot(p, viewDir);
+        CONST float p_dot_p = dot(p, p);
+        CONST float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
+        CONST float distanceToIntersection = -p_dot_v - sqrt(sqr(earthRadius) - squaredDistBetweenViewRayAndEarthCenter);
         // altitude==0 is a special case where distance to intersection calculation
         // is unreliable (has a lot of noise in its sign), so check it separately
         if(distanceToIntersection>0 || (altitude==0 && cosViewZenithAngle<0))
@@ -244,11 +258,11 @@ void main()
     // Aside from aesthetics, this affects brightness input to Stellarium's tone mapper.
     if(pseudoMirrorSkyBelowHorizon && viewRayIntersectsGround)
     {
-        const float horizonCZA = cosZenithAngleOfHorizon(altitude);
-        const float viewElev  = asin(clampCosine(cosViewZenithAngle));
-        const float horizElev = asin(clampCosine(horizonCZA));
-        const float newViewElev = 2*horizElev - viewElev;
-        const float viewDirXYnorm = length(viewDir-zenith*cosViewZenithAngle);
+        CONST float horizonCZA = cosZenithAngleOfHorizon(altitude);
+        CONST float viewElev  = asin(clampCosine(cosViewZenithAngle));
+        CONST float horizElev = asin(clampCosine(horizonCZA));
+        CONST float newViewElev = 2*horizElev - viewElev;
+        CONST float viewDirXYnorm = length(viewDir-zenith*cosViewZenithAngle);
         if(viewDirXYnorm == 0)
         {
             viewDir = zenith;
@@ -267,27 +281,27 @@ void main()
         viewRayIntersectsGround = false;
     }
 
-    const float cosSunZenithAngle =dot(zenith,sunDirection);
-    const float dotViewSun=dot(viewDir,sunDirection);
+    CONST float cosSunZenithAngle =dot(zenith,sunDirection);
+    CONST float dotViewSun=dot(viewDir,sunDirection);
 
-    const vec3 sunXYunnorm=sunDirection-dot(sunDirection,zenith)*zenith;
-    const vec3 viewXYunnorm=viewDir-dot(viewDir,zenith)*zenith;
-    const vec3 sunXY = sunXYunnorm.x!=0 || sunXYunnorm.y!=0 || sunXYunnorm.z!=0 ? normalize(sunXYunnorm) : vec3(0);
-    const vec3 viewXY = viewXYunnorm.x!=0 || viewXYunnorm.y!=0 || viewXYunnorm.z!=0 ? normalize(viewXYunnorm) : vec3(0);
-    const float azimuthRelativeToSun=safeAtan(dot(cross(sunXY, viewXY), zenith), dot(sunXY, viewXY));
+    CONST vec3 sunXYunnorm=sunDirection-dot(sunDirection,zenith)*zenith;
+    CONST vec3 viewXYunnorm=viewDir-dot(viewDir,zenith)*zenith;
+    CONST vec3 sunXY = sunXYunnorm.x!=0 || sunXYunnorm.y!=0 || sunXYunnorm.z!=0 ? normalize(sunXYunnorm) : vec3(0);
+    CONST vec3 viewXY = viewXYunnorm.x!=0 || viewXYunnorm.y!=0 || viewXYunnorm.z!=0 ? normalize(viewXYunnorm) : vec3(0);
+    CONST float azimuthRelativeToSun=safeAtan(dot(cross(sunXY, viewXY), zenith), dot(sunXY, viewXY));
 
-#if RENDERING_ZERO_SCATTERING
+#if 0 /*RENDERING_ZERO_SCATTERING*/
     vec4 radiance;
     if(viewRayIntersectsGround)
     {
         // XXX: keep in sync with the same code in computeScatteringDensity(), but don't forget about
         //      the difference in the usage of viewDir vs incDir.
-        const float distToGround = distanceToGround(cosViewZenithAngle, altitude);
-        const vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
-        const vec3 groundNormal = normalize(zenith*(earthRadius+altitude)+viewDir*distToGround);
-        const vec4 groundIrradiance = irradiance(dot(groundNormal, sunDirection), 0);
+        CONST float distToGround = distanceToGround(cosViewZenithAngle, altitude);
+        CONST vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
+        CONST vec3 groundNormal = normalize(zenith*(earthRadius+altitude)+viewDir*distToGround);
+        CONST vec4 groundIrradiance = irradiance(dot(groundNormal, sunDirection), 0);
         // Radiation scattered by the ground
-        const float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
+        CONST float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
         radiance = transmittanceToGround*groundAlbedo*groundIrradiance*solarIrradianceFixup*groundBRDF
                  + lightPollutionGroundLuminance*lightPollutionRelativeRadiance;
     }
@@ -304,22 +318,22 @@ void main()
     }
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_ZERO_SCATTERING
+#elif 0 /*RENDERING_ECLIPSED_ZERO_SCATTERING*/
     vec4 radiance;
-    const float dotViewMoon=dot(viewDir,normalize(moonPosition-cameraPosition));
+    CONST float dotViewMoon=dot(viewDir,normalize(moonPosition-cameraPosition));
     if(viewRayIntersectsGround)
     {
         // XXX: keep in sync with the similar code in non-eclipsed zero scattering rendering.
-        const float distToGround = distanceToGround(cosViewZenithAngle, altitude);
-        const vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
-        const vec3 pointOnGround = cameraPosition+viewDir*distToGround;
-        const vec4 directGroundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDirection, moonPosition);
+        CONST float distToGround = distanceToGround(cosViewZenithAngle, altitude);
+        CONST vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
+        CONST vec3 pointOnGround = cameraPosition+viewDir*distToGround;
+        CONST vec4 directGroundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDirection, moonPosition);
         // FIXME: add first-order indirect irradiance too: it's done in non-eclipsed irradiance (in the same
         // conditions: when limited to 2 orders). This should be calculated at the same time when second order
         // is: all the infrastructure is already there.
-        const vec4 groundIrradiance = directGroundIrradiance;
+        CONST vec4 groundIrradiance = directGroundIrradiance;
         // Radiation scattered by the ground
-        const float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
+        CONST float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
         radiance = transmittanceToGround*groundAlbedo*groundIrradiance*solarIrradianceFixup*groundBRDF
                  + lightPollutionGroundLuminance*lightPollutionRelativeRadiance;
     }
@@ -336,53 +350,53 @@ void main()
     }
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_ON_THE_FLY
-    const vec4 scattering=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPosition,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_ON_THE_FLY*/
+    CONST vec4 scattering=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPosition,
                                                           viewRayIntersectsGround);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE
-    const vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE*/
+    CONST vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                      viewRayIntersectsGround, eclipsedSingleScatteringTextureSize);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact at the point where azimuth texture coordinate changes from 1 to 0 (at azimuthRelativeToSun crossing
     // 0). This happens when I simply call texture(eclipsedScatteringTexture, texCoords) without specifying LOD.
     // Apparently, the driver uses the derivative for some reason, even though it shouldn't.
-    const vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
+    CONST vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE
-    const vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
+    CONST vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                      viewRayIntersectsGround, eclipsedSingleScatteringTextureSize);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact at the point where azimuth texture coordinate changes from 1 to 0 (at azimuthRelativeToSun crossing
     // 0). This happens when I simply call texture(eclipsedScatteringTexture, texCoords) without specifying LOD.
     // Apparently, the driver uses the derivative for some reason, even though it shouldn't.
-    const vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
+    CONST vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
     luminance=scattering*currentPhaseFunction(dotViewSun);
-#elif RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_RADIANCE
+#elif 0 /*RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_RADIANCE*/
     vec4 radiance=exp(sampleEclipseDoubleScattering3DTexture(eclipsedDoubleScatteringTexture,
                                                              cosSunZenithAngle, cosViewZenithAngle, azimuthRelativeToSun,
                                                              altitude, viewRayIntersectsGround));
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_LUMINANCE
+#elif 0 /*RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
     luminance=exp(sampleEclipseDoubleScattering3DTexture(eclipsedDoubleScatteringTexture,
                                                          cosSunZenithAngle, cosViewZenithAngle, azimuthRelativeToSun,
                                                          altitude, viewRayIntersectsGround));
 #elif 1 /*RENDERING_SINGLE_SCATTERING_ON_THE_FLY*/
-    const vec4 scattering=computeSingleScattering(cosSunZenithAngle,cosViewZenithAngle,dotViewSun,
+    CONST vec4 scattering=computeSingleScattering(cosSunZenithAngle,cosViewZenithAngle,dotViewSun,
                                                   altitude,viewRayIntersectsGround);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE
+#elif 0 /*RENDERING_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE*/
     vec4 scattering;
     if(useInterpolationGuides)
     {
@@ -399,7 +413,7 @@ void main()
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE
+#elif 0 /*RENDERING_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
     vec4 scattering;
     if(useInterpolationGuides)
     {
@@ -413,18 +427,18 @@ void main()
                                      dotViewSun, altitude, viewRayIntersectsGround);
     }
     luminance=scattering * (bool(0) ? vec4(1) : currentPhaseFunction(dotViewSun));
-#elif RENDERING_MULTIPLE_SCATTERING_LUMINANCE
+#elif 0 /*RENDERING_MULTIPLE_SCATTERING_LUMINANCE*/
     luminance=sample3DTexture(scatteringTexture, cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, viewRayIntersectsGround);
-#elif RENDERING_MULTIPLE_SCATTERING_RADIANCE
+#elif 0 /*RENDERING_MULTIPLE_SCATTERING_RADIANCE*/
     vec4 radiance=sample3DTexture(scatteringTexture, cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, viewRayIntersectsGround);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_LIGHT_POLLUTION_RADIANCE
+#elif 0 /*RENDERING_LIGHT_POLLUTION_RADIANCE*/
     vec4 radiance=lightPollutionGroundLuminance*lightPollutionScattering(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_LIGHT_POLLUTION_LUMINANCE
+#elif 0 /*RENDERING_LIGHT_POLLUTION_LUMINANCE*/
     luminance=lightPollutionGroundLuminance*lightPollutionScattering(altitude, cosViewZenithAngle, viewRayIntersectsGround);
 #else
 #error What to render?

--- a/atmosphere/default/shaders/single-scattering/on-the-fly/1/aerosols/single-scattering.frag
+++ b/atmosphere/default/shaders/single-scattering/on-the-fly/1/aerosols/single-scattering.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // single-scattering.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,15 +45,15 @@ const vec4 lightPollutionRelativeRadiance=vec4(2.15e-06,1.11400004e-06,3.8580001
 const vec4 wavelengths=vec4(485.333344,516.666687,548,579.333313);
 const int wlSetIndex=1;
 #endif
-#line 5 0 // single-scattering.frag
-#line 1 2 // densities.h.glsl
+#line 4 0 // single-scattering.frag
+#line 1 3 // densities.h.glsl
 float scattererNumberDensity_molecules(float altitude);
 float scattererNumberDensity_aerosols(float altitude);
 float absorberNumberDensity_ozone(float altitude);
 vec4 scatteringCrossSection();
 float scattererDensity(float altitude);
-#line 6 0 // single-scattering.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // single-scattering.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -74,8 +85,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // single-scattering.frag
-#line 1 4 // single-scattering.h.glsl
+#line 6 0 // single-scattering.frag
+#line 1 5 // single-scattering.h.glsl
 #ifndef INCLUDE_ONCE_1DB2EDC1_C687_4FFA_BFF4_D18A54BA651B
 #define INCLUDE_ONCE_1DB2EDC1_C687_4FFA_BFF4_D18A54BA651B
 
@@ -83,8 +94,8 @@ vec4 computeSingleScattering(const float cosSunZenithAngle, const float cosViewZ
                              const float dotViewSun, const float altitude,
                              const bool viewRayIntersectsGround);
 #endif
-#line 8 0 // single-scattering.frag
-#line 1 5 // texture-sampling-functions.h.glsl
+#line 7 0 // single-scattering.frag
+#line 1 6 // texture-sampling-functions.h.glsl
 #ifndef INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 #define INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float altitude);
@@ -96,20 +107,20 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                 const int scatteringOrder);
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 #endif
-#line 9 0 // single-scattering.frag
+#line 8 0 // single-scattering.frag
 
 // This function omits phase function and solar irradiance: these are to be applied somewhere in the calling code.
 vec4 computeSingleScatteringIntegrand(const float cosSunZenithAngle, const float cosViewZenithAngle,
                                       const float dotViewSun, const float altitude,
                                       const float dist, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle here the case when the
     // endpoint of the view ray intentionally appears in outer space.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosSunZenithAngleAtDist=clampCosine((r*cosSunZenithAngle+dist*dotViewSun)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosSunZenithAngleAtDist=clampCosine((r*cosSunZenithAngle+dist*dotViewSun)/(earthRadius+altAtDist));
 
-    const vec4 xmittance=transmittance(cosViewZenithAngle, altitude, dist, viewRayIntersectsGround)
+    CONST vec4 xmittance=transmittance(cosViewZenithAngle, altitude, dist, viewRayIntersectsGround)
                                                     *
                          transmittanceToAtmosphereBorder(cosSunZenithAngleAtDist, altAtDist)
                                                     *
@@ -121,14 +132,14 @@ vec4 computeSingleScattering(const float cosSunZenithAngle, const float cosViewZ
                              const float dotViewSun, const float altitude,
                              const bool viewRayIntersectsGround)
 {
-    const float integrInterval=distanceToNearestAtmosphereBoundary(cosViewZenithAngle, altitude,
+    CONST float integrInterval=distanceToNearestAtmosphereBoundary(cosViewZenithAngle, altitude,
                                                                    viewRayIntersectsGround);
     // Using the midpoint rule for quadrature
     vec4 spectrum=vec4(0);
-    const float dl=integrInterval/radialIntegrationPoints;
+    CONST float dl=integrInterval/radialIntegrationPoints;
     for(int n=0; n<radialIntegrationPoints; ++n)
     {
-        const float dist=(n+0.5)*dl;
+        CONST float dist=(n+0.5)*dl;
         spectrum += computeSingleScatteringIntegrand(cosSunZenithAngle, cosViewZenithAngle, dotViewSun,
                                                      altitude, dist, viewRayIntersectsGround);
     }

--- a/atmosphere/default/shaders/single-scattering/on-the-fly/1/aerosols/texture-coordinates.frag
+++ b/atmosphere/default/shaders/single-scattering/on-the-fly/1/aerosols/texture-coordinates.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-coordinates.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,8 +45,8 @@ const vec4 lightPollutionRelativeRadiance=vec4(2.15e-06,1.11400004e-06,3.8580001
 const vec4 wavelengths=vec4(485.333344,516.666687,548,579.333313);
 const int wlSetIndex=1;
 #endif
-#line 5 0 // texture-coordinates.frag
-#line 1 2 // texture-coordinates.h.glsl
+#line 4 0 // texture-coordinates.frag
+#line 1 3 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -104,8 +115,8 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 6 0 // texture-coordinates.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-coordinates.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -137,7 +148,7 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-coordinates.frag
+#line 6 0 // texture-coordinates.frag
 
 const float LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA=sqrt(atmosphereHeight*(atmosphereHeight+2*earthRadius));
 
@@ -205,18 +216,18 @@ vec3 indicesToTexCoords(const vec3 indices, const vec3 texSizes)
 
 TransmittanceTexVars transmittanceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
+    CONST float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
                                 texCoordToUnitRange(texCoord.t,transmittanceTextureSize.t);
     // Distance from Earth center to camera
-    const float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
-    const float altitude=r-earthRadius;
+    CONST float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
+    CONST float altitude=r-earthRadius;
 
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
     // distance to border of visible atmosphere from the view point
-    const float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
+    CONST float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
     // d==0 can happen when altitude==atmosphereHeight
-    const float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
+    CONST float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
     return TransmittanceTexVars(cosVZA,altitude);
 }
 
@@ -235,53 +246,53 @@ vec2 transmittanceTexVarsToTexCoord(const float cosVZA, float altitude)
     if(altitude<0)
         altitude=0;
 
-    const float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
+    CONST float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
                                       transmittanceTextureSize.t);
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
-    const float d=distanceToAtmosphereBorder(cosVZA,altitude);
-    const float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float d=distanceToAtmosphereBorder(cosVZA,altitude);
+    CONST float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
     return vec2(s,t);
 }
 
 // Output: vec2(cos(sunZenithAngle), altitude)
 IrradianceTexVars irradianceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
-    const float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
+    CONST float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
+    CONST float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
     return IrradianceTexVars(cosSZA,alt);
 }
 
 vec2 irradianceTexVarsToTexCoord(const float cosSunZenithAngle, const float altitude)
 {
-    const float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
-    const float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
+    CONST float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
+    CONST float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
     return vec2(s,t);
 }
 
 float cosSZAToUnitRangeTexCoord(const float cosSunZenithAngle)
 {
     // Distance to top atmosphere border along the ray groundUnderCamera-sun: (altitude, cosSunZenithAngle)
-    const float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name
-    const float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
+    CONST float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
     // TODO: choose a more descriptive name
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     return max(0.,1-a/A)/(a+1);
 }
 
 float unitRangeTexCoordToCosSZA(const float texCoord)
 {
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float a=(A-A*texCoord)/(1+A*texCoord);
-    const float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
+    CONST float a=(A-A*texCoord)/(1+A*texCoord);
+    CONST float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
     return distFromGroundToTopAtmoBorder==0 ? 1 :
         clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distFromGroundToTopAtmoBorder)) /
                     (2*earthRadius*distFromGroundToTopAtmoBorder));
@@ -292,24 +303,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
                                                const float dotViewSun, const float altitude,
                                                const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -317,24 +328,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float dotVSCoord=(dotViewSun+1)/2;
+    CONST float dotVSCoord=(dotViewSun+1)/2;
 
     // ------------------------------------
-    const float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
+    CONST float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
 
     return Scattering4DCoords(cosSZACoord, cosVZACoord, dotVSCoord, altCoord, viewRayIntersectsGround);
 }
 
 TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
@@ -342,16 +353,16 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture coordinates we combine into a single sampler3D coordinate.
-    const float texW = scatteringTextureSize[1];
-    const float texH = scatteringTextureSize[2];
-    const float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
-    const vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
+    CONST float texW = scatteringTextureSize[1];
+    CONST float texH = scatteringTextureSize[2];
+    CONST float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
+    CONST vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
                                         ceil (cosSZAIndex)*texW+coords.dotViewSun*(texW-1)) / (texW*texH-1);
-    const vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
+    CONST vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
 
-    const float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
+    CONST float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
 
-    const float alphaUpper=fract(cosSZAIndex);
+    CONST float alphaUpper=fract(cosSZAIndex);
     return TexCoordPair(vec3(cosVZAtc, combinedCoord.x, altitude), float(1-alphaUpper),
                         vec3(cosVZAtc, combinedCoord.y, altitude), float(alphaUpper));
 }
@@ -359,9 +370,9 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
+    CONST TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
     return texture(tex, texCoords.lower) * texCoords.alphaLower +
            texture(tex, texCoords.upper) * texCoords.alphaUpper;
 }
@@ -369,17 +380,17 @@ vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const f
 // 3D texture is the 3D single-altitude slice of a 4D texture
 vec3 scattering4DCoordsToTex3DCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2);
 
-    const float dvsSize = scatteringTextureSize[1];
-    const float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
+    CONST float dvsSize = scatteringTextureSize[1];
+    CONST float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
 
-    const float cszaSize = scatteringTextureSize[2];
-    const float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
+    CONST float cszaSize = scatteringTextureSize[2];
+    CONST float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
 
     return vec3(cosVZAtc, dotVStc, cosSZAtc);
 }
@@ -394,39 +405,39 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along dotViewSun coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[1];
-    const float posOfRow = indices[1];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[1];
+    CONST float posOfRow = indices[1];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         indexToTexCoord(currRow, numRows-1),
                                                         texCoordVerbatim));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               indexToTexCoord(currRow, numRows-1),
                                                               texCoordVerbatim));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          indexToTexCoord(currRow, numRows-1),
                                          texCoordVerbatim));
@@ -434,14 +445,14 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
 vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolationGuides01Tex,
                                  const vec3 indices)
 {
-    const float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
+    CONST float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
 
-    const float cosVZAIndex = indices[0];
-    const float dotVSIndex = indices[1];
-    const float currRow = floor(dotVSIndex);
-    const float posBetweenRows = dotVSIndex - currRow;
-    const float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cosVZAIndex = indices[0];
+    CONST float dotVSIndex = indices[1];
+    CONST float currRow = floor(dotVSIndex);
+    CONST float posBetweenRows = dotVSIndex - currRow;
+    CONST float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -449,14 +460,14 @@ vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolat
     indicesCurrRow[1] =     currRow;
     indicesNextRow[1] = min(currRow+1, scatteringTextureSize[1]-1.);
 
-    const vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
-    const vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
+    CONST vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
+    CONST vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
 
-    const vec4 valueCurrRow = texture(tex, coordsCurrRow);
-    const vec4 valueNextRow = texture(tex, coordsNextRow);
-    const float epsilon = 1e-37; // Prevents passing zero to log
-    const vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
-    const vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
+    CONST vec4 valueCurrRow = texture(tex, coordsCurrRow);
+    CONST vec4 valueNextRow = texture(tex, coordsNextRow);
+    CONST float epsilon = 1e-37; // Prevents passing zero to log
+    CONST vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
+    CONST vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
     return (logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow;
 }
 
@@ -465,37 +476,37 @@ float findGuide02Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along SZA coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[2];
-    const float posOfRow = indices[2];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[2];
+    CONST float posOfRow = indices[2];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
 }
@@ -505,19 +516,19 @@ vec4 sample3DTextureGuided(const sampler3D tex,
                            const float cosSunZenithAngle, const float cosViewZenithAngle,
                            const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
                                                                     dotViewSun, altitude, viewRayIntersectsGround);
     // Handle the external interpolation guides: the guides between a pair of VZA-dotViewSun 2D "pictures".
-    const vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
-    const vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
-    const float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
+    CONST vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
+    CONST float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
 
-    const float cvzaIndex = indices[0];
-    const float cszaIndex = indices[2];
-    const float currRow = floor(cszaIndex);
-    const float posBetweenRows = cszaIndex - currRow;
-    const float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cvzaIndex = indices[0];
+    CONST float cszaIndex = indices[2];
+    CONST float currRow = floor(cszaIndex);
+    CONST float posBetweenRows = cszaIndex - currRow;
+    CONST float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -526,58 +537,58 @@ vec4 sample3DTextureGuided(const sampler3D tex,
     indicesNextRow[2] = min(currRow+1, scatteringTextureSize[2]-1);
 
     // The caller will handle the internal interpolation guides: the ones between rows in each 2D "picture".
-    const vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
-    const vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
+    CONST vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
+    CONST vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
     return exp((logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow);
 }
 
 vec4 sample3DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
     return texture(tex, texCoords);
 }
 
 ScatteringTexVars scatteringTex4DCoordsToTexVars(const Scattering4DCoords coords)
 {
-    const float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
     // ------------------------------------
     float cosViewZenithAngle;
     if(coords.viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
     // ------------------------------------
-    const float dotViewSun=coords.dotViewSun*2-1;
+    CONST float dotViewSun=coords.dotViewSun*2-1;
 
     // ------------------------------------
-    const float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
+    CONST float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
 
     return ScatteringTexVars(cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, coords.viewRayIntersectsGround);
 }
 
 Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 {
-    const vec4 indexMax=scatteringTextureSize-vec4(1);
+    CONST vec4 indexMax=scatteringTextureSize-vec4(1);
     Scattering4DCoords coords4d;
     coords4d.viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
     // The following formulas assume that scatteringTextureSize[0] is even. For odd sizes they would change.
@@ -593,8 +604,8 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture indices we combine into a single sampler3D coordinate.
-    const float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
-    const float combinedIndex=texIndices[1];
+    CONST float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
+    CONST float combinedIndex=texIndices[1];
     coords4d.dotViewSun=mod(combinedIndex,texW)/(texW-1);
     coords4d.cosSunZenithAngle=floor(combinedIndex/texW)/(texH-1);
 
@@ -608,11 +619,11 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
 ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 {
-    const Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
+    CONST Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
     ScatteringTexVars vars=scatteringTex4DCoordsToTexVars(coords4d);
     // Clamp dotViewSun to its valid range of values, given cosViewZenithAngle and cosSunZenithAngle. This is
     // needed to prevent NaNs when computing the scattering texture.
-    const float cosVZA=vars.cosViewZenithAngle,
+    CONST float cosVZA=vars.cosViewZenithAngle,
                 cosSZA=vars.cosSunZenithAngle;
     vars.dotViewSun=clamp(vars.dotViewSun,
                           cosVZA*cosSZA-safeSqrt((1-sqr(cosVZA))*(1-sqr(cosSZA))),
@@ -622,54 +633,54 @@ ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 
 EclipseScatteringTexVars eclipseTexCoordsToTexVars(const vec2 texCoords, const float altitude)
 {
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
-    const bool viewRayIntersectsGround = texCoords.t<0.5;
+    CONST bool viewRayIntersectsGround = texCoords.t<0.5;
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
-    const float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
+    CONST float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
     return EclipseScatteringTexVars(azimuthRelativeToSun, cosViewZenithAngle, viewRayIntersectsGround);
 }
 
 EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                                    const float altitude, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -677,13 +688,13 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
-    const float azimuthCoord = azimuthRelativeToSun/(2*PI);
+    CONST float azimuthCoord = azimuthRelativeToSun/(2*PI);
 
     return EclipseScattering2DCoords(azimuthCoord, cosVZACoord);
 }
@@ -691,14 +702,14 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
 vec2 eclipseTexVarsToTexCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                const float altitude, const bool viewRayIntersectsGround, const vec2 texSize)
 {
-    const EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+    CONST EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                                     viewRayIntersectsGround);
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2);
-    const float azimuthTC = coords.azimuth + 1/(2*texSize.s);
+    CONST float azimuthTC = coords.azimuth + 1/(2*texSize.s);
 
     return vec2(azimuthTC, cosVZAtc);
 }
@@ -707,42 +718,42 @@ vec4 sampleEclipseDoubleScattering3DTexture(const sampler3D tex, const float cos
                                             const float cosViewZenithAngle, const float azimuthRelativeToSun,
                                             const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
+    CONST vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
                                                   eclipsedDoubleScatteringTextureSize.st);
-    const float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
-    const vec3 texCoords=vec3(coords2d, cosSZACoord);
+    CONST float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
+    CONST vec3 texCoords=vec3(coords2d, cosSZACoord);
 
     return texture(tex, texCoords);
 }
 
 LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 texIndices)
 {
-    const vec2 indexMax=lightPollutionTextureSize-vec2(1);
+    CONST vec2 indexMax=lightPollutionTextureSize-vec2(1);
 
-    const float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
-    const float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
+    CONST float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
-    const bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
-    const float cosViewZenithAngleCoord = viewRayIntersectsGround ?
+    CONST bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
+    CONST float cosViewZenithAngleCoord = viewRayIntersectsGround ?
                                    1-2*texIndices[0]/(indexMax[0]-1) :
                                    2*(texIndices[0]-1)/(indexMax[0]-1)-1;
     // ------------------------------------
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
@@ -753,23 +764,23 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 
 LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -777,27 +788,27 @@ LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, con
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     return LightPollution2DCoords(cosVZACoord, altCoord);
 }
 
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
-    const vec2 texSize = lightPollutionTextureSize;
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 texSize = lightPollutionTextureSize;
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2);
-    const float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
+    CONST float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
     return vec2(cosVZAtc, altitudeTC);
 }

--- a/atmosphere/default/shaders/single-scattering/on-the-fly/1/aerosols/texture-sampling-functions.frag
+++ b/atmosphere/default/shaders/single-scattering/on-the-fly/1/aerosols/texture-sampling-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-sampling-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,13 +45,13 @@ const vec4 lightPollutionRelativeRadiance=vec4(2.15e-06,1.11400004e-06,3.8580001
 const vec4 wavelengths=vec4(485.333344,516.666687,548,579.333313);
 const int wlSetIndex=1;
 #endif
-#line 5 0 // texture-sampling-functions.frag
-#line 1 2 // phase-functions.h.glsl
+#line 4 0 // texture-sampling-functions.frag
+#line 1 3 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 6 0 // texture-sampling-functions.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-sampling-functions.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -72,8 +83,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-sampling-functions.frag
-#line 1 4 // texture-coordinates.h.glsl
+#line 6 0 // texture-sampling-functions.frag
+#line 1 5 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -142,7 +153,7 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 8 0 // texture-sampling-functions.frag
+#line 7 0 // texture-sampling-functions.frag
 
 uniform sampler2D transmittanceTexture;
 uniform sampler2D irradianceTexture;
@@ -154,13 +165,13 @@ uniform sampler2D lightPollutionScatteringTexture;
 
 vec4 irradiance(const float cosSunZenithAngle, const float altitude)
 {
-    const vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
+    CONST vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
     return texture(irradianceTexture, texCoords);
 }
 
 vec4 opticalDepthToAtmosphereBorder(const float cosViewZenithAngle, const float altitude)
 {
-    const vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
+    CONST vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact when looking into nadir from TOA at some values of texture sizes (in particular, size of
     // transmittance texture for altitude being 4096). This happens when I simply call texture(eclipsedScatteringTexture,
@@ -178,11 +189,11 @@ vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float
 vec4 transmittance(const float cosViewZenithAngle, const float altitude, const float dist,
                    const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle view ray endpoint
     // in space here.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
 
     vec4 depth;
     if(viewRayIntersectsGround)
@@ -201,7 +212,7 @@ vec4 transmittance(const float cosViewZenithAngle, const float altitude, const f
 vec4 calcFirstScattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                          const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
+    CONST vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
                                           dotViewSun, altitude, viewRayIntersectsGround);
     return scattering*currentPhaseFunction(dotViewSun);
 }
@@ -220,6 +231,6 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
 
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     return texture(lightPollutionScatteringTexture, coords);
 }

--- a/atmosphere/default/shaders/single-scattering/on-the-fly/1/molecules/common-functions.frag
+++ b/atmosphere/default/shaders/single-scattering/on-the-fly/1/molecules/common-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // common-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(2.15e-06,1.11400004e-06,3.8580001
 const vec4 wavelengths=vec4(485.333344,516.666687,548,579.333313);
 const int wlSetIndex=1;
 #endif
-#line 5 0 // common-functions.frag
+#line 4 0 // common-functions.frag
 
 bool dbgDataPresent=false;
 bool debugDataPresent()
@@ -69,7 +80,7 @@ void setDebugData(float a,float b, float c, float d)
 
 void swap(inout float x, inout float y)
 {
-    const float t = x;
+    CONST float t = x;
     x = y;
     y = t;
 }
@@ -83,7 +94,7 @@ float safeSqrt(const float x)
 
 float safeAtan(const float y, const float x)
 {
-    const float a = atan(y,x);
+    CONST float a = atan(y,x);
     return x==0 && y==0 ? 0 : a;
 }
 
@@ -116,23 +127,23 @@ float pointAltitude(vec3 point)
 
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float Ratm=earthRadius+atmosphereHeight;
-    const float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float Ratm=earthRadius+atmosphereHeight;
+    CONST float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float distanceToGround(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(-safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float cosZenithAngleOfHorizon(const float altitude)
 {
-    const float R=earthRadius;
-    const float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
+    CONST float R=earthRadius;
+    CONST float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
     return -sqrt(2*h*R+sqr(h))/(R+h);
 }
 
@@ -151,8 +162,8 @@ float distanceToNearestAtmosphereBoundary(const float cosZenithAngle, const floa
 float sunVisibility(const float cosSunZenithAngle, float altitude)
 {
     if(altitude<0) altitude=0;
-    const float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
-    const float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
+    CONST float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
+    CONST float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
     /* Approximating visible fraction of solar disk by smoothstep between the position of the Sun
      * touching the horizon by its upper part and the position with lower part touching the horizon.
      * The calculation assumes that solar angular radius is small and thus approximately equals its sine.
@@ -182,13 +193,13 @@ float circlesIntersectionArea(float R1, float R2, float d)
 
 float angleBetween(const vec3 a, const vec3 b)
 {
-    const float d=dot(a,b);
-    const float c=length(cross(a,b));
+    CONST float d=dot(a,b);
+    CONST float c=length(cross(a,b));
     // To avoid loss of precision, don't use dot product near the singularity
     // of acos, and cross product near the singularity of asin
     if(abs(d) < abs(c))
         return acos(d/(length(a)*length(b)));
-    const float smallerAngle = asin(c/(length(a)*length(b)));
+    CONST float smallerAngle = asin(c/(length(a)*length(b)));
     if(d<0) return PI-smallerAngle;
     return smallerAngle;
 }
@@ -205,11 +216,11 @@ float moonAngularRadius(const vec3 cameraPosition, const vec3 moonPosition)
 
 float visibleSolidAngleOfSun(const vec3 camera, const vec3 sunDir, const vec3 moonPos)
 {
-    const float Rs=sunAngularRadius;
-    const float Rm=moonAngularRadius(camera,moonPos);
+    CONST float Rs=sunAngularRadius;
+    CONST float Rm=moonAngularRadius(camera,moonPos);
     float visibleSolidAngle=PI*sqr(Rs);
 
-    const float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
+    CONST float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
     if(dSM<Rs+Rm)
     {
         visibleSolidAngle -= circlesIntersectionArea(Rm,Rs,dSM);
@@ -229,12 +240,12 @@ float sphereIntegrationSolidAngleDifferential(const int pointCountOnSphere)
 }
 vec3 sphereIntegrationSampleDir(const int index, const int pointCountOnSphere)
 {
-    const float goldenRatio=1.6180339887499;
+    CONST float goldenRatio=1.6180339887499;
     // The range of n is 0.5, 1.5, ..., pointCountOnSphere-0.5
-    const float n=index+0.5;
+    CONST float n=index+0.5;
     // Explanation of the Fibonacci grid generation can be seen at https://stackoverflow.com/a/44164075/673852
-    const float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
-    const float azimuth=n*(2*PI*goldenRatio);
+    CONST float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
+    CONST float azimuth=n*(2*PI*goldenRatio);
     return vec3(cos(azimuth)*sin(zenithAngle),
                 sin(azimuth)*sin(zenithAngle),
                 cos(zenithAngle));

--- a/atmosphere/default/shaders/single-scattering/on-the-fly/1/molecules/densities.frag
+++ b/atmosphere/default/shaders/single-scattering/on-the-fly/1/molecules/densities.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // densities.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,20 +45,20 @@ const vec4 lightPollutionRelativeRadiance=vec4(2.15e-06,1.11400004e-06,3.8580001
 const vec4 wavelengths=vec4(485.333344,516.666687,548,579.333313);
 const int wlSetIndex=1;
 #endif
-#line 5 0 // densities.frag
+#line 4 0 // densities.frag
 float scattererNumberDensity_molecules(float altitude)
 {
-        const float rayleighScaleHeight=8*km;
+        CONST float rayleighScaleHeight=8*km;
         return 3.08458e25*exp(-1/rayleighScaleHeight * altitude);
 }
 float scattererNumberDensity_aerosols(float altitude)
 {
-        const float mieScaleHeight=1.2*km;
+        CONST float mieScaleHeight=1.2*km;
         return 1.03333e8*exp(-1/mieScaleHeight*altitude);
 }
 float absorberNumberDensity_ozone(float altitude)
 {
-        const float totalOzoneAmount=370*dobsonUnit;
+        CONST float totalOzoneAmount=370*dobsonUnit;
 
         float density;
 

--- a/atmosphere/default/shaders/single-scattering/on-the-fly/1/molecules/phase-functions.frag
+++ b/atmosphere/default/shaders/single-scattering/on-the-fly/1/molecules/phase-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // phase-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(2.15e-06,1.11400004e-06,3.8580001
 const vec4 wavelengths=vec4(485.333344,516.666687,548,579.333313);
 const int wlSetIndex=1;
 #endif
-#line 5 0 // phase-functions.frag
+#line 4 0 // phase-functions.frag
 
 vec4 phaseFunction_molecules(float dotViewSun)
 {
@@ -42,9 +53,9 @@ vec4 phaseFunction_molecules(float dotViewSun)
 }
 vec4 phaseFunction_aerosols(float dotViewSun)
 {
-        const float g=0.76;
-        const float g2=g*g;
-        const float k = 3/(8*PI)*(1-g2)/(2+g2);
+        CONST float g=0.76;
+        CONST float g2=g*g;
+        CONST float k = 3/(8*PI)*(1-g2)/(2+g2);
         return vec4(k * (1+sqr(dotViewSun)) / pow(1+g2 - 2*g*dotViewSun, 1.5) + 1/((1-dotViewSun)*600+0.05))*0.904;
 }
 vec4 currentPhaseFunction(float dotViewSun) { return phaseFunction_molecules(dotViewSun); }

--- a/atmosphere/default/shaders/single-scattering/on-the-fly/1/molecules/render.frag
+++ b/atmosphere/default/shaders/single-scattering/on-the-fly/1/molecules/render.frag
@@ -1,7 +1,21 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
 
-#line 1 1 // const.h.glsl
+
+
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 6 0 // render.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,11 +48,11 @@ const vec4 lightPollutionRelativeRadiance=vec4(2.15e-06,1.11400004e-06,3.8580001
 const vec4 wavelengths=vec4(485.333344,516.666687,548,579.333313);
 const int wlSetIndex=1;
 #endif
-#line 5 0 // render.frag
-#line 1 2 // calc-view-dir.h.glsl
+#line 7 0 // render.frag
+#line 1 3 // calc-view-dir.h.glsl
 vec3 calcViewDir();
-#line 6 0 // render.frag
-#line 1 3 // common-functions.h.glsl
+#line 8 0 // render.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -70,13 +84,13 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // render.frag
-#line 1 4 // phase-functions.h.glsl
+#line 9 0 // render.frag
+#line 1 5 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 8 0 // render.frag
-#line 1 5 // single-scattering.h.glsl
+#line 10 0 // render.frag
+#line 1 6 // single-scattering.h.glsl
 #ifndef INCLUDE_ONCE_1DB2EDC1_C687_4FFA_BFF4_D18A54BA651B
 #define INCLUDE_ONCE_1DB2EDC1_C687_4FFA_BFF4_D18A54BA651B
 
@@ -84,9 +98,9 @@ vec4 computeSingleScattering(const float cosSunZenithAngle, const float cosViewZ
                              const float dotViewSun, const float altitude,
                              const bool viewRayIntersectsGround);
 #endif
-#line 9 0 // render.frag
+#line 11 0 // render.frag
 
-#line 1 6 // texture-coordinates.h.glsl
+#line 1 7 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -155,10 +169,10 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 11 0 // render.frag
-#line 1 7 // radiance-to-luminance.h.glsl
+#line 13 0 // render.frag
+#line 1 8 // radiance-to-luminance.h.glsl
 const mat4 radianceToLuminance=mat4(1196.74268,3672.67432,12945.498,45528.7344,  835.02478,13767.5205,2120.37939,51317.4727,  8632.59277,21193.416,222.095078,27381.1602,  19410,18758.1973,35.7829971,6712.12158);
-#line 12 0 // render.frag
+#line 14 0 // render.frag
 
 
 
@@ -195,18 +209,18 @@ void main()
     // this approximation has the same order of magnitude as the assumption that the Earth and its atmosphere
     // are spherical.
     float altitude = max(cameraPosition.z, 0.);
-    const vec3 oldCamPos=cameraPosition;
+    CONST vec3 oldCamPos=cameraPosition;
     // Hide the uniform with this name, thus effectively modifying it for the following code
     vec3 cameraPosition=vec3(oldCamPos.xy, altitude);
 
     bool lookingIntoAtmosphere=true;
     if(altitude>atmosphereHeight)
     {
-        const vec3 p = cameraPosition - earthCenter;
-        const float p_dot_v = dot(p, viewDir);
-        const float p_dot_p = dot(p, p);
-        const float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
-        const float distanceToTOA = -p_dot_v - sqrt(sqr(earthRadius+atmosphereHeight) - squaredDistBetweenViewRayAndEarthCenter);
+        CONST vec3 p = cameraPosition - earthCenter;
+        CONST float p_dot_v = dot(p, viewDir);
+        CONST float p_dot_p = dot(p, p);
+        CONST float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
+        CONST float distanceToTOA = -p_dot_v - sqrt(sqr(earthRadius+atmosphereHeight) - squaredDistBetweenViewRayAndEarthCenter);
         if(distanceToTOA>=0)
         {
             cameraPosition += viewDir*distanceToTOA;
@@ -214,7 +228,7 @@ void main()
         }
         else
         {
-#if RENDERING_ANY_ZERO_SCATTERING
+#if 0 /*RENDERING_ANY_ZERO_SCATTERING*/
             lookingIntoAtmosphere=false;
 #else
             luminance=vec4(0);
@@ -224,16 +238,16 @@ void main()
         }
     }
 
-    const vec3 zenith=normalize(cameraPosition-earthCenter);
+    CONST vec3 zenith=normalize(cameraPosition-earthCenter);
     float cosViewZenithAngle=dot(zenith,viewDir);
 
     bool viewRayIntersectsGround=false;
     {
-        const vec3 p = cameraPosition - earthCenter;
-        const float p_dot_v = dot(p, viewDir);
-        const float p_dot_p = dot(p, p);
-        const float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
-        const float distanceToIntersection = -p_dot_v - sqrt(sqr(earthRadius) - squaredDistBetweenViewRayAndEarthCenter);
+        CONST vec3 p = cameraPosition - earthCenter;
+        CONST float p_dot_v = dot(p, viewDir);
+        CONST float p_dot_p = dot(p, p);
+        CONST float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
+        CONST float distanceToIntersection = -p_dot_v - sqrt(sqr(earthRadius) - squaredDistBetweenViewRayAndEarthCenter);
         // altitude==0 is a special case where distance to intersection calculation
         // is unreliable (has a lot of noise in its sign), so check it separately
         if(distanceToIntersection>0 || (altitude==0 && cosViewZenithAngle<0))
@@ -244,11 +258,11 @@ void main()
     // Aside from aesthetics, this affects brightness input to Stellarium's tone mapper.
     if(pseudoMirrorSkyBelowHorizon && viewRayIntersectsGround)
     {
-        const float horizonCZA = cosZenithAngleOfHorizon(altitude);
-        const float viewElev  = asin(clampCosine(cosViewZenithAngle));
-        const float horizElev = asin(clampCosine(horizonCZA));
-        const float newViewElev = 2*horizElev - viewElev;
-        const float viewDirXYnorm = length(viewDir-zenith*cosViewZenithAngle);
+        CONST float horizonCZA = cosZenithAngleOfHorizon(altitude);
+        CONST float viewElev  = asin(clampCosine(cosViewZenithAngle));
+        CONST float horizElev = asin(clampCosine(horizonCZA));
+        CONST float newViewElev = 2*horizElev - viewElev;
+        CONST float viewDirXYnorm = length(viewDir-zenith*cosViewZenithAngle);
         if(viewDirXYnorm == 0)
         {
             viewDir = zenith;
@@ -267,27 +281,27 @@ void main()
         viewRayIntersectsGround = false;
     }
 
-    const float cosSunZenithAngle =dot(zenith,sunDirection);
-    const float dotViewSun=dot(viewDir,sunDirection);
+    CONST float cosSunZenithAngle =dot(zenith,sunDirection);
+    CONST float dotViewSun=dot(viewDir,sunDirection);
 
-    const vec3 sunXYunnorm=sunDirection-dot(sunDirection,zenith)*zenith;
-    const vec3 viewXYunnorm=viewDir-dot(viewDir,zenith)*zenith;
-    const vec3 sunXY = sunXYunnorm.x!=0 || sunXYunnorm.y!=0 || sunXYunnorm.z!=0 ? normalize(sunXYunnorm) : vec3(0);
-    const vec3 viewXY = viewXYunnorm.x!=0 || viewXYunnorm.y!=0 || viewXYunnorm.z!=0 ? normalize(viewXYunnorm) : vec3(0);
-    const float azimuthRelativeToSun=safeAtan(dot(cross(sunXY, viewXY), zenith), dot(sunXY, viewXY));
+    CONST vec3 sunXYunnorm=sunDirection-dot(sunDirection,zenith)*zenith;
+    CONST vec3 viewXYunnorm=viewDir-dot(viewDir,zenith)*zenith;
+    CONST vec3 sunXY = sunXYunnorm.x!=0 || sunXYunnorm.y!=0 || sunXYunnorm.z!=0 ? normalize(sunXYunnorm) : vec3(0);
+    CONST vec3 viewXY = viewXYunnorm.x!=0 || viewXYunnorm.y!=0 || viewXYunnorm.z!=0 ? normalize(viewXYunnorm) : vec3(0);
+    CONST float azimuthRelativeToSun=safeAtan(dot(cross(sunXY, viewXY), zenith), dot(sunXY, viewXY));
 
-#if RENDERING_ZERO_SCATTERING
+#if 0 /*RENDERING_ZERO_SCATTERING*/
     vec4 radiance;
     if(viewRayIntersectsGround)
     {
         // XXX: keep in sync with the same code in computeScatteringDensity(), but don't forget about
         //      the difference in the usage of viewDir vs incDir.
-        const float distToGround = distanceToGround(cosViewZenithAngle, altitude);
-        const vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
-        const vec3 groundNormal = normalize(zenith*(earthRadius+altitude)+viewDir*distToGround);
-        const vec4 groundIrradiance = irradiance(dot(groundNormal, sunDirection), 0);
+        CONST float distToGround = distanceToGround(cosViewZenithAngle, altitude);
+        CONST vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
+        CONST vec3 groundNormal = normalize(zenith*(earthRadius+altitude)+viewDir*distToGround);
+        CONST vec4 groundIrradiance = irradiance(dot(groundNormal, sunDirection), 0);
         // Radiation scattered by the ground
-        const float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
+        CONST float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
         radiance = transmittanceToGround*groundAlbedo*groundIrradiance*solarIrradianceFixup*groundBRDF
                  + lightPollutionGroundLuminance*lightPollutionRelativeRadiance;
     }
@@ -304,22 +318,22 @@ void main()
     }
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_ZERO_SCATTERING
+#elif 0 /*RENDERING_ECLIPSED_ZERO_SCATTERING*/
     vec4 radiance;
-    const float dotViewMoon=dot(viewDir,normalize(moonPosition-cameraPosition));
+    CONST float dotViewMoon=dot(viewDir,normalize(moonPosition-cameraPosition));
     if(viewRayIntersectsGround)
     {
         // XXX: keep in sync with the similar code in non-eclipsed zero scattering rendering.
-        const float distToGround = distanceToGround(cosViewZenithAngle, altitude);
-        const vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
-        const vec3 pointOnGround = cameraPosition+viewDir*distToGround;
-        const vec4 directGroundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDirection, moonPosition);
+        CONST float distToGround = distanceToGround(cosViewZenithAngle, altitude);
+        CONST vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
+        CONST vec3 pointOnGround = cameraPosition+viewDir*distToGround;
+        CONST vec4 directGroundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDirection, moonPosition);
         // FIXME: add first-order indirect irradiance too: it's done in non-eclipsed irradiance (in the same
         // conditions: when limited to 2 orders). This should be calculated at the same time when second order
         // is: all the infrastructure is already there.
-        const vec4 groundIrradiance = directGroundIrradiance;
+        CONST vec4 groundIrradiance = directGroundIrradiance;
         // Radiation scattered by the ground
-        const float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
+        CONST float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
         radiance = transmittanceToGround*groundAlbedo*groundIrradiance*solarIrradianceFixup*groundBRDF
                  + lightPollutionGroundLuminance*lightPollutionRelativeRadiance;
     }
@@ -336,53 +350,53 @@ void main()
     }
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_ON_THE_FLY
-    const vec4 scattering=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPosition,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_ON_THE_FLY*/
+    CONST vec4 scattering=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPosition,
                                                           viewRayIntersectsGround);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE
-    const vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE*/
+    CONST vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                      viewRayIntersectsGround, eclipsedSingleScatteringTextureSize);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact at the point where azimuth texture coordinate changes from 1 to 0 (at azimuthRelativeToSun crossing
     // 0). This happens when I simply call texture(eclipsedScatteringTexture, texCoords) without specifying LOD.
     // Apparently, the driver uses the derivative for some reason, even though it shouldn't.
-    const vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
+    CONST vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE
-    const vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
+    CONST vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                      viewRayIntersectsGround, eclipsedSingleScatteringTextureSize);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact at the point where azimuth texture coordinate changes from 1 to 0 (at azimuthRelativeToSun crossing
     // 0). This happens when I simply call texture(eclipsedScatteringTexture, texCoords) without specifying LOD.
     // Apparently, the driver uses the derivative for some reason, even though it shouldn't.
-    const vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
+    CONST vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
     luminance=scattering*currentPhaseFunction(dotViewSun);
-#elif RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_RADIANCE
+#elif 0 /*RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_RADIANCE*/
     vec4 radiance=exp(sampleEclipseDoubleScattering3DTexture(eclipsedDoubleScatteringTexture,
                                                              cosSunZenithAngle, cosViewZenithAngle, azimuthRelativeToSun,
                                                              altitude, viewRayIntersectsGround));
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_LUMINANCE
+#elif 0 /*RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
     luminance=exp(sampleEclipseDoubleScattering3DTexture(eclipsedDoubleScatteringTexture,
                                                          cosSunZenithAngle, cosViewZenithAngle, azimuthRelativeToSun,
                                                          altitude, viewRayIntersectsGround));
 #elif 1 /*RENDERING_SINGLE_SCATTERING_ON_THE_FLY*/
-    const vec4 scattering=computeSingleScattering(cosSunZenithAngle,cosViewZenithAngle,dotViewSun,
+    CONST vec4 scattering=computeSingleScattering(cosSunZenithAngle,cosViewZenithAngle,dotViewSun,
                                                   altitude,viewRayIntersectsGround);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE
+#elif 0 /*RENDERING_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE*/
     vec4 scattering;
     if(useInterpolationGuides)
     {
@@ -399,7 +413,7 @@ void main()
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE
+#elif 0 /*RENDERING_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
     vec4 scattering;
     if(useInterpolationGuides)
     {
@@ -413,18 +427,18 @@ void main()
                                      dotViewSun, altitude, viewRayIntersectsGround);
     }
     luminance=scattering * (bool(1) ? vec4(1) : currentPhaseFunction(dotViewSun));
-#elif RENDERING_MULTIPLE_SCATTERING_LUMINANCE
+#elif 0 /*RENDERING_MULTIPLE_SCATTERING_LUMINANCE*/
     luminance=sample3DTexture(scatteringTexture, cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, viewRayIntersectsGround);
-#elif RENDERING_MULTIPLE_SCATTERING_RADIANCE
+#elif 0 /*RENDERING_MULTIPLE_SCATTERING_RADIANCE*/
     vec4 radiance=sample3DTexture(scatteringTexture, cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, viewRayIntersectsGround);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_LIGHT_POLLUTION_RADIANCE
+#elif 0 /*RENDERING_LIGHT_POLLUTION_RADIANCE*/
     vec4 radiance=lightPollutionGroundLuminance*lightPollutionScattering(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_LIGHT_POLLUTION_LUMINANCE
+#elif 0 /*RENDERING_LIGHT_POLLUTION_LUMINANCE*/
     luminance=lightPollutionGroundLuminance*lightPollutionScattering(altitude, cosViewZenithAngle, viewRayIntersectsGround);
 #else
 #error What to render?

--- a/atmosphere/default/shaders/single-scattering/on-the-fly/1/molecules/single-scattering.frag
+++ b/atmosphere/default/shaders/single-scattering/on-the-fly/1/molecules/single-scattering.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // single-scattering.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,15 +45,15 @@ const vec4 lightPollutionRelativeRadiance=vec4(2.15e-06,1.11400004e-06,3.8580001
 const vec4 wavelengths=vec4(485.333344,516.666687,548,579.333313);
 const int wlSetIndex=1;
 #endif
-#line 5 0 // single-scattering.frag
-#line 1 2 // densities.h.glsl
+#line 4 0 // single-scattering.frag
+#line 1 3 // densities.h.glsl
 float scattererNumberDensity_molecules(float altitude);
 float scattererNumberDensity_aerosols(float altitude);
 float absorberNumberDensity_ozone(float altitude);
 vec4 scatteringCrossSection();
 float scattererDensity(float altitude);
-#line 6 0 // single-scattering.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // single-scattering.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -74,8 +85,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // single-scattering.frag
-#line 1 4 // single-scattering.h.glsl
+#line 6 0 // single-scattering.frag
+#line 1 5 // single-scattering.h.glsl
 #ifndef INCLUDE_ONCE_1DB2EDC1_C687_4FFA_BFF4_D18A54BA651B
 #define INCLUDE_ONCE_1DB2EDC1_C687_4FFA_BFF4_D18A54BA651B
 
@@ -83,8 +94,8 @@ vec4 computeSingleScattering(const float cosSunZenithAngle, const float cosViewZ
                              const float dotViewSun, const float altitude,
                              const bool viewRayIntersectsGround);
 #endif
-#line 8 0 // single-scattering.frag
-#line 1 5 // texture-sampling-functions.h.glsl
+#line 7 0 // single-scattering.frag
+#line 1 6 // texture-sampling-functions.h.glsl
 #ifndef INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 #define INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float altitude);
@@ -96,20 +107,20 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                 const int scatteringOrder);
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 #endif
-#line 9 0 // single-scattering.frag
+#line 8 0 // single-scattering.frag
 
 // This function omits phase function and solar irradiance: these are to be applied somewhere in the calling code.
 vec4 computeSingleScatteringIntegrand(const float cosSunZenithAngle, const float cosViewZenithAngle,
                                       const float dotViewSun, const float altitude,
                                       const float dist, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle here the case when the
     // endpoint of the view ray intentionally appears in outer space.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosSunZenithAngleAtDist=clampCosine((r*cosSunZenithAngle+dist*dotViewSun)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosSunZenithAngleAtDist=clampCosine((r*cosSunZenithAngle+dist*dotViewSun)/(earthRadius+altAtDist));
 
-    const vec4 xmittance=transmittance(cosViewZenithAngle, altitude, dist, viewRayIntersectsGround)
+    CONST vec4 xmittance=transmittance(cosViewZenithAngle, altitude, dist, viewRayIntersectsGround)
                                                     *
                          transmittanceToAtmosphereBorder(cosSunZenithAngleAtDist, altAtDist)
                                                     *
@@ -121,14 +132,14 @@ vec4 computeSingleScattering(const float cosSunZenithAngle, const float cosViewZ
                              const float dotViewSun, const float altitude,
                              const bool viewRayIntersectsGround)
 {
-    const float integrInterval=distanceToNearestAtmosphereBoundary(cosViewZenithAngle, altitude,
+    CONST float integrInterval=distanceToNearestAtmosphereBoundary(cosViewZenithAngle, altitude,
                                                                    viewRayIntersectsGround);
     // Using the midpoint rule for quadrature
     vec4 spectrum=vec4(0);
-    const float dl=integrInterval/radialIntegrationPoints;
+    CONST float dl=integrInterval/radialIntegrationPoints;
     for(int n=0; n<radialIntegrationPoints; ++n)
     {
-        const float dist=(n+0.5)*dl;
+        CONST float dist=(n+0.5)*dl;
         spectrum += computeSingleScatteringIntegrand(cosSunZenithAngle, cosViewZenithAngle, dotViewSun,
                                                      altitude, dist, viewRayIntersectsGround);
     }

--- a/atmosphere/default/shaders/single-scattering/on-the-fly/1/molecules/texture-coordinates.frag
+++ b/atmosphere/default/shaders/single-scattering/on-the-fly/1/molecules/texture-coordinates.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-coordinates.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,8 +45,8 @@ const vec4 lightPollutionRelativeRadiance=vec4(2.15e-06,1.11400004e-06,3.8580001
 const vec4 wavelengths=vec4(485.333344,516.666687,548,579.333313);
 const int wlSetIndex=1;
 #endif
-#line 5 0 // texture-coordinates.frag
-#line 1 2 // texture-coordinates.h.glsl
+#line 4 0 // texture-coordinates.frag
+#line 1 3 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -104,8 +115,8 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 6 0 // texture-coordinates.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-coordinates.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -137,7 +148,7 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-coordinates.frag
+#line 6 0 // texture-coordinates.frag
 
 const float LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA=sqrt(atmosphereHeight*(atmosphereHeight+2*earthRadius));
 
@@ -205,18 +216,18 @@ vec3 indicesToTexCoords(const vec3 indices, const vec3 texSizes)
 
 TransmittanceTexVars transmittanceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
+    CONST float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
                                 texCoordToUnitRange(texCoord.t,transmittanceTextureSize.t);
     // Distance from Earth center to camera
-    const float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
-    const float altitude=r-earthRadius;
+    CONST float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
+    CONST float altitude=r-earthRadius;
 
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
     // distance to border of visible atmosphere from the view point
-    const float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
+    CONST float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
     // d==0 can happen when altitude==atmosphereHeight
-    const float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
+    CONST float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
     return TransmittanceTexVars(cosVZA,altitude);
 }
 
@@ -235,53 +246,53 @@ vec2 transmittanceTexVarsToTexCoord(const float cosVZA, float altitude)
     if(altitude<0)
         altitude=0;
 
-    const float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
+    CONST float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
                                       transmittanceTextureSize.t);
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
-    const float d=distanceToAtmosphereBorder(cosVZA,altitude);
-    const float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float d=distanceToAtmosphereBorder(cosVZA,altitude);
+    CONST float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
     return vec2(s,t);
 }
 
 // Output: vec2(cos(sunZenithAngle), altitude)
 IrradianceTexVars irradianceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
-    const float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
+    CONST float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
+    CONST float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
     return IrradianceTexVars(cosSZA,alt);
 }
 
 vec2 irradianceTexVarsToTexCoord(const float cosSunZenithAngle, const float altitude)
 {
-    const float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
-    const float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
+    CONST float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
+    CONST float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
     return vec2(s,t);
 }
 
 float cosSZAToUnitRangeTexCoord(const float cosSunZenithAngle)
 {
     // Distance to top atmosphere border along the ray groundUnderCamera-sun: (altitude, cosSunZenithAngle)
-    const float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name
-    const float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
+    CONST float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
     // TODO: choose a more descriptive name
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     return max(0.,1-a/A)/(a+1);
 }
 
 float unitRangeTexCoordToCosSZA(const float texCoord)
 {
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float a=(A-A*texCoord)/(1+A*texCoord);
-    const float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
+    CONST float a=(A-A*texCoord)/(1+A*texCoord);
+    CONST float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
     return distFromGroundToTopAtmoBorder==0 ? 1 :
         clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distFromGroundToTopAtmoBorder)) /
                     (2*earthRadius*distFromGroundToTopAtmoBorder));
@@ -292,24 +303,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
                                                const float dotViewSun, const float altitude,
                                                const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -317,24 +328,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float dotVSCoord=(dotViewSun+1)/2;
+    CONST float dotVSCoord=(dotViewSun+1)/2;
 
     // ------------------------------------
-    const float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
+    CONST float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
 
     return Scattering4DCoords(cosSZACoord, cosVZACoord, dotVSCoord, altCoord, viewRayIntersectsGround);
 }
 
 TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
@@ -342,16 +353,16 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture coordinates we combine into a single sampler3D coordinate.
-    const float texW = scatteringTextureSize[1];
-    const float texH = scatteringTextureSize[2];
-    const float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
-    const vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
+    CONST float texW = scatteringTextureSize[1];
+    CONST float texH = scatteringTextureSize[2];
+    CONST float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
+    CONST vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
                                         ceil (cosSZAIndex)*texW+coords.dotViewSun*(texW-1)) / (texW*texH-1);
-    const vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
+    CONST vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
 
-    const float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
+    CONST float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
 
-    const float alphaUpper=fract(cosSZAIndex);
+    CONST float alphaUpper=fract(cosSZAIndex);
     return TexCoordPair(vec3(cosVZAtc, combinedCoord.x, altitude), float(1-alphaUpper),
                         vec3(cosVZAtc, combinedCoord.y, altitude), float(alphaUpper));
 }
@@ -359,9 +370,9 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
+    CONST TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
     return texture(tex, texCoords.lower) * texCoords.alphaLower +
            texture(tex, texCoords.upper) * texCoords.alphaUpper;
 }
@@ -369,17 +380,17 @@ vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const f
 // 3D texture is the 3D single-altitude slice of a 4D texture
 vec3 scattering4DCoordsToTex3DCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2);
 
-    const float dvsSize = scatteringTextureSize[1];
-    const float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
+    CONST float dvsSize = scatteringTextureSize[1];
+    CONST float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
 
-    const float cszaSize = scatteringTextureSize[2];
-    const float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
+    CONST float cszaSize = scatteringTextureSize[2];
+    CONST float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
 
     return vec3(cosVZAtc, dotVStc, cosSZAtc);
 }
@@ -394,39 +405,39 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along dotViewSun coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[1];
-    const float posOfRow = indices[1];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[1];
+    CONST float posOfRow = indices[1];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         indexToTexCoord(currRow, numRows-1),
                                                         texCoordVerbatim));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               indexToTexCoord(currRow, numRows-1),
                                                               texCoordVerbatim));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          indexToTexCoord(currRow, numRows-1),
                                          texCoordVerbatim));
@@ -434,14 +445,14 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
 vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolationGuides01Tex,
                                  const vec3 indices)
 {
-    const float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
+    CONST float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
 
-    const float cosVZAIndex = indices[0];
-    const float dotVSIndex = indices[1];
-    const float currRow = floor(dotVSIndex);
-    const float posBetweenRows = dotVSIndex - currRow;
-    const float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cosVZAIndex = indices[0];
+    CONST float dotVSIndex = indices[1];
+    CONST float currRow = floor(dotVSIndex);
+    CONST float posBetweenRows = dotVSIndex - currRow;
+    CONST float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -449,14 +460,14 @@ vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolat
     indicesCurrRow[1] =     currRow;
     indicesNextRow[1] = min(currRow+1, scatteringTextureSize[1]-1.);
 
-    const vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
-    const vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
+    CONST vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
+    CONST vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
 
-    const vec4 valueCurrRow = texture(tex, coordsCurrRow);
-    const vec4 valueNextRow = texture(tex, coordsNextRow);
-    const float epsilon = 1e-37; // Prevents passing zero to log
-    const vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
-    const vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
+    CONST vec4 valueCurrRow = texture(tex, coordsCurrRow);
+    CONST vec4 valueNextRow = texture(tex, coordsNextRow);
+    CONST float epsilon = 1e-37; // Prevents passing zero to log
+    CONST vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
+    CONST vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
     return (logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow;
 }
 
@@ -465,37 +476,37 @@ float findGuide02Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along SZA coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[2];
-    const float posOfRow = indices[2];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[2];
+    CONST float posOfRow = indices[2];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
 }
@@ -505,19 +516,19 @@ vec4 sample3DTextureGuided(const sampler3D tex,
                            const float cosSunZenithAngle, const float cosViewZenithAngle,
                            const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
                                                                     dotViewSun, altitude, viewRayIntersectsGround);
     // Handle the external interpolation guides: the guides between a pair of VZA-dotViewSun 2D "pictures".
-    const vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
-    const vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
-    const float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
+    CONST vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
+    CONST float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
 
-    const float cvzaIndex = indices[0];
-    const float cszaIndex = indices[2];
-    const float currRow = floor(cszaIndex);
-    const float posBetweenRows = cszaIndex - currRow;
-    const float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cvzaIndex = indices[0];
+    CONST float cszaIndex = indices[2];
+    CONST float currRow = floor(cszaIndex);
+    CONST float posBetweenRows = cszaIndex - currRow;
+    CONST float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -526,58 +537,58 @@ vec4 sample3DTextureGuided(const sampler3D tex,
     indicesNextRow[2] = min(currRow+1, scatteringTextureSize[2]-1);
 
     // The caller will handle the internal interpolation guides: the ones between rows in each 2D "picture".
-    const vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
-    const vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
+    CONST vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
+    CONST vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
     return exp((logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow);
 }
 
 vec4 sample3DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
     return texture(tex, texCoords);
 }
 
 ScatteringTexVars scatteringTex4DCoordsToTexVars(const Scattering4DCoords coords)
 {
-    const float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
     // ------------------------------------
     float cosViewZenithAngle;
     if(coords.viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
     // ------------------------------------
-    const float dotViewSun=coords.dotViewSun*2-1;
+    CONST float dotViewSun=coords.dotViewSun*2-1;
 
     // ------------------------------------
-    const float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
+    CONST float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
 
     return ScatteringTexVars(cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, coords.viewRayIntersectsGround);
 }
 
 Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 {
-    const vec4 indexMax=scatteringTextureSize-vec4(1);
+    CONST vec4 indexMax=scatteringTextureSize-vec4(1);
     Scattering4DCoords coords4d;
     coords4d.viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
     // The following formulas assume that scatteringTextureSize[0] is even. For odd sizes they would change.
@@ -593,8 +604,8 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture indices we combine into a single sampler3D coordinate.
-    const float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
-    const float combinedIndex=texIndices[1];
+    CONST float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
+    CONST float combinedIndex=texIndices[1];
     coords4d.dotViewSun=mod(combinedIndex,texW)/(texW-1);
     coords4d.cosSunZenithAngle=floor(combinedIndex/texW)/(texH-1);
 
@@ -608,11 +619,11 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
 ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 {
-    const Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
+    CONST Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
     ScatteringTexVars vars=scatteringTex4DCoordsToTexVars(coords4d);
     // Clamp dotViewSun to its valid range of values, given cosViewZenithAngle and cosSunZenithAngle. This is
     // needed to prevent NaNs when computing the scattering texture.
-    const float cosVZA=vars.cosViewZenithAngle,
+    CONST float cosVZA=vars.cosViewZenithAngle,
                 cosSZA=vars.cosSunZenithAngle;
     vars.dotViewSun=clamp(vars.dotViewSun,
                           cosVZA*cosSZA-safeSqrt((1-sqr(cosVZA))*(1-sqr(cosSZA))),
@@ -622,54 +633,54 @@ ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 
 EclipseScatteringTexVars eclipseTexCoordsToTexVars(const vec2 texCoords, const float altitude)
 {
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
-    const bool viewRayIntersectsGround = texCoords.t<0.5;
+    CONST bool viewRayIntersectsGround = texCoords.t<0.5;
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
-    const float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
+    CONST float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
     return EclipseScatteringTexVars(azimuthRelativeToSun, cosViewZenithAngle, viewRayIntersectsGround);
 }
 
 EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                                    const float altitude, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -677,13 +688,13 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
-    const float azimuthCoord = azimuthRelativeToSun/(2*PI);
+    CONST float azimuthCoord = azimuthRelativeToSun/(2*PI);
 
     return EclipseScattering2DCoords(azimuthCoord, cosVZACoord);
 }
@@ -691,14 +702,14 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
 vec2 eclipseTexVarsToTexCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                const float altitude, const bool viewRayIntersectsGround, const vec2 texSize)
 {
-    const EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+    CONST EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                                     viewRayIntersectsGround);
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2);
-    const float azimuthTC = coords.azimuth + 1/(2*texSize.s);
+    CONST float azimuthTC = coords.azimuth + 1/(2*texSize.s);
 
     return vec2(azimuthTC, cosVZAtc);
 }
@@ -707,42 +718,42 @@ vec4 sampleEclipseDoubleScattering3DTexture(const sampler3D tex, const float cos
                                             const float cosViewZenithAngle, const float azimuthRelativeToSun,
                                             const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
+    CONST vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
                                                   eclipsedDoubleScatteringTextureSize.st);
-    const float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
-    const vec3 texCoords=vec3(coords2d, cosSZACoord);
+    CONST float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
+    CONST vec3 texCoords=vec3(coords2d, cosSZACoord);
 
     return texture(tex, texCoords);
 }
 
 LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 texIndices)
 {
-    const vec2 indexMax=lightPollutionTextureSize-vec2(1);
+    CONST vec2 indexMax=lightPollutionTextureSize-vec2(1);
 
-    const float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
-    const float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
+    CONST float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
-    const bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
-    const float cosViewZenithAngleCoord = viewRayIntersectsGround ?
+    CONST bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
+    CONST float cosViewZenithAngleCoord = viewRayIntersectsGround ?
                                    1-2*texIndices[0]/(indexMax[0]-1) :
                                    2*(texIndices[0]-1)/(indexMax[0]-1)-1;
     // ------------------------------------
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
@@ -753,23 +764,23 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 
 LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -777,27 +788,27 @@ LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, con
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     return LightPollution2DCoords(cosVZACoord, altCoord);
 }
 
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
-    const vec2 texSize = lightPollutionTextureSize;
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 texSize = lightPollutionTextureSize;
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2);
-    const float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
+    CONST float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
     return vec2(cosVZAtc, altitudeTC);
 }

--- a/atmosphere/default/shaders/single-scattering/on-the-fly/1/molecules/texture-sampling-functions.frag
+++ b/atmosphere/default/shaders/single-scattering/on-the-fly/1/molecules/texture-sampling-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-sampling-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,13 +45,13 @@ const vec4 lightPollutionRelativeRadiance=vec4(2.15e-06,1.11400004e-06,3.8580001
 const vec4 wavelengths=vec4(485.333344,516.666687,548,579.333313);
 const int wlSetIndex=1;
 #endif
-#line 5 0 // texture-sampling-functions.frag
-#line 1 2 // phase-functions.h.glsl
+#line 4 0 // texture-sampling-functions.frag
+#line 1 3 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 6 0 // texture-sampling-functions.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-sampling-functions.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -72,8 +83,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-sampling-functions.frag
-#line 1 4 // texture-coordinates.h.glsl
+#line 6 0 // texture-sampling-functions.frag
+#line 1 5 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -142,7 +153,7 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 8 0 // texture-sampling-functions.frag
+#line 7 0 // texture-sampling-functions.frag
 
 uniform sampler2D transmittanceTexture;
 uniform sampler2D irradianceTexture;
@@ -154,13 +165,13 @@ uniform sampler2D lightPollutionScatteringTexture;
 
 vec4 irradiance(const float cosSunZenithAngle, const float altitude)
 {
-    const vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
+    CONST vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
     return texture(irradianceTexture, texCoords);
 }
 
 vec4 opticalDepthToAtmosphereBorder(const float cosViewZenithAngle, const float altitude)
 {
-    const vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
+    CONST vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact when looking into nadir from TOA at some values of texture sizes (in particular, size of
     // transmittance texture for altitude being 4096). This happens when I simply call texture(eclipsedScatteringTexture,
@@ -178,11 +189,11 @@ vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float
 vec4 transmittance(const float cosViewZenithAngle, const float altitude, const float dist,
                    const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle view ray endpoint
     // in space here.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
 
     vec4 depth;
     if(viewRayIntersectsGround)
@@ -201,7 +212,7 @@ vec4 transmittance(const float cosViewZenithAngle, const float altitude, const f
 vec4 calcFirstScattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                          const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
+    CONST vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
                                           dotViewSun, altitude, viewRayIntersectsGround);
     return scattering*currentPhaseFunction(dotViewSun);
 }
@@ -220,6 +231,6 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
 
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     return texture(lightPollutionScatteringTexture, coords);
 }

--- a/atmosphere/default/shaders/single-scattering/on-the-fly/2/aerosols/common-functions.frag
+++ b/atmosphere/default/shaders/single-scattering/on-the-fly/2/aerosols/common-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // common-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.35000004e-05,1.33100002e-05,9.4
 const vec4 wavelengths=vec4(610.666687,642,673.333313,704.666687);
 const int wlSetIndex=2;
 #endif
-#line 5 0 // common-functions.frag
+#line 4 0 // common-functions.frag
 
 bool dbgDataPresent=false;
 bool debugDataPresent()
@@ -69,7 +80,7 @@ void setDebugData(float a,float b, float c, float d)
 
 void swap(inout float x, inout float y)
 {
-    const float t = x;
+    CONST float t = x;
     x = y;
     y = t;
 }
@@ -83,7 +94,7 @@ float safeSqrt(const float x)
 
 float safeAtan(const float y, const float x)
 {
-    const float a = atan(y,x);
+    CONST float a = atan(y,x);
     return x==0 && y==0 ? 0 : a;
 }
 
@@ -116,23 +127,23 @@ float pointAltitude(vec3 point)
 
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float Ratm=earthRadius+atmosphereHeight;
-    const float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float Ratm=earthRadius+atmosphereHeight;
+    CONST float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float distanceToGround(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(-safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float cosZenithAngleOfHorizon(const float altitude)
 {
-    const float R=earthRadius;
-    const float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
+    CONST float R=earthRadius;
+    CONST float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
     return -sqrt(2*h*R+sqr(h))/(R+h);
 }
 
@@ -151,8 +162,8 @@ float distanceToNearestAtmosphereBoundary(const float cosZenithAngle, const floa
 float sunVisibility(const float cosSunZenithAngle, float altitude)
 {
     if(altitude<0) altitude=0;
-    const float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
-    const float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
+    CONST float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
+    CONST float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
     /* Approximating visible fraction of solar disk by smoothstep between the position of the Sun
      * touching the horizon by its upper part and the position with lower part touching the horizon.
      * The calculation assumes that solar angular radius is small and thus approximately equals its sine.
@@ -182,13 +193,13 @@ float circlesIntersectionArea(float R1, float R2, float d)
 
 float angleBetween(const vec3 a, const vec3 b)
 {
-    const float d=dot(a,b);
-    const float c=length(cross(a,b));
+    CONST float d=dot(a,b);
+    CONST float c=length(cross(a,b));
     // To avoid loss of precision, don't use dot product near the singularity
     // of acos, and cross product near the singularity of asin
     if(abs(d) < abs(c))
         return acos(d/(length(a)*length(b)));
-    const float smallerAngle = asin(c/(length(a)*length(b)));
+    CONST float smallerAngle = asin(c/(length(a)*length(b)));
     if(d<0) return PI-smallerAngle;
     return smallerAngle;
 }
@@ -205,11 +216,11 @@ float moonAngularRadius(const vec3 cameraPosition, const vec3 moonPosition)
 
 float visibleSolidAngleOfSun(const vec3 camera, const vec3 sunDir, const vec3 moonPos)
 {
-    const float Rs=sunAngularRadius;
-    const float Rm=moonAngularRadius(camera,moonPos);
+    CONST float Rs=sunAngularRadius;
+    CONST float Rm=moonAngularRadius(camera,moonPos);
     float visibleSolidAngle=PI*sqr(Rs);
 
-    const float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
+    CONST float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
     if(dSM<Rs+Rm)
     {
         visibleSolidAngle -= circlesIntersectionArea(Rm,Rs,dSM);
@@ -229,12 +240,12 @@ float sphereIntegrationSolidAngleDifferential(const int pointCountOnSphere)
 }
 vec3 sphereIntegrationSampleDir(const int index, const int pointCountOnSphere)
 {
-    const float goldenRatio=1.6180339887499;
+    CONST float goldenRatio=1.6180339887499;
     // The range of n is 0.5, 1.5, ..., pointCountOnSphere-0.5
-    const float n=index+0.5;
+    CONST float n=index+0.5;
     // Explanation of the Fibonacci grid generation can be seen at https://stackoverflow.com/a/44164075/673852
-    const float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
-    const float azimuth=n*(2*PI*goldenRatio);
+    CONST float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
+    CONST float azimuth=n*(2*PI*goldenRatio);
     return vec3(cos(azimuth)*sin(zenithAngle),
                 sin(azimuth)*sin(zenithAngle),
                 cos(zenithAngle));

--- a/atmosphere/default/shaders/single-scattering/on-the-fly/2/aerosols/densities.frag
+++ b/atmosphere/default/shaders/single-scattering/on-the-fly/2/aerosols/densities.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // densities.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,20 +45,20 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.35000004e-05,1.33100002e-05,9.4
 const vec4 wavelengths=vec4(610.666687,642,673.333313,704.666687);
 const int wlSetIndex=2;
 #endif
-#line 5 0 // densities.frag
+#line 4 0 // densities.frag
 float scattererNumberDensity_molecules(float altitude)
 {
-        const float rayleighScaleHeight=8*km;
+        CONST float rayleighScaleHeight=8*km;
         return 3.08458e25*exp(-1/rayleighScaleHeight * altitude);
 }
 float scattererNumberDensity_aerosols(float altitude)
 {
-        const float mieScaleHeight=1.2*km;
+        CONST float mieScaleHeight=1.2*km;
         return 1.03333e8*exp(-1/mieScaleHeight*altitude);
 }
 float absorberNumberDensity_ozone(float altitude)
 {
-        const float totalOzoneAmount=370*dobsonUnit;
+        CONST float totalOzoneAmount=370*dobsonUnit;
 
         float density;
 

--- a/atmosphere/default/shaders/single-scattering/on-the-fly/2/aerosols/phase-functions.frag
+++ b/atmosphere/default/shaders/single-scattering/on-the-fly/2/aerosols/phase-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // phase-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.35000004e-05,1.33100002e-05,9.4
 const vec4 wavelengths=vec4(610.666687,642,673.333313,704.666687);
 const int wlSetIndex=2;
 #endif
-#line 5 0 // phase-functions.frag
+#line 4 0 // phase-functions.frag
 
 vec4 phaseFunction_molecules(float dotViewSun)
 {
@@ -42,9 +53,9 @@ vec4 phaseFunction_molecules(float dotViewSun)
 }
 vec4 phaseFunction_aerosols(float dotViewSun)
 {
-        const float g=0.76;
-        const float g2=g*g;
-        const float k = 3/(8*PI)*(1-g2)/(2+g2);
+        CONST float g=0.76;
+        CONST float g2=g*g;
+        CONST float k = 3/(8*PI)*(1-g2)/(2+g2);
         return vec4(k * (1+sqr(dotViewSun)) / pow(1+g2 - 2*g*dotViewSun, 1.5) + 1/((1-dotViewSun)*600+0.05))*0.904;
 }
 vec4 currentPhaseFunction(float dotViewSun) { return phaseFunction_aerosols(dotViewSun); }

--- a/atmosphere/default/shaders/single-scattering/on-the-fly/2/aerosols/render.frag
+++ b/atmosphere/default/shaders/single-scattering/on-the-fly/2/aerosols/render.frag
@@ -1,7 +1,21 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
 
-#line 1 1 // const.h.glsl
+
+
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 6 0 // render.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,11 +48,11 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.35000004e-05,1.33100002e-05,9.4
 const vec4 wavelengths=vec4(610.666687,642,673.333313,704.666687);
 const int wlSetIndex=2;
 #endif
-#line 5 0 // render.frag
-#line 1 2 // calc-view-dir.h.glsl
+#line 7 0 // render.frag
+#line 1 3 // calc-view-dir.h.glsl
 vec3 calcViewDir();
-#line 6 0 // render.frag
-#line 1 3 // common-functions.h.glsl
+#line 8 0 // render.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -70,13 +84,13 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // render.frag
-#line 1 4 // phase-functions.h.glsl
+#line 9 0 // render.frag
+#line 1 5 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 8 0 // render.frag
-#line 1 5 // single-scattering.h.glsl
+#line 10 0 // render.frag
+#line 1 6 // single-scattering.h.glsl
 #ifndef INCLUDE_ONCE_1DB2EDC1_C687_4FFA_BFF4_D18A54BA651B
 #define INCLUDE_ONCE_1DB2EDC1_C687_4FFA_BFF4_D18A54BA651B
 
@@ -84,9 +98,9 @@ vec4 computeSingleScattering(const float cosSunZenithAngle, const float cosViewZ
                              const float dotViewSun, const float altitude,
                              const bool viewRayIntersectsGround);
 #endif
-#line 9 0 // render.frag
+#line 11 0 // render.frag
 
-#line 1 6 // texture-coordinates.h.glsl
+#line 1 7 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -155,10 +169,10 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 11 0 // render.frag
-#line 1 7 // radiance-to-luminance.h.glsl
+#line 13 0 // render.frag
+#line 1 8 // radiance-to-luminance.h.glsl
 const mat4 radianceToLuminance=mat4(21296.1113,10585.7773,6.80903196,807.40564,  8819.19727,3416.5498,0.346691847,67.973465,  1511.18506,551.902527,0,6.17586422,  177.630722,64.1456985,0,0.693584085);
-#line 12 0 // render.frag
+#line 14 0 // render.frag
 
 
 
@@ -195,18 +209,18 @@ void main()
     // this approximation has the same order of magnitude as the assumption that the Earth and its atmosphere
     // are spherical.
     float altitude = max(cameraPosition.z, 0.);
-    const vec3 oldCamPos=cameraPosition;
+    CONST vec3 oldCamPos=cameraPosition;
     // Hide the uniform with this name, thus effectively modifying it for the following code
     vec3 cameraPosition=vec3(oldCamPos.xy, altitude);
 
     bool lookingIntoAtmosphere=true;
     if(altitude>atmosphereHeight)
     {
-        const vec3 p = cameraPosition - earthCenter;
-        const float p_dot_v = dot(p, viewDir);
-        const float p_dot_p = dot(p, p);
-        const float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
-        const float distanceToTOA = -p_dot_v - sqrt(sqr(earthRadius+atmosphereHeight) - squaredDistBetweenViewRayAndEarthCenter);
+        CONST vec3 p = cameraPosition - earthCenter;
+        CONST float p_dot_v = dot(p, viewDir);
+        CONST float p_dot_p = dot(p, p);
+        CONST float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
+        CONST float distanceToTOA = -p_dot_v - sqrt(sqr(earthRadius+atmosphereHeight) - squaredDistBetweenViewRayAndEarthCenter);
         if(distanceToTOA>=0)
         {
             cameraPosition += viewDir*distanceToTOA;
@@ -214,7 +228,7 @@ void main()
         }
         else
         {
-#if RENDERING_ANY_ZERO_SCATTERING
+#if 0 /*RENDERING_ANY_ZERO_SCATTERING*/
             lookingIntoAtmosphere=false;
 #else
             luminance=vec4(0);
@@ -224,16 +238,16 @@ void main()
         }
     }
 
-    const vec3 zenith=normalize(cameraPosition-earthCenter);
+    CONST vec3 zenith=normalize(cameraPosition-earthCenter);
     float cosViewZenithAngle=dot(zenith,viewDir);
 
     bool viewRayIntersectsGround=false;
     {
-        const vec3 p = cameraPosition - earthCenter;
-        const float p_dot_v = dot(p, viewDir);
-        const float p_dot_p = dot(p, p);
-        const float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
-        const float distanceToIntersection = -p_dot_v - sqrt(sqr(earthRadius) - squaredDistBetweenViewRayAndEarthCenter);
+        CONST vec3 p = cameraPosition - earthCenter;
+        CONST float p_dot_v = dot(p, viewDir);
+        CONST float p_dot_p = dot(p, p);
+        CONST float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
+        CONST float distanceToIntersection = -p_dot_v - sqrt(sqr(earthRadius) - squaredDistBetweenViewRayAndEarthCenter);
         // altitude==0 is a special case where distance to intersection calculation
         // is unreliable (has a lot of noise in its sign), so check it separately
         if(distanceToIntersection>0 || (altitude==0 && cosViewZenithAngle<0))
@@ -244,11 +258,11 @@ void main()
     // Aside from aesthetics, this affects brightness input to Stellarium's tone mapper.
     if(pseudoMirrorSkyBelowHorizon && viewRayIntersectsGround)
     {
-        const float horizonCZA = cosZenithAngleOfHorizon(altitude);
-        const float viewElev  = asin(clampCosine(cosViewZenithAngle));
-        const float horizElev = asin(clampCosine(horizonCZA));
-        const float newViewElev = 2*horizElev - viewElev;
-        const float viewDirXYnorm = length(viewDir-zenith*cosViewZenithAngle);
+        CONST float horizonCZA = cosZenithAngleOfHorizon(altitude);
+        CONST float viewElev  = asin(clampCosine(cosViewZenithAngle));
+        CONST float horizElev = asin(clampCosine(horizonCZA));
+        CONST float newViewElev = 2*horizElev - viewElev;
+        CONST float viewDirXYnorm = length(viewDir-zenith*cosViewZenithAngle);
         if(viewDirXYnorm == 0)
         {
             viewDir = zenith;
@@ -267,27 +281,27 @@ void main()
         viewRayIntersectsGround = false;
     }
 
-    const float cosSunZenithAngle =dot(zenith,sunDirection);
-    const float dotViewSun=dot(viewDir,sunDirection);
+    CONST float cosSunZenithAngle =dot(zenith,sunDirection);
+    CONST float dotViewSun=dot(viewDir,sunDirection);
 
-    const vec3 sunXYunnorm=sunDirection-dot(sunDirection,zenith)*zenith;
-    const vec3 viewXYunnorm=viewDir-dot(viewDir,zenith)*zenith;
-    const vec3 sunXY = sunXYunnorm.x!=0 || sunXYunnorm.y!=0 || sunXYunnorm.z!=0 ? normalize(sunXYunnorm) : vec3(0);
-    const vec3 viewXY = viewXYunnorm.x!=0 || viewXYunnorm.y!=0 || viewXYunnorm.z!=0 ? normalize(viewXYunnorm) : vec3(0);
-    const float azimuthRelativeToSun=safeAtan(dot(cross(sunXY, viewXY), zenith), dot(sunXY, viewXY));
+    CONST vec3 sunXYunnorm=sunDirection-dot(sunDirection,zenith)*zenith;
+    CONST vec3 viewXYunnorm=viewDir-dot(viewDir,zenith)*zenith;
+    CONST vec3 sunXY = sunXYunnorm.x!=0 || sunXYunnorm.y!=0 || sunXYunnorm.z!=0 ? normalize(sunXYunnorm) : vec3(0);
+    CONST vec3 viewXY = viewXYunnorm.x!=0 || viewXYunnorm.y!=0 || viewXYunnorm.z!=0 ? normalize(viewXYunnorm) : vec3(0);
+    CONST float azimuthRelativeToSun=safeAtan(dot(cross(sunXY, viewXY), zenith), dot(sunXY, viewXY));
 
-#if RENDERING_ZERO_SCATTERING
+#if 0 /*RENDERING_ZERO_SCATTERING*/
     vec4 radiance;
     if(viewRayIntersectsGround)
     {
         // XXX: keep in sync with the same code in computeScatteringDensity(), but don't forget about
         //      the difference in the usage of viewDir vs incDir.
-        const float distToGround = distanceToGround(cosViewZenithAngle, altitude);
-        const vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
-        const vec3 groundNormal = normalize(zenith*(earthRadius+altitude)+viewDir*distToGround);
-        const vec4 groundIrradiance = irradiance(dot(groundNormal, sunDirection), 0);
+        CONST float distToGround = distanceToGround(cosViewZenithAngle, altitude);
+        CONST vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
+        CONST vec3 groundNormal = normalize(zenith*(earthRadius+altitude)+viewDir*distToGround);
+        CONST vec4 groundIrradiance = irradiance(dot(groundNormal, sunDirection), 0);
         // Radiation scattered by the ground
-        const float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
+        CONST float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
         radiance = transmittanceToGround*groundAlbedo*groundIrradiance*solarIrradianceFixup*groundBRDF
                  + lightPollutionGroundLuminance*lightPollutionRelativeRadiance;
     }
@@ -304,22 +318,22 @@ void main()
     }
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_ZERO_SCATTERING
+#elif 0 /*RENDERING_ECLIPSED_ZERO_SCATTERING*/
     vec4 radiance;
-    const float dotViewMoon=dot(viewDir,normalize(moonPosition-cameraPosition));
+    CONST float dotViewMoon=dot(viewDir,normalize(moonPosition-cameraPosition));
     if(viewRayIntersectsGround)
     {
         // XXX: keep in sync with the similar code in non-eclipsed zero scattering rendering.
-        const float distToGround = distanceToGround(cosViewZenithAngle, altitude);
-        const vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
-        const vec3 pointOnGround = cameraPosition+viewDir*distToGround;
-        const vec4 directGroundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDirection, moonPosition);
+        CONST float distToGround = distanceToGround(cosViewZenithAngle, altitude);
+        CONST vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
+        CONST vec3 pointOnGround = cameraPosition+viewDir*distToGround;
+        CONST vec4 directGroundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDirection, moonPosition);
         // FIXME: add first-order indirect irradiance too: it's done in non-eclipsed irradiance (in the same
         // conditions: when limited to 2 orders). This should be calculated at the same time when second order
         // is: all the infrastructure is already there.
-        const vec4 groundIrradiance = directGroundIrradiance;
+        CONST vec4 groundIrradiance = directGroundIrradiance;
         // Radiation scattered by the ground
-        const float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
+        CONST float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
         radiance = transmittanceToGround*groundAlbedo*groundIrradiance*solarIrradianceFixup*groundBRDF
                  + lightPollutionGroundLuminance*lightPollutionRelativeRadiance;
     }
@@ -336,53 +350,53 @@ void main()
     }
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_ON_THE_FLY
-    const vec4 scattering=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPosition,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_ON_THE_FLY*/
+    CONST vec4 scattering=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPosition,
                                                           viewRayIntersectsGround);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE
-    const vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE*/
+    CONST vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                      viewRayIntersectsGround, eclipsedSingleScatteringTextureSize);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact at the point where azimuth texture coordinate changes from 1 to 0 (at azimuthRelativeToSun crossing
     // 0). This happens when I simply call texture(eclipsedScatteringTexture, texCoords) without specifying LOD.
     // Apparently, the driver uses the derivative for some reason, even though it shouldn't.
-    const vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
+    CONST vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE
-    const vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
+    CONST vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                      viewRayIntersectsGround, eclipsedSingleScatteringTextureSize);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact at the point where azimuth texture coordinate changes from 1 to 0 (at azimuthRelativeToSun crossing
     // 0). This happens when I simply call texture(eclipsedScatteringTexture, texCoords) without specifying LOD.
     // Apparently, the driver uses the derivative for some reason, even though it shouldn't.
-    const vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
+    CONST vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
     luminance=scattering*currentPhaseFunction(dotViewSun);
-#elif RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_RADIANCE
+#elif 0 /*RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_RADIANCE*/
     vec4 radiance=exp(sampleEclipseDoubleScattering3DTexture(eclipsedDoubleScatteringTexture,
                                                              cosSunZenithAngle, cosViewZenithAngle, azimuthRelativeToSun,
                                                              altitude, viewRayIntersectsGround));
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_LUMINANCE
+#elif 0 /*RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
     luminance=exp(sampleEclipseDoubleScattering3DTexture(eclipsedDoubleScatteringTexture,
                                                          cosSunZenithAngle, cosViewZenithAngle, azimuthRelativeToSun,
                                                          altitude, viewRayIntersectsGround));
 #elif 1 /*RENDERING_SINGLE_SCATTERING_ON_THE_FLY*/
-    const vec4 scattering=computeSingleScattering(cosSunZenithAngle,cosViewZenithAngle,dotViewSun,
+    CONST vec4 scattering=computeSingleScattering(cosSunZenithAngle,cosViewZenithAngle,dotViewSun,
                                                   altitude,viewRayIntersectsGround);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE
+#elif 0 /*RENDERING_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE*/
     vec4 scattering;
     if(useInterpolationGuides)
     {
@@ -399,7 +413,7 @@ void main()
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE
+#elif 0 /*RENDERING_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
     vec4 scattering;
     if(useInterpolationGuides)
     {
@@ -413,18 +427,18 @@ void main()
                                      dotViewSun, altitude, viewRayIntersectsGround);
     }
     luminance=scattering * (bool(0) ? vec4(1) : currentPhaseFunction(dotViewSun));
-#elif RENDERING_MULTIPLE_SCATTERING_LUMINANCE
+#elif 0 /*RENDERING_MULTIPLE_SCATTERING_LUMINANCE*/
     luminance=sample3DTexture(scatteringTexture, cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, viewRayIntersectsGround);
-#elif RENDERING_MULTIPLE_SCATTERING_RADIANCE
+#elif 0 /*RENDERING_MULTIPLE_SCATTERING_RADIANCE*/
     vec4 radiance=sample3DTexture(scatteringTexture, cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, viewRayIntersectsGround);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_LIGHT_POLLUTION_RADIANCE
+#elif 0 /*RENDERING_LIGHT_POLLUTION_RADIANCE*/
     vec4 radiance=lightPollutionGroundLuminance*lightPollutionScattering(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_LIGHT_POLLUTION_LUMINANCE
+#elif 0 /*RENDERING_LIGHT_POLLUTION_LUMINANCE*/
     luminance=lightPollutionGroundLuminance*lightPollutionScattering(altitude, cosViewZenithAngle, viewRayIntersectsGround);
 #else
 #error What to render?

--- a/atmosphere/default/shaders/single-scattering/on-the-fly/2/aerosols/single-scattering.frag
+++ b/atmosphere/default/shaders/single-scattering/on-the-fly/2/aerosols/single-scattering.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // single-scattering.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,15 +45,15 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.35000004e-05,1.33100002e-05,9.4
 const vec4 wavelengths=vec4(610.666687,642,673.333313,704.666687);
 const int wlSetIndex=2;
 #endif
-#line 5 0 // single-scattering.frag
-#line 1 2 // densities.h.glsl
+#line 4 0 // single-scattering.frag
+#line 1 3 // densities.h.glsl
 float scattererNumberDensity_molecules(float altitude);
 float scattererNumberDensity_aerosols(float altitude);
 float absorberNumberDensity_ozone(float altitude);
 vec4 scatteringCrossSection();
 float scattererDensity(float altitude);
-#line 6 0 // single-scattering.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // single-scattering.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -74,8 +85,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // single-scattering.frag
-#line 1 4 // single-scattering.h.glsl
+#line 6 0 // single-scattering.frag
+#line 1 5 // single-scattering.h.glsl
 #ifndef INCLUDE_ONCE_1DB2EDC1_C687_4FFA_BFF4_D18A54BA651B
 #define INCLUDE_ONCE_1DB2EDC1_C687_4FFA_BFF4_D18A54BA651B
 
@@ -83,8 +94,8 @@ vec4 computeSingleScattering(const float cosSunZenithAngle, const float cosViewZ
                              const float dotViewSun, const float altitude,
                              const bool viewRayIntersectsGround);
 #endif
-#line 8 0 // single-scattering.frag
-#line 1 5 // texture-sampling-functions.h.glsl
+#line 7 0 // single-scattering.frag
+#line 1 6 // texture-sampling-functions.h.glsl
 #ifndef INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 #define INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float altitude);
@@ -96,20 +107,20 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                 const int scatteringOrder);
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 #endif
-#line 9 0 // single-scattering.frag
+#line 8 0 // single-scattering.frag
 
 // This function omits phase function and solar irradiance: these are to be applied somewhere in the calling code.
 vec4 computeSingleScatteringIntegrand(const float cosSunZenithAngle, const float cosViewZenithAngle,
                                       const float dotViewSun, const float altitude,
                                       const float dist, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle here the case when the
     // endpoint of the view ray intentionally appears in outer space.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosSunZenithAngleAtDist=clampCosine((r*cosSunZenithAngle+dist*dotViewSun)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosSunZenithAngleAtDist=clampCosine((r*cosSunZenithAngle+dist*dotViewSun)/(earthRadius+altAtDist));
 
-    const vec4 xmittance=transmittance(cosViewZenithAngle, altitude, dist, viewRayIntersectsGround)
+    CONST vec4 xmittance=transmittance(cosViewZenithAngle, altitude, dist, viewRayIntersectsGround)
                                                     *
                          transmittanceToAtmosphereBorder(cosSunZenithAngleAtDist, altAtDist)
                                                     *
@@ -121,14 +132,14 @@ vec4 computeSingleScattering(const float cosSunZenithAngle, const float cosViewZ
                              const float dotViewSun, const float altitude,
                              const bool viewRayIntersectsGround)
 {
-    const float integrInterval=distanceToNearestAtmosphereBoundary(cosViewZenithAngle, altitude,
+    CONST float integrInterval=distanceToNearestAtmosphereBoundary(cosViewZenithAngle, altitude,
                                                                    viewRayIntersectsGround);
     // Using the midpoint rule for quadrature
     vec4 spectrum=vec4(0);
-    const float dl=integrInterval/radialIntegrationPoints;
+    CONST float dl=integrInterval/radialIntegrationPoints;
     for(int n=0; n<radialIntegrationPoints; ++n)
     {
-        const float dist=(n+0.5)*dl;
+        CONST float dist=(n+0.5)*dl;
         spectrum += computeSingleScatteringIntegrand(cosSunZenithAngle, cosViewZenithAngle, dotViewSun,
                                                      altitude, dist, viewRayIntersectsGround);
     }

--- a/atmosphere/default/shaders/single-scattering/on-the-fly/2/aerosols/texture-coordinates.frag
+++ b/atmosphere/default/shaders/single-scattering/on-the-fly/2/aerosols/texture-coordinates.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-coordinates.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,8 +45,8 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.35000004e-05,1.33100002e-05,9.4
 const vec4 wavelengths=vec4(610.666687,642,673.333313,704.666687);
 const int wlSetIndex=2;
 #endif
-#line 5 0 // texture-coordinates.frag
-#line 1 2 // texture-coordinates.h.glsl
+#line 4 0 // texture-coordinates.frag
+#line 1 3 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -104,8 +115,8 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 6 0 // texture-coordinates.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-coordinates.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -137,7 +148,7 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-coordinates.frag
+#line 6 0 // texture-coordinates.frag
 
 const float LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA=sqrt(atmosphereHeight*(atmosphereHeight+2*earthRadius));
 
@@ -205,18 +216,18 @@ vec3 indicesToTexCoords(const vec3 indices, const vec3 texSizes)
 
 TransmittanceTexVars transmittanceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
+    CONST float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
                                 texCoordToUnitRange(texCoord.t,transmittanceTextureSize.t);
     // Distance from Earth center to camera
-    const float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
-    const float altitude=r-earthRadius;
+    CONST float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
+    CONST float altitude=r-earthRadius;
 
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
     // distance to border of visible atmosphere from the view point
-    const float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
+    CONST float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
     // d==0 can happen when altitude==atmosphereHeight
-    const float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
+    CONST float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
     return TransmittanceTexVars(cosVZA,altitude);
 }
 
@@ -235,53 +246,53 @@ vec2 transmittanceTexVarsToTexCoord(const float cosVZA, float altitude)
     if(altitude<0)
         altitude=0;
 
-    const float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
+    CONST float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
                                       transmittanceTextureSize.t);
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
-    const float d=distanceToAtmosphereBorder(cosVZA,altitude);
-    const float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float d=distanceToAtmosphereBorder(cosVZA,altitude);
+    CONST float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
     return vec2(s,t);
 }
 
 // Output: vec2(cos(sunZenithAngle), altitude)
 IrradianceTexVars irradianceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
-    const float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
+    CONST float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
+    CONST float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
     return IrradianceTexVars(cosSZA,alt);
 }
 
 vec2 irradianceTexVarsToTexCoord(const float cosSunZenithAngle, const float altitude)
 {
-    const float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
-    const float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
+    CONST float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
+    CONST float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
     return vec2(s,t);
 }
 
 float cosSZAToUnitRangeTexCoord(const float cosSunZenithAngle)
 {
     // Distance to top atmosphere border along the ray groundUnderCamera-sun: (altitude, cosSunZenithAngle)
-    const float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name
-    const float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
+    CONST float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
     // TODO: choose a more descriptive name
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     return max(0.,1-a/A)/(a+1);
 }
 
 float unitRangeTexCoordToCosSZA(const float texCoord)
 {
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float a=(A-A*texCoord)/(1+A*texCoord);
-    const float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
+    CONST float a=(A-A*texCoord)/(1+A*texCoord);
+    CONST float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
     return distFromGroundToTopAtmoBorder==0 ? 1 :
         clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distFromGroundToTopAtmoBorder)) /
                     (2*earthRadius*distFromGroundToTopAtmoBorder));
@@ -292,24 +303,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
                                                const float dotViewSun, const float altitude,
                                                const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -317,24 +328,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float dotVSCoord=(dotViewSun+1)/2;
+    CONST float dotVSCoord=(dotViewSun+1)/2;
 
     // ------------------------------------
-    const float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
+    CONST float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
 
     return Scattering4DCoords(cosSZACoord, cosVZACoord, dotVSCoord, altCoord, viewRayIntersectsGround);
 }
 
 TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
@@ -342,16 +353,16 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture coordinates we combine into a single sampler3D coordinate.
-    const float texW = scatteringTextureSize[1];
-    const float texH = scatteringTextureSize[2];
-    const float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
-    const vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
+    CONST float texW = scatteringTextureSize[1];
+    CONST float texH = scatteringTextureSize[2];
+    CONST float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
+    CONST vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
                                         ceil (cosSZAIndex)*texW+coords.dotViewSun*(texW-1)) / (texW*texH-1);
-    const vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
+    CONST vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
 
-    const float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
+    CONST float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
 
-    const float alphaUpper=fract(cosSZAIndex);
+    CONST float alphaUpper=fract(cosSZAIndex);
     return TexCoordPair(vec3(cosVZAtc, combinedCoord.x, altitude), float(1-alphaUpper),
                         vec3(cosVZAtc, combinedCoord.y, altitude), float(alphaUpper));
 }
@@ -359,9 +370,9 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
+    CONST TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
     return texture(tex, texCoords.lower) * texCoords.alphaLower +
            texture(tex, texCoords.upper) * texCoords.alphaUpper;
 }
@@ -369,17 +380,17 @@ vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const f
 // 3D texture is the 3D single-altitude slice of a 4D texture
 vec3 scattering4DCoordsToTex3DCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2);
 
-    const float dvsSize = scatteringTextureSize[1];
-    const float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
+    CONST float dvsSize = scatteringTextureSize[1];
+    CONST float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
 
-    const float cszaSize = scatteringTextureSize[2];
-    const float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
+    CONST float cszaSize = scatteringTextureSize[2];
+    CONST float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
 
     return vec3(cosVZAtc, dotVStc, cosSZAtc);
 }
@@ -394,39 +405,39 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along dotViewSun coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[1];
-    const float posOfRow = indices[1];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[1];
+    CONST float posOfRow = indices[1];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         indexToTexCoord(currRow, numRows-1),
                                                         texCoordVerbatim));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               indexToTexCoord(currRow, numRows-1),
                                                               texCoordVerbatim));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          indexToTexCoord(currRow, numRows-1),
                                          texCoordVerbatim));
@@ -434,14 +445,14 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
 vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolationGuides01Tex,
                                  const vec3 indices)
 {
-    const float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
+    CONST float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
 
-    const float cosVZAIndex = indices[0];
-    const float dotVSIndex = indices[1];
-    const float currRow = floor(dotVSIndex);
-    const float posBetweenRows = dotVSIndex - currRow;
-    const float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cosVZAIndex = indices[0];
+    CONST float dotVSIndex = indices[1];
+    CONST float currRow = floor(dotVSIndex);
+    CONST float posBetweenRows = dotVSIndex - currRow;
+    CONST float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -449,14 +460,14 @@ vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolat
     indicesCurrRow[1] =     currRow;
     indicesNextRow[1] = min(currRow+1, scatteringTextureSize[1]-1.);
 
-    const vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
-    const vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
+    CONST vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
+    CONST vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
 
-    const vec4 valueCurrRow = texture(tex, coordsCurrRow);
-    const vec4 valueNextRow = texture(tex, coordsNextRow);
-    const float epsilon = 1e-37; // Prevents passing zero to log
-    const vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
-    const vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
+    CONST vec4 valueCurrRow = texture(tex, coordsCurrRow);
+    CONST vec4 valueNextRow = texture(tex, coordsNextRow);
+    CONST float epsilon = 1e-37; // Prevents passing zero to log
+    CONST vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
+    CONST vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
     return (logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow;
 }
 
@@ -465,37 +476,37 @@ float findGuide02Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along SZA coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[2];
-    const float posOfRow = indices[2];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[2];
+    CONST float posOfRow = indices[2];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
 }
@@ -505,19 +516,19 @@ vec4 sample3DTextureGuided(const sampler3D tex,
                            const float cosSunZenithAngle, const float cosViewZenithAngle,
                            const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
                                                                     dotViewSun, altitude, viewRayIntersectsGround);
     // Handle the external interpolation guides: the guides between a pair of VZA-dotViewSun 2D "pictures".
-    const vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
-    const vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
-    const float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
+    CONST vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
+    CONST float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
 
-    const float cvzaIndex = indices[0];
-    const float cszaIndex = indices[2];
-    const float currRow = floor(cszaIndex);
-    const float posBetweenRows = cszaIndex - currRow;
-    const float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cvzaIndex = indices[0];
+    CONST float cszaIndex = indices[2];
+    CONST float currRow = floor(cszaIndex);
+    CONST float posBetweenRows = cszaIndex - currRow;
+    CONST float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -526,58 +537,58 @@ vec4 sample3DTextureGuided(const sampler3D tex,
     indicesNextRow[2] = min(currRow+1, scatteringTextureSize[2]-1);
 
     // The caller will handle the internal interpolation guides: the ones between rows in each 2D "picture".
-    const vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
-    const vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
+    CONST vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
+    CONST vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
     return exp((logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow);
 }
 
 vec4 sample3DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
     return texture(tex, texCoords);
 }
 
 ScatteringTexVars scatteringTex4DCoordsToTexVars(const Scattering4DCoords coords)
 {
-    const float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
     // ------------------------------------
     float cosViewZenithAngle;
     if(coords.viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
     // ------------------------------------
-    const float dotViewSun=coords.dotViewSun*2-1;
+    CONST float dotViewSun=coords.dotViewSun*2-1;
 
     // ------------------------------------
-    const float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
+    CONST float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
 
     return ScatteringTexVars(cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, coords.viewRayIntersectsGround);
 }
 
 Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 {
-    const vec4 indexMax=scatteringTextureSize-vec4(1);
+    CONST vec4 indexMax=scatteringTextureSize-vec4(1);
     Scattering4DCoords coords4d;
     coords4d.viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
     // The following formulas assume that scatteringTextureSize[0] is even. For odd sizes they would change.
@@ -593,8 +604,8 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture indices we combine into a single sampler3D coordinate.
-    const float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
-    const float combinedIndex=texIndices[1];
+    CONST float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
+    CONST float combinedIndex=texIndices[1];
     coords4d.dotViewSun=mod(combinedIndex,texW)/(texW-1);
     coords4d.cosSunZenithAngle=floor(combinedIndex/texW)/(texH-1);
 
@@ -608,11 +619,11 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
 ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 {
-    const Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
+    CONST Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
     ScatteringTexVars vars=scatteringTex4DCoordsToTexVars(coords4d);
     // Clamp dotViewSun to its valid range of values, given cosViewZenithAngle and cosSunZenithAngle. This is
     // needed to prevent NaNs when computing the scattering texture.
-    const float cosVZA=vars.cosViewZenithAngle,
+    CONST float cosVZA=vars.cosViewZenithAngle,
                 cosSZA=vars.cosSunZenithAngle;
     vars.dotViewSun=clamp(vars.dotViewSun,
                           cosVZA*cosSZA-safeSqrt((1-sqr(cosVZA))*(1-sqr(cosSZA))),
@@ -622,54 +633,54 @@ ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 
 EclipseScatteringTexVars eclipseTexCoordsToTexVars(const vec2 texCoords, const float altitude)
 {
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
-    const bool viewRayIntersectsGround = texCoords.t<0.5;
+    CONST bool viewRayIntersectsGround = texCoords.t<0.5;
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
-    const float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
+    CONST float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
     return EclipseScatteringTexVars(azimuthRelativeToSun, cosViewZenithAngle, viewRayIntersectsGround);
 }
 
 EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                                    const float altitude, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -677,13 +688,13 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
-    const float azimuthCoord = azimuthRelativeToSun/(2*PI);
+    CONST float azimuthCoord = azimuthRelativeToSun/(2*PI);
 
     return EclipseScattering2DCoords(azimuthCoord, cosVZACoord);
 }
@@ -691,14 +702,14 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
 vec2 eclipseTexVarsToTexCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                const float altitude, const bool viewRayIntersectsGround, const vec2 texSize)
 {
-    const EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+    CONST EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                                     viewRayIntersectsGround);
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2);
-    const float azimuthTC = coords.azimuth + 1/(2*texSize.s);
+    CONST float azimuthTC = coords.azimuth + 1/(2*texSize.s);
 
     return vec2(azimuthTC, cosVZAtc);
 }
@@ -707,42 +718,42 @@ vec4 sampleEclipseDoubleScattering3DTexture(const sampler3D tex, const float cos
                                             const float cosViewZenithAngle, const float azimuthRelativeToSun,
                                             const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
+    CONST vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
                                                   eclipsedDoubleScatteringTextureSize.st);
-    const float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
-    const vec3 texCoords=vec3(coords2d, cosSZACoord);
+    CONST float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
+    CONST vec3 texCoords=vec3(coords2d, cosSZACoord);
 
     return texture(tex, texCoords);
 }
 
 LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 texIndices)
 {
-    const vec2 indexMax=lightPollutionTextureSize-vec2(1);
+    CONST vec2 indexMax=lightPollutionTextureSize-vec2(1);
 
-    const float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
-    const float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
+    CONST float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
-    const bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
-    const float cosViewZenithAngleCoord = viewRayIntersectsGround ?
+    CONST bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
+    CONST float cosViewZenithAngleCoord = viewRayIntersectsGround ?
                                    1-2*texIndices[0]/(indexMax[0]-1) :
                                    2*(texIndices[0]-1)/(indexMax[0]-1)-1;
     // ------------------------------------
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
@@ -753,23 +764,23 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 
 LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -777,27 +788,27 @@ LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, con
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     return LightPollution2DCoords(cosVZACoord, altCoord);
 }
 
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
-    const vec2 texSize = lightPollutionTextureSize;
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 texSize = lightPollutionTextureSize;
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2);
-    const float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
+    CONST float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
     return vec2(cosVZAtc, altitudeTC);
 }

--- a/atmosphere/default/shaders/single-scattering/on-the-fly/2/aerosols/texture-sampling-functions.frag
+++ b/atmosphere/default/shaders/single-scattering/on-the-fly/2/aerosols/texture-sampling-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-sampling-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,13 +45,13 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.35000004e-05,1.33100002e-05,9.4
 const vec4 wavelengths=vec4(610.666687,642,673.333313,704.666687);
 const int wlSetIndex=2;
 #endif
-#line 5 0 // texture-sampling-functions.frag
-#line 1 2 // phase-functions.h.glsl
+#line 4 0 // texture-sampling-functions.frag
+#line 1 3 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 6 0 // texture-sampling-functions.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-sampling-functions.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -72,8 +83,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-sampling-functions.frag
-#line 1 4 // texture-coordinates.h.glsl
+#line 6 0 // texture-sampling-functions.frag
+#line 1 5 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -142,7 +153,7 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 8 0 // texture-sampling-functions.frag
+#line 7 0 // texture-sampling-functions.frag
 
 uniform sampler2D transmittanceTexture;
 uniform sampler2D irradianceTexture;
@@ -154,13 +165,13 @@ uniform sampler2D lightPollutionScatteringTexture;
 
 vec4 irradiance(const float cosSunZenithAngle, const float altitude)
 {
-    const vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
+    CONST vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
     return texture(irradianceTexture, texCoords);
 }
 
 vec4 opticalDepthToAtmosphereBorder(const float cosViewZenithAngle, const float altitude)
 {
-    const vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
+    CONST vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact when looking into nadir from TOA at some values of texture sizes (in particular, size of
     // transmittance texture for altitude being 4096). This happens when I simply call texture(eclipsedScatteringTexture,
@@ -178,11 +189,11 @@ vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float
 vec4 transmittance(const float cosViewZenithAngle, const float altitude, const float dist,
                    const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle view ray endpoint
     // in space here.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
 
     vec4 depth;
     if(viewRayIntersectsGround)
@@ -201,7 +212,7 @@ vec4 transmittance(const float cosViewZenithAngle, const float altitude, const f
 vec4 calcFirstScattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                          const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
+    CONST vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
                                           dotViewSun, altitude, viewRayIntersectsGround);
     return scattering*currentPhaseFunction(dotViewSun);
 }
@@ -220,6 +231,6 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
 
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     return texture(lightPollutionScatteringTexture, coords);
 }

--- a/atmosphere/default/shaders/single-scattering/on-the-fly/2/molecules/common-functions.frag
+++ b/atmosphere/default/shaders/single-scattering/on-the-fly/2/molecules/common-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // common-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.35000004e-05,1.33100002e-05,9.4
 const vec4 wavelengths=vec4(610.666687,642,673.333313,704.666687);
 const int wlSetIndex=2;
 #endif
-#line 5 0 // common-functions.frag
+#line 4 0 // common-functions.frag
 
 bool dbgDataPresent=false;
 bool debugDataPresent()
@@ -69,7 +80,7 @@ void setDebugData(float a,float b, float c, float d)
 
 void swap(inout float x, inout float y)
 {
-    const float t = x;
+    CONST float t = x;
     x = y;
     y = t;
 }
@@ -83,7 +94,7 @@ float safeSqrt(const float x)
 
 float safeAtan(const float y, const float x)
 {
-    const float a = atan(y,x);
+    CONST float a = atan(y,x);
     return x==0 && y==0 ? 0 : a;
 }
 
@@ -116,23 +127,23 @@ float pointAltitude(vec3 point)
 
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float Ratm=earthRadius+atmosphereHeight;
-    const float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float Ratm=earthRadius+atmosphereHeight;
+    CONST float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float distanceToGround(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(-safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float cosZenithAngleOfHorizon(const float altitude)
 {
-    const float R=earthRadius;
-    const float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
+    CONST float R=earthRadius;
+    CONST float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
     return -sqrt(2*h*R+sqr(h))/(R+h);
 }
 
@@ -151,8 +162,8 @@ float distanceToNearestAtmosphereBoundary(const float cosZenithAngle, const floa
 float sunVisibility(const float cosSunZenithAngle, float altitude)
 {
     if(altitude<0) altitude=0;
-    const float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
-    const float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
+    CONST float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
+    CONST float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
     /* Approximating visible fraction of solar disk by smoothstep between the position of the Sun
      * touching the horizon by its upper part and the position with lower part touching the horizon.
      * The calculation assumes that solar angular radius is small and thus approximately equals its sine.
@@ -182,13 +193,13 @@ float circlesIntersectionArea(float R1, float R2, float d)
 
 float angleBetween(const vec3 a, const vec3 b)
 {
-    const float d=dot(a,b);
-    const float c=length(cross(a,b));
+    CONST float d=dot(a,b);
+    CONST float c=length(cross(a,b));
     // To avoid loss of precision, don't use dot product near the singularity
     // of acos, and cross product near the singularity of asin
     if(abs(d) < abs(c))
         return acos(d/(length(a)*length(b)));
-    const float smallerAngle = asin(c/(length(a)*length(b)));
+    CONST float smallerAngle = asin(c/(length(a)*length(b)));
     if(d<0) return PI-smallerAngle;
     return smallerAngle;
 }
@@ -205,11 +216,11 @@ float moonAngularRadius(const vec3 cameraPosition, const vec3 moonPosition)
 
 float visibleSolidAngleOfSun(const vec3 camera, const vec3 sunDir, const vec3 moonPos)
 {
-    const float Rs=sunAngularRadius;
-    const float Rm=moonAngularRadius(camera,moonPos);
+    CONST float Rs=sunAngularRadius;
+    CONST float Rm=moonAngularRadius(camera,moonPos);
     float visibleSolidAngle=PI*sqr(Rs);
 
-    const float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
+    CONST float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
     if(dSM<Rs+Rm)
     {
         visibleSolidAngle -= circlesIntersectionArea(Rm,Rs,dSM);
@@ -229,12 +240,12 @@ float sphereIntegrationSolidAngleDifferential(const int pointCountOnSphere)
 }
 vec3 sphereIntegrationSampleDir(const int index, const int pointCountOnSphere)
 {
-    const float goldenRatio=1.6180339887499;
+    CONST float goldenRatio=1.6180339887499;
     // The range of n is 0.5, 1.5, ..., pointCountOnSphere-0.5
-    const float n=index+0.5;
+    CONST float n=index+0.5;
     // Explanation of the Fibonacci grid generation can be seen at https://stackoverflow.com/a/44164075/673852
-    const float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
-    const float azimuth=n*(2*PI*goldenRatio);
+    CONST float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
+    CONST float azimuth=n*(2*PI*goldenRatio);
     return vec3(cos(azimuth)*sin(zenithAngle),
                 sin(azimuth)*sin(zenithAngle),
                 cos(zenithAngle));

--- a/atmosphere/default/shaders/single-scattering/on-the-fly/2/molecules/densities.frag
+++ b/atmosphere/default/shaders/single-scattering/on-the-fly/2/molecules/densities.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // densities.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,20 +45,20 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.35000004e-05,1.33100002e-05,9.4
 const vec4 wavelengths=vec4(610.666687,642,673.333313,704.666687);
 const int wlSetIndex=2;
 #endif
-#line 5 0 // densities.frag
+#line 4 0 // densities.frag
 float scattererNumberDensity_molecules(float altitude)
 {
-        const float rayleighScaleHeight=8*km;
+        CONST float rayleighScaleHeight=8*km;
         return 3.08458e25*exp(-1/rayleighScaleHeight * altitude);
 }
 float scattererNumberDensity_aerosols(float altitude)
 {
-        const float mieScaleHeight=1.2*km;
+        CONST float mieScaleHeight=1.2*km;
         return 1.03333e8*exp(-1/mieScaleHeight*altitude);
 }
 float absorberNumberDensity_ozone(float altitude)
 {
-        const float totalOzoneAmount=370*dobsonUnit;
+        CONST float totalOzoneAmount=370*dobsonUnit;
 
         float density;
 

--- a/atmosphere/default/shaders/single-scattering/on-the-fly/2/molecules/phase-functions.frag
+++ b/atmosphere/default/shaders/single-scattering/on-the-fly/2/molecules/phase-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // phase-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.35000004e-05,1.33100002e-05,9.4
 const vec4 wavelengths=vec4(610.666687,642,673.333313,704.666687);
 const int wlSetIndex=2;
 #endif
-#line 5 0 // phase-functions.frag
+#line 4 0 // phase-functions.frag
 
 vec4 phaseFunction_molecules(float dotViewSun)
 {
@@ -42,9 +53,9 @@ vec4 phaseFunction_molecules(float dotViewSun)
 }
 vec4 phaseFunction_aerosols(float dotViewSun)
 {
-        const float g=0.76;
-        const float g2=g*g;
-        const float k = 3/(8*PI)*(1-g2)/(2+g2);
+        CONST float g=0.76;
+        CONST float g2=g*g;
+        CONST float k = 3/(8*PI)*(1-g2)/(2+g2);
         return vec4(k * (1+sqr(dotViewSun)) / pow(1+g2 - 2*g*dotViewSun, 1.5) + 1/((1-dotViewSun)*600+0.05))*0.904;
 }
 vec4 currentPhaseFunction(float dotViewSun) { return phaseFunction_molecules(dotViewSun); }

--- a/atmosphere/default/shaders/single-scattering/on-the-fly/2/molecules/render.frag
+++ b/atmosphere/default/shaders/single-scattering/on-the-fly/2/molecules/render.frag
@@ -1,7 +1,21 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
 
-#line 1 1 // const.h.glsl
+
+
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 6 0 // render.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,11 +48,11 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.35000004e-05,1.33100002e-05,9.4
 const vec4 wavelengths=vec4(610.666687,642,673.333313,704.666687);
 const int wlSetIndex=2;
 #endif
-#line 5 0 // render.frag
-#line 1 2 // calc-view-dir.h.glsl
+#line 7 0 // render.frag
+#line 1 3 // calc-view-dir.h.glsl
 vec3 calcViewDir();
-#line 6 0 // render.frag
-#line 1 3 // common-functions.h.glsl
+#line 8 0 // render.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -70,13 +84,13 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // render.frag
-#line 1 4 // phase-functions.h.glsl
+#line 9 0 // render.frag
+#line 1 5 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 8 0 // render.frag
-#line 1 5 // single-scattering.h.glsl
+#line 10 0 // render.frag
+#line 1 6 // single-scattering.h.glsl
 #ifndef INCLUDE_ONCE_1DB2EDC1_C687_4FFA_BFF4_D18A54BA651B
 #define INCLUDE_ONCE_1DB2EDC1_C687_4FFA_BFF4_D18A54BA651B
 
@@ -84,9 +98,9 @@ vec4 computeSingleScattering(const float cosSunZenithAngle, const float cosViewZ
                              const float dotViewSun, const float altitude,
                              const bool viewRayIntersectsGround);
 #endif
-#line 9 0 // render.frag
+#line 11 0 // render.frag
 
-#line 1 6 // texture-coordinates.h.glsl
+#line 1 7 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -155,10 +169,10 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 11 0 // render.frag
-#line 1 7 // radiance-to-luminance.h.glsl
+#line 13 0 // render.frag
+#line 1 8 // radiance-to-luminance.h.glsl
 const mat4 radianceToLuminance=mat4(21296.1113,10585.7773,6.80903196,807.40564,  8819.19727,3416.5498,0.346691847,67.973465,  1511.18506,551.902527,0,6.17586422,  177.630722,64.1456985,0,0.693584085);
-#line 12 0 // render.frag
+#line 14 0 // render.frag
 
 
 
@@ -195,18 +209,18 @@ void main()
     // this approximation has the same order of magnitude as the assumption that the Earth and its atmosphere
     // are spherical.
     float altitude = max(cameraPosition.z, 0.);
-    const vec3 oldCamPos=cameraPosition;
+    CONST vec3 oldCamPos=cameraPosition;
     // Hide the uniform with this name, thus effectively modifying it for the following code
     vec3 cameraPosition=vec3(oldCamPos.xy, altitude);
 
     bool lookingIntoAtmosphere=true;
     if(altitude>atmosphereHeight)
     {
-        const vec3 p = cameraPosition - earthCenter;
-        const float p_dot_v = dot(p, viewDir);
-        const float p_dot_p = dot(p, p);
-        const float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
-        const float distanceToTOA = -p_dot_v - sqrt(sqr(earthRadius+atmosphereHeight) - squaredDistBetweenViewRayAndEarthCenter);
+        CONST vec3 p = cameraPosition - earthCenter;
+        CONST float p_dot_v = dot(p, viewDir);
+        CONST float p_dot_p = dot(p, p);
+        CONST float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
+        CONST float distanceToTOA = -p_dot_v - sqrt(sqr(earthRadius+atmosphereHeight) - squaredDistBetweenViewRayAndEarthCenter);
         if(distanceToTOA>=0)
         {
             cameraPosition += viewDir*distanceToTOA;
@@ -214,7 +228,7 @@ void main()
         }
         else
         {
-#if RENDERING_ANY_ZERO_SCATTERING
+#if 0 /*RENDERING_ANY_ZERO_SCATTERING*/
             lookingIntoAtmosphere=false;
 #else
             luminance=vec4(0);
@@ -224,16 +238,16 @@ void main()
         }
     }
 
-    const vec3 zenith=normalize(cameraPosition-earthCenter);
+    CONST vec3 zenith=normalize(cameraPosition-earthCenter);
     float cosViewZenithAngle=dot(zenith,viewDir);
 
     bool viewRayIntersectsGround=false;
     {
-        const vec3 p = cameraPosition - earthCenter;
-        const float p_dot_v = dot(p, viewDir);
-        const float p_dot_p = dot(p, p);
-        const float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
-        const float distanceToIntersection = -p_dot_v - sqrt(sqr(earthRadius) - squaredDistBetweenViewRayAndEarthCenter);
+        CONST vec3 p = cameraPosition - earthCenter;
+        CONST float p_dot_v = dot(p, viewDir);
+        CONST float p_dot_p = dot(p, p);
+        CONST float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
+        CONST float distanceToIntersection = -p_dot_v - sqrt(sqr(earthRadius) - squaredDistBetweenViewRayAndEarthCenter);
         // altitude==0 is a special case where distance to intersection calculation
         // is unreliable (has a lot of noise in its sign), so check it separately
         if(distanceToIntersection>0 || (altitude==0 && cosViewZenithAngle<0))
@@ -244,11 +258,11 @@ void main()
     // Aside from aesthetics, this affects brightness input to Stellarium's tone mapper.
     if(pseudoMirrorSkyBelowHorizon && viewRayIntersectsGround)
     {
-        const float horizonCZA = cosZenithAngleOfHorizon(altitude);
-        const float viewElev  = asin(clampCosine(cosViewZenithAngle));
-        const float horizElev = asin(clampCosine(horizonCZA));
-        const float newViewElev = 2*horizElev - viewElev;
-        const float viewDirXYnorm = length(viewDir-zenith*cosViewZenithAngle);
+        CONST float horizonCZA = cosZenithAngleOfHorizon(altitude);
+        CONST float viewElev  = asin(clampCosine(cosViewZenithAngle));
+        CONST float horizElev = asin(clampCosine(horizonCZA));
+        CONST float newViewElev = 2*horizElev - viewElev;
+        CONST float viewDirXYnorm = length(viewDir-zenith*cosViewZenithAngle);
         if(viewDirXYnorm == 0)
         {
             viewDir = zenith;
@@ -267,27 +281,27 @@ void main()
         viewRayIntersectsGround = false;
     }
 
-    const float cosSunZenithAngle =dot(zenith,sunDirection);
-    const float dotViewSun=dot(viewDir,sunDirection);
+    CONST float cosSunZenithAngle =dot(zenith,sunDirection);
+    CONST float dotViewSun=dot(viewDir,sunDirection);
 
-    const vec3 sunXYunnorm=sunDirection-dot(sunDirection,zenith)*zenith;
-    const vec3 viewXYunnorm=viewDir-dot(viewDir,zenith)*zenith;
-    const vec3 sunXY = sunXYunnorm.x!=0 || sunXYunnorm.y!=0 || sunXYunnorm.z!=0 ? normalize(sunXYunnorm) : vec3(0);
-    const vec3 viewXY = viewXYunnorm.x!=0 || viewXYunnorm.y!=0 || viewXYunnorm.z!=0 ? normalize(viewXYunnorm) : vec3(0);
-    const float azimuthRelativeToSun=safeAtan(dot(cross(sunXY, viewXY), zenith), dot(sunXY, viewXY));
+    CONST vec3 sunXYunnorm=sunDirection-dot(sunDirection,zenith)*zenith;
+    CONST vec3 viewXYunnorm=viewDir-dot(viewDir,zenith)*zenith;
+    CONST vec3 sunXY = sunXYunnorm.x!=0 || sunXYunnorm.y!=0 || sunXYunnorm.z!=0 ? normalize(sunXYunnorm) : vec3(0);
+    CONST vec3 viewXY = viewXYunnorm.x!=0 || viewXYunnorm.y!=0 || viewXYunnorm.z!=0 ? normalize(viewXYunnorm) : vec3(0);
+    CONST float azimuthRelativeToSun=safeAtan(dot(cross(sunXY, viewXY), zenith), dot(sunXY, viewXY));
 
-#if RENDERING_ZERO_SCATTERING
+#if 0 /*RENDERING_ZERO_SCATTERING*/
     vec4 radiance;
     if(viewRayIntersectsGround)
     {
         // XXX: keep in sync with the same code in computeScatteringDensity(), but don't forget about
         //      the difference in the usage of viewDir vs incDir.
-        const float distToGround = distanceToGround(cosViewZenithAngle, altitude);
-        const vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
-        const vec3 groundNormal = normalize(zenith*(earthRadius+altitude)+viewDir*distToGround);
-        const vec4 groundIrradiance = irradiance(dot(groundNormal, sunDirection), 0);
+        CONST float distToGround = distanceToGround(cosViewZenithAngle, altitude);
+        CONST vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
+        CONST vec3 groundNormal = normalize(zenith*(earthRadius+altitude)+viewDir*distToGround);
+        CONST vec4 groundIrradiance = irradiance(dot(groundNormal, sunDirection), 0);
         // Radiation scattered by the ground
-        const float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
+        CONST float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
         radiance = transmittanceToGround*groundAlbedo*groundIrradiance*solarIrradianceFixup*groundBRDF
                  + lightPollutionGroundLuminance*lightPollutionRelativeRadiance;
     }
@@ -304,22 +318,22 @@ void main()
     }
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_ZERO_SCATTERING
+#elif 0 /*RENDERING_ECLIPSED_ZERO_SCATTERING*/
     vec4 radiance;
-    const float dotViewMoon=dot(viewDir,normalize(moonPosition-cameraPosition));
+    CONST float dotViewMoon=dot(viewDir,normalize(moonPosition-cameraPosition));
     if(viewRayIntersectsGround)
     {
         // XXX: keep in sync with the similar code in non-eclipsed zero scattering rendering.
-        const float distToGround = distanceToGround(cosViewZenithAngle, altitude);
-        const vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
-        const vec3 pointOnGround = cameraPosition+viewDir*distToGround;
-        const vec4 directGroundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDirection, moonPosition);
+        CONST float distToGround = distanceToGround(cosViewZenithAngle, altitude);
+        CONST vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
+        CONST vec3 pointOnGround = cameraPosition+viewDir*distToGround;
+        CONST vec4 directGroundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDirection, moonPosition);
         // FIXME: add first-order indirect irradiance too: it's done in non-eclipsed irradiance (in the same
         // conditions: when limited to 2 orders). This should be calculated at the same time when second order
         // is: all the infrastructure is already there.
-        const vec4 groundIrradiance = directGroundIrradiance;
+        CONST vec4 groundIrradiance = directGroundIrradiance;
         // Radiation scattered by the ground
-        const float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
+        CONST float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
         radiance = transmittanceToGround*groundAlbedo*groundIrradiance*solarIrradianceFixup*groundBRDF
                  + lightPollutionGroundLuminance*lightPollutionRelativeRadiance;
     }
@@ -336,53 +350,53 @@ void main()
     }
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_ON_THE_FLY
-    const vec4 scattering=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPosition,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_ON_THE_FLY*/
+    CONST vec4 scattering=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPosition,
                                                           viewRayIntersectsGround);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE
-    const vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE*/
+    CONST vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                      viewRayIntersectsGround, eclipsedSingleScatteringTextureSize);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact at the point where azimuth texture coordinate changes from 1 to 0 (at azimuthRelativeToSun crossing
     // 0). This happens when I simply call texture(eclipsedScatteringTexture, texCoords) without specifying LOD.
     // Apparently, the driver uses the derivative for some reason, even though it shouldn't.
-    const vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
+    CONST vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE
-    const vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
+    CONST vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                      viewRayIntersectsGround, eclipsedSingleScatteringTextureSize);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact at the point where azimuth texture coordinate changes from 1 to 0 (at azimuthRelativeToSun crossing
     // 0). This happens when I simply call texture(eclipsedScatteringTexture, texCoords) without specifying LOD.
     // Apparently, the driver uses the derivative for some reason, even though it shouldn't.
-    const vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
+    CONST vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
     luminance=scattering*currentPhaseFunction(dotViewSun);
-#elif RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_RADIANCE
+#elif 0 /*RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_RADIANCE*/
     vec4 radiance=exp(sampleEclipseDoubleScattering3DTexture(eclipsedDoubleScatteringTexture,
                                                              cosSunZenithAngle, cosViewZenithAngle, azimuthRelativeToSun,
                                                              altitude, viewRayIntersectsGround));
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_LUMINANCE
+#elif 0 /*RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
     luminance=exp(sampleEclipseDoubleScattering3DTexture(eclipsedDoubleScatteringTexture,
                                                          cosSunZenithAngle, cosViewZenithAngle, azimuthRelativeToSun,
                                                          altitude, viewRayIntersectsGround));
 #elif 1 /*RENDERING_SINGLE_SCATTERING_ON_THE_FLY*/
-    const vec4 scattering=computeSingleScattering(cosSunZenithAngle,cosViewZenithAngle,dotViewSun,
+    CONST vec4 scattering=computeSingleScattering(cosSunZenithAngle,cosViewZenithAngle,dotViewSun,
                                                   altitude,viewRayIntersectsGround);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE
+#elif 0 /*RENDERING_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE*/
     vec4 scattering;
     if(useInterpolationGuides)
     {
@@ -399,7 +413,7 @@ void main()
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE
+#elif 0 /*RENDERING_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
     vec4 scattering;
     if(useInterpolationGuides)
     {
@@ -413,18 +427,18 @@ void main()
                                      dotViewSun, altitude, viewRayIntersectsGround);
     }
     luminance=scattering * (bool(1) ? vec4(1) : currentPhaseFunction(dotViewSun));
-#elif RENDERING_MULTIPLE_SCATTERING_LUMINANCE
+#elif 0 /*RENDERING_MULTIPLE_SCATTERING_LUMINANCE*/
     luminance=sample3DTexture(scatteringTexture, cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, viewRayIntersectsGround);
-#elif RENDERING_MULTIPLE_SCATTERING_RADIANCE
+#elif 0 /*RENDERING_MULTIPLE_SCATTERING_RADIANCE*/
     vec4 radiance=sample3DTexture(scatteringTexture, cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, viewRayIntersectsGround);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_LIGHT_POLLUTION_RADIANCE
+#elif 0 /*RENDERING_LIGHT_POLLUTION_RADIANCE*/
     vec4 radiance=lightPollutionGroundLuminance*lightPollutionScattering(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_LIGHT_POLLUTION_LUMINANCE
+#elif 0 /*RENDERING_LIGHT_POLLUTION_LUMINANCE*/
     luminance=lightPollutionGroundLuminance*lightPollutionScattering(altitude, cosViewZenithAngle, viewRayIntersectsGround);
 #else
 #error What to render?

--- a/atmosphere/default/shaders/single-scattering/on-the-fly/2/molecules/single-scattering.frag
+++ b/atmosphere/default/shaders/single-scattering/on-the-fly/2/molecules/single-scattering.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // single-scattering.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,15 +45,15 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.35000004e-05,1.33100002e-05,9.4
 const vec4 wavelengths=vec4(610.666687,642,673.333313,704.666687);
 const int wlSetIndex=2;
 #endif
-#line 5 0 // single-scattering.frag
-#line 1 2 // densities.h.glsl
+#line 4 0 // single-scattering.frag
+#line 1 3 // densities.h.glsl
 float scattererNumberDensity_molecules(float altitude);
 float scattererNumberDensity_aerosols(float altitude);
 float absorberNumberDensity_ozone(float altitude);
 vec4 scatteringCrossSection();
 float scattererDensity(float altitude);
-#line 6 0 // single-scattering.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // single-scattering.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -74,8 +85,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // single-scattering.frag
-#line 1 4 // single-scattering.h.glsl
+#line 6 0 // single-scattering.frag
+#line 1 5 // single-scattering.h.glsl
 #ifndef INCLUDE_ONCE_1DB2EDC1_C687_4FFA_BFF4_D18A54BA651B
 #define INCLUDE_ONCE_1DB2EDC1_C687_4FFA_BFF4_D18A54BA651B
 
@@ -83,8 +94,8 @@ vec4 computeSingleScattering(const float cosSunZenithAngle, const float cosViewZ
                              const float dotViewSun, const float altitude,
                              const bool viewRayIntersectsGround);
 #endif
-#line 8 0 // single-scattering.frag
-#line 1 5 // texture-sampling-functions.h.glsl
+#line 7 0 // single-scattering.frag
+#line 1 6 // texture-sampling-functions.h.glsl
 #ifndef INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 #define INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float altitude);
@@ -96,20 +107,20 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                 const int scatteringOrder);
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 #endif
-#line 9 0 // single-scattering.frag
+#line 8 0 // single-scattering.frag
 
 // This function omits phase function and solar irradiance: these are to be applied somewhere in the calling code.
 vec4 computeSingleScatteringIntegrand(const float cosSunZenithAngle, const float cosViewZenithAngle,
                                       const float dotViewSun, const float altitude,
                                       const float dist, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle here the case when the
     // endpoint of the view ray intentionally appears in outer space.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosSunZenithAngleAtDist=clampCosine((r*cosSunZenithAngle+dist*dotViewSun)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosSunZenithAngleAtDist=clampCosine((r*cosSunZenithAngle+dist*dotViewSun)/(earthRadius+altAtDist));
 
-    const vec4 xmittance=transmittance(cosViewZenithAngle, altitude, dist, viewRayIntersectsGround)
+    CONST vec4 xmittance=transmittance(cosViewZenithAngle, altitude, dist, viewRayIntersectsGround)
                                                     *
                          transmittanceToAtmosphereBorder(cosSunZenithAngleAtDist, altAtDist)
                                                     *
@@ -121,14 +132,14 @@ vec4 computeSingleScattering(const float cosSunZenithAngle, const float cosViewZ
                              const float dotViewSun, const float altitude,
                              const bool viewRayIntersectsGround)
 {
-    const float integrInterval=distanceToNearestAtmosphereBoundary(cosViewZenithAngle, altitude,
+    CONST float integrInterval=distanceToNearestAtmosphereBoundary(cosViewZenithAngle, altitude,
                                                                    viewRayIntersectsGround);
     // Using the midpoint rule for quadrature
     vec4 spectrum=vec4(0);
-    const float dl=integrInterval/radialIntegrationPoints;
+    CONST float dl=integrInterval/radialIntegrationPoints;
     for(int n=0; n<radialIntegrationPoints; ++n)
     {
-        const float dist=(n+0.5)*dl;
+        CONST float dist=(n+0.5)*dl;
         spectrum += computeSingleScatteringIntegrand(cosSunZenithAngle, cosViewZenithAngle, dotViewSun,
                                                      altitude, dist, viewRayIntersectsGround);
     }

--- a/atmosphere/default/shaders/single-scattering/on-the-fly/2/molecules/texture-coordinates.frag
+++ b/atmosphere/default/shaders/single-scattering/on-the-fly/2/molecules/texture-coordinates.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-coordinates.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,8 +45,8 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.35000004e-05,1.33100002e-05,9.4
 const vec4 wavelengths=vec4(610.666687,642,673.333313,704.666687);
 const int wlSetIndex=2;
 #endif
-#line 5 0 // texture-coordinates.frag
-#line 1 2 // texture-coordinates.h.glsl
+#line 4 0 // texture-coordinates.frag
+#line 1 3 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -104,8 +115,8 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 6 0 // texture-coordinates.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-coordinates.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -137,7 +148,7 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-coordinates.frag
+#line 6 0 // texture-coordinates.frag
 
 const float LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA=sqrt(atmosphereHeight*(atmosphereHeight+2*earthRadius));
 
@@ -205,18 +216,18 @@ vec3 indicesToTexCoords(const vec3 indices, const vec3 texSizes)
 
 TransmittanceTexVars transmittanceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
+    CONST float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
                                 texCoordToUnitRange(texCoord.t,transmittanceTextureSize.t);
     // Distance from Earth center to camera
-    const float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
-    const float altitude=r-earthRadius;
+    CONST float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
+    CONST float altitude=r-earthRadius;
 
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
     // distance to border of visible atmosphere from the view point
-    const float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
+    CONST float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
     // d==0 can happen when altitude==atmosphereHeight
-    const float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
+    CONST float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
     return TransmittanceTexVars(cosVZA,altitude);
 }
 
@@ -235,53 +246,53 @@ vec2 transmittanceTexVarsToTexCoord(const float cosVZA, float altitude)
     if(altitude<0)
         altitude=0;
 
-    const float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
+    CONST float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
                                       transmittanceTextureSize.t);
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
-    const float d=distanceToAtmosphereBorder(cosVZA,altitude);
-    const float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float d=distanceToAtmosphereBorder(cosVZA,altitude);
+    CONST float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
     return vec2(s,t);
 }
 
 // Output: vec2(cos(sunZenithAngle), altitude)
 IrradianceTexVars irradianceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
-    const float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
+    CONST float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
+    CONST float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
     return IrradianceTexVars(cosSZA,alt);
 }
 
 vec2 irradianceTexVarsToTexCoord(const float cosSunZenithAngle, const float altitude)
 {
-    const float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
-    const float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
+    CONST float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
+    CONST float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
     return vec2(s,t);
 }
 
 float cosSZAToUnitRangeTexCoord(const float cosSunZenithAngle)
 {
     // Distance to top atmosphere border along the ray groundUnderCamera-sun: (altitude, cosSunZenithAngle)
-    const float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name
-    const float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
+    CONST float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
     // TODO: choose a more descriptive name
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     return max(0.,1-a/A)/(a+1);
 }
 
 float unitRangeTexCoordToCosSZA(const float texCoord)
 {
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float a=(A-A*texCoord)/(1+A*texCoord);
-    const float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
+    CONST float a=(A-A*texCoord)/(1+A*texCoord);
+    CONST float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
     return distFromGroundToTopAtmoBorder==0 ? 1 :
         clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distFromGroundToTopAtmoBorder)) /
                     (2*earthRadius*distFromGroundToTopAtmoBorder));
@@ -292,24 +303,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
                                                const float dotViewSun, const float altitude,
                                                const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -317,24 +328,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float dotVSCoord=(dotViewSun+1)/2;
+    CONST float dotVSCoord=(dotViewSun+1)/2;
 
     // ------------------------------------
-    const float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
+    CONST float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
 
     return Scattering4DCoords(cosSZACoord, cosVZACoord, dotVSCoord, altCoord, viewRayIntersectsGround);
 }
 
 TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
@@ -342,16 +353,16 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture coordinates we combine into a single sampler3D coordinate.
-    const float texW = scatteringTextureSize[1];
-    const float texH = scatteringTextureSize[2];
-    const float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
-    const vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
+    CONST float texW = scatteringTextureSize[1];
+    CONST float texH = scatteringTextureSize[2];
+    CONST float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
+    CONST vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
                                         ceil (cosSZAIndex)*texW+coords.dotViewSun*(texW-1)) / (texW*texH-1);
-    const vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
+    CONST vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
 
-    const float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
+    CONST float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
 
-    const float alphaUpper=fract(cosSZAIndex);
+    CONST float alphaUpper=fract(cosSZAIndex);
     return TexCoordPair(vec3(cosVZAtc, combinedCoord.x, altitude), float(1-alphaUpper),
                         vec3(cosVZAtc, combinedCoord.y, altitude), float(alphaUpper));
 }
@@ -359,9 +370,9 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
+    CONST TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
     return texture(tex, texCoords.lower) * texCoords.alphaLower +
            texture(tex, texCoords.upper) * texCoords.alphaUpper;
 }
@@ -369,17 +380,17 @@ vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const f
 // 3D texture is the 3D single-altitude slice of a 4D texture
 vec3 scattering4DCoordsToTex3DCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2);
 
-    const float dvsSize = scatteringTextureSize[1];
-    const float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
+    CONST float dvsSize = scatteringTextureSize[1];
+    CONST float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
 
-    const float cszaSize = scatteringTextureSize[2];
-    const float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
+    CONST float cszaSize = scatteringTextureSize[2];
+    CONST float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
 
     return vec3(cosVZAtc, dotVStc, cosSZAtc);
 }
@@ -394,39 +405,39 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along dotViewSun coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[1];
-    const float posOfRow = indices[1];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[1];
+    CONST float posOfRow = indices[1];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         indexToTexCoord(currRow, numRows-1),
                                                         texCoordVerbatim));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               indexToTexCoord(currRow, numRows-1),
                                                               texCoordVerbatim));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          indexToTexCoord(currRow, numRows-1),
                                          texCoordVerbatim));
@@ -434,14 +445,14 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
 vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolationGuides01Tex,
                                  const vec3 indices)
 {
-    const float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
+    CONST float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
 
-    const float cosVZAIndex = indices[0];
-    const float dotVSIndex = indices[1];
-    const float currRow = floor(dotVSIndex);
-    const float posBetweenRows = dotVSIndex - currRow;
-    const float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cosVZAIndex = indices[0];
+    CONST float dotVSIndex = indices[1];
+    CONST float currRow = floor(dotVSIndex);
+    CONST float posBetweenRows = dotVSIndex - currRow;
+    CONST float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -449,14 +460,14 @@ vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolat
     indicesCurrRow[1] =     currRow;
     indicesNextRow[1] = min(currRow+1, scatteringTextureSize[1]-1.);
 
-    const vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
-    const vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
+    CONST vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
+    CONST vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
 
-    const vec4 valueCurrRow = texture(tex, coordsCurrRow);
-    const vec4 valueNextRow = texture(tex, coordsNextRow);
-    const float epsilon = 1e-37; // Prevents passing zero to log
-    const vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
-    const vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
+    CONST vec4 valueCurrRow = texture(tex, coordsCurrRow);
+    CONST vec4 valueNextRow = texture(tex, coordsNextRow);
+    CONST float epsilon = 1e-37; // Prevents passing zero to log
+    CONST vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
+    CONST vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
     return (logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow;
 }
 
@@ -465,37 +476,37 @@ float findGuide02Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along SZA coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[2];
-    const float posOfRow = indices[2];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[2];
+    CONST float posOfRow = indices[2];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
 }
@@ -505,19 +516,19 @@ vec4 sample3DTextureGuided(const sampler3D tex,
                            const float cosSunZenithAngle, const float cosViewZenithAngle,
                            const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
                                                                     dotViewSun, altitude, viewRayIntersectsGround);
     // Handle the external interpolation guides: the guides between a pair of VZA-dotViewSun 2D "pictures".
-    const vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
-    const vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
-    const float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
+    CONST vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
+    CONST float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
 
-    const float cvzaIndex = indices[0];
-    const float cszaIndex = indices[2];
-    const float currRow = floor(cszaIndex);
-    const float posBetweenRows = cszaIndex - currRow;
-    const float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cvzaIndex = indices[0];
+    CONST float cszaIndex = indices[2];
+    CONST float currRow = floor(cszaIndex);
+    CONST float posBetweenRows = cszaIndex - currRow;
+    CONST float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -526,58 +537,58 @@ vec4 sample3DTextureGuided(const sampler3D tex,
     indicesNextRow[2] = min(currRow+1, scatteringTextureSize[2]-1);
 
     // The caller will handle the internal interpolation guides: the ones between rows in each 2D "picture".
-    const vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
-    const vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
+    CONST vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
+    CONST vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
     return exp((logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow);
 }
 
 vec4 sample3DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
     return texture(tex, texCoords);
 }
 
 ScatteringTexVars scatteringTex4DCoordsToTexVars(const Scattering4DCoords coords)
 {
-    const float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
     // ------------------------------------
     float cosViewZenithAngle;
     if(coords.viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
     // ------------------------------------
-    const float dotViewSun=coords.dotViewSun*2-1;
+    CONST float dotViewSun=coords.dotViewSun*2-1;
 
     // ------------------------------------
-    const float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
+    CONST float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
 
     return ScatteringTexVars(cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, coords.viewRayIntersectsGround);
 }
 
 Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 {
-    const vec4 indexMax=scatteringTextureSize-vec4(1);
+    CONST vec4 indexMax=scatteringTextureSize-vec4(1);
     Scattering4DCoords coords4d;
     coords4d.viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
     // The following formulas assume that scatteringTextureSize[0] is even. For odd sizes they would change.
@@ -593,8 +604,8 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture indices we combine into a single sampler3D coordinate.
-    const float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
-    const float combinedIndex=texIndices[1];
+    CONST float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
+    CONST float combinedIndex=texIndices[1];
     coords4d.dotViewSun=mod(combinedIndex,texW)/(texW-1);
     coords4d.cosSunZenithAngle=floor(combinedIndex/texW)/(texH-1);
 
@@ -608,11 +619,11 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
 ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 {
-    const Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
+    CONST Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
     ScatteringTexVars vars=scatteringTex4DCoordsToTexVars(coords4d);
     // Clamp dotViewSun to its valid range of values, given cosViewZenithAngle and cosSunZenithAngle. This is
     // needed to prevent NaNs when computing the scattering texture.
-    const float cosVZA=vars.cosViewZenithAngle,
+    CONST float cosVZA=vars.cosViewZenithAngle,
                 cosSZA=vars.cosSunZenithAngle;
     vars.dotViewSun=clamp(vars.dotViewSun,
                           cosVZA*cosSZA-safeSqrt((1-sqr(cosVZA))*(1-sqr(cosSZA))),
@@ -622,54 +633,54 @@ ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 
 EclipseScatteringTexVars eclipseTexCoordsToTexVars(const vec2 texCoords, const float altitude)
 {
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
-    const bool viewRayIntersectsGround = texCoords.t<0.5;
+    CONST bool viewRayIntersectsGround = texCoords.t<0.5;
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
-    const float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
+    CONST float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
     return EclipseScatteringTexVars(azimuthRelativeToSun, cosViewZenithAngle, viewRayIntersectsGround);
 }
 
 EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                                    const float altitude, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -677,13 +688,13 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
-    const float azimuthCoord = azimuthRelativeToSun/(2*PI);
+    CONST float azimuthCoord = azimuthRelativeToSun/(2*PI);
 
     return EclipseScattering2DCoords(azimuthCoord, cosVZACoord);
 }
@@ -691,14 +702,14 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
 vec2 eclipseTexVarsToTexCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                const float altitude, const bool viewRayIntersectsGround, const vec2 texSize)
 {
-    const EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+    CONST EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                                     viewRayIntersectsGround);
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2);
-    const float azimuthTC = coords.azimuth + 1/(2*texSize.s);
+    CONST float azimuthTC = coords.azimuth + 1/(2*texSize.s);
 
     return vec2(azimuthTC, cosVZAtc);
 }
@@ -707,42 +718,42 @@ vec4 sampleEclipseDoubleScattering3DTexture(const sampler3D tex, const float cos
                                             const float cosViewZenithAngle, const float azimuthRelativeToSun,
                                             const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
+    CONST vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
                                                   eclipsedDoubleScatteringTextureSize.st);
-    const float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
-    const vec3 texCoords=vec3(coords2d, cosSZACoord);
+    CONST float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
+    CONST vec3 texCoords=vec3(coords2d, cosSZACoord);
 
     return texture(tex, texCoords);
 }
 
 LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 texIndices)
 {
-    const vec2 indexMax=lightPollutionTextureSize-vec2(1);
+    CONST vec2 indexMax=lightPollutionTextureSize-vec2(1);
 
-    const float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
-    const float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
+    CONST float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
-    const bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
-    const float cosViewZenithAngleCoord = viewRayIntersectsGround ?
+    CONST bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
+    CONST float cosViewZenithAngleCoord = viewRayIntersectsGround ?
                                    1-2*texIndices[0]/(indexMax[0]-1) :
                                    2*(texIndices[0]-1)/(indexMax[0]-1)-1;
     // ------------------------------------
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
@@ -753,23 +764,23 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 
 LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -777,27 +788,27 @@ LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, con
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     return LightPollution2DCoords(cosVZACoord, altCoord);
 }
 
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
-    const vec2 texSize = lightPollutionTextureSize;
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 texSize = lightPollutionTextureSize;
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2);
-    const float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
+    CONST float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
     return vec2(cosVZAtc, altitudeTC);
 }

--- a/atmosphere/default/shaders/single-scattering/on-the-fly/2/molecules/texture-sampling-functions.frag
+++ b/atmosphere/default/shaders/single-scattering/on-the-fly/2/molecules/texture-sampling-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-sampling-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,13 +45,13 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.35000004e-05,1.33100002e-05,9.4
 const vec4 wavelengths=vec4(610.666687,642,673.333313,704.666687);
 const int wlSetIndex=2;
 #endif
-#line 5 0 // texture-sampling-functions.frag
-#line 1 2 // phase-functions.h.glsl
+#line 4 0 // texture-sampling-functions.frag
+#line 1 3 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 6 0 // texture-sampling-functions.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-sampling-functions.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -72,8 +83,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-sampling-functions.frag
-#line 1 4 // texture-coordinates.h.glsl
+#line 6 0 // texture-sampling-functions.frag
+#line 1 5 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -142,7 +153,7 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 8 0 // texture-sampling-functions.frag
+#line 7 0 // texture-sampling-functions.frag
 
 uniform sampler2D transmittanceTexture;
 uniform sampler2D irradianceTexture;
@@ -154,13 +165,13 @@ uniform sampler2D lightPollutionScatteringTexture;
 
 vec4 irradiance(const float cosSunZenithAngle, const float altitude)
 {
-    const vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
+    CONST vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
     return texture(irradianceTexture, texCoords);
 }
 
 vec4 opticalDepthToAtmosphereBorder(const float cosViewZenithAngle, const float altitude)
 {
-    const vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
+    CONST vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact when looking into nadir from TOA at some values of texture sizes (in particular, size of
     // transmittance texture for altitude being 4096). This happens when I simply call texture(eclipsedScatteringTexture,
@@ -178,11 +189,11 @@ vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float
 vec4 transmittance(const float cosViewZenithAngle, const float altitude, const float dist,
                    const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle view ray endpoint
     // in space here.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
 
     vec4 depth;
     if(viewRayIntersectsGround)
@@ -201,7 +212,7 @@ vec4 transmittance(const float cosViewZenithAngle, const float altitude, const f
 vec4 calcFirstScattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                          const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
+    CONST vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
                                           dotViewSun, altitude, viewRayIntersectsGround);
     return scattering*currentPhaseFunction(dotViewSun);
 }
@@ -220,6 +231,6 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
 
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     return texture(lightPollutionScatteringTexture, coords);
 }

--- a/atmosphere/default/shaders/single-scattering/on-the-fly/3/aerosols/common-functions.frag
+++ b/atmosphere/default/shaders/single-scattering/on-the-fly/3/aerosols/common-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // common-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // common-functions.frag
+#line 4 0 // common-functions.frag
 
 bool dbgDataPresent=false;
 bool debugDataPresent()
@@ -69,7 +80,7 @@ void setDebugData(float a,float b, float c, float d)
 
 void swap(inout float x, inout float y)
 {
-    const float t = x;
+    CONST float t = x;
     x = y;
     y = t;
 }
@@ -83,7 +94,7 @@ float safeSqrt(const float x)
 
 float safeAtan(const float y, const float x)
 {
-    const float a = atan(y,x);
+    CONST float a = atan(y,x);
     return x==0 && y==0 ? 0 : a;
 }
 
@@ -116,23 +127,23 @@ float pointAltitude(vec3 point)
 
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float Ratm=earthRadius+atmosphereHeight;
-    const float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float Ratm=earthRadius+atmosphereHeight;
+    CONST float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float distanceToGround(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(-safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float cosZenithAngleOfHorizon(const float altitude)
 {
-    const float R=earthRadius;
-    const float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
+    CONST float R=earthRadius;
+    CONST float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
     return -sqrt(2*h*R+sqr(h))/(R+h);
 }
 
@@ -151,8 +162,8 @@ float distanceToNearestAtmosphereBoundary(const float cosZenithAngle, const floa
 float sunVisibility(const float cosSunZenithAngle, float altitude)
 {
     if(altitude<0) altitude=0;
-    const float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
-    const float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
+    CONST float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
+    CONST float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
     /* Approximating visible fraction of solar disk by smoothstep between the position of the Sun
      * touching the horizon by its upper part and the position with lower part touching the horizon.
      * The calculation assumes that solar angular radius is small and thus approximately equals its sine.
@@ -182,13 +193,13 @@ float circlesIntersectionArea(float R1, float R2, float d)
 
 float angleBetween(const vec3 a, const vec3 b)
 {
-    const float d=dot(a,b);
-    const float c=length(cross(a,b));
+    CONST float d=dot(a,b);
+    CONST float c=length(cross(a,b));
     // To avoid loss of precision, don't use dot product near the singularity
     // of acos, and cross product near the singularity of asin
     if(abs(d) < abs(c))
         return acos(d/(length(a)*length(b)));
-    const float smallerAngle = asin(c/(length(a)*length(b)));
+    CONST float smallerAngle = asin(c/(length(a)*length(b)));
     if(d<0) return PI-smallerAngle;
     return smallerAngle;
 }
@@ -205,11 +216,11 @@ float moonAngularRadius(const vec3 cameraPosition, const vec3 moonPosition)
 
 float visibleSolidAngleOfSun(const vec3 camera, const vec3 sunDir, const vec3 moonPos)
 {
-    const float Rs=sunAngularRadius;
-    const float Rm=moonAngularRadius(camera,moonPos);
+    CONST float Rs=sunAngularRadius;
+    CONST float Rm=moonAngularRadius(camera,moonPos);
     float visibleSolidAngle=PI*sqr(Rs);
 
-    const float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
+    CONST float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
     if(dSM<Rs+Rm)
     {
         visibleSolidAngle -= circlesIntersectionArea(Rm,Rs,dSM);
@@ -229,12 +240,12 @@ float sphereIntegrationSolidAngleDifferential(const int pointCountOnSphere)
 }
 vec3 sphereIntegrationSampleDir(const int index, const int pointCountOnSphere)
 {
-    const float goldenRatio=1.6180339887499;
+    CONST float goldenRatio=1.6180339887499;
     // The range of n is 0.5, 1.5, ..., pointCountOnSphere-0.5
-    const float n=index+0.5;
+    CONST float n=index+0.5;
     // Explanation of the Fibonacci grid generation can be seen at https://stackoverflow.com/a/44164075/673852
-    const float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
-    const float azimuth=n*(2*PI*goldenRatio);
+    CONST float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
+    CONST float azimuth=n*(2*PI*goldenRatio);
     return vec3(cos(azimuth)*sin(zenithAngle),
                 sin(azimuth)*sin(zenithAngle),
                 cos(zenithAngle));

--- a/atmosphere/default/shaders/single-scattering/on-the-fly/3/aerosols/densities.frag
+++ b/atmosphere/default/shaders/single-scattering/on-the-fly/3/aerosols/densities.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // densities.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,20 +45,20 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // densities.frag
+#line 4 0 // densities.frag
 float scattererNumberDensity_molecules(float altitude)
 {
-        const float rayleighScaleHeight=8*km;
+        CONST float rayleighScaleHeight=8*km;
         return 3.08458e25*exp(-1/rayleighScaleHeight * altitude);
 }
 float scattererNumberDensity_aerosols(float altitude)
 {
-        const float mieScaleHeight=1.2*km;
+        CONST float mieScaleHeight=1.2*km;
         return 1.03333e8*exp(-1/mieScaleHeight*altitude);
 }
 float absorberNumberDensity_ozone(float altitude)
 {
-        const float totalOzoneAmount=370*dobsonUnit;
+        CONST float totalOzoneAmount=370*dobsonUnit;
 
         float density;
 

--- a/atmosphere/default/shaders/single-scattering/on-the-fly/3/aerosols/phase-functions.frag
+++ b/atmosphere/default/shaders/single-scattering/on-the-fly/3/aerosols/phase-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // phase-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // phase-functions.frag
+#line 4 0 // phase-functions.frag
 
 vec4 phaseFunction_molecules(float dotViewSun)
 {
@@ -42,9 +53,9 @@ vec4 phaseFunction_molecules(float dotViewSun)
 }
 vec4 phaseFunction_aerosols(float dotViewSun)
 {
-        const float g=0.76;
-        const float g2=g*g;
-        const float k = 3/(8*PI)*(1-g2)/(2+g2);
+        CONST float g=0.76;
+        CONST float g2=g*g;
+        CONST float k = 3/(8*PI)*(1-g2)/(2+g2);
         return vec4(k * (1+sqr(dotViewSun)) / pow(1+g2 - 2*g*dotViewSun, 1.5) + 1/((1-dotViewSun)*600+0.05))*0.904;
 }
 vec4 currentPhaseFunction(float dotViewSun) { return phaseFunction_aerosols(dotViewSun); }

--- a/atmosphere/default/shaders/single-scattering/on-the-fly/3/aerosols/render.frag
+++ b/atmosphere/default/shaders/single-scattering/on-the-fly/3/aerosols/render.frag
@@ -1,7 +1,21 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
 
-#line 1 1 // const.h.glsl
+
+
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 6 0 // render.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,11 +48,11 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // render.frag
-#line 1 2 // calc-view-dir.h.glsl
+#line 7 0 // render.frag
+#line 1 3 // calc-view-dir.h.glsl
 vec3 calcViewDir();
-#line 6 0 // render.frag
-#line 1 3 // common-functions.h.glsl
+#line 8 0 // render.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -70,13 +84,13 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // render.frag
-#line 1 4 // phase-functions.h.glsl
+#line 9 0 // render.frag
+#line 1 5 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 8 0 // render.frag
-#line 1 5 // single-scattering.h.glsl
+#line 10 0 // render.frag
+#line 1 6 // single-scattering.h.glsl
 #ifndef INCLUDE_ONCE_1DB2EDC1_C687_4FFA_BFF4_D18A54BA651B
 #define INCLUDE_ONCE_1DB2EDC1_C687_4FFA_BFF4_D18A54BA651B
 
@@ -84,9 +98,9 @@ vec4 computeSingleScattering(const float cosSunZenithAngle, const float cosViewZ
                              const float dotViewSun, const float altitude,
                              const bool viewRayIntersectsGround);
 #endif
-#line 9 0 // render.frag
+#line 11 0 // render.frag
 
-#line 1 6 // texture-coordinates.h.glsl
+#line 1 7 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -155,10 +169,10 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 11 0 // render.frag
-#line 1 7 // radiance-to-luminance.h.glsl
+#line 13 0 // render.frag
+#line 1 8 // radiance-to-luminance.h.glsl
 const mat4 radianceToLuminance=mat4(19.8756237,7.17745161,0,0.0937032327,  2.13895917,0.772417068,0,0.0149318045,  0.241072536,0.0870557055,0,0,  0.0133876652,0.00483453181,0,0);
-#line 12 0 // render.frag
+#line 14 0 // render.frag
 
 
 
@@ -195,18 +209,18 @@ void main()
     // this approximation has the same order of magnitude as the assumption that the Earth and its atmosphere
     // are spherical.
     float altitude = max(cameraPosition.z, 0.);
-    const vec3 oldCamPos=cameraPosition;
+    CONST vec3 oldCamPos=cameraPosition;
     // Hide the uniform with this name, thus effectively modifying it for the following code
     vec3 cameraPosition=vec3(oldCamPos.xy, altitude);
 
     bool lookingIntoAtmosphere=true;
     if(altitude>atmosphereHeight)
     {
-        const vec3 p = cameraPosition - earthCenter;
-        const float p_dot_v = dot(p, viewDir);
-        const float p_dot_p = dot(p, p);
-        const float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
-        const float distanceToTOA = -p_dot_v - sqrt(sqr(earthRadius+atmosphereHeight) - squaredDistBetweenViewRayAndEarthCenter);
+        CONST vec3 p = cameraPosition - earthCenter;
+        CONST float p_dot_v = dot(p, viewDir);
+        CONST float p_dot_p = dot(p, p);
+        CONST float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
+        CONST float distanceToTOA = -p_dot_v - sqrt(sqr(earthRadius+atmosphereHeight) - squaredDistBetweenViewRayAndEarthCenter);
         if(distanceToTOA>=0)
         {
             cameraPosition += viewDir*distanceToTOA;
@@ -214,7 +228,7 @@ void main()
         }
         else
         {
-#if RENDERING_ANY_ZERO_SCATTERING
+#if 0 /*RENDERING_ANY_ZERO_SCATTERING*/
             lookingIntoAtmosphere=false;
 #else
             luminance=vec4(0);
@@ -224,16 +238,16 @@ void main()
         }
     }
 
-    const vec3 zenith=normalize(cameraPosition-earthCenter);
+    CONST vec3 zenith=normalize(cameraPosition-earthCenter);
     float cosViewZenithAngle=dot(zenith,viewDir);
 
     bool viewRayIntersectsGround=false;
     {
-        const vec3 p = cameraPosition - earthCenter;
-        const float p_dot_v = dot(p, viewDir);
-        const float p_dot_p = dot(p, p);
-        const float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
-        const float distanceToIntersection = -p_dot_v - sqrt(sqr(earthRadius) - squaredDistBetweenViewRayAndEarthCenter);
+        CONST vec3 p = cameraPosition - earthCenter;
+        CONST float p_dot_v = dot(p, viewDir);
+        CONST float p_dot_p = dot(p, p);
+        CONST float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
+        CONST float distanceToIntersection = -p_dot_v - sqrt(sqr(earthRadius) - squaredDistBetweenViewRayAndEarthCenter);
         // altitude==0 is a special case where distance to intersection calculation
         // is unreliable (has a lot of noise in its sign), so check it separately
         if(distanceToIntersection>0 || (altitude==0 && cosViewZenithAngle<0))
@@ -244,11 +258,11 @@ void main()
     // Aside from aesthetics, this affects brightness input to Stellarium's tone mapper.
     if(pseudoMirrorSkyBelowHorizon && viewRayIntersectsGround)
     {
-        const float horizonCZA = cosZenithAngleOfHorizon(altitude);
-        const float viewElev  = asin(clampCosine(cosViewZenithAngle));
-        const float horizElev = asin(clampCosine(horizonCZA));
-        const float newViewElev = 2*horizElev - viewElev;
-        const float viewDirXYnorm = length(viewDir-zenith*cosViewZenithAngle);
+        CONST float horizonCZA = cosZenithAngleOfHorizon(altitude);
+        CONST float viewElev  = asin(clampCosine(cosViewZenithAngle));
+        CONST float horizElev = asin(clampCosine(horizonCZA));
+        CONST float newViewElev = 2*horizElev - viewElev;
+        CONST float viewDirXYnorm = length(viewDir-zenith*cosViewZenithAngle);
         if(viewDirXYnorm == 0)
         {
             viewDir = zenith;
@@ -267,27 +281,27 @@ void main()
         viewRayIntersectsGround = false;
     }
 
-    const float cosSunZenithAngle =dot(zenith,sunDirection);
-    const float dotViewSun=dot(viewDir,sunDirection);
+    CONST float cosSunZenithAngle =dot(zenith,sunDirection);
+    CONST float dotViewSun=dot(viewDir,sunDirection);
 
-    const vec3 sunXYunnorm=sunDirection-dot(sunDirection,zenith)*zenith;
-    const vec3 viewXYunnorm=viewDir-dot(viewDir,zenith)*zenith;
-    const vec3 sunXY = sunXYunnorm.x!=0 || sunXYunnorm.y!=0 || sunXYunnorm.z!=0 ? normalize(sunXYunnorm) : vec3(0);
-    const vec3 viewXY = viewXYunnorm.x!=0 || viewXYunnorm.y!=0 || viewXYunnorm.z!=0 ? normalize(viewXYunnorm) : vec3(0);
-    const float azimuthRelativeToSun=safeAtan(dot(cross(sunXY, viewXY), zenith), dot(sunXY, viewXY));
+    CONST vec3 sunXYunnorm=sunDirection-dot(sunDirection,zenith)*zenith;
+    CONST vec3 viewXYunnorm=viewDir-dot(viewDir,zenith)*zenith;
+    CONST vec3 sunXY = sunXYunnorm.x!=0 || sunXYunnorm.y!=0 || sunXYunnorm.z!=0 ? normalize(sunXYunnorm) : vec3(0);
+    CONST vec3 viewXY = viewXYunnorm.x!=0 || viewXYunnorm.y!=0 || viewXYunnorm.z!=0 ? normalize(viewXYunnorm) : vec3(0);
+    CONST float azimuthRelativeToSun=safeAtan(dot(cross(sunXY, viewXY), zenith), dot(sunXY, viewXY));
 
-#if RENDERING_ZERO_SCATTERING
+#if 0 /*RENDERING_ZERO_SCATTERING*/
     vec4 radiance;
     if(viewRayIntersectsGround)
     {
         // XXX: keep in sync with the same code in computeScatteringDensity(), but don't forget about
         //      the difference in the usage of viewDir vs incDir.
-        const float distToGround = distanceToGround(cosViewZenithAngle, altitude);
-        const vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
-        const vec3 groundNormal = normalize(zenith*(earthRadius+altitude)+viewDir*distToGround);
-        const vec4 groundIrradiance = irradiance(dot(groundNormal, sunDirection), 0);
+        CONST float distToGround = distanceToGround(cosViewZenithAngle, altitude);
+        CONST vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
+        CONST vec3 groundNormal = normalize(zenith*(earthRadius+altitude)+viewDir*distToGround);
+        CONST vec4 groundIrradiance = irradiance(dot(groundNormal, sunDirection), 0);
         // Radiation scattered by the ground
-        const float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
+        CONST float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
         radiance = transmittanceToGround*groundAlbedo*groundIrradiance*solarIrradianceFixup*groundBRDF
                  + lightPollutionGroundLuminance*lightPollutionRelativeRadiance;
     }
@@ -304,22 +318,22 @@ void main()
     }
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_ZERO_SCATTERING
+#elif 0 /*RENDERING_ECLIPSED_ZERO_SCATTERING*/
     vec4 radiance;
-    const float dotViewMoon=dot(viewDir,normalize(moonPosition-cameraPosition));
+    CONST float dotViewMoon=dot(viewDir,normalize(moonPosition-cameraPosition));
     if(viewRayIntersectsGround)
     {
         // XXX: keep in sync with the similar code in non-eclipsed zero scattering rendering.
-        const float distToGround = distanceToGround(cosViewZenithAngle, altitude);
-        const vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
-        const vec3 pointOnGround = cameraPosition+viewDir*distToGround;
-        const vec4 directGroundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDirection, moonPosition);
+        CONST float distToGround = distanceToGround(cosViewZenithAngle, altitude);
+        CONST vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
+        CONST vec3 pointOnGround = cameraPosition+viewDir*distToGround;
+        CONST vec4 directGroundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDirection, moonPosition);
         // FIXME: add first-order indirect irradiance too: it's done in non-eclipsed irradiance (in the same
         // conditions: when limited to 2 orders). This should be calculated at the same time when second order
         // is: all the infrastructure is already there.
-        const vec4 groundIrradiance = directGroundIrradiance;
+        CONST vec4 groundIrradiance = directGroundIrradiance;
         // Radiation scattered by the ground
-        const float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
+        CONST float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
         radiance = transmittanceToGround*groundAlbedo*groundIrradiance*solarIrradianceFixup*groundBRDF
                  + lightPollutionGroundLuminance*lightPollutionRelativeRadiance;
     }
@@ -336,53 +350,53 @@ void main()
     }
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_ON_THE_FLY
-    const vec4 scattering=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPosition,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_ON_THE_FLY*/
+    CONST vec4 scattering=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPosition,
                                                           viewRayIntersectsGround);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE
-    const vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE*/
+    CONST vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                      viewRayIntersectsGround, eclipsedSingleScatteringTextureSize);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact at the point where azimuth texture coordinate changes from 1 to 0 (at azimuthRelativeToSun crossing
     // 0). This happens when I simply call texture(eclipsedScatteringTexture, texCoords) without specifying LOD.
     // Apparently, the driver uses the derivative for some reason, even though it shouldn't.
-    const vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
+    CONST vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE
-    const vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
+    CONST vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                      viewRayIntersectsGround, eclipsedSingleScatteringTextureSize);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact at the point where azimuth texture coordinate changes from 1 to 0 (at azimuthRelativeToSun crossing
     // 0). This happens when I simply call texture(eclipsedScatteringTexture, texCoords) without specifying LOD.
     // Apparently, the driver uses the derivative for some reason, even though it shouldn't.
-    const vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
+    CONST vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
     luminance=scattering*currentPhaseFunction(dotViewSun);
-#elif RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_RADIANCE
+#elif 0 /*RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_RADIANCE*/
     vec4 radiance=exp(sampleEclipseDoubleScattering3DTexture(eclipsedDoubleScatteringTexture,
                                                              cosSunZenithAngle, cosViewZenithAngle, azimuthRelativeToSun,
                                                              altitude, viewRayIntersectsGround));
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_LUMINANCE
+#elif 0 /*RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
     luminance=exp(sampleEclipseDoubleScattering3DTexture(eclipsedDoubleScatteringTexture,
                                                          cosSunZenithAngle, cosViewZenithAngle, azimuthRelativeToSun,
                                                          altitude, viewRayIntersectsGround));
 #elif 1 /*RENDERING_SINGLE_SCATTERING_ON_THE_FLY*/
-    const vec4 scattering=computeSingleScattering(cosSunZenithAngle,cosViewZenithAngle,dotViewSun,
+    CONST vec4 scattering=computeSingleScattering(cosSunZenithAngle,cosViewZenithAngle,dotViewSun,
                                                   altitude,viewRayIntersectsGround);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE
+#elif 0 /*RENDERING_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE*/
     vec4 scattering;
     if(useInterpolationGuides)
     {
@@ -399,7 +413,7 @@ void main()
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE
+#elif 0 /*RENDERING_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
     vec4 scattering;
     if(useInterpolationGuides)
     {
@@ -413,18 +427,18 @@ void main()
                                      dotViewSun, altitude, viewRayIntersectsGround);
     }
     luminance=scattering * (bool(0) ? vec4(1) : currentPhaseFunction(dotViewSun));
-#elif RENDERING_MULTIPLE_SCATTERING_LUMINANCE
+#elif 0 /*RENDERING_MULTIPLE_SCATTERING_LUMINANCE*/
     luminance=sample3DTexture(scatteringTexture, cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, viewRayIntersectsGround);
-#elif RENDERING_MULTIPLE_SCATTERING_RADIANCE
+#elif 0 /*RENDERING_MULTIPLE_SCATTERING_RADIANCE*/
     vec4 radiance=sample3DTexture(scatteringTexture, cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, viewRayIntersectsGround);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_LIGHT_POLLUTION_RADIANCE
+#elif 0 /*RENDERING_LIGHT_POLLUTION_RADIANCE*/
     vec4 radiance=lightPollutionGroundLuminance*lightPollutionScattering(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_LIGHT_POLLUTION_LUMINANCE
+#elif 0 /*RENDERING_LIGHT_POLLUTION_LUMINANCE*/
     luminance=lightPollutionGroundLuminance*lightPollutionScattering(altitude, cosViewZenithAngle, viewRayIntersectsGround);
 #else
 #error What to render?

--- a/atmosphere/default/shaders/single-scattering/on-the-fly/3/aerosols/single-scattering.frag
+++ b/atmosphere/default/shaders/single-scattering/on-the-fly/3/aerosols/single-scattering.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // single-scattering.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,15 +45,15 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // single-scattering.frag
-#line 1 2 // densities.h.glsl
+#line 4 0 // single-scattering.frag
+#line 1 3 // densities.h.glsl
 float scattererNumberDensity_molecules(float altitude);
 float scattererNumberDensity_aerosols(float altitude);
 float absorberNumberDensity_ozone(float altitude);
 vec4 scatteringCrossSection();
 float scattererDensity(float altitude);
-#line 6 0 // single-scattering.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // single-scattering.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -74,8 +85,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // single-scattering.frag
-#line 1 4 // single-scattering.h.glsl
+#line 6 0 // single-scattering.frag
+#line 1 5 // single-scattering.h.glsl
 #ifndef INCLUDE_ONCE_1DB2EDC1_C687_4FFA_BFF4_D18A54BA651B
 #define INCLUDE_ONCE_1DB2EDC1_C687_4FFA_BFF4_D18A54BA651B
 
@@ -83,8 +94,8 @@ vec4 computeSingleScattering(const float cosSunZenithAngle, const float cosViewZ
                              const float dotViewSun, const float altitude,
                              const bool viewRayIntersectsGround);
 #endif
-#line 8 0 // single-scattering.frag
-#line 1 5 // texture-sampling-functions.h.glsl
+#line 7 0 // single-scattering.frag
+#line 1 6 // texture-sampling-functions.h.glsl
 #ifndef INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 #define INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float altitude);
@@ -96,20 +107,20 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                 const int scatteringOrder);
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 #endif
-#line 9 0 // single-scattering.frag
+#line 8 0 // single-scattering.frag
 
 // This function omits phase function and solar irradiance: these are to be applied somewhere in the calling code.
 vec4 computeSingleScatteringIntegrand(const float cosSunZenithAngle, const float cosViewZenithAngle,
                                       const float dotViewSun, const float altitude,
                                       const float dist, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle here the case when the
     // endpoint of the view ray intentionally appears in outer space.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosSunZenithAngleAtDist=clampCosine((r*cosSunZenithAngle+dist*dotViewSun)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosSunZenithAngleAtDist=clampCosine((r*cosSunZenithAngle+dist*dotViewSun)/(earthRadius+altAtDist));
 
-    const vec4 xmittance=transmittance(cosViewZenithAngle, altitude, dist, viewRayIntersectsGround)
+    CONST vec4 xmittance=transmittance(cosViewZenithAngle, altitude, dist, viewRayIntersectsGround)
                                                     *
                          transmittanceToAtmosphereBorder(cosSunZenithAngleAtDist, altAtDist)
                                                     *
@@ -121,14 +132,14 @@ vec4 computeSingleScattering(const float cosSunZenithAngle, const float cosViewZ
                              const float dotViewSun, const float altitude,
                              const bool viewRayIntersectsGround)
 {
-    const float integrInterval=distanceToNearestAtmosphereBoundary(cosViewZenithAngle, altitude,
+    CONST float integrInterval=distanceToNearestAtmosphereBoundary(cosViewZenithAngle, altitude,
                                                                    viewRayIntersectsGround);
     // Using the midpoint rule for quadrature
     vec4 spectrum=vec4(0);
-    const float dl=integrInterval/radialIntegrationPoints;
+    CONST float dl=integrInterval/radialIntegrationPoints;
     for(int n=0; n<radialIntegrationPoints; ++n)
     {
-        const float dist=(n+0.5)*dl;
+        CONST float dist=(n+0.5)*dl;
         spectrum += computeSingleScatteringIntegrand(cosSunZenithAngle, cosViewZenithAngle, dotViewSun,
                                                      altitude, dist, viewRayIntersectsGround);
     }

--- a/atmosphere/default/shaders/single-scattering/on-the-fly/3/aerosols/texture-coordinates.frag
+++ b/atmosphere/default/shaders/single-scattering/on-the-fly/3/aerosols/texture-coordinates.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-coordinates.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,8 +45,8 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // texture-coordinates.frag
-#line 1 2 // texture-coordinates.h.glsl
+#line 4 0 // texture-coordinates.frag
+#line 1 3 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -104,8 +115,8 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 6 0 // texture-coordinates.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-coordinates.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -137,7 +148,7 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-coordinates.frag
+#line 6 0 // texture-coordinates.frag
 
 const float LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA=sqrt(atmosphereHeight*(atmosphereHeight+2*earthRadius));
 
@@ -205,18 +216,18 @@ vec3 indicesToTexCoords(const vec3 indices, const vec3 texSizes)
 
 TransmittanceTexVars transmittanceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
+    CONST float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
                                 texCoordToUnitRange(texCoord.t,transmittanceTextureSize.t);
     // Distance from Earth center to camera
-    const float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
-    const float altitude=r-earthRadius;
+    CONST float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
+    CONST float altitude=r-earthRadius;
 
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
     // distance to border of visible atmosphere from the view point
-    const float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
+    CONST float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
     // d==0 can happen when altitude==atmosphereHeight
-    const float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
+    CONST float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
     return TransmittanceTexVars(cosVZA,altitude);
 }
 
@@ -235,53 +246,53 @@ vec2 transmittanceTexVarsToTexCoord(const float cosVZA, float altitude)
     if(altitude<0)
         altitude=0;
 
-    const float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
+    CONST float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
                                       transmittanceTextureSize.t);
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
-    const float d=distanceToAtmosphereBorder(cosVZA,altitude);
-    const float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float d=distanceToAtmosphereBorder(cosVZA,altitude);
+    CONST float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
     return vec2(s,t);
 }
 
 // Output: vec2(cos(sunZenithAngle), altitude)
 IrradianceTexVars irradianceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
-    const float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
+    CONST float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
+    CONST float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
     return IrradianceTexVars(cosSZA,alt);
 }
 
 vec2 irradianceTexVarsToTexCoord(const float cosSunZenithAngle, const float altitude)
 {
-    const float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
-    const float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
+    CONST float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
+    CONST float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
     return vec2(s,t);
 }
 
 float cosSZAToUnitRangeTexCoord(const float cosSunZenithAngle)
 {
     // Distance to top atmosphere border along the ray groundUnderCamera-sun: (altitude, cosSunZenithAngle)
-    const float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name
-    const float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
+    CONST float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
     // TODO: choose a more descriptive name
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     return max(0.,1-a/A)/(a+1);
 }
 
 float unitRangeTexCoordToCosSZA(const float texCoord)
 {
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float a=(A-A*texCoord)/(1+A*texCoord);
-    const float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
+    CONST float a=(A-A*texCoord)/(1+A*texCoord);
+    CONST float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
     return distFromGroundToTopAtmoBorder==0 ? 1 :
         clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distFromGroundToTopAtmoBorder)) /
                     (2*earthRadius*distFromGroundToTopAtmoBorder));
@@ -292,24 +303,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
                                                const float dotViewSun, const float altitude,
                                                const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -317,24 +328,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float dotVSCoord=(dotViewSun+1)/2;
+    CONST float dotVSCoord=(dotViewSun+1)/2;
 
     // ------------------------------------
-    const float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
+    CONST float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
 
     return Scattering4DCoords(cosSZACoord, cosVZACoord, dotVSCoord, altCoord, viewRayIntersectsGround);
 }
 
 TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
@@ -342,16 +353,16 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture coordinates we combine into a single sampler3D coordinate.
-    const float texW = scatteringTextureSize[1];
-    const float texH = scatteringTextureSize[2];
-    const float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
-    const vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
+    CONST float texW = scatteringTextureSize[1];
+    CONST float texH = scatteringTextureSize[2];
+    CONST float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
+    CONST vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
                                         ceil (cosSZAIndex)*texW+coords.dotViewSun*(texW-1)) / (texW*texH-1);
-    const vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
+    CONST vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
 
-    const float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
+    CONST float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
 
-    const float alphaUpper=fract(cosSZAIndex);
+    CONST float alphaUpper=fract(cosSZAIndex);
     return TexCoordPair(vec3(cosVZAtc, combinedCoord.x, altitude), float(1-alphaUpper),
                         vec3(cosVZAtc, combinedCoord.y, altitude), float(alphaUpper));
 }
@@ -359,9 +370,9 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
+    CONST TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
     return texture(tex, texCoords.lower) * texCoords.alphaLower +
            texture(tex, texCoords.upper) * texCoords.alphaUpper;
 }
@@ -369,17 +380,17 @@ vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const f
 // 3D texture is the 3D single-altitude slice of a 4D texture
 vec3 scattering4DCoordsToTex3DCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2);
 
-    const float dvsSize = scatteringTextureSize[1];
-    const float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
+    CONST float dvsSize = scatteringTextureSize[1];
+    CONST float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
 
-    const float cszaSize = scatteringTextureSize[2];
-    const float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
+    CONST float cszaSize = scatteringTextureSize[2];
+    CONST float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
 
     return vec3(cosVZAtc, dotVStc, cosSZAtc);
 }
@@ -394,39 +405,39 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along dotViewSun coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[1];
-    const float posOfRow = indices[1];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[1];
+    CONST float posOfRow = indices[1];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         indexToTexCoord(currRow, numRows-1),
                                                         texCoordVerbatim));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               indexToTexCoord(currRow, numRows-1),
                                                               texCoordVerbatim));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          indexToTexCoord(currRow, numRows-1),
                                          texCoordVerbatim));
@@ -434,14 +445,14 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
 vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolationGuides01Tex,
                                  const vec3 indices)
 {
-    const float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
+    CONST float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
 
-    const float cosVZAIndex = indices[0];
-    const float dotVSIndex = indices[1];
-    const float currRow = floor(dotVSIndex);
-    const float posBetweenRows = dotVSIndex - currRow;
-    const float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cosVZAIndex = indices[0];
+    CONST float dotVSIndex = indices[1];
+    CONST float currRow = floor(dotVSIndex);
+    CONST float posBetweenRows = dotVSIndex - currRow;
+    CONST float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -449,14 +460,14 @@ vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolat
     indicesCurrRow[1] =     currRow;
     indicesNextRow[1] = min(currRow+1, scatteringTextureSize[1]-1.);
 
-    const vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
-    const vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
+    CONST vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
+    CONST vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
 
-    const vec4 valueCurrRow = texture(tex, coordsCurrRow);
-    const vec4 valueNextRow = texture(tex, coordsNextRow);
-    const float epsilon = 1e-37; // Prevents passing zero to log
-    const vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
-    const vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
+    CONST vec4 valueCurrRow = texture(tex, coordsCurrRow);
+    CONST vec4 valueNextRow = texture(tex, coordsNextRow);
+    CONST float epsilon = 1e-37; // Prevents passing zero to log
+    CONST vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
+    CONST vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
     return (logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow;
 }
 
@@ -465,37 +476,37 @@ float findGuide02Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along SZA coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[2];
-    const float posOfRow = indices[2];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[2];
+    CONST float posOfRow = indices[2];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
 }
@@ -505,19 +516,19 @@ vec4 sample3DTextureGuided(const sampler3D tex,
                            const float cosSunZenithAngle, const float cosViewZenithAngle,
                            const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
                                                                     dotViewSun, altitude, viewRayIntersectsGround);
     // Handle the external interpolation guides: the guides between a pair of VZA-dotViewSun 2D "pictures".
-    const vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
-    const vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
-    const float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
+    CONST vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
+    CONST float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
 
-    const float cvzaIndex = indices[0];
-    const float cszaIndex = indices[2];
-    const float currRow = floor(cszaIndex);
-    const float posBetweenRows = cszaIndex - currRow;
-    const float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cvzaIndex = indices[0];
+    CONST float cszaIndex = indices[2];
+    CONST float currRow = floor(cszaIndex);
+    CONST float posBetweenRows = cszaIndex - currRow;
+    CONST float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -526,58 +537,58 @@ vec4 sample3DTextureGuided(const sampler3D tex,
     indicesNextRow[2] = min(currRow+1, scatteringTextureSize[2]-1);
 
     // The caller will handle the internal interpolation guides: the ones between rows in each 2D "picture".
-    const vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
-    const vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
+    CONST vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
+    CONST vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
     return exp((logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow);
 }
 
 vec4 sample3DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
     return texture(tex, texCoords);
 }
 
 ScatteringTexVars scatteringTex4DCoordsToTexVars(const Scattering4DCoords coords)
 {
-    const float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
     // ------------------------------------
     float cosViewZenithAngle;
     if(coords.viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
     // ------------------------------------
-    const float dotViewSun=coords.dotViewSun*2-1;
+    CONST float dotViewSun=coords.dotViewSun*2-1;
 
     // ------------------------------------
-    const float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
+    CONST float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
 
     return ScatteringTexVars(cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, coords.viewRayIntersectsGround);
 }
 
 Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 {
-    const vec4 indexMax=scatteringTextureSize-vec4(1);
+    CONST vec4 indexMax=scatteringTextureSize-vec4(1);
     Scattering4DCoords coords4d;
     coords4d.viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
     // The following formulas assume that scatteringTextureSize[0] is even. For odd sizes they would change.
@@ -593,8 +604,8 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture indices we combine into a single sampler3D coordinate.
-    const float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
-    const float combinedIndex=texIndices[1];
+    CONST float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
+    CONST float combinedIndex=texIndices[1];
     coords4d.dotViewSun=mod(combinedIndex,texW)/(texW-1);
     coords4d.cosSunZenithAngle=floor(combinedIndex/texW)/(texH-1);
 
@@ -608,11 +619,11 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
 ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 {
-    const Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
+    CONST Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
     ScatteringTexVars vars=scatteringTex4DCoordsToTexVars(coords4d);
     // Clamp dotViewSun to its valid range of values, given cosViewZenithAngle and cosSunZenithAngle. This is
     // needed to prevent NaNs when computing the scattering texture.
-    const float cosVZA=vars.cosViewZenithAngle,
+    CONST float cosVZA=vars.cosViewZenithAngle,
                 cosSZA=vars.cosSunZenithAngle;
     vars.dotViewSun=clamp(vars.dotViewSun,
                           cosVZA*cosSZA-safeSqrt((1-sqr(cosVZA))*(1-sqr(cosSZA))),
@@ -622,54 +633,54 @@ ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 
 EclipseScatteringTexVars eclipseTexCoordsToTexVars(const vec2 texCoords, const float altitude)
 {
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
-    const bool viewRayIntersectsGround = texCoords.t<0.5;
+    CONST bool viewRayIntersectsGround = texCoords.t<0.5;
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
-    const float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
+    CONST float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
     return EclipseScatteringTexVars(azimuthRelativeToSun, cosViewZenithAngle, viewRayIntersectsGround);
 }
 
 EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                                    const float altitude, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -677,13 +688,13 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
-    const float azimuthCoord = azimuthRelativeToSun/(2*PI);
+    CONST float azimuthCoord = azimuthRelativeToSun/(2*PI);
 
     return EclipseScattering2DCoords(azimuthCoord, cosVZACoord);
 }
@@ -691,14 +702,14 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
 vec2 eclipseTexVarsToTexCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                const float altitude, const bool viewRayIntersectsGround, const vec2 texSize)
 {
-    const EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+    CONST EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                                     viewRayIntersectsGround);
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2);
-    const float azimuthTC = coords.azimuth + 1/(2*texSize.s);
+    CONST float azimuthTC = coords.azimuth + 1/(2*texSize.s);
 
     return vec2(azimuthTC, cosVZAtc);
 }
@@ -707,42 +718,42 @@ vec4 sampleEclipseDoubleScattering3DTexture(const sampler3D tex, const float cos
                                             const float cosViewZenithAngle, const float azimuthRelativeToSun,
                                             const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
+    CONST vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
                                                   eclipsedDoubleScatteringTextureSize.st);
-    const float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
-    const vec3 texCoords=vec3(coords2d, cosSZACoord);
+    CONST float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
+    CONST vec3 texCoords=vec3(coords2d, cosSZACoord);
 
     return texture(tex, texCoords);
 }
 
 LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 texIndices)
 {
-    const vec2 indexMax=lightPollutionTextureSize-vec2(1);
+    CONST vec2 indexMax=lightPollutionTextureSize-vec2(1);
 
-    const float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
-    const float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
+    CONST float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
-    const bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
-    const float cosViewZenithAngleCoord = viewRayIntersectsGround ?
+    CONST bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
+    CONST float cosViewZenithAngleCoord = viewRayIntersectsGround ?
                                    1-2*texIndices[0]/(indexMax[0]-1) :
                                    2*(texIndices[0]-1)/(indexMax[0]-1)-1;
     // ------------------------------------
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
@@ -753,23 +764,23 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 
 LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -777,27 +788,27 @@ LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, con
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     return LightPollution2DCoords(cosVZACoord, altCoord);
 }
 
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
-    const vec2 texSize = lightPollutionTextureSize;
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 texSize = lightPollutionTextureSize;
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2);
-    const float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
+    CONST float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
     return vec2(cosVZAtc, altitudeTC);
 }

--- a/atmosphere/default/shaders/single-scattering/on-the-fly/3/aerosols/texture-sampling-functions.frag
+++ b/atmosphere/default/shaders/single-scattering/on-the-fly/3/aerosols/texture-sampling-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-sampling-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,13 +45,13 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // texture-sampling-functions.frag
-#line 1 2 // phase-functions.h.glsl
+#line 4 0 // texture-sampling-functions.frag
+#line 1 3 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 6 0 // texture-sampling-functions.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-sampling-functions.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -72,8 +83,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-sampling-functions.frag
-#line 1 4 // texture-coordinates.h.glsl
+#line 6 0 // texture-sampling-functions.frag
+#line 1 5 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -142,7 +153,7 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 8 0 // texture-sampling-functions.frag
+#line 7 0 // texture-sampling-functions.frag
 
 uniform sampler2D transmittanceTexture;
 uniform sampler2D irradianceTexture;
@@ -154,13 +165,13 @@ uniform sampler2D lightPollutionScatteringTexture;
 
 vec4 irradiance(const float cosSunZenithAngle, const float altitude)
 {
-    const vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
+    CONST vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
     return texture(irradianceTexture, texCoords);
 }
 
 vec4 opticalDepthToAtmosphereBorder(const float cosViewZenithAngle, const float altitude)
 {
-    const vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
+    CONST vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact when looking into nadir from TOA at some values of texture sizes (in particular, size of
     // transmittance texture for altitude being 4096). This happens when I simply call texture(eclipsedScatteringTexture,
@@ -178,11 +189,11 @@ vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float
 vec4 transmittance(const float cosViewZenithAngle, const float altitude, const float dist,
                    const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle view ray endpoint
     // in space here.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
 
     vec4 depth;
     if(viewRayIntersectsGround)
@@ -201,7 +212,7 @@ vec4 transmittance(const float cosViewZenithAngle, const float altitude, const f
 vec4 calcFirstScattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                          const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
+    CONST vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
                                           dotViewSun, altitude, viewRayIntersectsGround);
     return scattering*currentPhaseFunction(dotViewSun);
 }
@@ -220,6 +231,6 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
 
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     return texture(lightPollutionScatteringTexture, coords);
 }

--- a/atmosphere/default/shaders/single-scattering/on-the-fly/3/molecules/common-functions.frag
+++ b/atmosphere/default/shaders/single-scattering/on-the-fly/3/molecules/common-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // common-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // common-functions.frag
+#line 4 0 // common-functions.frag
 
 bool dbgDataPresent=false;
 bool debugDataPresent()
@@ -69,7 +80,7 @@ void setDebugData(float a,float b, float c, float d)
 
 void swap(inout float x, inout float y)
 {
-    const float t = x;
+    CONST float t = x;
     x = y;
     y = t;
 }
@@ -83,7 +94,7 @@ float safeSqrt(const float x)
 
 float safeAtan(const float y, const float x)
 {
-    const float a = atan(y,x);
+    CONST float a = atan(y,x);
     return x==0 && y==0 ? 0 : a;
 }
 
@@ -116,23 +127,23 @@ float pointAltitude(vec3 point)
 
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float Ratm=earthRadius+atmosphereHeight;
-    const float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float Ratm=earthRadius+atmosphereHeight;
+    CONST float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float distanceToGround(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(-safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float cosZenithAngleOfHorizon(const float altitude)
 {
-    const float R=earthRadius;
-    const float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
+    CONST float R=earthRadius;
+    CONST float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
     return -sqrt(2*h*R+sqr(h))/(R+h);
 }
 
@@ -151,8 +162,8 @@ float distanceToNearestAtmosphereBoundary(const float cosZenithAngle, const floa
 float sunVisibility(const float cosSunZenithAngle, float altitude)
 {
     if(altitude<0) altitude=0;
-    const float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
-    const float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
+    CONST float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
+    CONST float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
     /* Approximating visible fraction of solar disk by smoothstep between the position of the Sun
      * touching the horizon by its upper part and the position with lower part touching the horizon.
      * The calculation assumes that solar angular radius is small and thus approximately equals its sine.
@@ -182,13 +193,13 @@ float circlesIntersectionArea(float R1, float R2, float d)
 
 float angleBetween(const vec3 a, const vec3 b)
 {
-    const float d=dot(a,b);
-    const float c=length(cross(a,b));
+    CONST float d=dot(a,b);
+    CONST float c=length(cross(a,b));
     // To avoid loss of precision, don't use dot product near the singularity
     // of acos, and cross product near the singularity of asin
     if(abs(d) < abs(c))
         return acos(d/(length(a)*length(b)));
-    const float smallerAngle = asin(c/(length(a)*length(b)));
+    CONST float smallerAngle = asin(c/(length(a)*length(b)));
     if(d<0) return PI-smallerAngle;
     return smallerAngle;
 }
@@ -205,11 +216,11 @@ float moonAngularRadius(const vec3 cameraPosition, const vec3 moonPosition)
 
 float visibleSolidAngleOfSun(const vec3 camera, const vec3 sunDir, const vec3 moonPos)
 {
-    const float Rs=sunAngularRadius;
-    const float Rm=moonAngularRadius(camera,moonPos);
+    CONST float Rs=sunAngularRadius;
+    CONST float Rm=moonAngularRadius(camera,moonPos);
     float visibleSolidAngle=PI*sqr(Rs);
 
-    const float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
+    CONST float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
     if(dSM<Rs+Rm)
     {
         visibleSolidAngle -= circlesIntersectionArea(Rm,Rs,dSM);
@@ -229,12 +240,12 @@ float sphereIntegrationSolidAngleDifferential(const int pointCountOnSphere)
 }
 vec3 sphereIntegrationSampleDir(const int index, const int pointCountOnSphere)
 {
-    const float goldenRatio=1.6180339887499;
+    CONST float goldenRatio=1.6180339887499;
     // The range of n is 0.5, 1.5, ..., pointCountOnSphere-0.5
-    const float n=index+0.5;
+    CONST float n=index+0.5;
     // Explanation of the Fibonacci grid generation can be seen at https://stackoverflow.com/a/44164075/673852
-    const float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
-    const float azimuth=n*(2*PI*goldenRatio);
+    CONST float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
+    CONST float azimuth=n*(2*PI*goldenRatio);
     return vec3(cos(azimuth)*sin(zenithAngle),
                 sin(azimuth)*sin(zenithAngle),
                 cos(zenithAngle));

--- a/atmosphere/default/shaders/single-scattering/on-the-fly/3/molecules/densities.frag
+++ b/atmosphere/default/shaders/single-scattering/on-the-fly/3/molecules/densities.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // densities.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,20 +45,20 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // densities.frag
+#line 4 0 // densities.frag
 float scattererNumberDensity_molecules(float altitude)
 {
-        const float rayleighScaleHeight=8*km;
+        CONST float rayleighScaleHeight=8*km;
         return 3.08458e25*exp(-1/rayleighScaleHeight * altitude);
 }
 float scattererNumberDensity_aerosols(float altitude)
 {
-        const float mieScaleHeight=1.2*km;
+        CONST float mieScaleHeight=1.2*km;
         return 1.03333e8*exp(-1/mieScaleHeight*altitude);
 }
 float absorberNumberDensity_ozone(float altitude)
 {
-        const float totalOzoneAmount=370*dobsonUnit;
+        CONST float totalOzoneAmount=370*dobsonUnit;
 
         float density;
 

--- a/atmosphere/default/shaders/single-scattering/on-the-fly/3/molecules/phase-functions.frag
+++ b/atmosphere/default/shaders/single-scattering/on-the-fly/3/molecules/phase-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // phase-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // phase-functions.frag
+#line 4 0 // phase-functions.frag
 
 vec4 phaseFunction_molecules(float dotViewSun)
 {
@@ -42,9 +53,9 @@ vec4 phaseFunction_molecules(float dotViewSun)
 }
 vec4 phaseFunction_aerosols(float dotViewSun)
 {
-        const float g=0.76;
-        const float g2=g*g;
-        const float k = 3/(8*PI)*(1-g2)/(2+g2);
+        CONST float g=0.76;
+        CONST float g2=g*g;
+        CONST float k = 3/(8*PI)*(1-g2)/(2+g2);
         return vec4(k * (1+sqr(dotViewSun)) / pow(1+g2 - 2*g*dotViewSun, 1.5) + 1/((1-dotViewSun)*600+0.05))*0.904;
 }
 vec4 currentPhaseFunction(float dotViewSun) { return phaseFunction_molecules(dotViewSun); }

--- a/atmosphere/default/shaders/single-scattering/on-the-fly/3/molecules/render.frag
+++ b/atmosphere/default/shaders/single-scattering/on-the-fly/3/molecules/render.frag
@@ -1,7 +1,21 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
 
-#line 1 1 // const.h.glsl
+
+
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 6 0 // render.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,11 +48,11 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // render.frag
-#line 1 2 // calc-view-dir.h.glsl
+#line 7 0 // render.frag
+#line 1 3 // calc-view-dir.h.glsl
 vec3 calcViewDir();
-#line 6 0 // render.frag
-#line 1 3 // common-functions.h.glsl
+#line 8 0 // render.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -70,13 +84,13 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // render.frag
-#line 1 4 // phase-functions.h.glsl
+#line 9 0 // render.frag
+#line 1 5 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 8 0 // render.frag
-#line 1 5 // single-scattering.h.glsl
+#line 10 0 // render.frag
+#line 1 6 // single-scattering.h.glsl
 #ifndef INCLUDE_ONCE_1DB2EDC1_C687_4FFA_BFF4_D18A54BA651B
 #define INCLUDE_ONCE_1DB2EDC1_C687_4FFA_BFF4_D18A54BA651B
 
@@ -84,9 +98,9 @@ vec4 computeSingleScattering(const float cosSunZenithAngle, const float cosViewZ
                              const float dotViewSun, const float altitude,
                              const bool viewRayIntersectsGround);
 #endif
-#line 9 0 // render.frag
+#line 11 0 // render.frag
 
-#line 1 6 // texture-coordinates.h.glsl
+#line 1 7 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -155,10 +169,10 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 11 0 // render.frag
-#line 1 7 // radiance-to-luminance.h.glsl
+#line 13 0 // render.frag
+#line 1 8 // radiance-to-luminance.h.glsl
 const mat4 radianceToLuminance=mat4(19.8756237,7.17745161,0,0.0937032327,  2.13895917,0.772417068,0,0.0149318045,  0.241072536,0.0870557055,0,0,  0.0133876652,0.00483453181,0,0);
-#line 12 0 // render.frag
+#line 14 0 // render.frag
 
 
 
@@ -195,18 +209,18 @@ void main()
     // this approximation has the same order of magnitude as the assumption that the Earth and its atmosphere
     // are spherical.
     float altitude = max(cameraPosition.z, 0.);
-    const vec3 oldCamPos=cameraPosition;
+    CONST vec3 oldCamPos=cameraPosition;
     // Hide the uniform with this name, thus effectively modifying it for the following code
     vec3 cameraPosition=vec3(oldCamPos.xy, altitude);
 
     bool lookingIntoAtmosphere=true;
     if(altitude>atmosphereHeight)
     {
-        const vec3 p = cameraPosition - earthCenter;
-        const float p_dot_v = dot(p, viewDir);
-        const float p_dot_p = dot(p, p);
-        const float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
-        const float distanceToTOA = -p_dot_v - sqrt(sqr(earthRadius+atmosphereHeight) - squaredDistBetweenViewRayAndEarthCenter);
+        CONST vec3 p = cameraPosition - earthCenter;
+        CONST float p_dot_v = dot(p, viewDir);
+        CONST float p_dot_p = dot(p, p);
+        CONST float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
+        CONST float distanceToTOA = -p_dot_v - sqrt(sqr(earthRadius+atmosphereHeight) - squaredDistBetweenViewRayAndEarthCenter);
         if(distanceToTOA>=0)
         {
             cameraPosition += viewDir*distanceToTOA;
@@ -214,7 +228,7 @@ void main()
         }
         else
         {
-#if RENDERING_ANY_ZERO_SCATTERING
+#if 0 /*RENDERING_ANY_ZERO_SCATTERING*/
             lookingIntoAtmosphere=false;
 #else
             luminance=vec4(0);
@@ -224,16 +238,16 @@ void main()
         }
     }
 
-    const vec3 zenith=normalize(cameraPosition-earthCenter);
+    CONST vec3 zenith=normalize(cameraPosition-earthCenter);
     float cosViewZenithAngle=dot(zenith,viewDir);
 
     bool viewRayIntersectsGround=false;
     {
-        const vec3 p = cameraPosition - earthCenter;
-        const float p_dot_v = dot(p, viewDir);
-        const float p_dot_p = dot(p, p);
-        const float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
-        const float distanceToIntersection = -p_dot_v - sqrt(sqr(earthRadius) - squaredDistBetweenViewRayAndEarthCenter);
+        CONST vec3 p = cameraPosition - earthCenter;
+        CONST float p_dot_v = dot(p, viewDir);
+        CONST float p_dot_p = dot(p, p);
+        CONST float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
+        CONST float distanceToIntersection = -p_dot_v - sqrt(sqr(earthRadius) - squaredDistBetweenViewRayAndEarthCenter);
         // altitude==0 is a special case where distance to intersection calculation
         // is unreliable (has a lot of noise in its sign), so check it separately
         if(distanceToIntersection>0 || (altitude==0 && cosViewZenithAngle<0))
@@ -244,11 +258,11 @@ void main()
     // Aside from aesthetics, this affects brightness input to Stellarium's tone mapper.
     if(pseudoMirrorSkyBelowHorizon && viewRayIntersectsGround)
     {
-        const float horizonCZA = cosZenithAngleOfHorizon(altitude);
-        const float viewElev  = asin(clampCosine(cosViewZenithAngle));
-        const float horizElev = asin(clampCosine(horizonCZA));
-        const float newViewElev = 2*horizElev - viewElev;
-        const float viewDirXYnorm = length(viewDir-zenith*cosViewZenithAngle);
+        CONST float horizonCZA = cosZenithAngleOfHorizon(altitude);
+        CONST float viewElev  = asin(clampCosine(cosViewZenithAngle));
+        CONST float horizElev = asin(clampCosine(horizonCZA));
+        CONST float newViewElev = 2*horizElev - viewElev;
+        CONST float viewDirXYnorm = length(viewDir-zenith*cosViewZenithAngle);
         if(viewDirXYnorm == 0)
         {
             viewDir = zenith;
@@ -267,27 +281,27 @@ void main()
         viewRayIntersectsGround = false;
     }
 
-    const float cosSunZenithAngle =dot(zenith,sunDirection);
-    const float dotViewSun=dot(viewDir,sunDirection);
+    CONST float cosSunZenithAngle =dot(zenith,sunDirection);
+    CONST float dotViewSun=dot(viewDir,sunDirection);
 
-    const vec3 sunXYunnorm=sunDirection-dot(sunDirection,zenith)*zenith;
-    const vec3 viewXYunnorm=viewDir-dot(viewDir,zenith)*zenith;
-    const vec3 sunXY = sunXYunnorm.x!=0 || sunXYunnorm.y!=0 || sunXYunnorm.z!=0 ? normalize(sunXYunnorm) : vec3(0);
-    const vec3 viewXY = viewXYunnorm.x!=0 || viewXYunnorm.y!=0 || viewXYunnorm.z!=0 ? normalize(viewXYunnorm) : vec3(0);
-    const float azimuthRelativeToSun=safeAtan(dot(cross(sunXY, viewXY), zenith), dot(sunXY, viewXY));
+    CONST vec3 sunXYunnorm=sunDirection-dot(sunDirection,zenith)*zenith;
+    CONST vec3 viewXYunnorm=viewDir-dot(viewDir,zenith)*zenith;
+    CONST vec3 sunXY = sunXYunnorm.x!=0 || sunXYunnorm.y!=0 || sunXYunnorm.z!=0 ? normalize(sunXYunnorm) : vec3(0);
+    CONST vec3 viewXY = viewXYunnorm.x!=0 || viewXYunnorm.y!=0 || viewXYunnorm.z!=0 ? normalize(viewXYunnorm) : vec3(0);
+    CONST float azimuthRelativeToSun=safeAtan(dot(cross(sunXY, viewXY), zenith), dot(sunXY, viewXY));
 
-#if RENDERING_ZERO_SCATTERING
+#if 0 /*RENDERING_ZERO_SCATTERING*/
     vec4 radiance;
     if(viewRayIntersectsGround)
     {
         // XXX: keep in sync with the same code in computeScatteringDensity(), but don't forget about
         //      the difference in the usage of viewDir vs incDir.
-        const float distToGround = distanceToGround(cosViewZenithAngle, altitude);
-        const vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
-        const vec3 groundNormal = normalize(zenith*(earthRadius+altitude)+viewDir*distToGround);
-        const vec4 groundIrradiance = irradiance(dot(groundNormal, sunDirection), 0);
+        CONST float distToGround = distanceToGround(cosViewZenithAngle, altitude);
+        CONST vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
+        CONST vec3 groundNormal = normalize(zenith*(earthRadius+altitude)+viewDir*distToGround);
+        CONST vec4 groundIrradiance = irradiance(dot(groundNormal, sunDirection), 0);
         // Radiation scattered by the ground
-        const float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
+        CONST float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
         radiance = transmittanceToGround*groundAlbedo*groundIrradiance*solarIrradianceFixup*groundBRDF
                  + lightPollutionGroundLuminance*lightPollutionRelativeRadiance;
     }
@@ -304,22 +318,22 @@ void main()
     }
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_ZERO_SCATTERING
+#elif 0 /*RENDERING_ECLIPSED_ZERO_SCATTERING*/
     vec4 radiance;
-    const float dotViewMoon=dot(viewDir,normalize(moonPosition-cameraPosition));
+    CONST float dotViewMoon=dot(viewDir,normalize(moonPosition-cameraPosition));
     if(viewRayIntersectsGround)
     {
         // XXX: keep in sync with the similar code in non-eclipsed zero scattering rendering.
-        const float distToGround = distanceToGround(cosViewZenithAngle, altitude);
-        const vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
-        const vec3 pointOnGround = cameraPosition+viewDir*distToGround;
-        const vec4 directGroundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDirection, moonPosition);
+        CONST float distToGround = distanceToGround(cosViewZenithAngle, altitude);
+        CONST vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
+        CONST vec3 pointOnGround = cameraPosition+viewDir*distToGround;
+        CONST vec4 directGroundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDirection, moonPosition);
         // FIXME: add first-order indirect irradiance too: it's done in non-eclipsed irradiance (in the same
         // conditions: when limited to 2 orders). This should be calculated at the same time when second order
         // is: all the infrastructure is already there.
-        const vec4 groundIrradiance = directGroundIrradiance;
+        CONST vec4 groundIrradiance = directGroundIrradiance;
         // Radiation scattered by the ground
-        const float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
+        CONST float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
         radiance = transmittanceToGround*groundAlbedo*groundIrradiance*solarIrradianceFixup*groundBRDF
                  + lightPollutionGroundLuminance*lightPollutionRelativeRadiance;
     }
@@ -336,53 +350,53 @@ void main()
     }
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_ON_THE_FLY
-    const vec4 scattering=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPosition,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_ON_THE_FLY*/
+    CONST vec4 scattering=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPosition,
                                                           viewRayIntersectsGround);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE
-    const vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE*/
+    CONST vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                      viewRayIntersectsGround, eclipsedSingleScatteringTextureSize);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact at the point where azimuth texture coordinate changes from 1 to 0 (at azimuthRelativeToSun crossing
     // 0). This happens when I simply call texture(eclipsedScatteringTexture, texCoords) without specifying LOD.
     // Apparently, the driver uses the derivative for some reason, even though it shouldn't.
-    const vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
+    CONST vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE
-    const vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
+    CONST vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                      viewRayIntersectsGround, eclipsedSingleScatteringTextureSize);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact at the point where azimuth texture coordinate changes from 1 to 0 (at azimuthRelativeToSun crossing
     // 0). This happens when I simply call texture(eclipsedScatteringTexture, texCoords) without specifying LOD.
     // Apparently, the driver uses the derivative for some reason, even though it shouldn't.
-    const vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
+    CONST vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
     luminance=scattering*currentPhaseFunction(dotViewSun);
-#elif RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_RADIANCE
+#elif 0 /*RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_RADIANCE*/
     vec4 radiance=exp(sampleEclipseDoubleScattering3DTexture(eclipsedDoubleScatteringTexture,
                                                              cosSunZenithAngle, cosViewZenithAngle, azimuthRelativeToSun,
                                                              altitude, viewRayIntersectsGround));
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_LUMINANCE
+#elif 0 /*RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
     luminance=exp(sampleEclipseDoubleScattering3DTexture(eclipsedDoubleScatteringTexture,
                                                          cosSunZenithAngle, cosViewZenithAngle, azimuthRelativeToSun,
                                                          altitude, viewRayIntersectsGround));
 #elif 1 /*RENDERING_SINGLE_SCATTERING_ON_THE_FLY*/
-    const vec4 scattering=computeSingleScattering(cosSunZenithAngle,cosViewZenithAngle,dotViewSun,
+    CONST vec4 scattering=computeSingleScattering(cosSunZenithAngle,cosViewZenithAngle,dotViewSun,
                                                   altitude,viewRayIntersectsGround);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE
+#elif 0 /*RENDERING_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE*/
     vec4 scattering;
     if(useInterpolationGuides)
     {
@@ -399,7 +413,7 @@ void main()
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE
+#elif 0 /*RENDERING_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
     vec4 scattering;
     if(useInterpolationGuides)
     {
@@ -413,18 +427,18 @@ void main()
                                      dotViewSun, altitude, viewRayIntersectsGround);
     }
     luminance=scattering * (bool(1) ? vec4(1) : currentPhaseFunction(dotViewSun));
-#elif RENDERING_MULTIPLE_SCATTERING_LUMINANCE
+#elif 0 /*RENDERING_MULTIPLE_SCATTERING_LUMINANCE*/
     luminance=sample3DTexture(scatteringTexture, cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, viewRayIntersectsGround);
-#elif RENDERING_MULTIPLE_SCATTERING_RADIANCE
+#elif 0 /*RENDERING_MULTIPLE_SCATTERING_RADIANCE*/
     vec4 radiance=sample3DTexture(scatteringTexture, cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, viewRayIntersectsGround);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_LIGHT_POLLUTION_RADIANCE
+#elif 0 /*RENDERING_LIGHT_POLLUTION_RADIANCE*/
     vec4 radiance=lightPollutionGroundLuminance*lightPollutionScattering(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_LIGHT_POLLUTION_LUMINANCE
+#elif 0 /*RENDERING_LIGHT_POLLUTION_LUMINANCE*/
     luminance=lightPollutionGroundLuminance*lightPollutionScattering(altitude, cosViewZenithAngle, viewRayIntersectsGround);
 #else
 #error What to render?

--- a/atmosphere/default/shaders/single-scattering/on-the-fly/3/molecules/single-scattering.frag
+++ b/atmosphere/default/shaders/single-scattering/on-the-fly/3/molecules/single-scattering.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // single-scattering.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,15 +45,15 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // single-scattering.frag
-#line 1 2 // densities.h.glsl
+#line 4 0 // single-scattering.frag
+#line 1 3 // densities.h.glsl
 float scattererNumberDensity_molecules(float altitude);
 float scattererNumberDensity_aerosols(float altitude);
 float absorberNumberDensity_ozone(float altitude);
 vec4 scatteringCrossSection();
 float scattererDensity(float altitude);
-#line 6 0 // single-scattering.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // single-scattering.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -74,8 +85,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // single-scattering.frag
-#line 1 4 // single-scattering.h.glsl
+#line 6 0 // single-scattering.frag
+#line 1 5 // single-scattering.h.glsl
 #ifndef INCLUDE_ONCE_1DB2EDC1_C687_4FFA_BFF4_D18A54BA651B
 #define INCLUDE_ONCE_1DB2EDC1_C687_4FFA_BFF4_D18A54BA651B
 
@@ -83,8 +94,8 @@ vec4 computeSingleScattering(const float cosSunZenithAngle, const float cosViewZ
                              const float dotViewSun, const float altitude,
                              const bool viewRayIntersectsGround);
 #endif
-#line 8 0 // single-scattering.frag
-#line 1 5 // texture-sampling-functions.h.glsl
+#line 7 0 // single-scattering.frag
+#line 1 6 // texture-sampling-functions.h.glsl
 #ifndef INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 #define INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float altitude);
@@ -96,20 +107,20 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                 const int scatteringOrder);
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 #endif
-#line 9 0 // single-scattering.frag
+#line 8 0 // single-scattering.frag
 
 // This function omits phase function and solar irradiance: these are to be applied somewhere in the calling code.
 vec4 computeSingleScatteringIntegrand(const float cosSunZenithAngle, const float cosViewZenithAngle,
                                       const float dotViewSun, const float altitude,
                                       const float dist, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle here the case when the
     // endpoint of the view ray intentionally appears in outer space.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosSunZenithAngleAtDist=clampCosine((r*cosSunZenithAngle+dist*dotViewSun)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosSunZenithAngleAtDist=clampCosine((r*cosSunZenithAngle+dist*dotViewSun)/(earthRadius+altAtDist));
 
-    const vec4 xmittance=transmittance(cosViewZenithAngle, altitude, dist, viewRayIntersectsGround)
+    CONST vec4 xmittance=transmittance(cosViewZenithAngle, altitude, dist, viewRayIntersectsGround)
                                                     *
                          transmittanceToAtmosphereBorder(cosSunZenithAngleAtDist, altAtDist)
                                                     *
@@ -121,14 +132,14 @@ vec4 computeSingleScattering(const float cosSunZenithAngle, const float cosViewZ
                              const float dotViewSun, const float altitude,
                              const bool viewRayIntersectsGround)
 {
-    const float integrInterval=distanceToNearestAtmosphereBoundary(cosViewZenithAngle, altitude,
+    CONST float integrInterval=distanceToNearestAtmosphereBoundary(cosViewZenithAngle, altitude,
                                                                    viewRayIntersectsGround);
     // Using the midpoint rule for quadrature
     vec4 spectrum=vec4(0);
-    const float dl=integrInterval/radialIntegrationPoints;
+    CONST float dl=integrInterval/radialIntegrationPoints;
     for(int n=0; n<radialIntegrationPoints; ++n)
     {
-        const float dist=(n+0.5)*dl;
+        CONST float dist=(n+0.5)*dl;
         spectrum += computeSingleScatteringIntegrand(cosSunZenithAngle, cosViewZenithAngle, dotViewSun,
                                                      altitude, dist, viewRayIntersectsGround);
     }

--- a/atmosphere/default/shaders/single-scattering/on-the-fly/3/molecules/texture-coordinates.frag
+++ b/atmosphere/default/shaders/single-scattering/on-the-fly/3/molecules/texture-coordinates.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-coordinates.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,8 +45,8 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // texture-coordinates.frag
-#line 1 2 // texture-coordinates.h.glsl
+#line 4 0 // texture-coordinates.frag
+#line 1 3 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -104,8 +115,8 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 6 0 // texture-coordinates.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-coordinates.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -137,7 +148,7 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-coordinates.frag
+#line 6 0 // texture-coordinates.frag
 
 const float LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA=sqrt(atmosphereHeight*(atmosphereHeight+2*earthRadius));
 
@@ -205,18 +216,18 @@ vec3 indicesToTexCoords(const vec3 indices, const vec3 texSizes)
 
 TransmittanceTexVars transmittanceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
+    CONST float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
                                 texCoordToUnitRange(texCoord.t,transmittanceTextureSize.t);
     // Distance from Earth center to camera
-    const float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
-    const float altitude=r-earthRadius;
+    CONST float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
+    CONST float altitude=r-earthRadius;
 
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
     // distance to border of visible atmosphere from the view point
-    const float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
+    CONST float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
     // d==0 can happen when altitude==atmosphereHeight
-    const float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
+    CONST float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
     return TransmittanceTexVars(cosVZA,altitude);
 }
 
@@ -235,53 +246,53 @@ vec2 transmittanceTexVarsToTexCoord(const float cosVZA, float altitude)
     if(altitude<0)
         altitude=0;
 
-    const float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
+    CONST float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
                                       transmittanceTextureSize.t);
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
-    const float d=distanceToAtmosphereBorder(cosVZA,altitude);
-    const float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float d=distanceToAtmosphereBorder(cosVZA,altitude);
+    CONST float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
     return vec2(s,t);
 }
 
 // Output: vec2(cos(sunZenithAngle), altitude)
 IrradianceTexVars irradianceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
-    const float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
+    CONST float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
+    CONST float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
     return IrradianceTexVars(cosSZA,alt);
 }
 
 vec2 irradianceTexVarsToTexCoord(const float cosSunZenithAngle, const float altitude)
 {
-    const float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
-    const float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
+    CONST float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
+    CONST float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
     return vec2(s,t);
 }
 
 float cosSZAToUnitRangeTexCoord(const float cosSunZenithAngle)
 {
     // Distance to top atmosphere border along the ray groundUnderCamera-sun: (altitude, cosSunZenithAngle)
-    const float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name
-    const float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
+    CONST float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
     // TODO: choose a more descriptive name
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     return max(0.,1-a/A)/(a+1);
 }
 
 float unitRangeTexCoordToCosSZA(const float texCoord)
 {
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float a=(A-A*texCoord)/(1+A*texCoord);
-    const float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
+    CONST float a=(A-A*texCoord)/(1+A*texCoord);
+    CONST float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
     return distFromGroundToTopAtmoBorder==0 ? 1 :
         clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distFromGroundToTopAtmoBorder)) /
                     (2*earthRadius*distFromGroundToTopAtmoBorder));
@@ -292,24 +303,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
                                                const float dotViewSun, const float altitude,
                                                const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -317,24 +328,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float dotVSCoord=(dotViewSun+1)/2;
+    CONST float dotVSCoord=(dotViewSun+1)/2;
 
     // ------------------------------------
-    const float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
+    CONST float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
 
     return Scattering4DCoords(cosSZACoord, cosVZACoord, dotVSCoord, altCoord, viewRayIntersectsGround);
 }
 
 TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
@@ -342,16 +353,16 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture coordinates we combine into a single sampler3D coordinate.
-    const float texW = scatteringTextureSize[1];
-    const float texH = scatteringTextureSize[2];
-    const float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
-    const vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
+    CONST float texW = scatteringTextureSize[1];
+    CONST float texH = scatteringTextureSize[2];
+    CONST float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
+    CONST vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
                                         ceil (cosSZAIndex)*texW+coords.dotViewSun*(texW-1)) / (texW*texH-1);
-    const vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
+    CONST vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
 
-    const float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
+    CONST float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
 
-    const float alphaUpper=fract(cosSZAIndex);
+    CONST float alphaUpper=fract(cosSZAIndex);
     return TexCoordPair(vec3(cosVZAtc, combinedCoord.x, altitude), float(1-alphaUpper),
                         vec3(cosVZAtc, combinedCoord.y, altitude), float(alphaUpper));
 }
@@ -359,9 +370,9 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
+    CONST TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
     return texture(tex, texCoords.lower) * texCoords.alphaLower +
            texture(tex, texCoords.upper) * texCoords.alphaUpper;
 }
@@ -369,17 +380,17 @@ vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const f
 // 3D texture is the 3D single-altitude slice of a 4D texture
 vec3 scattering4DCoordsToTex3DCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2);
 
-    const float dvsSize = scatteringTextureSize[1];
-    const float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
+    CONST float dvsSize = scatteringTextureSize[1];
+    CONST float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
 
-    const float cszaSize = scatteringTextureSize[2];
-    const float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
+    CONST float cszaSize = scatteringTextureSize[2];
+    CONST float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
 
     return vec3(cosVZAtc, dotVStc, cosSZAtc);
 }
@@ -394,39 +405,39 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along dotViewSun coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[1];
-    const float posOfRow = indices[1];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[1];
+    CONST float posOfRow = indices[1];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         indexToTexCoord(currRow, numRows-1),
                                                         texCoordVerbatim));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               indexToTexCoord(currRow, numRows-1),
                                                               texCoordVerbatim));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          indexToTexCoord(currRow, numRows-1),
                                          texCoordVerbatim));
@@ -434,14 +445,14 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
 vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolationGuides01Tex,
                                  const vec3 indices)
 {
-    const float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
+    CONST float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
 
-    const float cosVZAIndex = indices[0];
-    const float dotVSIndex = indices[1];
-    const float currRow = floor(dotVSIndex);
-    const float posBetweenRows = dotVSIndex - currRow;
-    const float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cosVZAIndex = indices[0];
+    CONST float dotVSIndex = indices[1];
+    CONST float currRow = floor(dotVSIndex);
+    CONST float posBetweenRows = dotVSIndex - currRow;
+    CONST float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -449,14 +460,14 @@ vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolat
     indicesCurrRow[1] =     currRow;
     indicesNextRow[1] = min(currRow+1, scatteringTextureSize[1]-1.);
 
-    const vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
-    const vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
+    CONST vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
+    CONST vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
 
-    const vec4 valueCurrRow = texture(tex, coordsCurrRow);
-    const vec4 valueNextRow = texture(tex, coordsNextRow);
-    const float epsilon = 1e-37; // Prevents passing zero to log
-    const vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
-    const vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
+    CONST vec4 valueCurrRow = texture(tex, coordsCurrRow);
+    CONST vec4 valueNextRow = texture(tex, coordsNextRow);
+    CONST float epsilon = 1e-37; // Prevents passing zero to log
+    CONST vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
+    CONST vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
     return (logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow;
 }
 
@@ -465,37 +476,37 @@ float findGuide02Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along SZA coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[2];
-    const float posOfRow = indices[2];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[2];
+    CONST float posOfRow = indices[2];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
 }
@@ -505,19 +516,19 @@ vec4 sample3DTextureGuided(const sampler3D tex,
                            const float cosSunZenithAngle, const float cosViewZenithAngle,
                            const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
                                                                     dotViewSun, altitude, viewRayIntersectsGround);
     // Handle the external interpolation guides: the guides between a pair of VZA-dotViewSun 2D "pictures".
-    const vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
-    const vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
-    const float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
+    CONST vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
+    CONST float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
 
-    const float cvzaIndex = indices[0];
-    const float cszaIndex = indices[2];
-    const float currRow = floor(cszaIndex);
-    const float posBetweenRows = cszaIndex - currRow;
-    const float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cvzaIndex = indices[0];
+    CONST float cszaIndex = indices[2];
+    CONST float currRow = floor(cszaIndex);
+    CONST float posBetweenRows = cszaIndex - currRow;
+    CONST float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -526,58 +537,58 @@ vec4 sample3DTextureGuided(const sampler3D tex,
     indicesNextRow[2] = min(currRow+1, scatteringTextureSize[2]-1);
 
     // The caller will handle the internal interpolation guides: the ones between rows in each 2D "picture".
-    const vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
-    const vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
+    CONST vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
+    CONST vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
     return exp((logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow);
 }
 
 vec4 sample3DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
     return texture(tex, texCoords);
 }
 
 ScatteringTexVars scatteringTex4DCoordsToTexVars(const Scattering4DCoords coords)
 {
-    const float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
     // ------------------------------------
     float cosViewZenithAngle;
     if(coords.viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
     // ------------------------------------
-    const float dotViewSun=coords.dotViewSun*2-1;
+    CONST float dotViewSun=coords.dotViewSun*2-1;
 
     // ------------------------------------
-    const float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
+    CONST float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
 
     return ScatteringTexVars(cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, coords.viewRayIntersectsGround);
 }
 
 Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 {
-    const vec4 indexMax=scatteringTextureSize-vec4(1);
+    CONST vec4 indexMax=scatteringTextureSize-vec4(1);
     Scattering4DCoords coords4d;
     coords4d.viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
     // The following formulas assume that scatteringTextureSize[0] is even. For odd sizes they would change.
@@ -593,8 +604,8 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture indices we combine into a single sampler3D coordinate.
-    const float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
-    const float combinedIndex=texIndices[1];
+    CONST float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
+    CONST float combinedIndex=texIndices[1];
     coords4d.dotViewSun=mod(combinedIndex,texW)/(texW-1);
     coords4d.cosSunZenithAngle=floor(combinedIndex/texW)/(texH-1);
 
@@ -608,11 +619,11 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
 ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 {
-    const Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
+    CONST Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
     ScatteringTexVars vars=scatteringTex4DCoordsToTexVars(coords4d);
     // Clamp dotViewSun to its valid range of values, given cosViewZenithAngle and cosSunZenithAngle. This is
     // needed to prevent NaNs when computing the scattering texture.
-    const float cosVZA=vars.cosViewZenithAngle,
+    CONST float cosVZA=vars.cosViewZenithAngle,
                 cosSZA=vars.cosSunZenithAngle;
     vars.dotViewSun=clamp(vars.dotViewSun,
                           cosVZA*cosSZA-safeSqrt((1-sqr(cosVZA))*(1-sqr(cosSZA))),
@@ -622,54 +633,54 @@ ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 
 EclipseScatteringTexVars eclipseTexCoordsToTexVars(const vec2 texCoords, const float altitude)
 {
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
-    const bool viewRayIntersectsGround = texCoords.t<0.5;
+    CONST bool viewRayIntersectsGround = texCoords.t<0.5;
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
-    const float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
+    CONST float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
     return EclipseScatteringTexVars(azimuthRelativeToSun, cosViewZenithAngle, viewRayIntersectsGround);
 }
 
 EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                                    const float altitude, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -677,13 +688,13 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
-    const float azimuthCoord = azimuthRelativeToSun/(2*PI);
+    CONST float azimuthCoord = azimuthRelativeToSun/(2*PI);
 
     return EclipseScattering2DCoords(azimuthCoord, cosVZACoord);
 }
@@ -691,14 +702,14 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
 vec2 eclipseTexVarsToTexCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                const float altitude, const bool viewRayIntersectsGround, const vec2 texSize)
 {
-    const EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+    CONST EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                                     viewRayIntersectsGround);
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2);
-    const float azimuthTC = coords.azimuth + 1/(2*texSize.s);
+    CONST float azimuthTC = coords.azimuth + 1/(2*texSize.s);
 
     return vec2(azimuthTC, cosVZAtc);
 }
@@ -707,42 +718,42 @@ vec4 sampleEclipseDoubleScattering3DTexture(const sampler3D tex, const float cos
                                             const float cosViewZenithAngle, const float azimuthRelativeToSun,
                                             const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
+    CONST vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
                                                   eclipsedDoubleScatteringTextureSize.st);
-    const float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
-    const vec3 texCoords=vec3(coords2d, cosSZACoord);
+    CONST float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
+    CONST vec3 texCoords=vec3(coords2d, cosSZACoord);
 
     return texture(tex, texCoords);
 }
 
 LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 texIndices)
 {
-    const vec2 indexMax=lightPollutionTextureSize-vec2(1);
+    CONST vec2 indexMax=lightPollutionTextureSize-vec2(1);
 
-    const float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
-    const float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
+    CONST float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
-    const bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
-    const float cosViewZenithAngleCoord = viewRayIntersectsGround ?
+    CONST bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
+    CONST float cosViewZenithAngleCoord = viewRayIntersectsGround ?
                                    1-2*texIndices[0]/(indexMax[0]-1) :
                                    2*(texIndices[0]-1)/(indexMax[0]-1)-1;
     // ------------------------------------
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
@@ -753,23 +764,23 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 
 LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -777,27 +788,27 @@ LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, con
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     return LightPollution2DCoords(cosVZACoord, altCoord);
 }
 
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
-    const vec2 texSize = lightPollutionTextureSize;
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 texSize = lightPollutionTextureSize;
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2);
-    const float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
+    CONST float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
     return vec2(cosVZAtc, altitudeTC);
 }

--- a/atmosphere/default/shaders/single-scattering/on-the-fly/3/molecules/texture-sampling-functions.frag
+++ b/atmosphere/default/shaders/single-scattering/on-the-fly/3/molecules/texture-sampling-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-sampling-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,13 +45,13 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // texture-sampling-functions.frag
-#line 1 2 // phase-functions.h.glsl
+#line 4 0 // texture-sampling-functions.frag
+#line 1 3 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 6 0 // texture-sampling-functions.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-sampling-functions.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -72,8 +83,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-sampling-functions.frag
-#line 1 4 // texture-coordinates.h.glsl
+#line 6 0 // texture-sampling-functions.frag
+#line 1 5 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -142,7 +153,7 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 8 0 // texture-sampling-functions.frag
+#line 7 0 // texture-sampling-functions.frag
 
 uniform sampler2D transmittanceTexture;
 uniform sampler2D irradianceTexture;
@@ -154,13 +165,13 @@ uniform sampler2D lightPollutionScatteringTexture;
 
 vec4 irradiance(const float cosSunZenithAngle, const float altitude)
 {
-    const vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
+    CONST vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
     return texture(irradianceTexture, texCoords);
 }
 
 vec4 opticalDepthToAtmosphereBorder(const float cosViewZenithAngle, const float altitude)
 {
-    const vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
+    CONST vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact when looking into nadir from TOA at some values of texture sizes (in particular, size of
     // transmittance texture for altitude being 4096). This happens when I simply call texture(eclipsedScatteringTexture,
@@ -178,11 +189,11 @@ vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float
 vec4 transmittance(const float cosViewZenithAngle, const float altitude, const float dist,
                    const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle view ray endpoint
     // in space here.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
 
     vec4 depth;
     if(viewRayIntersectsGround)
@@ -201,7 +212,7 @@ vec4 transmittance(const float cosViewZenithAngle, const float altitude, const f
 vec4 calcFirstScattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                          const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
+    CONST vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
                                           dotViewSun, altitude, viewRayIntersectsGround);
     return scattering*currentPhaseFunction(dotViewSun);
 }
@@ -220,6 +231,6 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
 
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     return texture(lightPollutionScatteringTexture, coords);
 }

--- a/atmosphere/default/shaders/single-scattering/precomputed/aerosols/common-functions.frag
+++ b/atmosphere/default/shaders/single-scattering/precomputed/aerosols/common-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // common-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // common-functions.frag
+#line 4 0 // common-functions.frag
 
 bool dbgDataPresent=false;
 bool debugDataPresent()
@@ -69,7 +80,7 @@ void setDebugData(float a,float b, float c, float d)
 
 void swap(inout float x, inout float y)
 {
-    const float t = x;
+    CONST float t = x;
     x = y;
     y = t;
 }
@@ -83,7 +94,7 @@ float safeSqrt(const float x)
 
 float safeAtan(const float y, const float x)
 {
-    const float a = atan(y,x);
+    CONST float a = atan(y,x);
     return x==0 && y==0 ? 0 : a;
 }
 
@@ -116,23 +127,23 @@ float pointAltitude(vec3 point)
 
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float Ratm=earthRadius+atmosphereHeight;
-    const float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float Ratm=earthRadius+atmosphereHeight;
+    CONST float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float distanceToGround(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(-safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float cosZenithAngleOfHorizon(const float altitude)
 {
-    const float R=earthRadius;
-    const float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
+    CONST float R=earthRadius;
+    CONST float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
     return -sqrt(2*h*R+sqr(h))/(R+h);
 }
 
@@ -151,8 +162,8 @@ float distanceToNearestAtmosphereBoundary(const float cosZenithAngle, const floa
 float sunVisibility(const float cosSunZenithAngle, float altitude)
 {
     if(altitude<0) altitude=0;
-    const float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
-    const float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
+    CONST float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
+    CONST float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
     /* Approximating visible fraction of solar disk by smoothstep between the position of the Sun
      * touching the horizon by its upper part and the position with lower part touching the horizon.
      * The calculation assumes that solar angular radius is small and thus approximately equals its sine.
@@ -182,13 +193,13 @@ float circlesIntersectionArea(float R1, float R2, float d)
 
 float angleBetween(const vec3 a, const vec3 b)
 {
-    const float d=dot(a,b);
-    const float c=length(cross(a,b));
+    CONST float d=dot(a,b);
+    CONST float c=length(cross(a,b));
     // To avoid loss of precision, don't use dot product near the singularity
     // of acos, and cross product near the singularity of asin
     if(abs(d) < abs(c))
         return acos(d/(length(a)*length(b)));
-    const float smallerAngle = asin(c/(length(a)*length(b)));
+    CONST float smallerAngle = asin(c/(length(a)*length(b)));
     if(d<0) return PI-smallerAngle;
     return smallerAngle;
 }
@@ -205,11 +216,11 @@ float moonAngularRadius(const vec3 cameraPosition, const vec3 moonPosition)
 
 float visibleSolidAngleOfSun(const vec3 camera, const vec3 sunDir, const vec3 moonPos)
 {
-    const float Rs=sunAngularRadius;
-    const float Rm=moonAngularRadius(camera,moonPos);
+    CONST float Rs=sunAngularRadius;
+    CONST float Rm=moonAngularRadius(camera,moonPos);
     float visibleSolidAngle=PI*sqr(Rs);
 
-    const float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
+    CONST float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
     if(dSM<Rs+Rm)
     {
         visibleSolidAngle -= circlesIntersectionArea(Rm,Rs,dSM);
@@ -229,12 +240,12 @@ float sphereIntegrationSolidAngleDifferential(const int pointCountOnSphere)
 }
 vec3 sphereIntegrationSampleDir(const int index, const int pointCountOnSphere)
 {
-    const float goldenRatio=1.6180339887499;
+    CONST float goldenRatio=1.6180339887499;
     // The range of n is 0.5, 1.5, ..., pointCountOnSphere-0.5
-    const float n=index+0.5;
+    CONST float n=index+0.5;
     // Explanation of the Fibonacci grid generation can be seen at https://stackoverflow.com/a/44164075/673852
-    const float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
-    const float azimuth=n*(2*PI*goldenRatio);
+    CONST float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
+    CONST float azimuth=n*(2*PI*goldenRatio);
     return vec3(cos(azimuth)*sin(zenithAngle),
                 sin(azimuth)*sin(zenithAngle),
                 cos(zenithAngle));

--- a/atmosphere/default/shaders/single-scattering/precomputed/aerosols/densities.frag
+++ b/atmosphere/default/shaders/single-scattering/precomputed/aerosols/densities.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // densities.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,20 +45,20 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // densities.frag
+#line 4 0 // densities.frag
 float scattererNumberDensity_molecules(float altitude)
 {
-        const float rayleighScaleHeight=8*km;
+        CONST float rayleighScaleHeight=8*km;
         return 3.08458e25*exp(-1/rayleighScaleHeight * altitude);
 }
 float scattererNumberDensity_aerosols(float altitude)
 {
-        const float mieScaleHeight=1.2*km;
+        CONST float mieScaleHeight=1.2*km;
         return 1.03333e8*exp(-1/mieScaleHeight*altitude);
 }
 float absorberNumberDensity_ozone(float altitude)
 {
-        const float totalOzoneAmount=370*dobsonUnit;
+        CONST float totalOzoneAmount=370*dobsonUnit;
 
         float density;
 

--- a/atmosphere/default/shaders/single-scattering/precomputed/aerosols/phase-functions.frag
+++ b/atmosphere/default/shaders/single-scattering/precomputed/aerosols/phase-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // phase-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // phase-functions.frag
+#line 4 0 // phase-functions.frag
 
 vec4 phaseFunction_molecules(float dotViewSun)
 {
@@ -42,9 +53,9 @@ vec4 phaseFunction_molecules(float dotViewSun)
 }
 vec4 phaseFunction_aerosols(float dotViewSun)
 {
-        const float g=0.76;
-        const float g2=g*g;
-        const float k = 3/(8*PI)*(1-g2)/(2+g2);
+        CONST float g=0.76;
+        CONST float g2=g*g;
+        CONST float k = 3/(8*PI)*(1-g2)/(2+g2);
         return vec4(k * (1+sqr(dotViewSun)) / pow(1+g2 - 2*g*dotViewSun, 1.5) + 1/((1-dotViewSun)*600+0.05))*0.904;
 }
 vec4 currentPhaseFunction(float dotViewSun) { return phaseFunction_aerosols(dotViewSun); }

--- a/atmosphere/default/shaders/single-scattering/precomputed/aerosols/render.frag
+++ b/atmosphere/default/shaders/single-scattering/precomputed/aerosols/render.frag
@@ -1,7 +1,21 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
 
-#line 1 1 // const.h.glsl
+
+
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 6 0 // render.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,11 +48,11 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // render.frag
-#line 1 2 // calc-view-dir.h.glsl
+#line 7 0 // render.frag
+#line 1 3 // calc-view-dir.h.glsl
 vec3 calcViewDir();
-#line 6 0 // render.frag
-#line 1 3 // common-functions.h.glsl
+#line 8 0 // render.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -70,13 +84,13 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // render.frag
-#line 1 4 // phase-functions.h.glsl
+#line 9 0 // render.frag
+#line 1 5 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 8 0 // render.frag
-#line 1 5 // single-scattering.h.glsl
+#line 10 0 // render.frag
+#line 1 6 // single-scattering.h.glsl
 #ifndef INCLUDE_ONCE_1DB2EDC1_C687_4FFA_BFF4_D18A54BA651B
 #define INCLUDE_ONCE_1DB2EDC1_C687_4FFA_BFF4_D18A54BA651B
 
@@ -84,9 +98,9 @@ vec4 computeSingleScattering(const float cosSunZenithAngle, const float cosViewZ
                              const float dotViewSun, const float altitude,
                              const bool viewRayIntersectsGround);
 #endif
-#line 9 0 // render.frag
+#line 11 0 // render.frag
 
-#line 1 6 // texture-coordinates.h.glsl
+#line 1 7 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -155,10 +169,10 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 11 0 // render.frag
-#line 1 7 // radiance-to-luminance.h.glsl
+#line 13 0 // render.frag
+#line 1 8 // radiance-to-luminance.h.glsl
 const mat4 radianceToLuminance=mat4(19.8756237,7.17745161,0,0.0937032327,  2.13895917,0.772417068,0,0.0149318045,  0.241072536,0.0870557055,0,0,  0.0133876652,0.00483453181,0,0);
-#line 12 0 // render.frag
+#line 14 0 // render.frag
 
 
 
@@ -195,18 +209,18 @@ void main()
     // this approximation has the same order of magnitude as the assumption that the Earth and its atmosphere
     // are spherical.
     float altitude = max(cameraPosition.z, 0.);
-    const vec3 oldCamPos=cameraPosition;
+    CONST vec3 oldCamPos=cameraPosition;
     // Hide the uniform with this name, thus effectively modifying it for the following code
     vec3 cameraPosition=vec3(oldCamPos.xy, altitude);
 
     bool lookingIntoAtmosphere=true;
     if(altitude>atmosphereHeight)
     {
-        const vec3 p = cameraPosition - earthCenter;
-        const float p_dot_v = dot(p, viewDir);
-        const float p_dot_p = dot(p, p);
-        const float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
-        const float distanceToTOA = -p_dot_v - sqrt(sqr(earthRadius+atmosphereHeight) - squaredDistBetweenViewRayAndEarthCenter);
+        CONST vec3 p = cameraPosition - earthCenter;
+        CONST float p_dot_v = dot(p, viewDir);
+        CONST float p_dot_p = dot(p, p);
+        CONST float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
+        CONST float distanceToTOA = -p_dot_v - sqrt(sqr(earthRadius+atmosphereHeight) - squaredDistBetweenViewRayAndEarthCenter);
         if(distanceToTOA>=0)
         {
             cameraPosition += viewDir*distanceToTOA;
@@ -214,7 +228,7 @@ void main()
         }
         else
         {
-#if RENDERING_ANY_ZERO_SCATTERING
+#if 0 /*RENDERING_ANY_ZERO_SCATTERING*/
             lookingIntoAtmosphere=false;
 #else
             luminance=vec4(0);
@@ -224,16 +238,16 @@ void main()
         }
     }
 
-    const vec3 zenith=normalize(cameraPosition-earthCenter);
+    CONST vec3 zenith=normalize(cameraPosition-earthCenter);
     float cosViewZenithAngle=dot(zenith,viewDir);
 
     bool viewRayIntersectsGround=false;
     {
-        const vec3 p = cameraPosition - earthCenter;
-        const float p_dot_v = dot(p, viewDir);
-        const float p_dot_p = dot(p, p);
-        const float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
-        const float distanceToIntersection = -p_dot_v - sqrt(sqr(earthRadius) - squaredDistBetweenViewRayAndEarthCenter);
+        CONST vec3 p = cameraPosition - earthCenter;
+        CONST float p_dot_v = dot(p, viewDir);
+        CONST float p_dot_p = dot(p, p);
+        CONST float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
+        CONST float distanceToIntersection = -p_dot_v - sqrt(sqr(earthRadius) - squaredDistBetweenViewRayAndEarthCenter);
         // altitude==0 is a special case where distance to intersection calculation
         // is unreliable (has a lot of noise in its sign), so check it separately
         if(distanceToIntersection>0 || (altitude==0 && cosViewZenithAngle<0))
@@ -244,11 +258,11 @@ void main()
     // Aside from aesthetics, this affects brightness input to Stellarium's tone mapper.
     if(pseudoMirrorSkyBelowHorizon && viewRayIntersectsGround)
     {
-        const float horizonCZA = cosZenithAngleOfHorizon(altitude);
-        const float viewElev  = asin(clampCosine(cosViewZenithAngle));
-        const float horizElev = asin(clampCosine(horizonCZA));
-        const float newViewElev = 2*horizElev - viewElev;
-        const float viewDirXYnorm = length(viewDir-zenith*cosViewZenithAngle);
+        CONST float horizonCZA = cosZenithAngleOfHorizon(altitude);
+        CONST float viewElev  = asin(clampCosine(cosViewZenithAngle));
+        CONST float horizElev = asin(clampCosine(horizonCZA));
+        CONST float newViewElev = 2*horizElev - viewElev;
+        CONST float viewDirXYnorm = length(viewDir-zenith*cosViewZenithAngle);
         if(viewDirXYnorm == 0)
         {
             viewDir = zenith;
@@ -267,27 +281,27 @@ void main()
         viewRayIntersectsGround = false;
     }
 
-    const float cosSunZenithAngle =dot(zenith,sunDirection);
-    const float dotViewSun=dot(viewDir,sunDirection);
+    CONST float cosSunZenithAngle =dot(zenith,sunDirection);
+    CONST float dotViewSun=dot(viewDir,sunDirection);
 
-    const vec3 sunXYunnorm=sunDirection-dot(sunDirection,zenith)*zenith;
-    const vec3 viewXYunnorm=viewDir-dot(viewDir,zenith)*zenith;
-    const vec3 sunXY = sunXYunnorm.x!=0 || sunXYunnorm.y!=0 || sunXYunnorm.z!=0 ? normalize(sunXYunnorm) : vec3(0);
-    const vec3 viewXY = viewXYunnorm.x!=0 || viewXYunnorm.y!=0 || viewXYunnorm.z!=0 ? normalize(viewXYunnorm) : vec3(0);
-    const float azimuthRelativeToSun=safeAtan(dot(cross(sunXY, viewXY), zenith), dot(sunXY, viewXY));
+    CONST vec3 sunXYunnorm=sunDirection-dot(sunDirection,zenith)*zenith;
+    CONST vec3 viewXYunnorm=viewDir-dot(viewDir,zenith)*zenith;
+    CONST vec3 sunXY = sunXYunnorm.x!=0 || sunXYunnorm.y!=0 || sunXYunnorm.z!=0 ? normalize(sunXYunnorm) : vec3(0);
+    CONST vec3 viewXY = viewXYunnorm.x!=0 || viewXYunnorm.y!=0 || viewXYunnorm.z!=0 ? normalize(viewXYunnorm) : vec3(0);
+    CONST float azimuthRelativeToSun=safeAtan(dot(cross(sunXY, viewXY), zenith), dot(sunXY, viewXY));
 
-#if RENDERING_ZERO_SCATTERING
+#if 0 /*RENDERING_ZERO_SCATTERING*/
     vec4 radiance;
     if(viewRayIntersectsGround)
     {
         // XXX: keep in sync with the same code in computeScatteringDensity(), but don't forget about
         //      the difference in the usage of viewDir vs incDir.
-        const float distToGround = distanceToGround(cosViewZenithAngle, altitude);
-        const vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
-        const vec3 groundNormal = normalize(zenith*(earthRadius+altitude)+viewDir*distToGround);
-        const vec4 groundIrradiance = irradiance(dot(groundNormal, sunDirection), 0);
+        CONST float distToGround = distanceToGround(cosViewZenithAngle, altitude);
+        CONST vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
+        CONST vec3 groundNormal = normalize(zenith*(earthRadius+altitude)+viewDir*distToGround);
+        CONST vec4 groundIrradiance = irradiance(dot(groundNormal, sunDirection), 0);
         // Radiation scattered by the ground
-        const float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
+        CONST float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
         radiance = transmittanceToGround*groundAlbedo*groundIrradiance*solarIrradianceFixup*groundBRDF
                  + lightPollutionGroundLuminance*lightPollutionRelativeRadiance;
     }
@@ -304,22 +318,22 @@ void main()
     }
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_ZERO_SCATTERING
+#elif 0 /*RENDERING_ECLIPSED_ZERO_SCATTERING*/
     vec4 radiance;
-    const float dotViewMoon=dot(viewDir,normalize(moonPosition-cameraPosition));
+    CONST float dotViewMoon=dot(viewDir,normalize(moonPosition-cameraPosition));
     if(viewRayIntersectsGround)
     {
         // XXX: keep in sync with the similar code in non-eclipsed zero scattering rendering.
-        const float distToGround = distanceToGround(cosViewZenithAngle, altitude);
-        const vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
-        const vec3 pointOnGround = cameraPosition+viewDir*distToGround;
-        const vec4 directGroundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDirection, moonPosition);
+        CONST float distToGround = distanceToGround(cosViewZenithAngle, altitude);
+        CONST vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
+        CONST vec3 pointOnGround = cameraPosition+viewDir*distToGround;
+        CONST vec4 directGroundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDirection, moonPosition);
         // FIXME: add first-order indirect irradiance too: it's done in non-eclipsed irradiance (in the same
         // conditions: when limited to 2 orders). This should be calculated at the same time when second order
         // is: all the infrastructure is already there.
-        const vec4 groundIrradiance = directGroundIrradiance;
+        CONST vec4 groundIrradiance = directGroundIrradiance;
         // Radiation scattered by the ground
-        const float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
+        CONST float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
         radiance = transmittanceToGround*groundAlbedo*groundIrradiance*solarIrradianceFixup*groundBRDF
                  + lightPollutionGroundLuminance*lightPollutionRelativeRadiance;
     }
@@ -336,53 +350,53 @@ void main()
     }
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_ON_THE_FLY
-    const vec4 scattering=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPosition,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_ON_THE_FLY*/
+    CONST vec4 scattering=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPosition,
                                                           viewRayIntersectsGround);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE
-    const vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE*/
+    CONST vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                      viewRayIntersectsGround, eclipsedSingleScatteringTextureSize);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact at the point where azimuth texture coordinate changes from 1 to 0 (at azimuthRelativeToSun crossing
     // 0). This happens when I simply call texture(eclipsedScatteringTexture, texCoords) without specifying LOD.
     // Apparently, the driver uses the derivative for some reason, even though it shouldn't.
-    const vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
+    CONST vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE
-    const vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
+    CONST vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                      viewRayIntersectsGround, eclipsedSingleScatteringTextureSize);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact at the point where azimuth texture coordinate changes from 1 to 0 (at azimuthRelativeToSun crossing
     // 0). This happens when I simply call texture(eclipsedScatteringTexture, texCoords) without specifying LOD.
     // Apparently, the driver uses the derivative for some reason, even though it shouldn't.
-    const vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
+    CONST vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
     luminance=scattering*currentPhaseFunction(dotViewSun);
-#elif RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_RADIANCE
+#elif 0 /*RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_RADIANCE*/
     vec4 radiance=exp(sampleEclipseDoubleScattering3DTexture(eclipsedDoubleScatteringTexture,
                                                              cosSunZenithAngle, cosViewZenithAngle, azimuthRelativeToSun,
                                                              altitude, viewRayIntersectsGround));
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_LUMINANCE
+#elif 0 /*RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
     luminance=exp(sampleEclipseDoubleScattering3DTexture(eclipsedDoubleScatteringTexture,
                                                          cosSunZenithAngle, cosViewZenithAngle, azimuthRelativeToSun,
                                                          altitude, viewRayIntersectsGround));
-#elif RENDERING_SINGLE_SCATTERING_ON_THE_FLY
-    const vec4 scattering=computeSingleScattering(cosSunZenithAngle,cosViewZenithAngle,dotViewSun,
+#elif 0 /*RENDERING_SINGLE_SCATTERING_ON_THE_FLY*/
+    CONST vec4 scattering=computeSingleScattering(cosSunZenithAngle,cosViewZenithAngle,dotViewSun,
                                                   altitude,viewRayIntersectsGround);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE
+#elif 0 /*RENDERING_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE*/
     vec4 scattering;
     if(useInterpolationGuides)
     {
@@ -413,18 +427,18 @@ void main()
                                      dotViewSun, altitude, viewRayIntersectsGround);
     }
     luminance=scattering * (bool(0) ? vec4(1) : currentPhaseFunction(dotViewSun));
-#elif RENDERING_MULTIPLE_SCATTERING_LUMINANCE
+#elif 0 /*RENDERING_MULTIPLE_SCATTERING_LUMINANCE*/
     luminance=sample3DTexture(scatteringTexture, cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, viewRayIntersectsGround);
-#elif RENDERING_MULTIPLE_SCATTERING_RADIANCE
+#elif 0 /*RENDERING_MULTIPLE_SCATTERING_RADIANCE*/
     vec4 radiance=sample3DTexture(scatteringTexture, cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, viewRayIntersectsGround);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_LIGHT_POLLUTION_RADIANCE
+#elif 0 /*RENDERING_LIGHT_POLLUTION_RADIANCE*/
     vec4 radiance=lightPollutionGroundLuminance*lightPollutionScattering(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_LIGHT_POLLUTION_LUMINANCE
+#elif 0 /*RENDERING_LIGHT_POLLUTION_LUMINANCE*/
     luminance=lightPollutionGroundLuminance*lightPollutionScattering(altitude, cosViewZenithAngle, viewRayIntersectsGround);
 #else
 #error What to render?

--- a/atmosphere/default/shaders/single-scattering/precomputed/aerosols/single-scattering.frag
+++ b/atmosphere/default/shaders/single-scattering/precomputed/aerosols/single-scattering.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // single-scattering.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,15 +45,15 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // single-scattering.frag
-#line 1 2 // densities.h.glsl
+#line 4 0 // single-scattering.frag
+#line 1 3 // densities.h.glsl
 float scattererNumberDensity_molecules(float altitude);
 float scattererNumberDensity_aerosols(float altitude);
 float absorberNumberDensity_ozone(float altitude);
 vec4 scatteringCrossSection();
 float scattererDensity(float altitude);
-#line 6 0 // single-scattering.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // single-scattering.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -74,8 +85,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // single-scattering.frag
-#line 1 4 // single-scattering.h.glsl
+#line 6 0 // single-scattering.frag
+#line 1 5 // single-scattering.h.glsl
 #ifndef INCLUDE_ONCE_1DB2EDC1_C687_4FFA_BFF4_D18A54BA651B
 #define INCLUDE_ONCE_1DB2EDC1_C687_4FFA_BFF4_D18A54BA651B
 
@@ -83,8 +94,8 @@ vec4 computeSingleScattering(const float cosSunZenithAngle, const float cosViewZ
                              const float dotViewSun, const float altitude,
                              const bool viewRayIntersectsGround);
 #endif
-#line 8 0 // single-scattering.frag
-#line 1 5 // texture-sampling-functions.h.glsl
+#line 7 0 // single-scattering.frag
+#line 1 6 // texture-sampling-functions.h.glsl
 #ifndef INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 #define INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float altitude);
@@ -96,20 +107,20 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                 const int scatteringOrder);
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 #endif
-#line 9 0 // single-scattering.frag
+#line 8 0 // single-scattering.frag
 
 // This function omits phase function and solar irradiance: these are to be applied somewhere in the calling code.
 vec4 computeSingleScatteringIntegrand(const float cosSunZenithAngle, const float cosViewZenithAngle,
                                       const float dotViewSun, const float altitude,
                                       const float dist, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle here the case when the
     // endpoint of the view ray intentionally appears in outer space.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosSunZenithAngleAtDist=clampCosine((r*cosSunZenithAngle+dist*dotViewSun)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosSunZenithAngleAtDist=clampCosine((r*cosSunZenithAngle+dist*dotViewSun)/(earthRadius+altAtDist));
 
-    const vec4 xmittance=transmittance(cosViewZenithAngle, altitude, dist, viewRayIntersectsGround)
+    CONST vec4 xmittance=transmittance(cosViewZenithAngle, altitude, dist, viewRayIntersectsGround)
                                                     *
                          transmittanceToAtmosphereBorder(cosSunZenithAngleAtDist, altAtDist)
                                                     *
@@ -121,14 +132,14 @@ vec4 computeSingleScattering(const float cosSunZenithAngle, const float cosViewZ
                              const float dotViewSun, const float altitude,
                              const bool viewRayIntersectsGround)
 {
-    const float integrInterval=distanceToNearestAtmosphereBoundary(cosViewZenithAngle, altitude,
+    CONST float integrInterval=distanceToNearestAtmosphereBoundary(cosViewZenithAngle, altitude,
                                                                    viewRayIntersectsGround);
     // Using the midpoint rule for quadrature
     vec4 spectrum=vec4(0);
-    const float dl=integrInterval/radialIntegrationPoints;
+    CONST float dl=integrInterval/radialIntegrationPoints;
     for(int n=0; n<radialIntegrationPoints; ++n)
     {
-        const float dist=(n+0.5)*dl;
+        CONST float dist=(n+0.5)*dl;
         spectrum += computeSingleScatteringIntegrand(cosSunZenithAngle, cosViewZenithAngle, dotViewSun,
                                                      altitude, dist, viewRayIntersectsGround);
     }

--- a/atmosphere/default/shaders/single-scattering/precomputed/aerosols/texture-coordinates.frag
+++ b/atmosphere/default/shaders/single-scattering/precomputed/aerosols/texture-coordinates.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-coordinates.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,8 +45,8 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // texture-coordinates.frag
-#line 1 2 // texture-coordinates.h.glsl
+#line 4 0 // texture-coordinates.frag
+#line 1 3 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -104,8 +115,8 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 6 0 // texture-coordinates.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-coordinates.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -137,7 +148,7 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-coordinates.frag
+#line 6 0 // texture-coordinates.frag
 
 const float LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA=sqrt(atmosphereHeight*(atmosphereHeight+2*earthRadius));
 
@@ -205,18 +216,18 @@ vec3 indicesToTexCoords(const vec3 indices, const vec3 texSizes)
 
 TransmittanceTexVars transmittanceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
+    CONST float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
                                 texCoordToUnitRange(texCoord.t,transmittanceTextureSize.t);
     // Distance from Earth center to camera
-    const float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
-    const float altitude=r-earthRadius;
+    CONST float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
+    CONST float altitude=r-earthRadius;
 
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
     // distance to border of visible atmosphere from the view point
-    const float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
+    CONST float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
     // d==0 can happen when altitude==atmosphereHeight
-    const float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
+    CONST float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
     return TransmittanceTexVars(cosVZA,altitude);
 }
 
@@ -235,53 +246,53 @@ vec2 transmittanceTexVarsToTexCoord(const float cosVZA, float altitude)
     if(altitude<0)
         altitude=0;
 
-    const float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
+    CONST float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
                                       transmittanceTextureSize.t);
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
-    const float d=distanceToAtmosphereBorder(cosVZA,altitude);
-    const float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float d=distanceToAtmosphereBorder(cosVZA,altitude);
+    CONST float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
     return vec2(s,t);
 }
 
 // Output: vec2(cos(sunZenithAngle), altitude)
 IrradianceTexVars irradianceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
-    const float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
+    CONST float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
+    CONST float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
     return IrradianceTexVars(cosSZA,alt);
 }
 
 vec2 irradianceTexVarsToTexCoord(const float cosSunZenithAngle, const float altitude)
 {
-    const float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
-    const float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
+    CONST float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
+    CONST float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
     return vec2(s,t);
 }
 
 float cosSZAToUnitRangeTexCoord(const float cosSunZenithAngle)
 {
     // Distance to top atmosphere border along the ray groundUnderCamera-sun: (altitude, cosSunZenithAngle)
-    const float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name
-    const float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
+    CONST float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
     // TODO: choose a more descriptive name
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     return max(0.,1-a/A)/(a+1);
 }
 
 float unitRangeTexCoordToCosSZA(const float texCoord)
 {
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float a=(A-A*texCoord)/(1+A*texCoord);
-    const float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
+    CONST float a=(A-A*texCoord)/(1+A*texCoord);
+    CONST float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
     return distFromGroundToTopAtmoBorder==0 ? 1 :
         clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distFromGroundToTopAtmoBorder)) /
                     (2*earthRadius*distFromGroundToTopAtmoBorder));
@@ -292,24 +303,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
                                                const float dotViewSun, const float altitude,
                                                const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -317,24 +328,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float dotVSCoord=(dotViewSun+1)/2;
+    CONST float dotVSCoord=(dotViewSun+1)/2;
 
     // ------------------------------------
-    const float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
+    CONST float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
 
     return Scattering4DCoords(cosSZACoord, cosVZACoord, dotVSCoord, altCoord, viewRayIntersectsGround);
 }
 
 TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
@@ -342,16 +353,16 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture coordinates we combine into a single sampler3D coordinate.
-    const float texW = scatteringTextureSize[1];
-    const float texH = scatteringTextureSize[2];
-    const float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
-    const vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
+    CONST float texW = scatteringTextureSize[1];
+    CONST float texH = scatteringTextureSize[2];
+    CONST float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
+    CONST vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
                                         ceil (cosSZAIndex)*texW+coords.dotViewSun*(texW-1)) / (texW*texH-1);
-    const vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
+    CONST vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
 
-    const float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
+    CONST float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
 
-    const float alphaUpper=fract(cosSZAIndex);
+    CONST float alphaUpper=fract(cosSZAIndex);
     return TexCoordPair(vec3(cosVZAtc, combinedCoord.x, altitude), float(1-alphaUpper),
                         vec3(cosVZAtc, combinedCoord.y, altitude), float(alphaUpper));
 }
@@ -359,9 +370,9 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
+    CONST TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
     return texture(tex, texCoords.lower) * texCoords.alphaLower +
            texture(tex, texCoords.upper) * texCoords.alphaUpper;
 }
@@ -369,17 +380,17 @@ vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const f
 // 3D texture is the 3D single-altitude slice of a 4D texture
 vec3 scattering4DCoordsToTex3DCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2);
 
-    const float dvsSize = scatteringTextureSize[1];
-    const float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
+    CONST float dvsSize = scatteringTextureSize[1];
+    CONST float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
 
-    const float cszaSize = scatteringTextureSize[2];
-    const float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
+    CONST float cszaSize = scatteringTextureSize[2];
+    CONST float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
 
     return vec3(cosVZAtc, dotVStc, cosSZAtc);
 }
@@ -394,39 +405,39 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along dotViewSun coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[1];
-    const float posOfRow = indices[1];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[1];
+    CONST float posOfRow = indices[1];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         indexToTexCoord(currRow, numRows-1),
                                                         texCoordVerbatim));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               indexToTexCoord(currRow, numRows-1),
                                                               texCoordVerbatim));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          indexToTexCoord(currRow, numRows-1),
                                          texCoordVerbatim));
@@ -434,14 +445,14 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
 vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolationGuides01Tex,
                                  const vec3 indices)
 {
-    const float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
+    CONST float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
 
-    const float cosVZAIndex = indices[0];
-    const float dotVSIndex = indices[1];
-    const float currRow = floor(dotVSIndex);
-    const float posBetweenRows = dotVSIndex - currRow;
-    const float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cosVZAIndex = indices[0];
+    CONST float dotVSIndex = indices[1];
+    CONST float currRow = floor(dotVSIndex);
+    CONST float posBetweenRows = dotVSIndex - currRow;
+    CONST float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -449,14 +460,14 @@ vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolat
     indicesCurrRow[1] =     currRow;
     indicesNextRow[1] = min(currRow+1, scatteringTextureSize[1]-1.);
 
-    const vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
-    const vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
+    CONST vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
+    CONST vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
 
-    const vec4 valueCurrRow = texture(tex, coordsCurrRow);
-    const vec4 valueNextRow = texture(tex, coordsNextRow);
-    const float epsilon = 1e-37; // Prevents passing zero to log
-    const vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
-    const vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
+    CONST vec4 valueCurrRow = texture(tex, coordsCurrRow);
+    CONST vec4 valueNextRow = texture(tex, coordsNextRow);
+    CONST float epsilon = 1e-37; // Prevents passing zero to log
+    CONST vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
+    CONST vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
     return (logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow;
 }
 
@@ -465,37 +476,37 @@ float findGuide02Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along SZA coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[2];
-    const float posOfRow = indices[2];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[2];
+    CONST float posOfRow = indices[2];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
 }
@@ -505,19 +516,19 @@ vec4 sample3DTextureGuided(const sampler3D tex,
                            const float cosSunZenithAngle, const float cosViewZenithAngle,
                            const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
                                                                     dotViewSun, altitude, viewRayIntersectsGround);
     // Handle the external interpolation guides: the guides between a pair of VZA-dotViewSun 2D "pictures".
-    const vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
-    const vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
-    const float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
+    CONST vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
+    CONST float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
 
-    const float cvzaIndex = indices[0];
-    const float cszaIndex = indices[2];
-    const float currRow = floor(cszaIndex);
-    const float posBetweenRows = cszaIndex - currRow;
-    const float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cvzaIndex = indices[0];
+    CONST float cszaIndex = indices[2];
+    CONST float currRow = floor(cszaIndex);
+    CONST float posBetweenRows = cszaIndex - currRow;
+    CONST float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -526,58 +537,58 @@ vec4 sample3DTextureGuided(const sampler3D tex,
     indicesNextRow[2] = min(currRow+1, scatteringTextureSize[2]-1);
 
     // The caller will handle the internal interpolation guides: the ones between rows in each 2D "picture".
-    const vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
-    const vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
+    CONST vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
+    CONST vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
     return exp((logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow);
 }
 
 vec4 sample3DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
     return texture(tex, texCoords);
 }
 
 ScatteringTexVars scatteringTex4DCoordsToTexVars(const Scattering4DCoords coords)
 {
-    const float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
     // ------------------------------------
     float cosViewZenithAngle;
     if(coords.viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
     // ------------------------------------
-    const float dotViewSun=coords.dotViewSun*2-1;
+    CONST float dotViewSun=coords.dotViewSun*2-1;
 
     // ------------------------------------
-    const float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
+    CONST float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
 
     return ScatteringTexVars(cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, coords.viewRayIntersectsGround);
 }
 
 Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 {
-    const vec4 indexMax=scatteringTextureSize-vec4(1);
+    CONST vec4 indexMax=scatteringTextureSize-vec4(1);
     Scattering4DCoords coords4d;
     coords4d.viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
     // The following formulas assume that scatteringTextureSize[0] is even. For odd sizes they would change.
@@ -593,8 +604,8 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture indices we combine into a single sampler3D coordinate.
-    const float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
-    const float combinedIndex=texIndices[1];
+    CONST float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
+    CONST float combinedIndex=texIndices[1];
     coords4d.dotViewSun=mod(combinedIndex,texW)/(texW-1);
     coords4d.cosSunZenithAngle=floor(combinedIndex/texW)/(texH-1);
 
@@ -608,11 +619,11 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
 ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 {
-    const Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
+    CONST Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
     ScatteringTexVars vars=scatteringTex4DCoordsToTexVars(coords4d);
     // Clamp dotViewSun to its valid range of values, given cosViewZenithAngle and cosSunZenithAngle. This is
     // needed to prevent NaNs when computing the scattering texture.
-    const float cosVZA=vars.cosViewZenithAngle,
+    CONST float cosVZA=vars.cosViewZenithAngle,
                 cosSZA=vars.cosSunZenithAngle;
     vars.dotViewSun=clamp(vars.dotViewSun,
                           cosVZA*cosSZA-safeSqrt((1-sqr(cosVZA))*(1-sqr(cosSZA))),
@@ -622,54 +633,54 @@ ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 
 EclipseScatteringTexVars eclipseTexCoordsToTexVars(const vec2 texCoords, const float altitude)
 {
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
-    const bool viewRayIntersectsGround = texCoords.t<0.5;
+    CONST bool viewRayIntersectsGround = texCoords.t<0.5;
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
-    const float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
+    CONST float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
     return EclipseScatteringTexVars(azimuthRelativeToSun, cosViewZenithAngle, viewRayIntersectsGround);
 }
 
 EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                                    const float altitude, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -677,13 +688,13 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
-    const float azimuthCoord = azimuthRelativeToSun/(2*PI);
+    CONST float azimuthCoord = azimuthRelativeToSun/(2*PI);
 
     return EclipseScattering2DCoords(azimuthCoord, cosVZACoord);
 }
@@ -691,14 +702,14 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
 vec2 eclipseTexVarsToTexCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                const float altitude, const bool viewRayIntersectsGround, const vec2 texSize)
 {
-    const EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+    CONST EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                                     viewRayIntersectsGround);
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2);
-    const float azimuthTC = coords.azimuth + 1/(2*texSize.s);
+    CONST float azimuthTC = coords.azimuth + 1/(2*texSize.s);
 
     return vec2(azimuthTC, cosVZAtc);
 }
@@ -707,42 +718,42 @@ vec4 sampleEclipseDoubleScattering3DTexture(const sampler3D tex, const float cos
                                             const float cosViewZenithAngle, const float azimuthRelativeToSun,
                                             const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
+    CONST vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
                                                   eclipsedDoubleScatteringTextureSize.st);
-    const float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
-    const vec3 texCoords=vec3(coords2d, cosSZACoord);
+    CONST float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
+    CONST vec3 texCoords=vec3(coords2d, cosSZACoord);
 
     return texture(tex, texCoords);
 }
 
 LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 texIndices)
 {
-    const vec2 indexMax=lightPollutionTextureSize-vec2(1);
+    CONST vec2 indexMax=lightPollutionTextureSize-vec2(1);
 
-    const float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
-    const float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
+    CONST float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
-    const bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
-    const float cosViewZenithAngleCoord = viewRayIntersectsGround ?
+    CONST bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
+    CONST float cosViewZenithAngleCoord = viewRayIntersectsGround ?
                                    1-2*texIndices[0]/(indexMax[0]-1) :
                                    2*(texIndices[0]-1)/(indexMax[0]-1)-1;
     // ------------------------------------
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
@@ -753,23 +764,23 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 
 LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -777,27 +788,27 @@ LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, con
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     return LightPollution2DCoords(cosVZACoord, altCoord);
 }
 
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
-    const vec2 texSize = lightPollutionTextureSize;
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 texSize = lightPollutionTextureSize;
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2);
-    const float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
+    CONST float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
     return vec2(cosVZAtc, altitudeTC);
 }

--- a/atmosphere/default/shaders/single-scattering/precomputed/aerosols/texture-sampling-functions.frag
+++ b/atmosphere/default/shaders/single-scattering/precomputed/aerosols/texture-sampling-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-sampling-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,13 +45,13 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // texture-sampling-functions.frag
-#line 1 2 // phase-functions.h.glsl
+#line 4 0 // texture-sampling-functions.frag
+#line 1 3 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 6 0 // texture-sampling-functions.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-sampling-functions.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -72,8 +83,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-sampling-functions.frag
-#line 1 4 // texture-coordinates.h.glsl
+#line 6 0 // texture-sampling-functions.frag
+#line 1 5 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -142,7 +153,7 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 8 0 // texture-sampling-functions.frag
+#line 7 0 // texture-sampling-functions.frag
 
 uniform sampler2D transmittanceTexture;
 uniform sampler2D irradianceTexture;
@@ -154,13 +165,13 @@ uniform sampler2D lightPollutionScatteringTexture;
 
 vec4 irradiance(const float cosSunZenithAngle, const float altitude)
 {
-    const vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
+    CONST vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
     return texture(irradianceTexture, texCoords);
 }
 
 vec4 opticalDepthToAtmosphereBorder(const float cosViewZenithAngle, const float altitude)
 {
-    const vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
+    CONST vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact when looking into nadir from TOA at some values of texture sizes (in particular, size of
     // transmittance texture for altitude being 4096). This happens when I simply call texture(eclipsedScatteringTexture,
@@ -178,11 +189,11 @@ vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float
 vec4 transmittance(const float cosViewZenithAngle, const float altitude, const float dist,
                    const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle view ray endpoint
     // in space here.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
 
     vec4 depth;
     if(viewRayIntersectsGround)
@@ -201,7 +212,7 @@ vec4 transmittance(const float cosViewZenithAngle, const float altitude, const f
 vec4 calcFirstScattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                          const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
+    CONST vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
                                           dotViewSun, altitude, viewRayIntersectsGround);
     return scattering*currentPhaseFunction(dotViewSun);
 }
@@ -220,6 +231,6 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
 
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     return texture(lightPollutionScatteringTexture, coords);
 }

--- a/atmosphere/default/shaders/single-scattering/precomputed/molecules/common-functions.frag
+++ b/atmosphere/default/shaders/single-scattering/precomputed/molecules/common-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // common-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // common-functions.frag
+#line 4 0 // common-functions.frag
 
 bool dbgDataPresent=false;
 bool debugDataPresent()
@@ -69,7 +80,7 @@ void setDebugData(float a,float b, float c, float d)
 
 void swap(inout float x, inout float y)
 {
-    const float t = x;
+    CONST float t = x;
     x = y;
     y = t;
 }
@@ -83,7 +94,7 @@ float safeSqrt(const float x)
 
 float safeAtan(const float y, const float x)
 {
-    const float a = atan(y,x);
+    CONST float a = atan(y,x);
     return x==0 && y==0 ? 0 : a;
 }
 
@@ -116,23 +127,23 @@ float pointAltitude(vec3 point)
 
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float Ratm=earthRadius+atmosphereHeight;
-    const float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float Ratm=earthRadius+atmosphereHeight;
+    CONST float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float distanceToGround(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(-safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float cosZenithAngleOfHorizon(const float altitude)
 {
-    const float R=earthRadius;
-    const float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
+    CONST float R=earthRadius;
+    CONST float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
     return -sqrt(2*h*R+sqr(h))/(R+h);
 }
 
@@ -151,8 +162,8 @@ float distanceToNearestAtmosphereBoundary(const float cosZenithAngle, const floa
 float sunVisibility(const float cosSunZenithAngle, float altitude)
 {
     if(altitude<0) altitude=0;
-    const float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
-    const float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
+    CONST float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
+    CONST float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
     /* Approximating visible fraction of solar disk by smoothstep between the position of the Sun
      * touching the horizon by its upper part and the position with lower part touching the horizon.
      * The calculation assumes that solar angular radius is small and thus approximately equals its sine.
@@ -182,13 +193,13 @@ float circlesIntersectionArea(float R1, float R2, float d)
 
 float angleBetween(const vec3 a, const vec3 b)
 {
-    const float d=dot(a,b);
-    const float c=length(cross(a,b));
+    CONST float d=dot(a,b);
+    CONST float c=length(cross(a,b));
     // To avoid loss of precision, don't use dot product near the singularity
     // of acos, and cross product near the singularity of asin
     if(abs(d) < abs(c))
         return acos(d/(length(a)*length(b)));
-    const float smallerAngle = asin(c/(length(a)*length(b)));
+    CONST float smallerAngle = asin(c/(length(a)*length(b)));
     if(d<0) return PI-smallerAngle;
     return smallerAngle;
 }
@@ -205,11 +216,11 @@ float moonAngularRadius(const vec3 cameraPosition, const vec3 moonPosition)
 
 float visibleSolidAngleOfSun(const vec3 camera, const vec3 sunDir, const vec3 moonPos)
 {
-    const float Rs=sunAngularRadius;
-    const float Rm=moonAngularRadius(camera,moonPos);
+    CONST float Rs=sunAngularRadius;
+    CONST float Rm=moonAngularRadius(camera,moonPos);
     float visibleSolidAngle=PI*sqr(Rs);
 
-    const float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
+    CONST float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
     if(dSM<Rs+Rm)
     {
         visibleSolidAngle -= circlesIntersectionArea(Rm,Rs,dSM);
@@ -229,12 +240,12 @@ float sphereIntegrationSolidAngleDifferential(const int pointCountOnSphere)
 }
 vec3 sphereIntegrationSampleDir(const int index, const int pointCountOnSphere)
 {
-    const float goldenRatio=1.6180339887499;
+    CONST float goldenRatio=1.6180339887499;
     // The range of n is 0.5, 1.5, ..., pointCountOnSphere-0.5
-    const float n=index+0.5;
+    CONST float n=index+0.5;
     // Explanation of the Fibonacci grid generation can be seen at https://stackoverflow.com/a/44164075/673852
-    const float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
-    const float azimuth=n*(2*PI*goldenRatio);
+    CONST float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
+    CONST float azimuth=n*(2*PI*goldenRatio);
     return vec3(cos(azimuth)*sin(zenithAngle),
                 sin(azimuth)*sin(zenithAngle),
                 cos(zenithAngle));

--- a/atmosphere/default/shaders/single-scattering/precomputed/molecules/densities.frag
+++ b/atmosphere/default/shaders/single-scattering/precomputed/molecules/densities.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // densities.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,20 +45,20 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // densities.frag
+#line 4 0 // densities.frag
 float scattererNumberDensity_molecules(float altitude)
 {
-        const float rayleighScaleHeight=8*km;
+        CONST float rayleighScaleHeight=8*km;
         return 3.08458e25*exp(-1/rayleighScaleHeight * altitude);
 }
 float scattererNumberDensity_aerosols(float altitude)
 {
-        const float mieScaleHeight=1.2*km;
+        CONST float mieScaleHeight=1.2*km;
         return 1.03333e8*exp(-1/mieScaleHeight*altitude);
 }
 float absorberNumberDensity_ozone(float altitude)
 {
-        const float totalOzoneAmount=370*dobsonUnit;
+        CONST float totalOzoneAmount=370*dobsonUnit;
 
         float density;
 

--- a/atmosphere/default/shaders/single-scattering/precomputed/molecules/phase-functions.frag
+++ b/atmosphere/default/shaders/single-scattering/precomputed/molecules/phase-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // phase-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // phase-functions.frag
+#line 4 0 // phase-functions.frag
 
 vec4 phaseFunction_molecules(float dotViewSun)
 {
@@ -42,9 +53,9 @@ vec4 phaseFunction_molecules(float dotViewSun)
 }
 vec4 phaseFunction_aerosols(float dotViewSun)
 {
-        const float g=0.76;
-        const float g2=g*g;
-        const float k = 3/(8*PI)*(1-g2)/(2+g2);
+        CONST float g=0.76;
+        CONST float g2=g*g;
+        CONST float k = 3/(8*PI)*(1-g2)/(2+g2);
         return vec4(k * (1+sqr(dotViewSun)) / pow(1+g2 - 2*g*dotViewSun, 1.5) + 1/((1-dotViewSun)*600+0.05))*0.904;
 }
 vec4 currentPhaseFunction(float dotViewSun) { return phaseFunction_molecules(dotViewSun); }

--- a/atmosphere/default/shaders/single-scattering/precomputed/molecules/render.frag
+++ b/atmosphere/default/shaders/single-scattering/precomputed/molecules/render.frag
@@ -1,7 +1,21 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
 
-#line 1 1 // const.h.glsl
+
+
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 6 0 // render.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,11 +48,11 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // render.frag
-#line 1 2 // calc-view-dir.h.glsl
+#line 7 0 // render.frag
+#line 1 3 // calc-view-dir.h.glsl
 vec3 calcViewDir();
-#line 6 0 // render.frag
-#line 1 3 // common-functions.h.glsl
+#line 8 0 // render.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -70,13 +84,13 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // render.frag
-#line 1 4 // phase-functions.h.glsl
+#line 9 0 // render.frag
+#line 1 5 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 8 0 // render.frag
-#line 1 5 // single-scattering.h.glsl
+#line 10 0 // render.frag
+#line 1 6 // single-scattering.h.glsl
 #ifndef INCLUDE_ONCE_1DB2EDC1_C687_4FFA_BFF4_D18A54BA651B
 #define INCLUDE_ONCE_1DB2EDC1_C687_4FFA_BFF4_D18A54BA651B
 
@@ -84,9 +98,9 @@ vec4 computeSingleScattering(const float cosSunZenithAngle, const float cosViewZ
                              const float dotViewSun, const float altitude,
                              const bool viewRayIntersectsGround);
 #endif
-#line 9 0 // render.frag
+#line 11 0 // render.frag
 
-#line 1 6 // texture-coordinates.h.glsl
+#line 1 7 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -155,10 +169,10 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 11 0 // render.frag
-#line 1 7 // radiance-to-luminance.h.glsl
+#line 13 0 // render.frag
+#line 1 8 // radiance-to-luminance.h.glsl
 const mat4 radianceToLuminance=mat4(19.8756237,7.17745161,0,0.0937032327,  2.13895917,0.772417068,0,0.0149318045,  0.241072536,0.0870557055,0,0,  0.0133876652,0.00483453181,0,0);
-#line 12 0 // render.frag
+#line 14 0 // render.frag
 
 
 
@@ -195,18 +209,18 @@ void main()
     // this approximation has the same order of magnitude as the assumption that the Earth and its atmosphere
     // are spherical.
     float altitude = max(cameraPosition.z, 0.);
-    const vec3 oldCamPos=cameraPosition;
+    CONST vec3 oldCamPos=cameraPosition;
     // Hide the uniform with this name, thus effectively modifying it for the following code
     vec3 cameraPosition=vec3(oldCamPos.xy, altitude);
 
     bool lookingIntoAtmosphere=true;
     if(altitude>atmosphereHeight)
     {
-        const vec3 p = cameraPosition - earthCenter;
-        const float p_dot_v = dot(p, viewDir);
-        const float p_dot_p = dot(p, p);
-        const float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
-        const float distanceToTOA = -p_dot_v - sqrt(sqr(earthRadius+atmosphereHeight) - squaredDistBetweenViewRayAndEarthCenter);
+        CONST vec3 p = cameraPosition - earthCenter;
+        CONST float p_dot_v = dot(p, viewDir);
+        CONST float p_dot_p = dot(p, p);
+        CONST float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
+        CONST float distanceToTOA = -p_dot_v - sqrt(sqr(earthRadius+atmosphereHeight) - squaredDistBetweenViewRayAndEarthCenter);
         if(distanceToTOA>=0)
         {
             cameraPosition += viewDir*distanceToTOA;
@@ -214,7 +228,7 @@ void main()
         }
         else
         {
-#if RENDERING_ANY_ZERO_SCATTERING
+#if 0 /*RENDERING_ANY_ZERO_SCATTERING*/
             lookingIntoAtmosphere=false;
 #else
             luminance=vec4(0);
@@ -224,16 +238,16 @@ void main()
         }
     }
 
-    const vec3 zenith=normalize(cameraPosition-earthCenter);
+    CONST vec3 zenith=normalize(cameraPosition-earthCenter);
     float cosViewZenithAngle=dot(zenith,viewDir);
 
     bool viewRayIntersectsGround=false;
     {
-        const vec3 p = cameraPosition - earthCenter;
-        const float p_dot_v = dot(p, viewDir);
-        const float p_dot_p = dot(p, p);
-        const float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
-        const float distanceToIntersection = -p_dot_v - sqrt(sqr(earthRadius) - squaredDistBetweenViewRayAndEarthCenter);
+        CONST vec3 p = cameraPosition - earthCenter;
+        CONST float p_dot_v = dot(p, viewDir);
+        CONST float p_dot_p = dot(p, p);
+        CONST float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
+        CONST float distanceToIntersection = -p_dot_v - sqrt(sqr(earthRadius) - squaredDistBetweenViewRayAndEarthCenter);
         // altitude==0 is a special case where distance to intersection calculation
         // is unreliable (has a lot of noise in its sign), so check it separately
         if(distanceToIntersection>0 || (altitude==0 && cosViewZenithAngle<0))
@@ -244,11 +258,11 @@ void main()
     // Aside from aesthetics, this affects brightness input to Stellarium's tone mapper.
     if(pseudoMirrorSkyBelowHorizon && viewRayIntersectsGround)
     {
-        const float horizonCZA = cosZenithAngleOfHorizon(altitude);
-        const float viewElev  = asin(clampCosine(cosViewZenithAngle));
-        const float horizElev = asin(clampCosine(horizonCZA));
-        const float newViewElev = 2*horizElev - viewElev;
-        const float viewDirXYnorm = length(viewDir-zenith*cosViewZenithAngle);
+        CONST float horizonCZA = cosZenithAngleOfHorizon(altitude);
+        CONST float viewElev  = asin(clampCosine(cosViewZenithAngle));
+        CONST float horizElev = asin(clampCosine(horizonCZA));
+        CONST float newViewElev = 2*horizElev - viewElev;
+        CONST float viewDirXYnorm = length(viewDir-zenith*cosViewZenithAngle);
         if(viewDirXYnorm == 0)
         {
             viewDir = zenith;
@@ -267,27 +281,27 @@ void main()
         viewRayIntersectsGround = false;
     }
 
-    const float cosSunZenithAngle =dot(zenith,sunDirection);
-    const float dotViewSun=dot(viewDir,sunDirection);
+    CONST float cosSunZenithAngle =dot(zenith,sunDirection);
+    CONST float dotViewSun=dot(viewDir,sunDirection);
 
-    const vec3 sunXYunnorm=sunDirection-dot(sunDirection,zenith)*zenith;
-    const vec3 viewXYunnorm=viewDir-dot(viewDir,zenith)*zenith;
-    const vec3 sunXY = sunXYunnorm.x!=0 || sunXYunnorm.y!=0 || sunXYunnorm.z!=0 ? normalize(sunXYunnorm) : vec3(0);
-    const vec3 viewXY = viewXYunnorm.x!=0 || viewXYunnorm.y!=0 || viewXYunnorm.z!=0 ? normalize(viewXYunnorm) : vec3(0);
-    const float azimuthRelativeToSun=safeAtan(dot(cross(sunXY, viewXY), zenith), dot(sunXY, viewXY));
+    CONST vec3 sunXYunnorm=sunDirection-dot(sunDirection,zenith)*zenith;
+    CONST vec3 viewXYunnorm=viewDir-dot(viewDir,zenith)*zenith;
+    CONST vec3 sunXY = sunXYunnorm.x!=0 || sunXYunnorm.y!=0 || sunXYunnorm.z!=0 ? normalize(sunXYunnorm) : vec3(0);
+    CONST vec3 viewXY = viewXYunnorm.x!=0 || viewXYunnorm.y!=0 || viewXYunnorm.z!=0 ? normalize(viewXYunnorm) : vec3(0);
+    CONST float azimuthRelativeToSun=safeAtan(dot(cross(sunXY, viewXY), zenith), dot(sunXY, viewXY));
 
-#if RENDERING_ZERO_SCATTERING
+#if 0 /*RENDERING_ZERO_SCATTERING*/
     vec4 radiance;
     if(viewRayIntersectsGround)
     {
         // XXX: keep in sync with the same code in computeScatteringDensity(), but don't forget about
         //      the difference in the usage of viewDir vs incDir.
-        const float distToGround = distanceToGround(cosViewZenithAngle, altitude);
-        const vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
-        const vec3 groundNormal = normalize(zenith*(earthRadius+altitude)+viewDir*distToGround);
-        const vec4 groundIrradiance = irradiance(dot(groundNormal, sunDirection), 0);
+        CONST float distToGround = distanceToGround(cosViewZenithAngle, altitude);
+        CONST vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
+        CONST vec3 groundNormal = normalize(zenith*(earthRadius+altitude)+viewDir*distToGround);
+        CONST vec4 groundIrradiance = irradiance(dot(groundNormal, sunDirection), 0);
         // Radiation scattered by the ground
-        const float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
+        CONST float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
         radiance = transmittanceToGround*groundAlbedo*groundIrradiance*solarIrradianceFixup*groundBRDF
                  + lightPollutionGroundLuminance*lightPollutionRelativeRadiance;
     }
@@ -304,22 +318,22 @@ void main()
     }
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_ZERO_SCATTERING
+#elif 0 /*RENDERING_ECLIPSED_ZERO_SCATTERING*/
     vec4 radiance;
-    const float dotViewMoon=dot(viewDir,normalize(moonPosition-cameraPosition));
+    CONST float dotViewMoon=dot(viewDir,normalize(moonPosition-cameraPosition));
     if(viewRayIntersectsGround)
     {
         // XXX: keep in sync with the similar code in non-eclipsed zero scattering rendering.
-        const float distToGround = distanceToGround(cosViewZenithAngle, altitude);
-        const vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
-        const vec3 pointOnGround = cameraPosition+viewDir*distToGround;
-        const vec4 directGroundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDirection, moonPosition);
+        CONST float distToGround = distanceToGround(cosViewZenithAngle, altitude);
+        CONST vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
+        CONST vec3 pointOnGround = cameraPosition+viewDir*distToGround;
+        CONST vec4 directGroundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDirection, moonPosition);
         // FIXME: add first-order indirect irradiance too: it's done in non-eclipsed irradiance (in the same
         // conditions: when limited to 2 orders). This should be calculated at the same time when second order
         // is: all the infrastructure is already there.
-        const vec4 groundIrradiance = directGroundIrradiance;
+        CONST vec4 groundIrradiance = directGroundIrradiance;
         // Radiation scattered by the ground
-        const float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
+        CONST float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
         radiance = transmittanceToGround*groundAlbedo*groundIrradiance*solarIrradianceFixup*groundBRDF
                  + lightPollutionGroundLuminance*lightPollutionRelativeRadiance;
     }
@@ -336,53 +350,53 @@ void main()
     }
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_ON_THE_FLY
-    const vec4 scattering=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPosition,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_ON_THE_FLY*/
+    CONST vec4 scattering=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPosition,
                                                           viewRayIntersectsGround);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE
-    const vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE*/
+    CONST vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                      viewRayIntersectsGround, eclipsedSingleScatteringTextureSize);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact at the point where azimuth texture coordinate changes from 1 to 0 (at azimuthRelativeToSun crossing
     // 0). This happens when I simply call texture(eclipsedScatteringTexture, texCoords) without specifying LOD.
     // Apparently, the driver uses the derivative for some reason, even though it shouldn't.
-    const vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
+    CONST vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE
-    const vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
+    CONST vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                      viewRayIntersectsGround, eclipsedSingleScatteringTextureSize);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact at the point where azimuth texture coordinate changes from 1 to 0 (at azimuthRelativeToSun crossing
     // 0). This happens when I simply call texture(eclipsedScatteringTexture, texCoords) without specifying LOD.
     // Apparently, the driver uses the derivative for some reason, even though it shouldn't.
-    const vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
+    CONST vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
     luminance=scattering*currentPhaseFunction(dotViewSun);
-#elif RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_RADIANCE
+#elif 0 /*RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_RADIANCE*/
     vec4 radiance=exp(sampleEclipseDoubleScattering3DTexture(eclipsedDoubleScatteringTexture,
                                                              cosSunZenithAngle, cosViewZenithAngle, azimuthRelativeToSun,
                                                              altitude, viewRayIntersectsGround));
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_LUMINANCE
+#elif 0 /*RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
     luminance=exp(sampleEclipseDoubleScattering3DTexture(eclipsedDoubleScatteringTexture,
                                                          cosSunZenithAngle, cosViewZenithAngle, azimuthRelativeToSun,
                                                          altitude, viewRayIntersectsGround));
-#elif RENDERING_SINGLE_SCATTERING_ON_THE_FLY
-    const vec4 scattering=computeSingleScattering(cosSunZenithAngle,cosViewZenithAngle,dotViewSun,
+#elif 0 /*RENDERING_SINGLE_SCATTERING_ON_THE_FLY*/
+    CONST vec4 scattering=computeSingleScattering(cosSunZenithAngle,cosViewZenithAngle,dotViewSun,
                                                   altitude,viewRayIntersectsGround);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE
+#elif 0 /*RENDERING_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE*/
     vec4 scattering;
     if(useInterpolationGuides)
     {
@@ -413,18 +427,18 @@ void main()
                                      dotViewSun, altitude, viewRayIntersectsGround);
     }
     luminance=scattering * (bool(1) ? vec4(1) : currentPhaseFunction(dotViewSun));
-#elif RENDERING_MULTIPLE_SCATTERING_LUMINANCE
+#elif 0 /*RENDERING_MULTIPLE_SCATTERING_LUMINANCE*/
     luminance=sample3DTexture(scatteringTexture, cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, viewRayIntersectsGround);
-#elif RENDERING_MULTIPLE_SCATTERING_RADIANCE
+#elif 0 /*RENDERING_MULTIPLE_SCATTERING_RADIANCE*/
     vec4 radiance=sample3DTexture(scatteringTexture, cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, viewRayIntersectsGround);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_LIGHT_POLLUTION_RADIANCE
+#elif 0 /*RENDERING_LIGHT_POLLUTION_RADIANCE*/
     vec4 radiance=lightPollutionGroundLuminance*lightPollutionScattering(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_LIGHT_POLLUTION_LUMINANCE
+#elif 0 /*RENDERING_LIGHT_POLLUTION_LUMINANCE*/
     luminance=lightPollutionGroundLuminance*lightPollutionScattering(altitude, cosViewZenithAngle, viewRayIntersectsGround);
 #else
 #error What to render?

--- a/atmosphere/default/shaders/single-scattering/precomputed/molecules/single-scattering.frag
+++ b/atmosphere/default/shaders/single-scattering/precomputed/molecules/single-scattering.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // single-scattering.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,15 +45,15 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // single-scattering.frag
-#line 1 2 // densities.h.glsl
+#line 4 0 // single-scattering.frag
+#line 1 3 // densities.h.glsl
 float scattererNumberDensity_molecules(float altitude);
 float scattererNumberDensity_aerosols(float altitude);
 float absorberNumberDensity_ozone(float altitude);
 vec4 scatteringCrossSection();
 float scattererDensity(float altitude);
-#line 6 0 // single-scattering.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // single-scattering.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -74,8 +85,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // single-scattering.frag
-#line 1 4 // single-scattering.h.glsl
+#line 6 0 // single-scattering.frag
+#line 1 5 // single-scattering.h.glsl
 #ifndef INCLUDE_ONCE_1DB2EDC1_C687_4FFA_BFF4_D18A54BA651B
 #define INCLUDE_ONCE_1DB2EDC1_C687_4FFA_BFF4_D18A54BA651B
 
@@ -83,8 +94,8 @@ vec4 computeSingleScattering(const float cosSunZenithAngle, const float cosViewZ
                              const float dotViewSun, const float altitude,
                              const bool viewRayIntersectsGround);
 #endif
-#line 8 0 // single-scattering.frag
-#line 1 5 // texture-sampling-functions.h.glsl
+#line 7 0 // single-scattering.frag
+#line 1 6 // texture-sampling-functions.h.glsl
 #ifndef INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 #define INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float altitude);
@@ -96,20 +107,20 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                 const int scatteringOrder);
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 #endif
-#line 9 0 // single-scattering.frag
+#line 8 0 // single-scattering.frag
 
 // This function omits phase function and solar irradiance: these are to be applied somewhere in the calling code.
 vec4 computeSingleScatteringIntegrand(const float cosSunZenithAngle, const float cosViewZenithAngle,
                                       const float dotViewSun, const float altitude,
                                       const float dist, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle here the case when the
     // endpoint of the view ray intentionally appears in outer space.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosSunZenithAngleAtDist=clampCosine((r*cosSunZenithAngle+dist*dotViewSun)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosSunZenithAngleAtDist=clampCosine((r*cosSunZenithAngle+dist*dotViewSun)/(earthRadius+altAtDist));
 
-    const vec4 xmittance=transmittance(cosViewZenithAngle, altitude, dist, viewRayIntersectsGround)
+    CONST vec4 xmittance=transmittance(cosViewZenithAngle, altitude, dist, viewRayIntersectsGround)
                                                     *
                          transmittanceToAtmosphereBorder(cosSunZenithAngleAtDist, altAtDist)
                                                     *
@@ -121,14 +132,14 @@ vec4 computeSingleScattering(const float cosSunZenithAngle, const float cosViewZ
                              const float dotViewSun, const float altitude,
                              const bool viewRayIntersectsGround)
 {
-    const float integrInterval=distanceToNearestAtmosphereBoundary(cosViewZenithAngle, altitude,
+    CONST float integrInterval=distanceToNearestAtmosphereBoundary(cosViewZenithAngle, altitude,
                                                                    viewRayIntersectsGround);
     // Using the midpoint rule for quadrature
     vec4 spectrum=vec4(0);
-    const float dl=integrInterval/radialIntegrationPoints;
+    CONST float dl=integrInterval/radialIntegrationPoints;
     for(int n=0; n<radialIntegrationPoints; ++n)
     {
-        const float dist=(n+0.5)*dl;
+        CONST float dist=(n+0.5)*dl;
         spectrum += computeSingleScatteringIntegrand(cosSunZenithAngle, cosViewZenithAngle, dotViewSun,
                                                      altitude, dist, viewRayIntersectsGround);
     }

--- a/atmosphere/default/shaders/single-scattering/precomputed/molecules/texture-coordinates.frag
+++ b/atmosphere/default/shaders/single-scattering/precomputed/molecules/texture-coordinates.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-coordinates.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,8 +45,8 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // texture-coordinates.frag
-#line 1 2 // texture-coordinates.h.glsl
+#line 4 0 // texture-coordinates.frag
+#line 1 3 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -104,8 +115,8 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 6 0 // texture-coordinates.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-coordinates.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -137,7 +148,7 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-coordinates.frag
+#line 6 0 // texture-coordinates.frag
 
 const float LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA=sqrt(atmosphereHeight*(atmosphereHeight+2*earthRadius));
 
@@ -205,18 +216,18 @@ vec3 indicesToTexCoords(const vec3 indices, const vec3 texSizes)
 
 TransmittanceTexVars transmittanceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
+    CONST float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
                                 texCoordToUnitRange(texCoord.t,transmittanceTextureSize.t);
     // Distance from Earth center to camera
-    const float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
-    const float altitude=r-earthRadius;
+    CONST float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
+    CONST float altitude=r-earthRadius;
 
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
     // distance to border of visible atmosphere from the view point
-    const float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
+    CONST float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
     // d==0 can happen when altitude==atmosphereHeight
-    const float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
+    CONST float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
     return TransmittanceTexVars(cosVZA,altitude);
 }
 
@@ -235,53 +246,53 @@ vec2 transmittanceTexVarsToTexCoord(const float cosVZA, float altitude)
     if(altitude<0)
         altitude=0;
 
-    const float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
+    CONST float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
                                       transmittanceTextureSize.t);
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
-    const float d=distanceToAtmosphereBorder(cosVZA,altitude);
-    const float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float d=distanceToAtmosphereBorder(cosVZA,altitude);
+    CONST float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
     return vec2(s,t);
 }
 
 // Output: vec2(cos(sunZenithAngle), altitude)
 IrradianceTexVars irradianceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
-    const float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
+    CONST float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
+    CONST float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
     return IrradianceTexVars(cosSZA,alt);
 }
 
 vec2 irradianceTexVarsToTexCoord(const float cosSunZenithAngle, const float altitude)
 {
-    const float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
-    const float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
+    CONST float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
+    CONST float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
     return vec2(s,t);
 }
 
 float cosSZAToUnitRangeTexCoord(const float cosSunZenithAngle)
 {
     // Distance to top atmosphere border along the ray groundUnderCamera-sun: (altitude, cosSunZenithAngle)
-    const float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name
-    const float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
+    CONST float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
     // TODO: choose a more descriptive name
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     return max(0.,1-a/A)/(a+1);
 }
 
 float unitRangeTexCoordToCosSZA(const float texCoord)
 {
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float a=(A-A*texCoord)/(1+A*texCoord);
-    const float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
+    CONST float a=(A-A*texCoord)/(1+A*texCoord);
+    CONST float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
     return distFromGroundToTopAtmoBorder==0 ? 1 :
         clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distFromGroundToTopAtmoBorder)) /
                     (2*earthRadius*distFromGroundToTopAtmoBorder));
@@ -292,24 +303,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
                                                const float dotViewSun, const float altitude,
                                                const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -317,24 +328,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float dotVSCoord=(dotViewSun+1)/2;
+    CONST float dotVSCoord=(dotViewSun+1)/2;
 
     // ------------------------------------
-    const float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
+    CONST float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
 
     return Scattering4DCoords(cosSZACoord, cosVZACoord, dotVSCoord, altCoord, viewRayIntersectsGround);
 }
 
 TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
@@ -342,16 +353,16 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture coordinates we combine into a single sampler3D coordinate.
-    const float texW = scatteringTextureSize[1];
-    const float texH = scatteringTextureSize[2];
-    const float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
-    const vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
+    CONST float texW = scatteringTextureSize[1];
+    CONST float texH = scatteringTextureSize[2];
+    CONST float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
+    CONST vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
                                         ceil (cosSZAIndex)*texW+coords.dotViewSun*(texW-1)) / (texW*texH-1);
-    const vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
+    CONST vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
 
-    const float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
+    CONST float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
 
-    const float alphaUpper=fract(cosSZAIndex);
+    CONST float alphaUpper=fract(cosSZAIndex);
     return TexCoordPair(vec3(cosVZAtc, combinedCoord.x, altitude), float(1-alphaUpper),
                         vec3(cosVZAtc, combinedCoord.y, altitude), float(alphaUpper));
 }
@@ -359,9 +370,9 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
+    CONST TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
     return texture(tex, texCoords.lower) * texCoords.alphaLower +
            texture(tex, texCoords.upper) * texCoords.alphaUpper;
 }
@@ -369,17 +380,17 @@ vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const f
 // 3D texture is the 3D single-altitude slice of a 4D texture
 vec3 scattering4DCoordsToTex3DCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2);
 
-    const float dvsSize = scatteringTextureSize[1];
-    const float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
+    CONST float dvsSize = scatteringTextureSize[1];
+    CONST float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
 
-    const float cszaSize = scatteringTextureSize[2];
-    const float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
+    CONST float cszaSize = scatteringTextureSize[2];
+    CONST float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
 
     return vec3(cosVZAtc, dotVStc, cosSZAtc);
 }
@@ -394,39 +405,39 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along dotViewSun coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[1];
-    const float posOfRow = indices[1];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[1];
+    CONST float posOfRow = indices[1];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         indexToTexCoord(currRow, numRows-1),
                                                         texCoordVerbatim));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               indexToTexCoord(currRow, numRows-1),
                                                               texCoordVerbatim));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          indexToTexCoord(currRow, numRows-1),
                                          texCoordVerbatim));
@@ -434,14 +445,14 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
 vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolationGuides01Tex,
                                  const vec3 indices)
 {
-    const float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
+    CONST float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
 
-    const float cosVZAIndex = indices[0];
-    const float dotVSIndex = indices[1];
-    const float currRow = floor(dotVSIndex);
-    const float posBetweenRows = dotVSIndex - currRow;
-    const float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cosVZAIndex = indices[0];
+    CONST float dotVSIndex = indices[1];
+    CONST float currRow = floor(dotVSIndex);
+    CONST float posBetweenRows = dotVSIndex - currRow;
+    CONST float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -449,14 +460,14 @@ vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolat
     indicesCurrRow[1] =     currRow;
     indicesNextRow[1] = min(currRow+1, scatteringTextureSize[1]-1.);
 
-    const vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
-    const vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
+    CONST vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
+    CONST vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
 
-    const vec4 valueCurrRow = texture(tex, coordsCurrRow);
-    const vec4 valueNextRow = texture(tex, coordsNextRow);
-    const float epsilon = 1e-37; // Prevents passing zero to log
-    const vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
-    const vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
+    CONST vec4 valueCurrRow = texture(tex, coordsCurrRow);
+    CONST vec4 valueNextRow = texture(tex, coordsNextRow);
+    CONST float epsilon = 1e-37; // Prevents passing zero to log
+    CONST vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
+    CONST vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
     return (logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow;
 }
 
@@ -465,37 +476,37 @@ float findGuide02Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along SZA coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[2];
-    const float posOfRow = indices[2];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[2];
+    CONST float posOfRow = indices[2];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
 }
@@ -505,19 +516,19 @@ vec4 sample3DTextureGuided(const sampler3D tex,
                            const float cosSunZenithAngle, const float cosViewZenithAngle,
                            const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
                                                                     dotViewSun, altitude, viewRayIntersectsGround);
     // Handle the external interpolation guides: the guides between a pair of VZA-dotViewSun 2D "pictures".
-    const vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
-    const vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
-    const float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
+    CONST vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
+    CONST float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
 
-    const float cvzaIndex = indices[0];
-    const float cszaIndex = indices[2];
-    const float currRow = floor(cszaIndex);
-    const float posBetweenRows = cszaIndex - currRow;
-    const float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cvzaIndex = indices[0];
+    CONST float cszaIndex = indices[2];
+    CONST float currRow = floor(cszaIndex);
+    CONST float posBetweenRows = cszaIndex - currRow;
+    CONST float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -526,58 +537,58 @@ vec4 sample3DTextureGuided(const sampler3D tex,
     indicesNextRow[2] = min(currRow+1, scatteringTextureSize[2]-1);
 
     // The caller will handle the internal interpolation guides: the ones between rows in each 2D "picture".
-    const vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
-    const vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
+    CONST vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
+    CONST vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
     return exp((logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow);
 }
 
 vec4 sample3DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
     return texture(tex, texCoords);
 }
 
 ScatteringTexVars scatteringTex4DCoordsToTexVars(const Scattering4DCoords coords)
 {
-    const float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
     // ------------------------------------
     float cosViewZenithAngle;
     if(coords.viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
     // ------------------------------------
-    const float dotViewSun=coords.dotViewSun*2-1;
+    CONST float dotViewSun=coords.dotViewSun*2-1;
 
     // ------------------------------------
-    const float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
+    CONST float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
 
     return ScatteringTexVars(cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, coords.viewRayIntersectsGround);
 }
 
 Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 {
-    const vec4 indexMax=scatteringTextureSize-vec4(1);
+    CONST vec4 indexMax=scatteringTextureSize-vec4(1);
     Scattering4DCoords coords4d;
     coords4d.viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
     // The following formulas assume that scatteringTextureSize[0] is even. For odd sizes they would change.
@@ -593,8 +604,8 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture indices we combine into a single sampler3D coordinate.
-    const float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
-    const float combinedIndex=texIndices[1];
+    CONST float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
+    CONST float combinedIndex=texIndices[1];
     coords4d.dotViewSun=mod(combinedIndex,texW)/(texW-1);
     coords4d.cosSunZenithAngle=floor(combinedIndex/texW)/(texH-1);
 
@@ -608,11 +619,11 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
 ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 {
-    const Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
+    CONST Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
     ScatteringTexVars vars=scatteringTex4DCoordsToTexVars(coords4d);
     // Clamp dotViewSun to its valid range of values, given cosViewZenithAngle and cosSunZenithAngle. This is
     // needed to prevent NaNs when computing the scattering texture.
-    const float cosVZA=vars.cosViewZenithAngle,
+    CONST float cosVZA=vars.cosViewZenithAngle,
                 cosSZA=vars.cosSunZenithAngle;
     vars.dotViewSun=clamp(vars.dotViewSun,
                           cosVZA*cosSZA-safeSqrt((1-sqr(cosVZA))*(1-sqr(cosSZA))),
@@ -622,54 +633,54 @@ ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 
 EclipseScatteringTexVars eclipseTexCoordsToTexVars(const vec2 texCoords, const float altitude)
 {
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
-    const bool viewRayIntersectsGround = texCoords.t<0.5;
+    CONST bool viewRayIntersectsGround = texCoords.t<0.5;
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
-    const float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
+    CONST float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
     return EclipseScatteringTexVars(azimuthRelativeToSun, cosViewZenithAngle, viewRayIntersectsGround);
 }
 
 EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                                    const float altitude, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -677,13 +688,13 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
-    const float azimuthCoord = azimuthRelativeToSun/(2*PI);
+    CONST float azimuthCoord = azimuthRelativeToSun/(2*PI);
 
     return EclipseScattering2DCoords(azimuthCoord, cosVZACoord);
 }
@@ -691,14 +702,14 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
 vec2 eclipseTexVarsToTexCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                const float altitude, const bool viewRayIntersectsGround, const vec2 texSize)
 {
-    const EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+    CONST EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                                     viewRayIntersectsGround);
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2);
-    const float azimuthTC = coords.azimuth + 1/(2*texSize.s);
+    CONST float azimuthTC = coords.azimuth + 1/(2*texSize.s);
 
     return vec2(azimuthTC, cosVZAtc);
 }
@@ -707,42 +718,42 @@ vec4 sampleEclipseDoubleScattering3DTexture(const sampler3D tex, const float cos
                                             const float cosViewZenithAngle, const float azimuthRelativeToSun,
                                             const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
+    CONST vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
                                                   eclipsedDoubleScatteringTextureSize.st);
-    const float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
-    const vec3 texCoords=vec3(coords2d, cosSZACoord);
+    CONST float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
+    CONST vec3 texCoords=vec3(coords2d, cosSZACoord);
 
     return texture(tex, texCoords);
 }
 
 LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 texIndices)
 {
-    const vec2 indexMax=lightPollutionTextureSize-vec2(1);
+    CONST vec2 indexMax=lightPollutionTextureSize-vec2(1);
 
-    const float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
-    const float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
+    CONST float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
-    const bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
-    const float cosViewZenithAngleCoord = viewRayIntersectsGround ?
+    CONST bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
+    CONST float cosViewZenithAngleCoord = viewRayIntersectsGround ?
                                    1-2*texIndices[0]/(indexMax[0]-1) :
                                    2*(texIndices[0]-1)/(indexMax[0]-1)-1;
     // ------------------------------------
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
@@ -753,23 +764,23 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 
 LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -777,27 +788,27 @@ LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, con
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     return LightPollution2DCoords(cosVZACoord, altCoord);
 }
 
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
-    const vec2 texSize = lightPollutionTextureSize;
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 texSize = lightPollutionTextureSize;
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2);
-    const float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
+    CONST float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
     return vec2(cosVZAtc, altitudeTC);
 }

--- a/atmosphere/default/shaders/single-scattering/precomputed/molecules/texture-sampling-functions.frag
+++ b/atmosphere/default/shaders/single-scattering/precomputed/molecules/texture-sampling-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-sampling-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,13 +45,13 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // texture-sampling-functions.frag
-#line 1 2 // phase-functions.h.glsl
+#line 4 0 // texture-sampling-functions.frag
+#line 1 3 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 6 0 // texture-sampling-functions.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-sampling-functions.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -72,8 +83,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-sampling-functions.frag
-#line 1 4 // texture-coordinates.h.glsl
+#line 6 0 // texture-sampling-functions.frag
+#line 1 5 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -142,7 +153,7 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 8 0 // texture-sampling-functions.frag
+#line 7 0 // texture-sampling-functions.frag
 
 uniform sampler2D transmittanceTexture;
 uniform sampler2D irradianceTexture;
@@ -154,13 +165,13 @@ uniform sampler2D lightPollutionScatteringTexture;
 
 vec4 irradiance(const float cosSunZenithAngle, const float altitude)
 {
-    const vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
+    CONST vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
     return texture(irradianceTexture, texCoords);
 }
 
 vec4 opticalDepthToAtmosphereBorder(const float cosViewZenithAngle, const float altitude)
 {
-    const vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
+    CONST vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact when looking into nadir from TOA at some values of texture sizes (in particular, size of
     // transmittance texture for altitude being 4096). This happens when I simply call texture(eclipsedScatteringTexture,
@@ -178,11 +189,11 @@ vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float
 vec4 transmittance(const float cosViewZenithAngle, const float altitude, const float dist,
                    const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle view ray endpoint
     // in space here.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
 
     vec4 depth;
     if(viewRayIntersectsGround)
@@ -201,7 +212,7 @@ vec4 transmittance(const float cosViewZenithAngle, const float altitude, const f
 vec4 calcFirstScattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                          const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
+    CONST vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
                                           dotViewSun, altitude, viewRayIntersectsGround);
     return scattering*currentPhaseFunction(dotViewSun);
 }
@@ -220,6 +231,6 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
 
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     return texture(lightPollutionScatteringTexture, coords);
 }

--- a/atmosphere/default/shaders/zero-order-scattering/0/common-functions.frag
+++ b/atmosphere/default/shaders/zero-order-scattering/0/common-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // common-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // common-functions.frag
+#line 4 0 // common-functions.frag
 
 bool dbgDataPresent=false;
 bool debugDataPresent()
@@ -69,7 +80,7 @@ void setDebugData(float a,float b, float c, float d)
 
 void swap(inout float x, inout float y)
 {
-    const float t = x;
+    CONST float t = x;
     x = y;
     y = t;
 }
@@ -83,7 +94,7 @@ float safeSqrt(const float x)
 
 float safeAtan(const float y, const float x)
 {
-    const float a = atan(y,x);
+    CONST float a = atan(y,x);
     return x==0 && y==0 ? 0 : a;
 }
 
@@ -116,23 +127,23 @@ float pointAltitude(vec3 point)
 
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float Ratm=earthRadius+atmosphereHeight;
-    const float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float Ratm=earthRadius+atmosphereHeight;
+    CONST float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float distanceToGround(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(-safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float cosZenithAngleOfHorizon(const float altitude)
 {
-    const float R=earthRadius;
-    const float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
+    CONST float R=earthRadius;
+    CONST float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
     return -sqrt(2*h*R+sqr(h))/(R+h);
 }
 
@@ -151,8 +162,8 @@ float distanceToNearestAtmosphereBoundary(const float cosZenithAngle, const floa
 float sunVisibility(const float cosSunZenithAngle, float altitude)
 {
     if(altitude<0) altitude=0;
-    const float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
-    const float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
+    CONST float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
+    CONST float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
     /* Approximating visible fraction of solar disk by smoothstep between the position of the Sun
      * touching the horizon by its upper part and the position with lower part touching the horizon.
      * The calculation assumes that solar angular radius is small and thus approximately equals its sine.
@@ -182,13 +193,13 @@ float circlesIntersectionArea(float R1, float R2, float d)
 
 float angleBetween(const vec3 a, const vec3 b)
 {
-    const float d=dot(a,b);
-    const float c=length(cross(a,b));
+    CONST float d=dot(a,b);
+    CONST float c=length(cross(a,b));
     // To avoid loss of precision, don't use dot product near the singularity
     // of acos, and cross product near the singularity of asin
     if(abs(d) < abs(c))
         return acos(d/(length(a)*length(b)));
-    const float smallerAngle = asin(c/(length(a)*length(b)));
+    CONST float smallerAngle = asin(c/(length(a)*length(b)));
     if(d<0) return PI-smallerAngle;
     return smallerAngle;
 }
@@ -205,11 +216,11 @@ float moonAngularRadius(const vec3 cameraPosition, const vec3 moonPosition)
 
 float visibleSolidAngleOfSun(const vec3 camera, const vec3 sunDir, const vec3 moonPos)
 {
-    const float Rs=sunAngularRadius;
-    const float Rm=moonAngularRadius(camera,moonPos);
+    CONST float Rs=sunAngularRadius;
+    CONST float Rm=moonAngularRadius(camera,moonPos);
     float visibleSolidAngle=PI*sqr(Rs);
 
-    const float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
+    CONST float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
     if(dSM<Rs+Rm)
     {
         visibleSolidAngle -= circlesIntersectionArea(Rm,Rs,dSM);
@@ -229,12 +240,12 @@ float sphereIntegrationSolidAngleDifferential(const int pointCountOnSphere)
 }
 vec3 sphereIntegrationSampleDir(const int index, const int pointCountOnSphere)
 {
-    const float goldenRatio=1.6180339887499;
+    CONST float goldenRatio=1.6180339887499;
     // The range of n is 0.5, 1.5, ..., pointCountOnSphere-0.5
-    const float n=index+0.5;
+    CONST float n=index+0.5;
     // Explanation of the Fibonacci grid generation can be seen at https://stackoverflow.com/a/44164075/673852
-    const float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
-    const float azimuth=n*(2*PI*goldenRatio);
+    CONST float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
+    CONST float azimuth=n*(2*PI*goldenRatio);
     return vec3(cos(azimuth)*sin(zenithAngle),
                 sin(azimuth)*sin(zenithAngle),
                 cos(zenithAngle));

--- a/atmosphere/default/shaders/zero-order-scattering/0/phase-functions.frag
+++ b/atmosphere/default/shaders/zero-order-scattering/0/phase-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // phase-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // phase-functions.frag
+#line 4 0 // phase-functions.frag
 
 vec4 phaseFunction_molecules(float dotViewSun)
 {
@@ -42,8 +53,8 @@ vec4 phaseFunction_molecules(float dotViewSun)
 }
 vec4 phaseFunction_aerosols(float dotViewSun)
 {
-        const float g=0.76;
-        const float g2=g*g;
-        const float k = 3/(8*PI)*(1-g2)/(2+g2);
+        CONST float g=0.76;
+        CONST float g2=g*g;
+        CONST float k = 3/(8*PI)*(1-g2)/(2+g2);
         return vec4(k * (1+sqr(dotViewSun)) / pow(1+g2 - 2*g*dotViewSun, 1.5) + 1/((1-dotViewSun)*600+0.05))*0.904;
 }

--- a/atmosphere/default/shaders/zero-order-scattering/0/render.frag
+++ b/atmosphere/default/shaders/zero-order-scattering/0/render.frag
@@ -1,7 +1,21 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
 
-#line 1 1 // const.h.glsl
+
+
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 6 0 // render.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,11 +48,11 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // render.frag
-#line 1 2 // calc-view-dir.h.glsl
+#line 7 0 // render.frag
+#line 1 3 // calc-view-dir.h.glsl
 vec3 calcViewDir();
-#line 6 0 // render.frag
-#line 1 3 // common-functions.h.glsl
+#line 8 0 // render.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -70,11 +84,11 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // render.frag
+#line 9 0 // render.frag
 
 
 
-#line 1 4 // texture-coordinates.h.glsl
+#line 1 5 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -143,11 +157,11 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 11 0 // render.frag
-#line 1 5 // radiance-to-luminance.h.glsl
+#line 13 0 // render.frag
+#line 1 6 // radiance-to-luminance.h.glsl
 const mat4 radianceToLuminance=mat4(1.38997746,0.0419133306,6.48549128,0,  105.968163,3.00652099,500.960266,142.641495,  3776.24023,119.971481,18207.7598,6412.0166,  6910.01318,981.06665,37504.0586,26741.9102);
-#line 12 0 // render.frag
-#line 1 6 // texture-sampling-functions.h.glsl
+#line 14 0 // render.frag
+#line 1 7 // texture-sampling-functions.h.glsl
 #ifndef INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 #define INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float altitude);
@@ -159,7 +173,7 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                 const int scatteringOrder);
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 #endif
-#line 13 0 // render.frag
+#line 15 0 // render.frag
 
 
 
@@ -195,18 +209,18 @@ void main()
     // this approximation has the same order of magnitude as the assumption that the Earth and its atmosphere
     // are spherical.
     float altitude = max(cameraPosition.z, 0.);
-    const vec3 oldCamPos=cameraPosition;
+    CONST vec3 oldCamPos=cameraPosition;
     // Hide the uniform with this name, thus effectively modifying it for the following code
     vec3 cameraPosition=vec3(oldCamPos.xy, altitude);
 
     bool lookingIntoAtmosphere=true;
     if(altitude>atmosphereHeight)
     {
-        const vec3 p = cameraPosition - earthCenter;
-        const float p_dot_v = dot(p, viewDir);
-        const float p_dot_p = dot(p, p);
-        const float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
-        const float distanceToTOA = -p_dot_v - sqrt(sqr(earthRadius+atmosphereHeight) - squaredDistBetweenViewRayAndEarthCenter);
+        CONST vec3 p = cameraPosition - earthCenter;
+        CONST float p_dot_v = dot(p, viewDir);
+        CONST float p_dot_p = dot(p, p);
+        CONST float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
+        CONST float distanceToTOA = -p_dot_v - sqrt(sqr(earthRadius+atmosphereHeight) - squaredDistBetweenViewRayAndEarthCenter);
         if(distanceToTOA>=0)
         {
             cameraPosition += viewDir*distanceToTOA;
@@ -224,16 +238,16 @@ void main()
         }
     }
 
-    const vec3 zenith=normalize(cameraPosition-earthCenter);
+    CONST vec3 zenith=normalize(cameraPosition-earthCenter);
     float cosViewZenithAngle=dot(zenith,viewDir);
 
     bool viewRayIntersectsGround=false;
     {
-        const vec3 p = cameraPosition - earthCenter;
-        const float p_dot_v = dot(p, viewDir);
-        const float p_dot_p = dot(p, p);
-        const float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
-        const float distanceToIntersection = -p_dot_v - sqrt(sqr(earthRadius) - squaredDistBetweenViewRayAndEarthCenter);
+        CONST vec3 p = cameraPosition - earthCenter;
+        CONST float p_dot_v = dot(p, viewDir);
+        CONST float p_dot_p = dot(p, p);
+        CONST float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
+        CONST float distanceToIntersection = -p_dot_v - sqrt(sqr(earthRadius) - squaredDistBetweenViewRayAndEarthCenter);
         // altitude==0 is a special case where distance to intersection calculation
         // is unreliable (has a lot of noise in its sign), so check it separately
         if(distanceToIntersection>0 || (altitude==0 && cosViewZenithAngle<0))
@@ -244,11 +258,11 @@ void main()
     // Aside from aesthetics, this affects brightness input to Stellarium's tone mapper.
     if(pseudoMirrorSkyBelowHorizon && viewRayIntersectsGround)
     {
-        const float horizonCZA = cosZenithAngleOfHorizon(altitude);
-        const float viewElev  = asin(clampCosine(cosViewZenithAngle));
-        const float horizElev = asin(clampCosine(horizonCZA));
-        const float newViewElev = 2*horizElev - viewElev;
-        const float viewDirXYnorm = length(viewDir-zenith*cosViewZenithAngle);
+        CONST float horizonCZA = cosZenithAngleOfHorizon(altitude);
+        CONST float viewElev  = asin(clampCosine(cosViewZenithAngle));
+        CONST float horizElev = asin(clampCosine(horizonCZA));
+        CONST float newViewElev = 2*horizElev - viewElev;
+        CONST float viewDirXYnorm = length(viewDir-zenith*cosViewZenithAngle);
         if(viewDirXYnorm == 0)
         {
             viewDir = zenith;
@@ -267,14 +281,14 @@ void main()
         viewRayIntersectsGround = false;
     }
 
-    const float cosSunZenithAngle =dot(zenith,sunDirection);
-    const float dotViewSun=dot(viewDir,sunDirection);
+    CONST float cosSunZenithAngle =dot(zenith,sunDirection);
+    CONST float dotViewSun=dot(viewDir,sunDirection);
 
-    const vec3 sunXYunnorm=sunDirection-dot(sunDirection,zenith)*zenith;
-    const vec3 viewXYunnorm=viewDir-dot(viewDir,zenith)*zenith;
-    const vec3 sunXY = sunXYunnorm.x!=0 || sunXYunnorm.y!=0 || sunXYunnorm.z!=0 ? normalize(sunXYunnorm) : vec3(0);
-    const vec3 viewXY = viewXYunnorm.x!=0 || viewXYunnorm.y!=0 || viewXYunnorm.z!=0 ? normalize(viewXYunnorm) : vec3(0);
-    const float azimuthRelativeToSun=safeAtan(dot(cross(sunXY, viewXY), zenith), dot(sunXY, viewXY));
+    CONST vec3 sunXYunnorm=sunDirection-dot(sunDirection,zenith)*zenith;
+    CONST vec3 viewXYunnorm=viewDir-dot(viewDir,zenith)*zenith;
+    CONST vec3 sunXY = sunXYunnorm.x!=0 || sunXYunnorm.y!=0 || sunXYunnorm.z!=0 ? normalize(sunXYunnorm) : vec3(0);
+    CONST vec3 viewXY = viewXYunnorm.x!=0 || viewXYunnorm.y!=0 || viewXYunnorm.z!=0 ? normalize(viewXYunnorm) : vec3(0);
+    CONST float azimuthRelativeToSun=safeAtan(dot(cross(sunXY, viewXY), zenith), dot(sunXY, viewXY));
 
 #if 1 /*RENDERING_ZERO_SCATTERING*/
     vec4 radiance;
@@ -282,12 +296,12 @@ void main()
     {
         // XXX: keep in sync with the same code in computeScatteringDensity(), but don't forget about
         //      the difference in the usage of viewDir vs incDir.
-        const float distToGround = distanceToGround(cosViewZenithAngle, altitude);
-        const vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
-        const vec3 groundNormal = normalize(zenith*(earthRadius+altitude)+viewDir*distToGround);
-        const vec4 groundIrradiance = irradiance(dot(groundNormal, sunDirection), 0);
+        CONST float distToGround = distanceToGround(cosViewZenithAngle, altitude);
+        CONST vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
+        CONST vec3 groundNormal = normalize(zenith*(earthRadius+altitude)+viewDir*distToGround);
+        CONST vec4 groundIrradiance = irradiance(dot(groundNormal, sunDirection), 0);
         // Radiation scattered by the ground
-        const float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
+        CONST float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
         radiance = transmittanceToGround*groundAlbedo*groundIrradiance*solarIrradianceFixup*groundBRDF
                  + lightPollutionGroundLuminance*lightPollutionRelativeRadiance;
     }
@@ -304,22 +318,22 @@ void main()
     }
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_ZERO_SCATTERING
+#elif 0 /*RENDERING_ECLIPSED_ZERO_SCATTERING*/
     vec4 radiance;
-    const float dotViewMoon=dot(viewDir,normalize(moonPosition-cameraPosition));
+    CONST float dotViewMoon=dot(viewDir,normalize(moonPosition-cameraPosition));
     if(viewRayIntersectsGround)
     {
         // XXX: keep in sync with the similar code in non-eclipsed zero scattering rendering.
-        const float distToGround = distanceToGround(cosViewZenithAngle, altitude);
-        const vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
-        const vec3 pointOnGround = cameraPosition+viewDir*distToGround;
-        const vec4 directGroundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDirection, moonPosition);
+        CONST float distToGround = distanceToGround(cosViewZenithAngle, altitude);
+        CONST vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
+        CONST vec3 pointOnGround = cameraPosition+viewDir*distToGround;
+        CONST vec4 directGroundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDirection, moonPosition);
         // FIXME: add first-order indirect irradiance too: it's done in non-eclipsed irradiance (in the same
         // conditions: when limited to 2 orders). This should be calculated at the same time when second order
         // is: all the infrastructure is already there.
-        const vec4 groundIrradiance = directGroundIrradiance;
+        CONST vec4 groundIrradiance = directGroundIrradiance;
         // Radiation scattered by the ground
-        const float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
+        CONST float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
         radiance = transmittanceToGround*groundAlbedo*groundIrradiance*solarIrradianceFixup*groundBRDF
                  + lightPollutionGroundLuminance*lightPollutionRelativeRadiance;
     }
@@ -336,53 +350,53 @@ void main()
     }
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_ON_THE_FLY
-    const vec4 scattering=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPosition,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_ON_THE_FLY*/
+    CONST vec4 scattering=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPosition,
                                                           viewRayIntersectsGround);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE
-    const vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE*/
+    CONST vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                      viewRayIntersectsGround, eclipsedSingleScatteringTextureSize);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact at the point where azimuth texture coordinate changes from 1 to 0 (at azimuthRelativeToSun crossing
     // 0). This happens when I simply call texture(eclipsedScatteringTexture, texCoords) without specifying LOD.
     // Apparently, the driver uses the derivative for some reason, even though it shouldn't.
-    const vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
+    CONST vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE
-    const vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
+    CONST vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                      viewRayIntersectsGround, eclipsedSingleScatteringTextureSize);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact at the point where azimuth texture coordinate changes from 1 to 0 (at azimuthRelativeToSun crossing
     // 0). This happens when I simply call texture(eclipsedScatteringTexture, texCoords) without specifying LOD.
     // Apparently, the driver uses the derivative for some reason, even though it shouldn't.
-    const vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
+    CONST vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
     luminance=scattering*currentPhaseFunction(dotViewSun);
-#elif RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_RADIANCE
+#elif 0 /*RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_RADIANCE*/
     vec4 radiance=exp(sampleEclipseDoubleScattering3DTexture(eclipsedDoubleScatteringTexture,
                                                              cosSunZenithAngle, cosViewZenithAngle, azimuthRelativeToSun,
                                                              altitude, viewRayIntersectsGround));
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_LUMINANCE
+#elif 0 /*RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
     luminance=exp(sampleEclipseDoubleScattering3DTexture(eclipsedDoubleScatteringTexture,
                                                          cosSunZenithAngle, cosViewZenithAngle, azimuthRelativeToSun,
                                                          altitude, viewRayIntersectsGround));
-#elif RENDERING_SINGLE_SCATTERING_ON_THE_FLY
-    const vec4 scattering=computeSingleScattering(cosSunZenithAngle,cosViewZenithAngle,dotViewSun,
+#elif 0 /*RENDERING_SINGLE_SCATTERING_ON_THE_FLY*/
+    CONST vec4 scattering=computeSingleScattering(cosSunZenithAngle,cosViewZenithAngle,dotViewSun,
                                                   altitude,viewRayIntersectsGround);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE
+#elif 0 /*RENDERING_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE*/
     vec4 scattering;
     if(useInterpolationGuides)
     {
@@ -399,7 +413,7 @@ void main()
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE
+#elif 0 /*RENDERING_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
     vec4 scattering;
     if(useInterpolationGuides)
     {
@@ -413,18 +427,18 @@ void main()
                                      dotViewSun, altitude, viewRayIntersectsGround);
     }
     luminance=scattering * (bool(PHASE_FUNCTION_IS_EMBEDDED) ? vec4(1) : currentPhaseFunction(dotViewSun));
-#elif RENDERING_MULTIPLE_SCATTERING_LUMINANCE
+#elif 0 /*RENDERING_MULTIPLE_SCATTERING_LUMINANCE*/
     luminance=sample3DTexture(scatteringTexture, cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, viewRayIntersectsGround);
-#elif RENDERING_MULTIPLE_SCATTERING_RADIANCE
+#elif 0 /*RENDERING_MULTIPLE_SCATTERING_RADIANCE*/
     vec4 radiance=sample3DTexture(scatteringTexture, cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, viewRayIntersectsGround);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_LIGHT_POLLUTION_RADIANCE
+#elif 0 /*RENDERING_LIGHT_POLLUTION_RADIANCE*/
     vec4 radiance=lightPollutionGroundLuminance*lightPollutionScattering(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_LIGHT_POLLUTION_LUMINANCE
+#elif 0 /*RENDERING_LIGHT_POLLUTION_LUMINANCE*/
     luminance=lightPollutionGroundLuminance*lightPollutionScattering(altitude, cosViewZenithAngle, viewRayIntersectsGround);
 #else
 #error What to render?

--- a/atmosphere/default/shaders/zero-order-scattering/0/texture-coordinates.frag
+++ b/atmosphere/default/shaders/zero-order-scattering/0/texture-coordinates.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-coordinates.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,8 +45,8 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // texture-coordinates.frag
-#line 1 2 // texture-coordinates.h.glsl
+#line 4 0 // texture-coordinates.frag
+#line 1 3 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -104,8 +115,8 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 6 0 // texture-coordinates.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-coordinates.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -137,7 +148,7 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-coordinates.frag
+#line 6 0 // texture-coordinates.frag
 
 const float LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA=sqrt(atmosphereHeight*(atmosphereHeight+2*earthRadius));
 
@@ -205,18 +216,18 @@ vec3 indicesToTexCoords(const vec3 indices, const vec3 texSizes)
 
 TransmittanceTexVars transmittanceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
+    CONST float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
                                 texCoordToUnitRange(texCoord.t,transmittanceTextureSize.t);
     // Distance from Earth center to camera
-    const float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
-    const float altitude=r-earthRadius;
+    CONST float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
+    CONST float altitude=r-earthRadius;
 
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
     // distance to border of visible atmosphere from the view point
-    const float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
+    CONST float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
     // d==0 can happen when altitude==atmosphereHeight
-    const float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
+    CONST float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
     return TransmittanceTexVars(cosVZA,altitude);
 }
 
@@ -235,53 +246,53 @@ vec2 transmittanceTexVarsToTexCoord(const float cosVZA, float altitude)
     if(altitude<0)
         altitude=0;
 
-    const float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
+    CONST float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
                                       transmittanceTextureSize.t);
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
-    const float d=distanceToAtmosphereBorder(cosVZA,altitude);
-    const float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float d=distanceToAtmosphereBorder(cosVZA,altitude);
+    CONST float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
     return vec2(s,t);
 }
 
 // Output: vec2(cos(sunZenithAngle), altitude)
 IrradianceTexVars irradianceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
-    const float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
+    CONST float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
+    CONST float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
     return IrradianceTexVars(cosSZA,alt);
 }
 
 vec2 irradianceTexVarsToTexCoord(const float cosSunZenithAngle, const float altitude)
 {
-    const float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
-    const float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
+    CONST float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
+    CONST float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
     return vec2(s,t);
 }
 
 float cosSZAToUnitRangeTexCoord(const float cosSunZenithAngle)
 {
     // Distance to top atmosphere border along the ray groundUnderCamera-sun: (altitude, cosSunZenithAngle)
-    const float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name
-    const float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
+    CONST float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
     // TODO: choose a more descriptive name
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     return max(0.,1-a/A)/(a+1);
 }
 
 float unitRangeTexCoordToCosSZA(const float texCoord)
 {
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float a=(A-A*texCoord)/(1+A*texCoord);
-    const float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
+    CONST float a=(A-A*texCoord)/(1+A*texCoord);
+    CONST float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
     return distFromGroundToTopAtmoBorder==0 ? 1 :
         clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distFromGroundToTopAtmoBorder)) /
                     (2*earthRadius*distFromGroundToTopAtmoBorder));
@@ -292,24 +303,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
                                                const float dotViewSun, const float altitude,
                                                const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -317,24 +328,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float dotVSCoord=(dotViewSun+1)/2;
+    CONST float dotVSCoord=(dotViewSun+1)/2;
 
     // ------------------------------------
-    const float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
+    CONST float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
 
     return Scattering4DCoords(cosSZACoord, cosVZACoord, dotVSCoord, altCoord, viewRayIntersectsGround);
 }
 
 TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
@@ -342,16 +353,16 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture coordinates we combine into a single sampler3D coordinate.
-    const float texW = scatteringTextureSize[1];
-    const float texH = scatteringTextureSize[2];
-    const float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
-    const vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
+    CONST float texW = scatteringTextureSize[1];
+    CONST float texH = scatteringTextureSize[2];
+    CONST float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
+    CONST vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
                                         ceil (cosSZAIndex)*texW+coords.dotViewSun*(texW-1)) / (texW*texH-1);
-    const vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
+    CONST vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
 
-    const float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
+    CONST float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
 
-    const float alphaUpper=fract(cosSZAIndex);
+    CONST float alphaUpper=fract(cosSZAIndex);
     return TexCoordPair(vec3(cosVZAtc, combinedCoord.x, altitude), float(1-alphaUpper),
                         vec3(cosVZAtc, combinedCoord.y, altitude), float(alphaUpper));
 }
@@ -359,9 +370,9 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
+    CONST TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
     return texture(tex, texCoords.lower) * texCoords.alphaLower +
            texture(tex, texCoords.upper) * texCoords.alphaUpper;
 }
@@ -369,17 +380,17 @@ vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const f
 // 3D texture is the 3D single-altitude slice of a 4D texture
 vec3 scattering4DCoordsToTex3DCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2);
 
-    const float dvsSize = scatteringTextureSize[1];
-    const float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
+    CONST float dvsSize = scatteringTextureSize[1];
+    CONST float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
 
-    const float cszaSize = scatteringTextureSize[2];
-    const float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
+    CONST float cszaSize = scatteringTextureSize[2];
+    CONST float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
 
     return vec3(cosVZAtc, dotVStc, cosSZAtc);
 }
@@ -394,39 +405,39 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along dotViewSun coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[1];
-    const float posOfRow = indices[1];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[1];
+    CONST float posOfRow = indices[1];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         indexToTexCoord(currRow, numRows-1),
                                                         texCoordVerbatim));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               indexToTexCoord(currRow, numRows-1),
                                                               texCoordVerbatim));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          indexToTexCoord(currRow, numRows-1),
                                          texCoordVerbatim));
@@ -434,14 +445,14 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
 vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolationGuides01Tex,
                                  const vec3 indices)
 {
-    const float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
+    CONST float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
 
-    const float cosVZAIndex = indices[0];
-    const float dotVSIndex = indices[1];
-    const float currRow = floor(dotVSIndex);
-    const float posBetweenRows = dotVSIndex - currRow;
-    const float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cosVZAIndex = indices[0];
+    CONST float dotVSIndex = indices[1];
+    CONST float currRow = floor(dotVSIndex);
+    CONST float posBetweenRows = dotVSIndex - currRow;
+    CONST float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -449,14 +460,14 @@ vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolat
     indicesCurrRow[1] =     currRow;
     indicesNextRow[1] = min(currRow+1, scatteringTextureSize[1]-1.);
 
-    const vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
-    const vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
+    CONST vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
+    CONST vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
 
-    const vec4 valueCurrRow = texture(tex, coordsCurrRow);
-    const vec4 valueNextRow = texture(tex, coordsNextRow);
-    const float epsilon = 1e-37; // Prevents passing zero to log
-    const vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
-    const vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
+    CONST vec4 valueCurrRow = texture(tex, coordsCurrRow);
+    CONST vec4 valueNextRow = texture(tex, coordsNextRow);
+    CONST float epsilon = 1e-37; // Prevents passing zero to log
+    CONST vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
+    CONST vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
     return (logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow;
 }
 
@@ -465,37 +476,37 @@ float findGuide02Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along SZA coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[2];
-    const float posOfRow = indices[2];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[2];
+    CONST float posOfRow = indices[2];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
 }
@@ -505,19 +516,19 @@ vec4 sample3DTextureGuided(const sampler3D tex,
                            const float cosSunZenithAngle, const float cosViewZenithAngle,
                            const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
                                                                     dotViewSun, altitude, viewRayIntersectsGround);
     // Handle the external interpolation guides: the guides between a pair of VZA-dotViewSun 2D "pictures".
-    const vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
-    const vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
-    const float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
+    CONST vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
+    CONST float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
 
-    const float cvzaIndex = indices[0];
-    const float cszaIndex = indices[2];
-    const float currRow = floor(cszaIndex);
-    const float posBetweenRows = cszaIndex - currRow;
-    const float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cvzaIndex = indices[0];
+    CONST float cszaIndex = indices[2];
+    CONST float currRow = floor(cszaIndex);
+    CONST float posBetweenRows = cszaIndex - currRow;
+    CONST float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -526,58 +537,58 @@ vec4 sample3DTextureGuided(const sampler3D tex,
     indicesNextRow[2] = min(currRow+1, scatteringTextureSize[2]-1);
 
     // The caller will handle the internal interpolation guides: the ones between rows in each 2D "picture".
-    const vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
-    const vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
+    CONST vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
+    CONST vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
     return exp((logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow);
 }
 
 vec4 sample3DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
     return texture(tex, texCoords);
 }
 
 ScatteringTexVars scatteringTex4DCoordsToTexVars(const Scattering4DCoords coords)
 {
-    const float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
     // ------------------------------------
     float cosViewZenithAngle;
     if(coords.viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
     // ------------------------------------
-    const float dotViewSun=coords.dotViewSun*2-1;
+    CONST float dotViewSun=coords.dotViewSun*2-1;
 
     // ------------------------------------
-    const float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
+    CONST float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
 
     return ScatteringTexVars(cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, coords.viewRayIntersectsGround);
 }
 
 Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 {
-    const vec4 indexMax=scatteringTextureSize-vec4(1);
+    CONST vec4 indexMax=scatteringTextureSize-vec4(1);
     Scattering4DCoords coords4d;
     coords4d.viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
     // The following formulas assume that scatteringTextureSize[0] is even. For odd sizes they would change.
@@ -593,8 +604,8 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture indices we combine into a single sampler3D coordinate.
-    const float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
-    const float combinedIndex=texIndices[1];
+    CONST float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
+    CONST float combinedIndex=texIndices[1];
     coords4d.dotViewSun=mod(combinedIndex,texW)/(texW-1);
     coords4d.cosSunZenithAngle=floor(combinedIndex/texW)/(texH-1);
 
@@ -608,11 +619,11 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
 ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 {
-    const Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
+    CONST Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
     ScatteringTexVars vars=scatteringTex4DCoordsToTexVars(coords4d);
     // Clamp dotViewSun to its valid range of values, given cosViewZenithAngle and cosSunZenithAngle. This is
     // needed to prevent NaNs when computing the scattering texture.
-    const float cosVZA=vars.cosViewZenithAngle,
+    CONST float cosVZA=vars.cosViewZenithAngle,
                 cosSZA=vars.cosSunZenithAngle;
     vars.dotViewSun=clamp(vars.dotViewSun,
                           cosVZA*cosSZA-safeSqrt((1-sqr(cosVZA))*(1-sqr(cosSZA))),
@@ -622,54 +633,54 @@ ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 
 EclipseScatteringTexVars eclipseTexCoordsToTexVars(const vec2 texCoords, const float altitude)
 {
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
-    const bool viewRayIntersectsGround = texCoords.t<0.5;
+    CONST bool viewRayIntersectsGround = texCoords.t<0.5;
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
-    const float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
+    CONST float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
     return EclipseScatteringTexVars(azimuthRelativeToSun, cosViewZenithAngle, viewRayIntersectsGround);
 }
 
 EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                                    const float altitude, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -677,13 +688,13 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
-    const float azimuthCoord = azimuthRelativeToSun/(2*PI);
+    CONST float azimuthCoord = azimuthRelativeToSun/(2*PI);
 
     return EclipseScattering2DCoords(azimuthCoord, cosVZACoord);
 }
@@ -691,14 +702,14 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
 vec2 eclipseTexVarsToTexCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                const float altitude, const bool viewRayIntersectsGround, const vec2 texSize)
 {
-    const EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+    CONST EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                                     viewRayIntersectsGround);
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2);
-    const float azimuthTC = coords.azimuth + 1/(2*texSize.s);
+    CONST float azimuthTC = coords.azimuth + 1/(2*texSize.s);
 
     return vec2(azimuthTC, cosVZAtc);
 }
@@ -707,42 +718,42 @@ vec4 sampleEclipseDoubleScattering3DTexture(const sampler3D tex, const float cos
                                             const float cosViewZenithAngle, const float azimuthRelativeToSun,
                                             const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
+    CONST vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
                                                   eclipsedDoubleScatteringTextureSize.st);
-    const float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
-    const vec3 texCoords=vec3(coords2d, cosSZACoord);
+    CONST float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
+    CONST vec3 texCoords=vec3(coords2d, cosSZACoord);
 
     return texture(tex, texCoords);
 }
 
 LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 texIndices)
 {
-    const vec2 indexMax=lightPollutionTextureSize-vec2(1);
+    CONST vec2 indexMax=lightPollutionTextureSize-vec2(1);
 
-    const float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
-    const float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
+    CONST float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
-    const bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
-    const float cosViewZenithAngleCoord = viewRayIntersectsGround ?
+    CONST bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
+    CONST float cosViewZenithAngleCoord = viewRayIntersectsGround ?
                                    1-2*texIndices[0]/(indexMax[0]-1) :
                                    2*(texIndices[0]-1)/(indexMax[0]-1)-1;
     // ------------------------------------
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
@@ -753,23 +764,23 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 
 LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -777,27 +788,27 @@ LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, con
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     return LightPollution2DCoords(cosVZACoord, altCoord);
 }
 
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
-    const vec2 texSize = lightPollutionTextureSize;
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 texSize = lightPollutionTextureSize;
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2);
-    const float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
+    CONST float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
     return vec2(cosVZAtc, altitudeTC);
 }

--- a/atmosphere/default/shaders/zero-order-scattering/0/texture-sampling-functions.frag
+++ b/atmosphere/default/shaders/zero-order-scattering/0/texture-sampling-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-sampling-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,13 +45,13 @@ const vec4 lightPollutionRelativeRadiance=vec4(0,0,4.3e-07,1.623e-06);
 const vec4 wavelengths=vec4(360,391.333344,422.666656,454);
 const int wlSetIndex=0;
 #endif
-#line 5 0 // texture-sampling-functions.frag
-#line 1 2 // phase-functions.h.glsl
+#line 4 0 // texture-sampling-functions.frag
+#line 1 3 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 6 0 // texture-sampling-functions.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-sampling-functions.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -72,8 +83,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-sampling-functions.frag
-#line 1 4 // texture-coordinates.h.glsl
+#line 6 0 // texture-sampling-functions.frag
+#line 1 5 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -142,7 +153,7 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 8 0 // texture-sampling-functions.frag
+#line 7 0 // texture-sampling-functions.frag
 
 uniform sampler2D transmittanceTexture;
 uniform sampler2D irradianceTexture;
@@ -154,13 +165,13 @@ uniform sampler2D lightPollutionScatteringTexture;
 
 vec4 irradiance(const float cosSunZenithAngle, const float altitude)
 {
-    const vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
+    CONST vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
     return texture(irradianceTexture, texCoords);
 }
 
 vec4 opticalDepthToAtmosphereBorder(const float cosViewZenithAngle, const float altitude)
 {
-    const vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
+    CONST vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact when looking into nadir from TOA at some values of texture sizes (in particular, size of
     // transmittance texture for altitude being 4096). This happens when I simply call texture(eclipsedScatteringTexture,
@@ -178,11 +189,11 @@ vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float
 vec4 transmittance(const float cosViewZenithAngle, const float altitude, const float dist,
                    const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle view ray endpoint
     // in space here.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
 
     vec4 depth;
     if(viewRayIntersectsGround)
@@ -201,7 +212,7 @@ vec4 transmittance(const float cosViewZenithAngle, const float altitude, const f
 vec4 calcFirstScattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                          const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
+    CONST vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
                                           dotViewSun, altitude, viewRayIntersectsGround);
     return scattering*currentPhaseFunction(dotViewSun);
 }
@@ -220,6 +231,6 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
 
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     return texture(lightPollutionScatteringTexture, coords);
 }

--- a/atmosphere/default/shaders/zero-order-scattering/1/common-functions.frag
+++ b/atmosphere/default/shaders/zero-order-scattering/1/common-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // common-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(2.15e-06,1.11400004e-06,3.8580001
 const vec4 wavelengths=vec4(485.333344,516.666687,548,579.333313);
 const int wlSetIndex=1;
 #endif
-#line 5 0 // common-functions.frag
+#line 4 0 // common-functions.frag
 
 bool dbgDataPresent=false;
 bool debugDataPresent()
@@ -69,7 +80,7 @@ void setDebugData(float a,float b, float c, float d)
 
 void swap(inout float x, inout float y)
 {
-    const float t = x;
+    CONST float t = x;
     x = y;
     y = t;
 }
@@ -83,7 +94,7 @@ float safeSqrt(const float x)
 
 float safeAtan(const float y, const float x)
 {
-    const float a = atan(y,x);
+    CONST float a = atan(y,x);
     return x==0 && y==0 ? 0 : a;
 }
 
@@ -116,23 +127,23 @@ float pointAltitude(vec3 point)
 
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float Ratm=earthRadius+atmosphereHeight;
-    const float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float Ratm=earthRadius+atmosphereHeight;
+    CONST float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float distanceToGround(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(-safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float cosZenithAngleOfHorizon(const float altitude)
 {
-    const float R=earthRadius;
-    const float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
+    CONST float R=earthRadius;
+    CONST float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
     return -sqrt(2*h*R+sqr(h))/(R+h);
 }
 
@@ -151,8 +162,8 @@ float distanceToNearestAtmosphereBoundary(const float cosZenithAngle, const floa
 float sunVisibility(const float cosSunZenithAngle, float altitude)
 {
     if(altitude<0) altitude=0;
-    const float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
-    const float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
+    CONST float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
+    CONST float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
     /* Approximating visible fraction of solar disk by smoothstep between the position of the Sun
      * touching the horizon by its upper part and the position with lower part touching the horizon.
      * The calculation assumes that solar angular radius is small and thus approximately equals its sine.
@@ -182,13 +193,13 @@ float circlesIntersectionArea(float R1, float R2, float d)
 
 float angleBetween(const vec3 a, const vec3 b)
 {
-    const float d=dot(a,b);
-    const float c=length(cross(a,b));
+    CONST float d=dot(a,b);
+    CONST float c=length(cross(a,b));
     // To avoid loss of precision, don't use dot product near the singularity
     // of acos, and cross product near the singularity of asin
     if(abs(d) < abs(c))
         return acos(d/(length(a)*length(b)));
-    const float smallerAngle = asin(c/(length(a)*length(b)));
+    CONST float smallerAngle = asin(c/(length(a)*length(b)));
     if(d<0) return PI-smallerAngle;
     return smallerAngle;
 }
@@ -205,11 +216,11 @@ float moonAngularRadius(const vec3 cameraPosition, const vec3 moonPosition)
 
 float visibleSolidAngleOfSun(const vec3 camera, const vec3 sunDir, const vec3 moonPos)
 {
-    const float Rs=sunAngularRadius;
-    const float Rm=moonAngularRadius(camera,moonPos);
+    CONST float Rs=sunAngularRadius;
+    CONST float Rm=moonAngularRadius(camera,moonPos);
     float visibleSolidAngle=PI*sqr(Rs);
 
-    const float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
+    CONST float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
     if(dSM<Rs+Rm)
     {
         visibleSolidAngle -= circlesIntersectionArea(Rm,Rs,dSM);
@@ -229,12 +240,12 @@ float sphereIntegrationSolidAngleDifferential(const int pointCountOnSphere)
 }
 vec3 sphereIntegrationSampleDir(const int index, const int pointCountOnSphere)
 {
-    const float goldenRatio=1.6180339887499;
+    CONST float goldenRatio=1.6180339887499;
     // The range of n is 0.5, 1.5, ..., pointCountOnSphere-0.5
-    const float n=index+0.5;
+    CONST float n=index+0.5;
     // Explanation of the Fibonacci grid generation can be seen at https://stackoverflow.com/a/44164075/673852
-    const float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
-    const float azimuth=n*(2*PI*goldenRatio);
+    CONST float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
+    CONST float azimuth=n*(2*PI*goldenRatio);
     return vec3(cos(azimuth)*sin(zenithAngle),
                 sin(azimuth)*sin(zenithAngle),
                 cos(zenithAngle));

--- a/atmosphere/default/shaders/zero-order-scattering/1/phase-functions.frag
+++ b/atmosphere/default/shaders/zero-order-scattering/1/phase-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // phase-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(2.15e-06,1.11400004e-06,3.8580001
 const vec4 wavelengths=vec4(485.333344,516.666687,548,579.333313);
 const int wlSetIndex=1;
 #endif
-#line 5 0 // phase-functions.frag
+#line 4 0 // phase-functions.frag
 
 vec4 phaseFunction_molecules(float dotViewSun)
 {
@@ -42,8 +53,8 @@ vec4 phaseFunction_molecules(float dotViewSun)
 }
 vec4 phaseFunction_aerosols(float dotViewSun)
 {
-        const float g=0.76;
-        const float g2=g*g;
-        const float k = 3/(8*PI)*(1-g2)/(2+g2);
+        CONST float g=0.76;
+        CONST float g2=g*g;
+        CONST float k = 3/(8*PI)*(1-g2)/(2+g2);
         return vec4(k * (1+sqr(dotViewSun)) / pow(1+g2 - 2*g*dotViewSun, 1.5) + 1/((1-dotViewSun)*600+0.05))*0.904;
 }

--- a/atmosphere/default/shaders/zero-order-scattering/1/render.frag
+++ b/atmosphere/default/shaders/zero-order-scattering/1/render.frag
@@ -1,7 +1,21 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
 
-#line 1 1 // const.h.glsl
+
+
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 6 0 // render.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,11 +48,11 @@ const vec4 lightPollutionRelativeRadiance=vec4(2.15e-06,1.11400004e-06,3.8580001
 const vec4 wavelengths=vec4(485.333344,516.666687,548,579.333313);
 const int wlSetIndex=1;
 #endif
-#line 5 0 // render.frag
-#line 1 2 // calc-view-dir.h.glsl
+#line 7 0 // render.frag
+#line 1 3 // calc-view-dir.h.glsl
 vec3 calcViewDir();
-#line 6 0 // render.frag
-#line 1 3 // common-functions.h.glsl
+#line 8 0 // render.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -70,11 +84,11 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // render.frag
+#line 9 0 // render.frag
 
 
 
-#line 1 4 // texture-coordinates.h.glsl
+#line 1 5 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -143,11 +157,11 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 11 0 // render.frag
-#line 1 5 // radiance-to-luminance.h.glsl
+#line 13 0 // render.frag
+#line 1 6 // radiance-to-luminance.h.glsl
 const mat4 radianceToLuminance=mat4(1196.74268,3672.67432,12945.498,45528.7344,  835.02478,13767.5205,2120.37939,51317.4727,  8632.59277,21193.416,222.095078,27381.1602,  19410,18758.1973,35.7829971,6712.12158);
-#line 12 0 // render.frag
-#line 1 6 // texture-sampling-functions.h.glsl
+#line 14 0 // render.frag
+#line 1 7 // texture-sampling-functions.h.glsl
 #ifndef INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 #define INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float altitude);
@@ -159,7 +173,7 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                 const int scatteringOrder);
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 #endif
-#line 13 0 // render.frag
+#line 15 0 // render.frag
 
 
 
@@ -195,18 +209,18 @@ void main()
     // this approximation has the same order of magnitude as the assumption that the Earth and its atmosphere
     // are spherical.
     float altitude = max(cameraPosition.z, 0.);
-    const vec3 oldCamPos=cameraPosition;
+    CONST vec3 oldCamPos=cameraPosition;
     // Hide the uniform with this name, thus effectively modifying it for the following code
     vec3 cameraPosition=vec3(oldCamPos.xy, altitude);
 
     bool lookingIntoAtmosphere=true;
     if(altitude>atmosphereHeight)
     {
-        const vec3 p = cameraPosition - earthCenter;
-        const float p_dot_v = dot(p, viewDir);
-        const float p_dot_p = dot(p, p);
-        const float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
-        const float distanceToTOA = -p_dot_v - sqrt(sqr(earthRadius+atmosphereHeight) - squaredDistBetweenViewRayAndEarthCenter);
+        CONST vec3 p = cameraPosition - earthCenter;
+        CONST float p_dot_v = dot(p, viewDir);
+        CONST float p_dot_p = dot(p, p);
+        CONST float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
+        CONST float distanceToTOA = -p_dot_v - sqrt(sqr(earthRadius+atmosphereHeight) - squaredDistBetweenViewRayAndEarthCenter);
         if(distanceToTOA>=0)
         {
             cameraPosition += viewDir*distanceToTOA;
@@ -224,16 +238,16 @@ void main()
         }
     }
 
-    const vec3 zenith=normalize(cameraPosition-earthCenter);
+    CONST vec3 zenith=normalize(cameraPosition-earthCenter);
     float cosViewZenithAngle=dot(zenith,viewDir);
 
     bool viewRayIntersectsGround=false;
     {
-        const vec3 p = cameraPosition - earthCenter;
-        const float p_dot_v = dot(p, viewDir);
-        const float p_dot_p = dot(p, p);
-        const float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
-        const float distanceToIntersection = -p_dot_v - sqrt(sqr(earthRadius) - squaredDistBetweenViewRayAndEarthCenter);
+        CONST vec3 p = cameraPosition - earthCenter;
+        CONST float p_dot_v = dot(p, viewDir);
+        CONST float p_dot_p = dot(p, p);
+        CONST float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
+        CONST float distanceToIntersection = -p_dot_v - sqrt(sqr(earthRadius) - squaredDistBetweenViewRayAndEarthCenter);
         // altitude==0 is a special case where distance to intersection calculation
         // is unreliable (has a lot of noise in its sign), so check it separately
         if(distanceToIntersection>0 || (altitude==0 && cosViewZenithAngle<0))
@@ -244,11 +258,11 @@ void main()
     // Aside from aesthetics, this affects brightness input to Stellarium's tone mapper.
     if(pseudoMirrorSkyBelowHorizon && viewRayIntersectsGround)
     {
-        const float horizonCZA = cosZenithAngleOfHorizon(altitude);
-        const float viewElev  = asin(clampCosine(cosViewZenithAngle));
-        const float horizElev = asin(clampCosine(horizonCZA));
-        const float newViewElev = 2*horizElev - viewElev;
-        const float viewDirXYnorm = length(viewDir-zenith*cosViewZenithAngle);
+        CONST float horizonCZA = cosZenithAngleOfHorizon(altitude);
+        CONST float viewElev  = asin(clampCosine(cosViewZenithAngle));
+        CONST float horizElev = asin(clampCosine(horizonCZA));
+        CONST float newViewElev = 2*horizElev - viewElev;
+        CONST float viewDirXYnorm = length(viewDir-zenith*cosViewZenithAngle);
         if(viewDirXYnorm == 0)
         {
             viewDir = zenith;
@@ -267,14 +281,14 @@ void main()
         viewRayIntersectsGround = false;
     }
 
-    const float cosSunZenithAngle =dot(zenith,sunDirection);
-    const float dotViewSun=dot(viewDir,sunDirection);
+    CONST float cosSunZenithAngle =dot(zenith,sunDirection);
+    CONST float dotViewSun=dot(viewDir,sunDirection);
 
-    const vec3 sunXYunnorm=sunDirection-dot(sunDirection,zenith)*zenith;
-    const vec3 viewXYunnorm=viewDir-dot(viewDir,zenith)*zenith;
-    const vec3 sunXY = sunXYunnorm.x!=0 || sunXYunnorm.y!=0 || sunXYunnorm.z!=0 ? normalize(sunXYunnorm) : vec3(0);
-    const vec3 viewXY = viewXYunnorm.x!=0 || viewXYunnorm.y!=0 || viewXYunnorm.z!=0 ? normalize(viewXYunnorm) : vec3(0);
-    const float azimuthRelativeToSun=safeAtan(dot(cross(sunXY, viewXY), zenith), dot(sunXY, viewXY));
+    CONST vec3 sunXYunnorm=sunDirection-dot(sunDirection,zenith)*zenith;
+    CONST vec3 viewXYunnorm=viewDir-dot(viewDir,zenith)*zenith;
+    CONST vec3 sunXY = sunXYunnorm.x!=0 || sunXYunnorm.y!=0 || sunXYunnorm.z!=0 ? normalize(sunXYunnorm) : vec3(0);
+    CONST vec3 viewXY = viewXYunnorm.x!=0 || viewXYunnorm.y!=0 || viewXYunnorm.z!=0 ? normalize(viewXYunnorm) : vec3(0);
+    CONST float azimuthRelativeToSun=safeAtan(dot(cross(sunXY, viewXY), zenith), dot(sunXY, viewXY));
 
 #if 1 /*RENDERING_ZERO_SCATTERING*/
     vec4 radiance;
@@ -282,12 +296,12 @@ void main()
     {
         // XXX: keep in sync with the same code in computeScatteringDensity(), but don't forget about
         //      the difference in the usage of viewDir vs incDir.
-        const float distToGround = distanceToGround(cosViewZenithAngle, altitude);
-        const vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
-        const vec3 groundNormal = normalize(zenith*(earthRadius+altitude)+viewDir*distToGround);
-        const vec4 groundIrradiance = irradiance(dot(groundNormal, sunDirection), 0);
+        CONST float distToGround = distanceToGround(cosViewZenithAngle, altitude);
+        CONST vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
+        CONST vec3 groundNormal = normalize(zenith*(earthRadius+altitude)+viewDir*distToGround);
+        CONST vec4 groundIrradiance = irradiance(dot(groundNormal, sunDirection), 0);
         // Radiation scattered by the ground
-        const float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
+        CONST float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
         radiance = transmittanceToGround*groundAlbedo*groundIrradiance*solarIrradianceFixup*groundBRDF
                  + lightPollutionGroundLuminance*lightPollutionRelativeRadiance;
     }
@@ -304,22 +318,22 @@ void main()
     }
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_ZERO_SCATTERING
+#elif 0 /*RENDERING_ECLIPSED_ZERO_SCATTERING*/
     vec4 radiance;
-    const float dotViewMoon=dot(viewDir,normalize(moonPosition-cameraPosition));
+    CONST float dotViewMoon=dot(viewDir,normalize(moonPosition-cameraPosition));
     if(viewRayIntersectsGround)
     {
         // XXX: keep in sync with the similar code in non-eclipsed zero scattering rendering.
-        const float distToGround = distanceToGround(cosViewZenithAngle, altitude);
-        const vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
-        const vec3 pointOnGround = cameraPosition+viewDir*distToGround;
-        const vec4 directGroundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDirection, moonPosition);
+        CONST float distToGround = distanceToGround(cosViewZenithAngle, altitude);
+        CONST vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
+        CONST vec3 pointOnGround = cameraPosition+viewDir*distToGround;
+        CONST vec4 directGroundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDirection, moonPosition);
         // FIXME: add first-order indirect irradiance too: it's done in non-eclipsed irradiance (in the same
         // conditions: when limited to 2 orders). This should be calculated at the same time when second order
         // is: all the infrastructure is already there.
-        const vec4 groundIrradiance = directGroundIrradiance;
+        CONST vec4 groundIrradiance = directGroundIrradiance;
         // Radiation scattered by the ground
-        const float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
+        CONST float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
         radiance = transmittanceToGround*groundAlbedo*groundIrradiance*solarIrradianceFixup*groundBRDF
                  + lightPollutionGroundLuminance*lightPollutionRelativeRadiance;
     }
@@ -336,53 +350,53 @@ void main()
     }
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_ON_THE_FLY
-    const vec4 scattering=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPosition,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_ON_THE_FLY*/
+    CONST vec4 scattering=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPosition,
                                                           viewRayIntersectsGround);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE
-    const vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE*/
+    CONST vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                      viewRayIntersectsGround, eclipsedSingleScatteringTextureSize);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact at the point where azimuth texture coordinate changes from 1 to 0 (at azimuthRelativeToSun crossing
     // 0). This happens when I simply call texture(eclipsedScatteringTexture, texCoords) without specifying LOD.
     // Apparently, the driver uses the derivative for some reason, even though it shouldn't.
-    const vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
+    CONST vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE
-    const vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
+    CONST vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                      viewRayIntersectsGround, eclipsedSingleScatteringTextureSize);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact at the point where azimuth texture coordinate changes from 1 to 0 (at azimuthRelativeToSun crossing
     // 0). This happens when I simply call texture(eclipsedScatteringTexture, texCoords) without specifying LOD.
     // Apparently, the driver uses the derivative for some reason, even though it shouldn't.
-    const vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
+    CONST vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
     luminance=scattering*currentPhaseFunction(dotViewSun);
-#elif RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_RADIANCE
+#elif 0 /*RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_RADIANCE*/
     vec4 radiance=exp(sampleEclipseDoubleScattering3DTexture(eclipsedDoubleScatteringTexture,
                                                              cosSunZenithAngle, cosViewZenithAngle, azimuthRelativeToSun,
                                                              altitude, viewRayIntersectsGround));
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_LUMINANCE
+#elif 0 /*RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
     luminance=exp(sampleEclipseDoubleScattering3DTexture(eclipsedDoubleScatteringTexture,
                                                          cosSunZenithAngle, cosViewZenithAngle, azimuthRelativeToSun,
                                                          altitude, viewRayIntersectsGround));
-#elif RENDERING_SINGLE_SCATTERING_ON_THE_FLY
-    const vec4 scattering=computeSingleScattering(cosSunZenithAngle,cosViewZenithAngle,dotViewSun,
+#elif 0 /*RENDERING_SINGLE_SCATTERING_ON_THE_FLY*/
+    CONST vec4 scattering=computeSingleScattering(cosSunZenithAngle,cosViewZenithAngle,dotViewSun,
                                                   altitude,viewRayIntersectsGround);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE
+#elif 0 /*RENDERING_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE*/
     vec4 scattering;
     if(useInterpolationGuides)
     {
@@ -399,7 +413,7 @@ void main()
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE
+#elif 0 /*RENDERING_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
     vec4 scattering;
     if(useInterpolationGuides)
     {
@@ -413,18 +427,18 @@ void main()
                                      dotViewSun, altitude, viewRayIntersectsGround);
     }
     luminance=scattering * (bool(PHASE_FUNCTION_IS_EMBEDDED) ? vec4(1) : currentPhaseFunction(dotViewSun));
-#elif RENDERING_MULTIPLE_SCATTERING_LUMINANCE
+#elif 0 /*RENDERING_MULTIPLE_SCATTERING_LUMINANCE*/
     luminance=sample3DTexture(scatteringTexture, cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, viewRayIntersectsGround);
-#elif RENDERING_MULTIPLE_SCATTERING_RADIANCE
+#elif 0 /*RENDERING_MULTIPLE_SCATTERING_RADIANCE*/
     vec4 radiance=sample3DTexture(scatteringTexture, cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, viewRayIntersectsGround);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_LIGHT_POLLUTION_RADIANCE
+#elif 0 /*RENDERING_LIGHT_POLLUTION_RADIANCE*/
     vec4 radiance=lightPollutionGroundLuminance*lightPollutionScattering(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_LIGHT_POLLUTION_LUMINANCE
+#elif 0 /*RENDERING_LIGHT_POLLUTION_LUMINANCE*/
     luminance=lightPollutionGroundLuminance*lightPollutionScattering(altitude, cosViewZenithAngle, viewRayIntersectsGround);
 #else
 #error What to render?

--- a/atmosphere/default/shaders/zero-order-scattering/1/texture-coordinates.frag
+++ b/atmosphere/default/shaders/zero-order-scattering/1/texture-coordinates.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-coordinates.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,8 +45,8 @@ const vec4 lightPollutionRelativeRadiance=vec4(2.15e-06,1.11400004e-06,3.8580001
 const vec4 wavelengths=vec4(485.333344,516.666687,548,579.333313);
 const int wlSetIndex=1;
 #endif
-#line 5 0 // texture-coordinates.frag
-#line 1 2 // texture-coordinates.h.glsl
+#line 4 0 // texture-coordinates.frag
+#line 1 3 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -104,8 +115,8 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 6 0 // texture-coordinates.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-coordinates.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -137,7 +148,7 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-coordinates.frag
+#line 6 0 // texture-coordinates.frag
 
 const float LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA=sqrt(atmosphereHeight*(atmosphereHeight+2*earthRadius));
 
@@ -205,18 +216,18 @@ vec3 indicesToTexCoords(const vec3 indices, const vec3 texSizes)
 
 TransmittanceTexVars transmittanceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
+    CONST float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
                                 texCoordToUnitRange(texCoord.t,transmittanceTextureSize.t);
     // Distance from Earth center to camera
-    const float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
-    const float altitude=r-earthRadius;
+    CONST float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
+    CONST float altitude=r-earthRadius;
 
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
     // distance to border of visible atmosphere from the view point
-    const float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
+    CONST float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
     // d==0 can happen when altitude==atmosphereHeight
-    const float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
+    CONST float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
     return TransmittanceTexVars(cosVZA,altitude);
 }
 
@@ -235,53 +246,53 @@ vec2 transmittanceTexVarsToTexCoord(const float cosVZA, float altitude)
     if(altitude<0)
         altitude=0;
 
-    const float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
+    CONST float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
                                       transmittanceTextureSize.t);
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
-    const float d=distanceToAtmosphereBorder(cosVZA,altitude);
-    const float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float d=distanceToAtmosphereBorder(cosVZA,altitude);
+    CONST float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
     return vec2(s,t);
 }
 
 // Output: vec2(cos(sunZenithAngle), altitude)
 IrradianceTexVars irradianceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
-    const float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
+    CONST float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
+    CONST float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
     return IrradianceTexVars(cosSZA,alt);
 }
 
 vec2 irradianceTexVarsToTexCoord(const float cosSunZenithAngle, const float altitude)
 {
-    const float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
-    const float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
+    CONST float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
+    CONST float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
     return vec2(s,t);
 }
 
 float cosSZAToUnitRangeTexCoord(const float cosSunZenithAngle)
 {
     // Distance to top atmosphere border along the ray groundUnderCamera-sun: (altitude, cosSunZenithAngle)
-    const float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name
-    const float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
+    CONST float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
     // TODO: choose a more descriptive name
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     return max(0.,1-a/A)/(a+1);
 }
 
 float unitRangeTexCoordToCosSZA(const float texCoord)
 {
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float a=(A-A*texCoord)/(1+A*texCoord);
-    const float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
+    CONST float a=(A-A*texCoord)/(1+A*texCoord);
+    CONST float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
     return distFromGroundToTopAtmoBorder==0 ? 1 :
         clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distFromGroundToTopAtmoBorder)) /
                     (2*earthRadius*distFromGroundToTopAtmoBorder));
@@ -292,24 +303,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
                                                const float dotViewSun, const float altitude,
                                                const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -317,24 +328,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float dotVSCoord=(dotViewSun+1)/2;
+    CONST float dotVSCoord=(dotViewSun+1)/2;
 
     // ------------------------------------
-    const float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
+    CONST float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
 
     return Scattering4DCoords(cosSZACoord, cosVZACoord, dotVSCoord, altCoord, viewRayIntersectsGround);
 }
 
 TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
@@ -342,16 +353,16 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture coordinates we combine into a single sampler3D coordinate.
-    const float texW = scatteringTextureSize[1];
-    const float texH = scatteringTextureSize[2];
-    const float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
-    const vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
+    CONST float texW = scatteringTextureSize[1];
+    CONST float texH = scatteringTextureSize[2];
+    CONST float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
+    CONST vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
                                         ceil (cosSZAIndex)*texW+coords.dotViewSun*(texW-1)) / (texW*texH-1);
-    const vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
+    CONST vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
 
-    const float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
+    CONST float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
 
-    const float alphaUpper=fract(cosSZAIndex);
+    CONST float alphaUpper=fract(cosSZAIndex);
     return TexCoordPair(vec3(cosVZAtc, combinedCoord.x, altitude), float(1-alphaUpper),
                         vec3(cosVZAtc, combinedCoord.y, altitude), float(alphaUpper));
 }
@@ -359,9 +370,9 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
+    CONST TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
     return texture(tex, texCoords.lower) * texCoords.alphaLower +
            texture(tex, texCoords.upper) * texCoords.alphaUpper;
 }
@@ -369,17 +380,17 @@ vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const f
 // 3D texture is the 3D single-altitude slice of a 4D texture
 vec3 scattering4DCoordsToTex3DCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2);
 
-    const float dvsSize = scatteringTextureSize[1];
-    const float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
+    CONST float dvsSize = scatteringTextureSize[1];
+    CONST float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
 
-    const float cszaSize = scatteringTextureSize[2];
-    const float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
+    CONST float cszaSize = scatteringTextureSize[2];
+    CONST float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
 
     return vec3(cosVZAtc, dotVStc, cosSZAtc);
 }
@@ -394,39 +405,39 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along dotViewSun coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[1];
-    const float posOfRow = indices[1];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[1];
+    CONST float posOfRow = indices[1];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         indexToTexCoord(currRow, numRows-1),
                                                         texCoordVerbatim));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               indexToTexCoord(currRow, numRows-1),
                                                               texCoordVerbatim));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          indexToTexCoord(currRow, numRows-1),
                                          texCoordVerbatim));
@@ -434,14 +445,14 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
 vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolationGuides01Tex,
                                  const vec3 indices)
 {
-    const float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
+    CONST float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
 
-    const float cosVZAIndex = indices[0];
-    const float dotVSIndex = indices[1];
-    const float currRow = floor(dotVSIndex);
-    const float posBetweenRows = dotVSIndex - currRow;
-    const float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cosVZAIndex = indices[0];
+    CONST float dotVSIndex = indices[1];
+    CONST float currRow = floor(dotVSIndex);
+    CONST float posBetweenRows = dotVSIndex - currRow;
+    CONST float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -449,14 +460,14 @@ vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolat
     indicesCurrRow[1] =     currRow;
     indicesNextRow[1] = min(currRow+1, scatteringTextureSize[1]-1.);
 
-    const vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
-    const vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
+    CONST vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
+    CONST vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
 
-    const vec4 valueCurrRow = texture(tex, coordsCurrRow);
-    const vec4 valueNextRow = texture(tex, coordsNextRow);
-    const float epsilon = 1e-37; // Prevents passing zero to log
-    const vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
-    const vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
+    CONST vec4 valueCurrRow = texture(tex, coordsCurrRow);
+    CONST vec4 valueNextRow = texture(tex, coordsNextRow);
+    CONST float epsilon = 1e-37; // Prevents passing zero to log
+    CONST vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
+    CONST vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
     return (logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow;
 }
 
@@ -465,37 +476,37 @@ float findGuide02Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along SZA coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[2];
-    const float posOfRow = indices[2];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[2];
+    CONST float posOfRow = indices[2];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
 }
@@ -505,19 +516,19 @@ vec4 sample3DTextureGuided(const sampler3D tex,
                            const float cosSunZenithAngle, const float cosViewZenithAngle,
                            const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
                                                                     dotViewSun, altitude, viewRayIntersectsGround);
     // Handle the external interpolation guides: the guides between a pair of VZA-dotViewSun 2D "pictures".
-    const vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
-    const vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
-    const float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
+    CONST vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
+    CONST float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
 
-    const float cvzaIndex = indices[0];
-    const float cszaIndex = indices[2];
-    const float currRow = floor(cszaIndex);
-    const float posBetweenRows = cszaIndex - currRow;
-    const float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cvzaIndex = indices[0];
+    CONST float cszaIndex = indices[2];
+    CONST float currRow = floor(cszaIndex);
+    CONST float posBetweenRows = cszaIndex - currRow;
+    CONST float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -526,58 +537,58 @@ vec4 sample3DTextureGuided(const sampler3D tex,
     indicesNextRow[2] = min(currRow+1, scatteringTextureSize[2]-1);
 
     // The caller will handle the internal interpolation guides: the ones between rows in each 2D "picture".
-    const vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
-    const vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
+    CONST vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
+    CONST vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
     return exp((logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow);
 }
 
 vec4 sample3DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
     return texture(tex, texCoords);
 }
 
 ScatteringTexVars scatteringTex4DCoordsToTexVars(const Scattering4DCoords coords)
 {
-    const float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
     // ------------------------------------
     float cosViewZenithAngle;
     if(coords.viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
     // ------------------------------------
-    const float dotViewSun=coords.dotViewSun*2-1;
+    CONST float dotViewSun=coords.dotViewSun*2-1;
 
     // ------------------------------------
-    const float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
+    CONST float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
 
     return ScatteringTexVars(cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, coords.viewRayIntersectsGround);
 }
 
 Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 {
-    const vec4 indexMax=scatteringTextureSize-vec4(1);
+    CONST vec4 indexMax=scatteringTextureSize-vec4(1);
     Scattering4DCoords coords4d;
     coords4d.viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
     // The following formulas assume that scatteringTextureSize[0] is even. For odd sizes they would change.
@@ -593,8 +604,8 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture indices we combine into a single sampler3D coordinate.
-    const float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
-    const float combinedIndex=texIndices[1];
+    CONST float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
+    CONST float combinedIndex=texIndices[1];
     coords4d.dotViewSun=mod(combinedIndex,texW)/(texW-1);
     coords4d.cosSunZenithAngle=floor(combinedIndex/texW)/(texH-1);
 
@@ -608,11 +619,11 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
 ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 {
-    const Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
+    CONST Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
     ScatteringTexVars vars=scatteringTex4DCoordsToTexVars(coords4d);
     // Clamp dotViewSun to its valid range of values, given cosViewZenithAngle and cosSunZenithAngle. This is
     // needed to prevent NaNs when computing the scattering texture.
-    const float cosVZA=vars.cosViewZenithAngle,
+    CONST float cosVZA=vars.cosViewZenithAngle,
                 cosSZA=vars.cosSunZenithAngle;
     vars.dotViewSun=clamp(vars.dotViewSun,
                           cosVZA*cosSZA-safeSqrt((1-sqr(cosVZA))*(1-sqr(cosSZA))),
@@ -622,54 +633,54 @@ ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 
 EclipseScatteringTexVars eclipseTexCoordsToTexVars(const vec2 texCoords, const float altitude)
 {
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
-    const bool viewRayIntersectsGround = texCoords.t<0.5;
+    CONST bool viewRayIntersectsGround = texCoords.t<0.5;
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
-    const float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
+    CONST float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
     return EclipseScatteringTexVars(azimuthRelativeToSun, cosViewZenithAngle, viewRayIntersectsGround);
 }
 
 EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                                    const float altitude, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -677,13 +688,13 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
-    const float azimuthCoord = azimuthRelativeToSun/(2*PI);
+    CONST float azimuthCoord = azimuthRelativeToSun/(2*PI);
 
     return EclipseScattering2DCoords(azimuthCoord, cosVZACoord);
 }
@@ -691,14 +702,14 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
 vec2 eclipseTexVarsToTexCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                const float altitude, const bool viewRayIntersectsGround, const vec2 texSize)
 {
-    const EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+    CONST EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                                     viewRayIntersectsGround);
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2);
-    const float azimuthTC = coords.azimuth + 1/(2*texSize.s);
+    CONST float azimuthTC = coords.azimuth + 1/(2*texSize.s);
 
     return vec2(azimuthTC, cosVZAtc);
 }
@@ -707,42 +718,42 @@ vec4 sampleEclipseDoubleScattering3DTexture(const sampler3D tex, const float cos
                                             const float cosViewZenithAngle, const float azimuthRelativeToSun,
                                             const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
+    CONST vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
                                                   eclipsedDoubleScatteringTextureSize.st);
-    const float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
-    const vec3 texCoords=vec3(coords2d, cosSZACoord);
+    CONST float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
+    CONST vec3 texCoords=vec3(coords2d, cosSZACoord);
 
     return texture(tex, texCoords);
 }
 
 LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 texIndices)
 {
-    const vec2 indexMax=lightPollutionTextureSize-vec2(1);
+    CONST vec2 indexMax=lightPollutionTextureSize-vec2(1);
 
-    const float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
-    const float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
+    CONST float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
-    const bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
-    const float cosViewZenithAngleCoord = viewRayIntersectsGround ?
+    CONST bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
+    CONST float cosViewZenithAngleCoord = viewRayIntersectsGround ?
                                    1-2*texIndices[0]/(indexMax[0]-1) :
                                    2*(texIndices[0]-1)/(indexMax[0]-1)-1;
     // ------------------------------------
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
@@ -753,23 +764,23 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 
 LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -777,27 +788,27 @@ LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, con
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     return LightPollution2DCoords(cosVZACoord, altCoord);
 }
 
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
-    const vec2 texSize = lightPollutionTextureSize;
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 texSize = lightPollutionTextureSize;
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2);
-    const float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
+    CONST float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
     return vec2(cosVZAtc, altitudeTC);
 }

--- a/atmosphere/default/shaders/zero-order-scattering/1/texture-sampling-functions.frag
+++ b/atmosphere/default/shaders/zero-order-scattering/1/texture-sampling-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-sampling-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,13 +45,13 @@ const vec4 lightPollutionRelativeRadiance=vec4(2.15e-06,1.11400004e-06,3.8580001
 const vec4 wavelengths=vec4(485.333344,516.666687,548,579.333313);
 const int wlSetIndex=1;
 #endif
-#line 5 0 // texture-sampling-functions.frag
-#line 1 2 // phase-functions.h.glsl
+#line 4 0 // texture-sampling-functions.frag
+#line 1 3 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 6 0 // texture-sampling-functions.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-sampling-functions.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -72,8 +83,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-sampling-functions.frag
-#line 1 4 // texture-coordinates.h.glsl
+#line 6 0 // texture-sampling-functions.frag
+#line 1 5 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -142,7 +153,7 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 8 0 // texture-sampling-functions.frag
+#line 7 0 // texture-sampling-functions.frag
 
 uniform sampler2D transmittanceTexture;
 uniform sampler2D irradianceTexture;
@@ -154,13 +165,13 @@ uniform sampler2D lightPollutionScatteringTexture;
 
 vec4 irradiance(const float cosSunZenithAngle, const float altitude)
 {
-    const vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
+    CONST vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
     return texture(irradianceTexture, texCoords);
 }
 
 vec4 opticalDepthToAtmosphereBorder(const float cosViewZenithAngle, const float altitude)
 {
-    const vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
+    CONST vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact when looking into nadir from TOA at some values of texture sizes (in particular, size of
     // transmittance texture for altitude being 4096). This happens when I simply call texture(eclipsedScatteringTexture,
@@ -178,11 +189,11 @@ vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float
 vec4 transmittance(const float cosViewZenithAngle, const float altitude, const float dist,
                    const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle view ray endpoint
     // in space here.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
 
     vec4 depth;
     if(viewRayIntersectsGround)
@@ -201,7 +212,7 @@ vec4 transmittance(const float cosViewZenithAngle, const float altitude, const f
 vec4 calcFirstScattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                          const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
+    CONST vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
                                           dotViewSun, altitude, viewRayIntersectsGround);
     return scattering*currentPhaseFunction(dotViewSun);
 }
@@ -220,6 +231,6 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
 
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     return texture(lightPollutionScatteringTexture, coords);
 }

--- a/atmosphere/default/shaders/zero-order-scattering/2/common-functions.frag
+++ b/atmosphere/default/shaders/zero-order-scattering/2/common-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // common-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.35000004e-05,1.33100002e-05,9.4
 const vec4 wavelengths=vec4(610.666687,642,673.333313,704.666687);
 const int wlSetIndex=2;
 #endif
-#line 5 0 // common-functions.frag
+#line 4 0 // common-functions.frag
 
 bool dbgDataPresent=false;
 bool debugDataPresent()
@@ -69,7 +80,7 @@ void setDebugData(float a,float b, float c, float d)
 
 void swap(inout float x, inout float y)
 {
-    const float t = x;
+    CONST float t = x;
     x = y;
     y = t;
 }
@@ -83,7 +94,7 @@ float safeSqrt(const float x)
 
 float safeAtan(const float y, const float x)
 {
-    const float a = atan(y,x);
+    CONST float a = atan(y,x);
     return x==0 && y==0 ? 0 : a;
 }
 
@@ -116,23 +127,23 @@ float pointAltitude(vec3 point)
 
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float Ratm=earthRadius+atmosphereHeight;
-    const float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float Ratm=earthRadius+atmosphereHeight;
+    CONST float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float distanceToGround(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(-safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float cosZenithAngleOfHorizon(const float altitude)
 {
-    const float R=earthRadius;
-    const float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
+    CONST float R=earthRadius;
+    CONST float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
     return -sqrt(2*h*R+sqr(h))/(R+h);
 }
 
@@ -151,8 +162,8 @@ float distanceToNearestAtmosphereBoundary(const float cosZenithAngle, const floa
 float sunVisibility(const float cosSunZenithAngle, float altitude)
 {
     if(altitude<0) altitude=0;
-    const float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
-    const float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
+    CONST float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
+    CONST float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
     /* Approximating visible fraction of solar disk by smoothstep between the position of the Sun
      * touching the horizon by its upper part and the position with lower part touching the horizon.
      * The calculation assumes that solar angular radius is small and thus approximately equals its sine.
@@ -182,13 +193,13 @@ float circlesIntersectionArea(float R1, float R2, float d)
 
 float angleBetween(const vec3 a, const vec3 b)
 {
-    const float d=dot(a,b);
-    const float c=length(cross(a,b));
+    CONST float d=dot(a,b);
+    CONST float c=length(cross(a,b));
     // To avoid loss of precision, don't use dot product near the singularity
     // of acos, and cross product near the singularity of asin
     if(abs(d) < abs(c))
         return acos(d/(length(a)*length(b)));
-    const float smallerAngle = asin(c/(length(a)*length(b)));
+    CONST float smallerAngle = asin(c/(length(a)*length(b)));
     if(d<0) return PI-smallerAngle;
     return smallerAngle;
 }
@@ -205,11 +216,11 @@ float moonAngularRadius(const vec3 cameraPosition, const vec3 moonPosition)
 
 float visibleSolidAngleOfSun(const vec3 camera, const vec3 sunDir, const vec3 moonPos)
 {
-    const float Rs=sunAngularRadius;
-    const float Rm=moonAngularRadius(camera,moonPos);
+    CONST float Rs=sunAngularRadius;
+    CONST float Rm=moonAngularRadius(camera,moonPos);
     float visibleSolidAngle=PI*sqr(Rs);
 
-    const float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
+    CONST float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
     if(dSM<Rs+Rm)
     {
         visibleSolidAngle -= circlesIntersectionArea(Rm,Rs,dSM);
@@ -229,12 +240,12 @@ float sphereIntegrationSolidAngleDifferential(const int pointCountOnSphere)
 }
 vec3 sphereIntegrationSampleDir(const int index, const int pointCountOnSphere)
 {
-    const float goldenRatio=1.6180339887499;
+    CONST float goldenRatio=1.6180339887499;
     // The range of n is 0.5, 1.5, ..., pointCountOnSphere-0.5
-    const float n=index+0.5;
+    CONST float n=index+0.5;
     // Explanation of the Fibonacci grid generation can be seen at https://stackoverflow.com/a/44164075/673852
-    const float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
-    const float azimuth=n*(2*PI*goldenRatio);
+    CONST float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
+    CONST float azimuth=n*(2*PI*goldenRatio);
     return vec3(cos(azimuth)*sin(zenithAngle),
                 sin(azimuth)*sin(zenithAngle),
                 cos(zenithAngle));

--- a/atmosphere/default/shaders/zero-order-scattering/2/phase-functions.frag
+++ b/atmosphere/default/shaders/zero-order-scattering/2/phase-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // phase-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.35000004e-05,1.33100002e-05,9.4
 const vec4 wavelengths=vec4(610.666687,642,673.333313,704.666687);
 const int wlSetIndex=2;
 #endif
-#line 5 0 // phase-functions.frag
+#line 4 0 // phase-functions.frag
 
 vec4 phaseFunction_molecules(float dotViewSun)
 {
@@ -42,8 +53,8 @@ vec4 phaseFunction_molecules(float dotViewSun)
 }
 vec4 phaseFunction_aerosols(float dotViewSun)
 {
-        const float g=0.76;
-        const float g2=g*g;
-        const float k = 3/(8*PI)*(1-g2)/(2+g2);
+        CONST float g=0.76;
+        CONST float g2=g*g;
+        CONST float k = 3/(8*PI)*(1-g2)/(2+g2);
         return vec4(k * (1+sqr(dotViewSun)) / pow(1+g2 - 2*g*dotViewSun, 1.5) + 1/((1-dotViewSun)*600+0.05))*0.904;
 }

--- a/atmosphere/default/shaders/zero-order-scattering/2/render.frag
+++ b/atmosphere/default/shaders/zero-order-scattering/2/render.frag
@@ -1,7 +1,21 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
 
-#line 1 1 // const.h.glsl
+
+
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 6 0 // render.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,11 +48,11 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.35000004e-05,1.33100002e-05,9.4
 const vec4 wavelengths=vec4(610.666687,642,673.333313,704.666687);
 const int wlSetIndex=2;
 #endif
-#line 5 0 // render.frag
-#line 1 2 // calc-view-dir.h.glsl
+#line 7 0 // render.frag
+#line 1 3 // calc-view-dir.h.glsl
 vec3 calcViewDir();
-#line 6 0 // render.frag
-#line 1 3 // common-functions.h.glsl
+#line 8 0 // render.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -70,11 +84,11 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // render.frag
+#line 9 0 // render.frag
 
 
 
-#line 1 4 // texture-coordinates.h.glsl
+#line 1 5 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -143,11 +157,11 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 11 0 // render.frag
-#line 1 5 // radiance-to-luminance.h.glsl
+#line 13 0 // render.frag
+#line 1 6 // radiance-to-luminance.h.glsl
 const mat4 radianceToLuminance=mat4(21296.1113,10585.7773,6.80903196,807.40564,  8819.19727,3416.5498,0.346691847,67.973465,  1511.18506,551.902527,0,6.17586422,  177.630722,64.1456985,0,0.693584085);
-#line 12 0 // render.frag
-#line 1 6 // texture-sampling-functions.h.glsl
+#line 14 0 // render.frag
+#line 1 7 // texture-sampling-functions.h.glsl
 #ifndef INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 #define INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float altitude);
@@ -159,7 +173,7 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                 const int scatteringOrder);
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 #endif
-#line 13 0 // render.frag
+#line 15 0 // render.frag
 
 
 
@@ -195,18 +209,18 @@ void main()
     // this approximation has the same order of magnitude as the assumption that the Earth and its atmosphere
     // are spherical.
     float altitude = max(cameraPosition.z, 0.);
-    const vec3 oldCamPos=cameraPosition;
+    CONST vec3 oldCamPos=cameraPosition;
     // Hide the uniform with this name, thus effectively modifying it for the following code
     vec3 cameraPosition=vec3(oldCamPos.xy, altitude);
 
     bool lookingIntoAtmosphere=true;
     if(altitude>atmosphereHeight)
     {
-        const vec3 p = cameraPosition - earthCenter;
-        const float p_dot_v = dot(p, viewDir);
-        const float p_dot_p = dot(p, p);
-        const float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
-        const float distanceToTOA = -p_dot_v - sqrt(sqr(earthRadius+atmosphereHeight) - squaredDistBetweenViewRayAndEarthCenter);
+        CONST vec3 p = cameraPosition - earthCenter;
+        CONST float p_dot_v = dot(p, viewDir);
+        CONST float p_dot_p = dot(p, p);
+        CONST float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
+        CONST float distanceToTOA = -p_dot_v - sqrt(sqr(earthRadius+atmosphereHeight) - squaredDistBetweenViewRayAndEarthCenter);
         if(distanceToTOA>=0)
         {
             cameraPosition += viewDir*distanceToTOA;
@@ -224,16 +238,16 @@ void main()
         }
     }
 
-    const vec3 zenith=normalize(cameraPosition-earthCenter);
+    CONST vec3 zenith=normalize(cameraPosition-earthCenter);
     float cosViewZenithAngle=dot(zenith,viewDir);
 
     bool viewRayIntersectsGround=false;
     {
-        const vec3 p = cameraPosition - earthCenter;
-        const float p_dot_v = dot(p, viewDir);
-        const float p_dot_p = dot(p, p);
-        const float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
-        const float distanceToIntersection = -p_dot_v - sqrt(sqr(earthRadius) - squaredDistBetweenViewRayAndEarthCenter);
+        CONST vec3 p = cameraPosition - earthCenter;
+        CONST float p_dot_v = dot(p, viewDir);
+        CONST float p_dot_p = dot(p, p);
+        CONST float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
+        CONST float distanceToIntersection = -p_dot_v - sqrt(sqr(earthRadius) - squaredDistBetweenViewRayAndEarthCenter);
         // altitude==0 is a special case where distance to intersection calculation
         // is unreliable (has a lot of noise in its sign), so check it separately
         if(distanceToIntersection>0 || (altitude==0 && cosViewZenithAngle<0))
@@ -244,11 +258,11 @@ void main()
     // Aside from aesthetics, this affects brightness input to Stellarium's tone mapper.
     if(pseudoMirrorSkyBelowHorizon && viewRayIntersectsGround)
     {
-        const float horizonCZA = cosZenithAngleOfHorizon(altitude);
-        const float viewElev  = asin(clampCosine(cosViewZenithAngle));
-        const float horizElev = asin(clampCosine(horizonCZA));
-        const float newViewElev = 2*horizElev - viewElev;
-        const float viewDirXYnorm = length(viewDir-zenith*cosViewZenithAngle);
+        CONST float horizonCZA = cosZenithAngleOfHorizon(altitude);
+        CONST float viewElev  = asin(clampCosine(cosViewZenithAngle));
+        CONST float horizElev = asin(clampCosine(horizonCZA));
+        CONST float newViewElev = 2*horizElev - viewElev;
+        CONST float viewDirXYnorm = length(viewDir-zenith*cosViewZenithAngle);
         if(viewDirXYnorm == 0)
         {
             viewDir = zenith;
@@ -267,14 +281,14 @@ void main()
         viewRayIntersectsGround = false;
     }
 
-    const float cosSunZenithAngle =dot(zenith,sunDirection);
-    const float dotViewSun=dot(viewDir,sunDirection);
+    CONST float cosSunZenithAngle =dot(zenith,sunDirection);
+    CONST float dotViewSun=dot(viewDir,sunDirection);
 
-    const vec3 sunXYunnorm=sunDirection-dot(sunDirection,zenith)*zenith;
-    const vec3 viewXYunnorm=viewDir-dot(viewDir,zenith)*zenith;
-    const vec3 sunXY = sunXYunnorm.x!=0 || sunXYunnorm.y!=0 || sunXYunnorm.z!=0 ? normalize(sunXYunnorm) : vec3(0);
-    const vec3 viewXY = viewXYunnorm.x!=0 || viewXYunnorm.y!=0 || viewXYunnorm.z!=0 ? normalize(viewXYunnorm) : vec3(0);
-    const float azimuthRelativeToSun=safeAtan(dot(cross(sunXY, viewXY), zenith), dot(sunXY, viewXY));
+    CONST vec3 sunXYunnorm=sunDirection-dot(sunDirection,zenith)*zenith;
+    CONST vec3 viewXYunnorm=viewDir-dot(viewDir,zenith)*zenith;
+    CONST vec3 sunXY = sunXYunnorm.x!=0 || sunXYunnorm.y!=0 || sunXYunnorm.z!=0 ? normalize(sunXYunnorm) : vec3(0);
+    CONST vec3 viewXY = viewXYunnorm.x!=0 || viewXYunnorm.y!=0 || viewXYunnorm.z!=0 ? normalize(viewXYunnorm) : vec3(0);
+    CONST float azimuthRelativeToSun=safeAtan(dot(cross(sunXY, viewXY), zenith), dot(sunXY, viewXY));
 
 #if 1 /*RENDERING_ZERO_SCATTERING*/
     vec4 radiance;
@@ -282,12 +296,12 @@ void main()
     {
         // XXX: keep in sync with the same code in computeScatteringDensity(), but don't forget about
         //      the difference in the usage of viewDir vs incDir.
-        const float distToGround = distanceToGround(cosViewZenithAngle, altitude);
-        const vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
-        const vec3 groundNormal = normalize(zenith*(earthRadius+altitude)+viewDir*distToGround);
-        const vec4 groundIrradiance = irradiance(dot(groundNormal, sunDirection), 0);
+        CONST float distToGround = distanceToGround(cosViewZenithAngle, altitude);
+        CONST vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
+        CONST vec3 groundNormal = normalize(zenith*(earthRadius+altitude)+viewDir*distToGround);
+        CONST vec4 groundIrradiance = irradiance(dot(groundNormal, sunDirection), 0);
         // Radiation scattered by the ground
-        const float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
+        CONST float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
         radiance = transmittanceToGround*groundAlbedo*groundIrradiance*solarIrradianceFixup*groundBRDF
                  + lightPollutionGroundLuminance*lightPollutionRelativeRadiance;
     }
@@ -304,22 +318,22 @@ void main()
     }
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_ZERO_SCATTERING
+#elif 0 /*RENDERING_ECLIPSED_ZERO_SCATTERING*/
     vec4 radiance;
-    const float dotViewMoon=dot(viewDir,normalize(moonPosition-cameraPosition));
+    CONST float dotViewMoon=dot(viewDir,normalize(moonPosition-cameraPosition));
     if(viewRayIntersectsGround)
     {
         // XXX: keep in sync with the similar code in non-eclipsed zero scattering rendering.
-        const float distToGround = distanceToGround(cosViewZenithAngle, altitude);
-        const vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
-        const vec3 pointOnGround = cameraPosition+viewDir*distToGround;
-        const vec4 directGroundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDirection, moonPosition);
+        CONST float distToGround = distanceToGround(cosViewZenithAngle, altitude);
+        CONST vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
+        CONST vec3 pointOnGround = cameraPosition+viewDir*distToGround;
+        CONST vec4 directGroundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDirection, moonPosition);
         // FIXME: add first-order indirect irradiance too: it's done in non-eclipsed irradiance (in the same
         // conditions: when limited to 2 orders). This should be calculated at the same time when second order
         // is: all the infrastructure is already there.
-        const vec4 groundIrradiance = directGroundIrradiance;
+        CONST vec4 groundIrradiance = directGroundIrradiance;
         // Radiation scattered by the ground
-        const float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
+        CONST float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
         radiance = transmittanceToGround*groundAlbedo*groundIrradiance*solarIrradianceFixup*groundBRDF
                  + lightPollutionGroundLuminance*lightPollutionRelativeRadiance;
     }
@@ -336,53 +350,53 @@ void main()
     }
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_ON_THE_FLY
-    const vec4 scattering=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPosition,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_ON_THE_FLY*/
+    CONST vec4 scattering=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPosition,
                                                           viewRayIntersectsGround);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE
-    const vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE*/
+    CONST vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                      viewRayIntersectsGround, eclipsedSingleScatteringTextureSize);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact at the point where azimuth texture coordinate changes from 1 to 0 (at azimuthRelativeToSun crossing
     // 0). This happens when I simply call texture(eclipsedScatteringTexture, texCoords) without specifying LOD.
     // Apparently, the driver uses the derivative for some reason, even though it shouldn't.
-    const vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
+    CONST vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE
-    const vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
+    CONST vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                      viewRayIntersectsGround, eclipsedSingleScatteringTextureSize);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact at the point where azimuth texture coordinate changes from 1 to 0 (at azimuthRelativeToSun crossing
     // 0). This happens when I simply call texture(eclipsedScatteringTexture, texCoords) without specifying LOD.
     // Apparently, the driver uses the derivative for some reason, even though it shouldn't.
-    const vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
+    CONST vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
     luminance=scattering*currentPhaseFunction(dotViewSun);
-#elif RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_RADIANCE
+#elif 0 /*RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_RADIANCE*/
     vec4 radiance=exp(sampleEclipseDoubleScattering3DTexture(eclipsedDoubleScatteringTexture,
                                                              cosSunZenithAngle, cosViewZenithAngle, azimuthRelativeToSun,
                                                              altitude, viewRayIntersectsGround));
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_LUMINANCE
+#elif 0 /*RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
     luminance=exp(sampleEclipseDoubleScattering3DTexture(eclipsedDoubleScatteringTexture,
                                                          cosSunZenithAngle, cosViewZenithAngle, azimuthRelativeToSun,
                                                          altitude, viewRayIntersectsGround));
-#elif RENDERING_SINGLE_SCATTERING_ON_THE_FLY
-    const vec4 scattering=computeSingleScattering(cosSunZenithAngle,cosViewZenithAngle,dotViewSun,
+#elif 0 /*RENDERING_SINGLE_SCATTERING_ON_THE_FLY*/
+    CONST vec4 scattering=computeSingleScattering(cosSunZenithAngle,cosViewZenithAngle,dotViewSun,
                                                   altitude,viewRayIntersectsGround);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE
+#elif 0 /*RENDERING_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE*/
     vec4 scattering;
     if(useInterpolationGuides)
     {
@@ -399,7 +413,7 @@ void main()
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE
+#elif 0 /*RENDERING_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
     vec4 scattering;
     if(useInterpolationGuides)
     {
@@ -413,18 +427,18 @@ void main()
                                      dotViewSun, altitude, viewRayIntersectsGround);
     }
     luminance=scattering * (bool(PHASE_FUNCTION_IS_EMBEDDED) ? vec4(1) : currentPhaseFunction(dotViewSun));
-#elif RENDERING_MULTIPLE_SCATTERING_LUMINANCE
+#elif 0 /*RENDERING_MULTIPLE_SCATTERING_LUMINANCE*/
     luminance=sample3DTexture(scatteringTexture, cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, viewRayIntersectsGround);
-#elif RENDERING_MULTIPLE_SCATTERING_RADIANCE
+#elif 0 /*RENDERING_MULTIPLE_SCATTERING_RADIANCE*/
     vec4 radiance=sample3DTexture(scatteringTexture, cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, viewRayIntersectsGround);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_LIGHT_POLLUTION_RADIANCE
+#elif 0 /*RENDERING_LIGHT_POLLUTION_RADIANCE*/
     vec4 radiance=lightPollutionGroundLuminance*lightPollutionScattering(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_LIGHT_POLLUTION_LUMINANCE
+#elif 0 /*RENDERING_LIGHT_POLLUTION_LUMINANCE*/
     luminance=lightPollutionGroundLuminance*lightPollutionScattering(altitude, cosViewZenithAngle, viewRayIntersectsGround);
 #else
 #error What to render?

--- a/atmosphere/default/shaders/zero-order-scattering/2/texture-coordinates.frag
+++ b/atmosphere/default/shaders/zero-order-scattering/2/texture-coordinates.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-coordinates.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,8 +45,8 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.35000004e-05,1.33100002e-05,9.4
 const vec4 wavelengths=vec4(610.666687,642,673.333313,704.666687);
 const int wlSetIndex=2;
 #endif
-#line 5 0 // texture-coordinates.frag
-#line 1 2 // texture-coordinates.h.glsl
+#line 4 0 // texture-coordinates.frag
+#line 1 3 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -104,8 +115,8 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 6 0 // texture-coordinates.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-coordinates.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -137,7 +148,7 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-coordinates.frag
+#line 6 0 // texture-coordinates.frag
 
 const float LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA=sqrt(atmosphereHeight*(atmosphereHeight+2*earthRadius));
 
@@ -205,18 +216,18 @@ vec3 indicesToTexCoords(const vec3 indices, const vec3 texSizes)
 
 TransmittanceTexVars transmittanceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
+    CONST float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
                                 texCoordToUnitRange(texCoord.t,transmittanceTextureSize.t);
     // Distance from Earth center to camera
-    const float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
-    const float altitude=r-earthRadius;
+    CONST float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
+    CONST float altitude=r-earthRadius;
 
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
     // distance to border of visible atmosphere from the view point
-    const float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
+    CONST float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
     // d==0 can happen when altitude==atmosphereHeight
-    const float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
+    CONST float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
     return TransmittanceTexVars(cosVZA,altitude);
 }
 
@@ -235,53 +246,53 @@ vec2 transmittanceTexVarsToTexCoord(const float cosVZA, float altitude)
     if(altitude<0)
         altitude=0;
 
-    const float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
+    CONST float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
                                       transmittanceTextureSize.t);
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
-    const float d=distanceToAtmosphereBorder(cosVZA,altitude);
-    const float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float d=distanceToAtmosphereBorder(cosVZA,altitude);
+    CONST float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
     return vec2(s,t);
 }
 
 // Output: vec2(cos(sunZenithAngle), altitude)
 IrradianceTexVars irradianceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
-    const float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
+    CONST float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
+    CONST float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
     return IrradianceTexVars(cosSZA,alt);
 }
 
 vec2 irradianceTexVarsToTexCoord(const float cosSunZenithAngle, const float altitude)
 {
-    const float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
-    const float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
+    CONST float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
+    CONST float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
     return vec2(s,t);
 }
 
 float cosSZAToUnitRangeTexCoord(const float cosSunZenithAngle)
 {
     // Distance to top atmosphere border along the ray groundUnderCamera-sun: (altitude, cosSunZenithAngle)
-    const float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name
-    const float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
+    CONST float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
     // TODO: choose a more descriptive name
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     return max(0.,1-a/A)/(a+1);
 }
 
 float unitRangeTexCoordToCosSZA(const float texCoord)
 {
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float a=(A-A*texCoord)/(1+A*texCoord);
-    const float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
+    CONST float a=(A-A*texCoord)/(1+A*texCoord);
+    CONST float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
     return distFromGroundToTopAtmoBorder==0 ? 1 :
         clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distFromGroundToTopAtmoBorder)) /
                     (2*earthRadius*distFromGroundToTopAtmoBorder));
@@ -292,24 +303,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
                                                const float dotViewSun, const float altitude,
                                                const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -317,24 +328,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float dotVSCoord=(dotViewSun+1)/2;
+    CONST float dotVSCoord=(dotViewSun+1)/2;
 
     // ------------------------------------
-    const float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
+    CONST float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
 
     return Scattering4DCoords(cosSZACoord, cosVZACoord, dotVSCoord, altCoord, viewRayIntersectsGround);
 }
 
 TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
@@ -342,16 +353,16 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture coordinates we combine into a single sampler3D coordinate.
-    const float texW = scatteringTextureSize[1];
-    const float texH = scatteringTextureSize[2];
-    const float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
-    const vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
+    CONST float texW = scatteringTextureSize[1];
+    CONST float texH = scatteringTextureSize[2];
+    CONST float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
+    CONST vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
                                         ceil (cosSZAIndex)*texW+coords.dotViewSun*(texW-1)) / (texW*texH-1);
-    const vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
+    CONST vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
 
-    const float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
+    CONST float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
 
-    const float alphaUpper=fract(cosSZAIndex);
+    CONST float alphaUpper=fract(cosSZAIndex);
     return TexCoordPair(vec3(cosVZAtc, combinedCoord.x, altitude), float(1-alphaUpper),
                         vec3(cosVZAtc, combinedCoord.y, altitude), float(alphaUpper));
 }
@@ -359,9 +370,9 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
+    CONST TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
     return texture(tex, texCoords.lower) * texCoords.alphaLower +
            texture(tex, texCoords.upper) * texCoords.alphaUpper;
 }
@@ -369,17 +380,17 @@ vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const f
 // 3D texture is the 3D single-altitude slice of a 4D texture
 vec3 scattering4DCoordsToTex3DCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2);
 
-    const float dvsSize = scatteringTextureSize[1];
-    const float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
+    CONST float dvsSize = scatteringTextureSize[1];
+    CONST float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
 
-    const float cszaSize = scatteringTextureSize[2];
-    const float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
+    CONST float cszaSize = scatteringTextureSize[2];
+    CONST float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
 
     return vec3(cosVZAtc, dotVStc, cosSZAtc);
 }
@@ -394,39 +405,39 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along dotViewSun coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[1];
-    const float posOfRow = indices[1];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[1];
+    CONST float posOfRow = indices[1];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         indexToTexCoord(currRow, numRows-1),
                                                         texCoordVerbatim));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               indexToTexCoord(currRow, numRows-1),
                                                               texCoordVerbatim));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          indexToTexCoord(currRow, numRows-1),
                                          texCoordVerbatim));
@@ -434,14 +445,14 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
 vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolationGuides01Tex,
                                  const vec3 indices)
 {
-    const float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
+    CONST float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
 
-    const float cosVZAIndex = indices[0];
-    const float dotVSIndex = indices[1];
-    const float currRow = floor(dotVSIndex);
-    const float posBetweenRows = dotVSIndex - currRow;
-    const float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cosVZAIndex = indices[0];
+    CONST float dotVSIndex = indices[1];
+    CONST float currRow = floor(dotVSIndex);
+    CONST float posBetweenRows = dotVSIndex - currRow;
+    CONST float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -449,14 +460,14 @@ vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolat
     indicesCurrRow[1] =     currRow;
     indicesNextRow[1] = min(currRow+1, scatteringTextureSize[1]-1.);
 
-    const vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
-    const vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
+    CONST vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
+    CONST vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
 
-    const vec4 valueCurrRow = texture(tex, coordsCurrRow);
-    const vec4 valueNextRow = texture(tex, coordsNextRow);
-    const float epsilon = 1e-37; // Prevents passing zero to log
-    const vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
-    const vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
+    CONST vec4 valueCurrRow = texture(tex, coordsCurrRow);
+    CONST vec4 valueNextRow = texture(tex, coordsNextRow);
+    CONST float epsilon = 1e-37; // Prevents passing zero to log
+    CONST vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
+    CONST vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
     return (logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow;
 }
 
@@ -465,37 +476,37 @@ float findGuide02Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along SZA coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[2];
-    const float posOfRow = indices[2];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[2];
+    CONST float posOfRow = indices[2];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
 }
@@ -505,19 +516,19 @@ vec4 sample3DTextureGuided(const sampler3D tex,
                            const float cosSunZenithAngle, const float cosViewZenithAngle,
                            const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
                                                                     dotViewSun, altitude, viewRayIntersectsGround);
     // Handle the external interpolation guides: the guides between a pair of VZA-dotViewSun 2D "pictures".
-    const vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
-    const vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
-    const float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
+    CONST vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
+    CONST float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
 
-    const float cvzaIndex = indices[0];
-    const float cszaIndex = indices[2];
-    const float currRow = floor(cszaIndex);
-    const float posBetweenRows = cszaIndex - currRow;
-    const float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cvzaIndex = indices[0];
+    CONST float cszaIndex = indices[2];
+    CONST float currRow = floor(cszaIndex);
+    CONST float posBetweenRows = cszaIndex - currRow;
+    CONST float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -526,58 +537,58 @@ vec4 sample3DTextureGuided(const sampler3D tex,
     indicesNextRow[2] = min(currRow+1, scatteringTextureSize[2]-1);
 
     // The caller will handle the internal interpolation guides: the ones between rows in each 2D "picture".
-    const vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
-    const vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
+    CONST vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
+    CONST vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
     return exp((logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow);
 }
 
 vec4 sample3DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
     return texture(tex, texCoords);
 }
 
 ScatteringTexVars scatteringTex4DCoordsToTexVars(const Scattering4DCoords coords)
 {
-    const float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
     // ------------------------------------
     float cosViewZenithAngle;
     if(coords.viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
     // ------------------------------------
-    const float dotViewSun=coords.dotViewSun*2-1;
+    CONST float dotViewSun=coords.dotViewSun*2-1;
 
     // ------------------------------------
-    const float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
+    CONST float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
 
     return ScatteringTexVars(cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, coords.viewRayIntersectsGround);
 }
 
 Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 {
-    const vec4 indexMax=scatteringTextureSize-vec4(1);
+    CONST vec4 indexMax=scatteringTextureSize-vec4(1);
     Scattering4DCoords coords4d;
     coords4d.viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
     // The following formulas assume that scatteringTextureSize[0] is even. For odd sizes they would change.
@@ -593,8 +604,8 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture indices we combine into a single sampler3D coordinate.
-    const float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
-    const float combinedIndex=texIndices[1];
+    CONST float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
+    CONST float combinedIndex=texIndices[1];
     coords4d.dotViewSun=mod(combinedIndex,texW)/(texW-1);
     coords4d.cosSunZenithAngle=floor(combinedIndex/texW)/(texH-1);
 
@@ -608,11 +619,11 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
 ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 {
-    const Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
+    CONST Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
     ScatteringTexVars vars=scatteringTex4DCoordsToTexVars(coords4d);
     // Clamp dotViewSun to its valid range of values, given cosViewZenithAngle and cosSunZenithAngle. This is
     // needed to prevent NaNs when computing the scattering texture.
-    const float cosVZA=vars.cosViewZenithAngle,
+    CONST float cosVZA=vars.cosViewZenithAngle,
                 cosSZA=vars.cosSunZenithAngle;
     vars.dotViewSun=clamp(vars.dotViewSun,
                           cosVZA*cosSZA-safeSqrt((1-sqr(cosVZA))*(1-sqr(cosSZA))),
@@ -622,54 +633,54 @@ ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 
 EclipseScatteringTexVars eclipseTexCoordsToTexVars(const vec2 texCoords, const float altitude)
 {
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
-    const bool viewRayIntersectsGround = texCoords.t<0.5;
+    CONST bool viewRayIntersectsGround = texCoords.t<0.5;
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
-    const float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
+    CONST float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
     return EclipseScatteringTexVars(azimuthRelativeToSun, cosViewZenithAngle, viewRayIntersectsGround);
 }
 
 EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                                    const float altitude, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -677,13 +688,13 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
-    const float azimuthCoord = azimuthRelativeToSun/(2*PI);
+    CONST float azimuthCoord = azimuthRelativeToSun/(2*PI);
 
     return EclipseScattering2DCoords(azimuthCoord, cosVZACoord);
 }
@@ -691,14 +702,14 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
 vec2 eclipseTexVarsToTexCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                const float altitude, const bool viewRayIntersectsGround, const vec2 texSize)
 {
-    const EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+    CONST EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                                     viewRayIntersectsGround);
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2);
-    const float azimuthTC = coords.azimuth + 1/(2*texSize.s);
+    CONST float azimuthTC = coords.azimuth + 1/(2*texSize.s);
 
     return vec2(azimuthTC, cosVZAtc);
 }
@@ -707,42 +718,42 @@ vec4 sampleEclipseDoubleScattering3DTexture(const sampler3D tex, const float cos
                                             const float cosViewZenithAngle, const float azimuthRelativeToSun,
                                             const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
+    CONST vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
                                                   eclipsedDoubleScatteringTextureSize.st);
-    const float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
-    const vec3 texCoords=vec3(coords2d, cosSZACoord);
+    CONST float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
+    CONST vec3 texCoords=vec3(coords2d, cosSZACoord);
 
     return texture(tex, texCoords);
 }
 
 LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 texIndices)
 {
-    const vec2 indexMax=lightPollutionTextureSize-vec2(1);
+    CONST vec2 indexMax=lightPollutionTextureSize-vec2(1);
 
-    const float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
-    const float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
+    CONST float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
-    const bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
-    const float cosViewZenithAngleCoord = viewRayIntersectsGround ?
+    CONST bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
+    CONST float cosViewZenithAngleCoord = viewRayIntersectsGround ?
                                    1-2*texIndices[0]/(indexMax[0]-1) :
                                    2*(texIndices[0]-1)/(indexMax[0]-1)-1;
     // ------------------------------------
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
@@ -753,23 +764,23 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 
 LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -777,27 +788,27 @@ LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, con
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     return LightPollution2DCoords(cosVZACoord, altCoord);
 }
 
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
-    const vec2 texSize = lightPollutionTextureSize;
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 texSize = lightPollutionTextureSize;
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2);
-    const float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
+    CONST float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
     return vec2(cosVZAtc, altitudeTC);
 }

--- a/atmosphere/default/shaders/zero-order-scattering/2/texture-sampling-functions.frag
+++ b/atmosphere/default/shaders/zero-order-scattering/2/texture-sampling-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-sampling-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,13 +45,13 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.35000004e-05,1.33100002e-05,9.4
 const vec4 wavelengths=vec4(610.666687,642,673.333313,704.666687);
 const int wlSetIndex=2;
 #endif
-#line 5 0 // texture-sampling-functions.frag
-#line 1 2 // phase-functions.h.glsl
+#line 4 0 // texture-sampling-functions.frag
+#line 1 3 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 6 0 // texture-sampling-functions.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-sampling-functions.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -72,8 +83,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-sampling-functions.frag
-#line 1 4 // texture-coordinates.h.glsl
+#line 6 0 // texture-sampling-functions.frag
+#line 1 5 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -142,7 +153,7 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 8 0 // texture-sampling-functions.frag
+#line 7 0 // texture-sampling-functions.frag
 
 uniform sampler2D transmittanceTexture;
 uniform sampler2D irradianceTexture;
@@ -154,13 +165,13 @@ uniform sampler2D lightPollutionScatteringTexture;
 
 vec4 irradiance(const float cosSunZenithAngle, const float altitude)
 {
-    const vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
+    CONST vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
     return texture(irradianceTexture, texCoords);
 }
 
 vec4 opticalDepthToAtmosphereBorder(const float cosViewZenithAngle, const float altitude)
 {
-    const vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
+    CONST vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact when looking into nadir from TOA at some values of texture sizes (in particular, size of
     // transmittance texture for altitude being 4096). This happens when I simply call texture(eclipsedScatteringTexture,
@@ -178,11 +189,11 @@ vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float
 vec4 transmittance(const float cosViewZenithAngle, const float altitude, const float dist,
                    const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle view ray endpoint
     // in space here.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
 
     vec4 depth;
     if(viewRayIntersectsGround)
@@ -201,7 +212,7 @@ vec4 transmittance(const float cosViewZenithAngle, const float altitude, const f
 vec4 calcFirstScattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                          const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
+    CONST vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
                                           dotViewSun, altitude, viewRayIntersectsGround);
     return scattering*currentPhaseFunction(dotViewSun);
 }
@@ -220,6 +231,6 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
 
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     return texture(lightPollutionScatteringTexture, coords);
 }

--- a/atmosphere/default/shaders/zero-order-scattering/3/common-functions.frag
+++ b/atmosphere/default/shaders/zero-order-scattering/3/common-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // common-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // common-functions.frag
+#line 4 0 // common-functions.frag
 
 bool dbgDataPresent=false;
 bool debugDataPresent()
@@ -69,7 +80,7 @@ void setDebugData(float a,float b, float c, float d)
 
 void swap(inout float x, inout float y)
 {
-    const float t = x;
+    CONST float t = x;
     x = y;
     y = t;
 }
@@ -83,7 +94,7 @@ float safeSqrt(const float x)
 
 float safeAtan(const float y, const float x)
 {
-    const float a = atan(y,x);
+    CONST float a = atan(y,x);
     return x==0 && y==0 ? 0 : a;
 }
 
@@ -116,23 +127,23 @@ float pointAltitude(vec3 point)
 
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float Ratm=earthRadius+atmosphereHeight;
-    const float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float Ratm=earthRadius+atmosphereHeight;
+    CONST float discriminant=sqr(Ratm)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float distanceToGround(const float cosZenithAngle, const float observerAltitude)
 {
-    const float Robs=earthRadius+observerAltitude;
-    const float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
+    CONST float Robs=earthRadius+observerAltitude;
+    CONST float discriminant=sqr(earthRadius)-sqr(Robs)*(1-sqr(cosZenithAngle));
     return clampDistance(-safeSqrt(discriminant)-Robs*cosZenithAngle);
 }
 
 float cosZenithAngleOfHorizon(const float altitude)
 {
-    const float R=earthRadius;
-    const float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
+    CONST float R=earthRadius;
+    CONST float h=max(0.,altitude); // negative values would result in sqrt(-|x|)
     return -sqrt(2*h*R+sqr(h))/(R+h);
 }
 
@@ -151,8 +162,8 @@ float distanceToNearestAtmosphereBoundary(const float cosZenithAngle, const floa
 float sunVisibility(const float cosSunZenithAngle, float altitude)
 {
     if(altitude<0) altitude=0;
-    const float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
-    const float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
+    CONST float sinHorizonZenithAngle = earthRadius/(earthRadius+altitude);
+    CONST float cosHorizonZenithAngle = -sqrt(1-sqr(sinHorizonZenithAngle));
     /* Approximating visible fraction of solar disk by smoothstep between the position of the Sun
      * touching the horizon by its upper part and the position with lower part touching the horizon.
      * The calculation assumes that solar angular radius is small and thus approximately equals its sine.
@@ -182,13 +193,13 @@ float circlesIntersectionArea(float R1, float R2, float d)
 
 float angleBetween(const vec3 a, const vec3 b)
 {
-    const float d=dot(a,b);
-    const float c=length(cross(a,b));
+    CONST float d=dot(a,b);
+    CONST float c=length(cross(a,b));
     // To avoid loss of precision, don't use dot product near the singularity
     // of acos, and cross product near the singularity of asin
     if(abs(d) < abs(c))
         return acos(d/(length(a)*length(b)));
-    const float smallerAngle = asin(c/(length(a)*length(b)));
+    CONST float smallerAngle = asin(c/(length(a)*length(b)));
     if(d<0) return PI-smallerAngle;
     return smallerAngle;
 }
@@ -205,11 +216,11 @@ float moonAngularRadius(const vec3 cameraPosition, const vec3 moonPosition)
 
 float visibleSolidAngleOfSun(const vec3 camera, const vec3 sunDir, const vec3 moonPos)
 {
-    const float Rs=sunAngularRadius;
-    const float Rm=moonAngularRadius(camera,moonPos);
+    CONST float Rs=sunAngularRadius;
+    CONST float Rm=moonAngularRadius(camera,moonPos);
     float visibleSolidAngle=PI*sqr(Rs);
 
-    const float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
+    CONST float dSM=angleBetweenSunAndMoon(camera,sunDir,moonPos);
     if(dSM<Rs+Rm)
     {
         visibleSolidAngle -= circlesIntersectionArea(Rm,Rs,dSM);
@@ -229,12 +240,12 @@ float sphereIntegrationSolidAngleDifferential(const int pointCountOnSphere)
 }
 vec3 sphereIntegrationSampleDir(const int index, const int pointCountOnSphere)
 {
-    const float goldenRatio=1.6180339887499;
+    CONST float goldenRatio=1.6180339887499;
     // The range of n is 0.5, 1.5, ..., pointCountOnSphere-0.5
-    const float n=index+0.5;
+    CONST float n=index+0.5;
     // Explanation of the Fibonacci grid generation can be seen at https://stackoverflow.com/a/44164075/673852
-    const float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
-    const float azimuth=n*(2*PI*goldenRatio);
+    CONST float zenithAngle=acos(clamp(1-(2.*n)/pointCountOnSphere, -1.,1.));
+    CONST float azimuth=n*(2*PI*goldenRatio);
     return vec3(cos(azimuth)*sin(zenithAngle),
                 sin(azimuth)*sin(zenithAngle),
                 cos(zenithAngle));

--- a/atmosphere/default/shaders/zero-order-scattering/3/phase-functions.frag
+++ b/atmosphere/default/shaders/zero-order-scattering/3/phase-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // phase-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,7 +45,7 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // phase-functions.frag
+#line 4 0 // phase-functions.frag
 
 vec4 phaseFunction_molecules(float dotViewSun)
 {
@@ -42,8 +53,8 @@ vec4 phaseFunction_molecules(float dotViewSun)
 }
 vec4 phaseFunction_aerosols(float dotViewSun)
 {
-        const float g=0.76;
-        const float g2=g*g;
-        const float k = 3/(8*PI)*(1-g2)/(2+g2);
+        CONST float g=0.76;
+        CONST float g2=g*g;
+        CONST float k = 3/(8*PI)*(1-g2)/(2+g2);
         return vec4(k * (1+sqr(dotViewSun)) / pow(1+g2 - 2*g*dotViewSun, 1.5) + 1/((1-dotViewSun)*600+0.05))*0.904;
 }

--- a/atmosphere/default/shaders/zero-order-scattering/3/render.frag
+++ b/atmosphere/default/shaders/zero-order-scattering/3/render.frag
@@ -1,7 +1,21 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
 
-#line 1 1 // const.h.glsl
+
+
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 6 0 // render.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,11 +48,11 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // render.frag
-#line 1 2 // calc-view-dir.h.glsl
+#line 7 0 // render.frag
+#line 1 3 // calc-view-dir.h.glsl
 vec3 calcViewDir();
-#line 6 0 // render.frag
-#line 1 3 // common-functions.h.glsl
+#line 8 0 // render.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -70,11 +84,11 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // render.frag
+#line 9 0 // render.frag
 
 
 
-#line 1 4 // texture-coordinates.h.glsl
+#line 1 5 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -143,11 +157,11 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 11 0 // render.frag
-#line 1 5 // radiance-to-luminance.h.glsl
+#line 13 0 // render.frag
+#line 1 6 // radiance-to-luminance.h.glsl
 const mat4 radianceToLuminance=mat4(19.8756237,7.17745161,0,0.0937032327,  2.13895917,0.772417068,0,0.0149318045,  0.241072536,0.0870557055,0,0,  0.0133876652,0.00483453181,0,0);
-#line 12 0 // render.frag
-#line 1 6 // texture-sampling-functions.h.glsl
+#line 14 0 // render.frag
+#line 1 7 // texture-sampling-functions.h.glsl
 #ifndef INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 #define INCLUDE_ONCE_AF5AE9F4_8A9A_4521_838A_F8281B8FEB53
 vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float altitude);
@@ -159,7 +173,7 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                 const int scatteringOrder);
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 #endif
-#line 13 0 // render.frag
+#line 15 0 // render.frag
 
 
 
@@ -195,18 +209,18 @@ void main()
     // this approximation has the same order of magnitude as the assumption that the Earth and its atmosphere
     // are spherical.
     float altitude = max(cameraPosition.z, 0.);
-    const vec3 oldCamPos=cameraPosition;
+    CONST vec3 oldCamPos=cameraPosition;
     // Hide the uniform with this name, thus effectively modifying it for the following code
     vec3 cameraPosition=vec3(oldCamPos.xy, altitude);
 
     bool lookingIntoAtmosphere=true;
     if(altitude>atmosphereHeight)
     {
-        const vec3 p = cameraPosition - earthCenter;
-        const float p_dot_v = dot(p, viewDir);
-        const float p_dot_p = dot(p, p);
-        const float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
-        const float distanceToTOA = -p_dot_v - sqrt(sqr(earthRadius+atmosphereHeight) - squaredDistBetweenViewRayAndEarthCenter);
+        CONST vec3 p = cameraPosition - earthCenter;
+        CONST float p_dot_v = dot(p, viewDir);
+        CONST float p_dot_p = dot(p, p);
+        CONST float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
+        CONST float distanceToTOA = -p_dot_v - sqrt(sqr(earthRadius+atmosphereHeight) - squaredDistBetweenViewRayAndEarthCenter);
         if(distanceToTOA>=0)
         {
             cameraPosition += viewDir*distanceToTOA;
@@ -224,16 +238,16 @@ void main()
         }
     }
 
-    const vec3 zenith=normalize(cameraPosition-earthCenter);
+    CONST vec3 zenith=normalize(cameraPosition-earthCenter);
     float cosViewZenithAngle=dot(zenith,viewDir);
 
     bool viewRayIntersectsGround=false;
     {
-        const vec3 p = cameraPosition - earthCenter;
-        const float p_dot_v = dot(p, viewDir);
-        const float p_dot_p = dot(p, p);
-        const float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
-        const float distanceToIntersection = -p_dot_v - sqrt(sqr(earthRadius) - squaredDistBetweenViewRayAndEarthCenter);
+        CONST vec3 p = cameraPosition - earthCenter;
+        CONST float p_dot_v = dot(p, viewDir);
+        CONST float p_dot_p = dot(p, p);
+        CONST float squaredDistBetweenViewRayAndEarthCenter = p_dot_p - sqr(p_dot_v);
+        CONST float distanceToIntersection = -p_dot_v - sqrt(sqr(earthRadius) - squaredDistBetweenViewRayAndEarthCenter);
         // altitude==0 is a special case where distance to intersection calculation
         // is unreliable (has a lot of noise in its sign), so check it separately
         if(distanceToIntersection>0 || (altitude==0 && cosViewZenithAngle<0))
@@ -244,11 +258,11 @@ void main()
     // Aside from aesthetics, this affects brightness input to Stellarium's tone mapper.
     if(pseudoMirrorSkyBelowHorizon && viewRayIntersectsGround)
     {
-        const float horizonCZA = cosZenithAngleOfHorizon(altitude);
-        const float viewElev  = asin(clampCosine(cosViewZenithAngle));
-        const float horizElev = asin(clampCosine(horizonCZA));
-        const float newViewElev = 2*horizElev - viewElev;
-        const float viewDirXYnorm = length(viewDir-zenith*cosViewZenithAngle);
+        CONST float horizonCZA = cosZenithAngleOfHorizon(altitude);
+        CONST float viewElev  = asin(clampCosine(cosViewZenithAngle));
+        CONST float horizElev = asin(clampCosine(horizonCZA));
+        CONST float newViewElev = 2*horizElev - viewElev;
+        CONST float viewDirXYnorm = length(viewDir-zenith*cosViewZenithAngle);
         if(viewDirXYnorm == 0)
         {
             viewDir = zenith;
@@ -267,14 +281,14 @@ void main()
         viewRayIntersectsGround = false;
     }
 
-    const float cosSunZenithAngle =dot(zenith,sunDirection);
-    const float dotViewSun=dot(viewDir,sunDirection);
+    CONST float cosSunZenithAngle =dot(zenith,sunDirection);
+    CONST float dotViewSun=dot(viewDir,sunDirection);
 
-    const vec3 sunXYunnorm=sunDirection-dot(sunDirection,zenith)*zenith;
-    const vec3 viewXYunnorm=viewDir-dot(viewDir,zenith)*zenith;
-    const vec3 sunXY = sunXYunnorm.x!=0 || sunXYunnorm.y!=0 || sunXYunnorm.z!=0 ? normalize(sunXYunnorm) : vec3(0);
-    const vec3 viewXY = viewXYunnorm.x!=0 || viewXYunnorm.y!=0 || viewXYunnorm.z!=0 ? normalize(viewXYunnorm) : vec3(0);
-    const float azimuthRelativeToSun=safeAtan(dot(cross(sunXY, viewXY), zenith), dot(sunXY, viewXY));
+    CONST vec3 sunXYunnorm=sunDirection-dot(sunDirection,zenith)*zenith;
+    CONST vec3 viewXYunnorm=viewDir-dot(viewDir,zenith)*zenith;
+    CONST vec3 sunXY = sunXYunnorm.x!=0 || sunXYunnorm.y!=0 || sunXYunnorm.z!=0 ? normalize(sunXYunnorm) : vec3(0);
+    CONST vec3 viewXY = viewXYunnorm.x!=0 || viewXYunnorm.y!=0 || viewXYunnorm.z!=0 ? normalize(viewXYunnorm) : vec3(0);
+    CONST float azimuthRelativeToSun=safeAtan(dot(cross(sunXY, viewXY), zenith), dot(sunXY, viewXY));
 
 #if 1 /*RENDERING_ZERO_SCATTERING*/
     vec4 radiance;
@@ -282,12 +296,12 @@ void main()
     {
         // XXX: keep in sync with the same code in computeScatteringDensity(), but don't forget about
         //      the difference in the usage of viewDir vs incDir.
-        const float distToGround = distanceToGround(cosViewZenithAngle, altitude);
-        const vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
-        const vec3 groundNormal = normalize(zenith*(earthRadius+altitude)+viewDir*distToGround);
-        const vec4 groundIrradiance = irradiance(dot(groundNormal, sunDirection), 0);
+        CONST float distToGround = distanceToGround(cosViewZenithAngle, altitude);
+        CONST vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
+        CONST vec3 groundNormal = normalize(zenith*(earthRadius+altitude)+viewDir*distToGround);
+        CONST vec4 groundIrradiance = irradiance(dot(groundNormal, sunDirection), 0);
         // Radiation scattered by the ground
-        const float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
+        CONST float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
         radiance = transmittanceToGround*groundAlbedo*groundIrradiance*solarIrradianceFixup*groundBRDF
                  + lightPollutionGroundLuminance*lightPollutionRelativeRadiance;
     }
@@ -304,22 +318,22 @@ void main()
     }
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_ZERO_SCATTERING
+#elif 0 /*RENDERING_ECLIPSED_ZERO_SCATTERING*/
     vec4 radiance;
-    const float dotViewMoon=dot(viewDir,normalize(moonPosition-cameraPosition));
+    CONST float dotViewMoon=dot(viewDir,normalize(moonPosition-cameraPosition));
     if(viewRayIntersectsGround)
     {
         // XXX: keep in sync with the similar code in non-eclipsed zero scattering rendering.
-        const float distToGround = distanceToGround(cosViewZenithAngle, altitude);
-        const vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
-        const vec3 pointOnGround = cameraPosition+viewDir*distToGround;
-        const vec4 directGroundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDirection, moonPosition);
+        CONST float distToGround = distanceToGround(cosViewZenithAngle, altitude);
+        CONST vec4 transmittanceToGround=transmittance(cosViewZenithAngle, altitude, distToGround, viewRayIntersectsGround);
+        CONST vec3 pointOnGround = cameraPosition+viewDir*distToGround;
+        CONST vec4 directGroundIrradiance = calcEclipsedDirectGroundIrradiance(pointOnGround, sunDirection, moonPosition);
         // FIXME: add first-order indirect irradiance too: it's done in non-eclipsed irradiance (in the same
         // conditions: when limited to 2 orders). This should be calculated at the same time when second order
         // is: all the infrastructure is already there.
-        const vec4 groundIrradiance = directGroundIrradiance;
+        CONST vec4 groundIrradiance = directGroundIrradiance;
         // Radiation scattered by the ground
-        const float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
+        CONST float groundBRDF = 1/PI; // Assuming Lambertian BRDF, which is constant
         radiance = transmittanceToGround*groundAlbedo*groundIrradiance*solarIrradianceFixup*groundBRDF
                  + lightPollutionGroundLuminance*lightPollutionRelativeRadiance;
     }
@@ -336,53 +350,53 @@ void main()
     }
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_ON_THE_FLY
-    const vec4 scattering=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPosition,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_ON_THE_FLY*/
+    CONST vec4 scattering=computeSingleScatteringEclipsed(cameraPosition,viewDir,sunDirection,moonPosition,
                                                           viewRayIntersectsGround);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE
-    const vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE*/
+    CONST vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                      viewRayIntersectsGround, eclipsedSingleScatteringTextureSize);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact at the point where azimuth texture coordinate changes from 1 to 0 (at azimuthRelativeToSun crossing
     // 0). This happens when I simply call texture(eclipsedScatteringTexture, texCoords) without specifying LOD.
     // Apparently, the driver uses the derivative for some reason, even though it shouldn't.
-    const vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
+    CONST vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE
-    const vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+#elif 0 /*RENDERING_ECLIPSED_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
+    CONST vec2 texCoords = eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                      viewRayIntersectsGround, eclipsedSingleScatteringTextureSize);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact at the point where azimuth texture coordinate changes from 1 to 0 (at azimuthRelativeToSun crossing
     // 0). This happens when I simply call texture(eclipsedScatteringTexture, texCoords) without specifying LOD.
     // Apparently, the driver uses the derivative for some reason, even though it shouldn't.
-    const vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
+    CONST vec4 scattering = textureLod(eclipsedScatteringTexture, texCoords, 0);
     luminance=scattering*currentPhaseFunction(dotViewSun);
-#elif RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_RADIANCE
+#elif 0 /*RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_RADIANCE*/
     vec4 radiance=exp(sampleEclipseDoubleScattering3DTexture(eclipsedDoubleScatteringTexture,
                                                              cosSunZenithAngle, cosViewZenithAngle, azimuthRelativeToSun,
                                                              altitude, viewRayIntersectsGround));
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_LUMINANCE
+#elif 0 /*RENDERING_ECLIPSED_DOUBLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
     luminance=exp(sampleEclipseDoubleScattering3DTexture(eclipsedDoubleScatteringTexture,
                                                          cosSunZenithAngle, cosViewZenithAngle, azimuthRelativeToSun,
                                                          altitude, viewRayIntersectsGround));
-#elif RENDERING_SINGLE_SCATTERING_ON_THE_FLY
-    const vec4 scattering=computeSingleScattering(cosSunZenithAngle,cosViewZenithAngle,dotViewSun,
+#elif 0 /*RENDERING_SINGLE_SCATTERING_ON_THE_FLY*/
+    CONST vec4 scattering=computeSingleScattering(cosSunZenithAngle,cosViewZenithAngle,dotViewSun,
                                                   altitude,viewRayIntersectsGround);
     vec4 radiance=scattering*currentPhaseFunction(dotViewSun);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE
+#elif 0 /*RENDERING_SINGLE_SCATTERING_PRECOMPUTED_RADIANCE*/
     vec4 scattering;
     if(useInterpolationGuides)
     {
@@ -399,7 +413,7 @@ void main()
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE
+#elif 0 /*RENDERING_SINGLE_SCATTERING_PRECOMPUTED_LUMINANCE*/
     vec4 scattering;
     if(useInterpolationGuides)
     {
@@ -413,18 +427,18 @@ void main()
                                      dotViewSun, altitude, viewRayIntersectsGround);
     }
     luminance=scattering * (bool(PHASE_FUNCTION_IS_EMBEDDED) ? vec4(1) : currentPhaseFunction(dotViewSun));
-#elif RENDERING_MULTIPLE_SCATTERING_LUMINANCE
+#elif 0 /*RENDERING_MULTIPLE_SCATTERING_LUMINANCE*/
     luminance=sample3DTexture(scatteringTexture, cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, viewRayIntersectsGround);
-#elif RENDERING_MULTIPLE_SCATTERING_RADIANCE
+#elif 0 /*RENDERING_MULTIPLE_SCATTERING_RADIANCE*/
     vec4 radiance=sample3DTexture(scatteringTexture, cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, viewRayIntersectsGround);
     radiance*=solarIrradianceFixup;
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_LIGHT_POLLUTION_RADIANCE
+#elif 0 /*RENDERING_LIGHT_POLLUTION_RADIANCE*/
     vec4 radiance=lightPollutionGroundLuminance*lightPollutionScattering(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     luminance=radianceToLuminance*radiance;
     radianceOutput=radiance;
-#elif RENDERING_LIGHT_POLLUTION_LUMINANCE
+#elif 0 /*RENDERING_LIGHT_POLLUTION_LUMINANCE*/
     luminance=lightPollutionGroundLuminance*lightPollutionScattering(altitude, cosViewZenithAngle, viewRayIntersectsGround);
 #else
 #error What to render?

--- a/atmosphere/default/shaders/zero-order-scattering/3/texture-coordinates.frag
+++ b/atmosphere/default/shaders/zero-order-scattering/3/texture-coordinates.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-coordinates.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,8 +45,8 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // texture-coordinates.frag
-#line 1 2 // texture-coordinates.h.glsl
+#line 4 0 // texture-coordinates.frag
+#line 1 3 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -104,8 +115,8 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 6 0 // texture-coordinates.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-coordinates.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -137,7 +148,7 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-coordinates.frag
+#line 6 0 // texture-coordinates.frag
 
 const float LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA=sqrt(atmosphereHeight*(atmosphereHeight+2*earthRadius));
 
@@ -205,18 +216,18 @@ vec3 indicesToTexCoords(const vec3 indices, const vec3 texSizes)
 
 TransmittanceTexVars transmittanceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
+    CONST float distToHorizon=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA *
                                 texCoordToUnitRange(texCoord.t,transmittanceTextureSize.t);
     // Distance from Earth center to camera
-    const float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
-    const float altitude=r-earthRadius;
+    CONST float r=sqrt(sqr(distToHorizon)+sqr(earthRadius));
+    CONST float altitude=r-earthRadius;
 
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
     // distance to border of visible atmosphere from the view point
-    const float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
+    CONST float d=dMin+(dMax-dMin)*texCoordToUnitRange(texCoord.s,transmittanceTextureSize.s);
     // d==0 can happen when altitude==atmosphereHeight
-    const float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
+    CONST float cosVZA = d==0 ? 1 : (2*r*dMin+sqr(dMin)-sqr(d))/(2*r*d);
     return TransmittanceTexVars(cosVZA,altitude);
 }
 
@@ -235,53 +246,53 @@ vec2 transmittanceTexVarsToTexCoord(const float cosVZA, float altitude)
     if(altitude<0)
         altitude=0;
 
-    const float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
+    CONST float distToHorizon=sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float t=unitRangeToTexCoord(distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA,
                                       transmittanceTextureSize.t);
-    const float dMin=atmosphereHeight-altitude; // distance to zenith
-    const float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
-    const float d=distanceToAtmosphereBorder(cosVZA,altitude);
-    const float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
+    CONST float dMin=atmosphereHeight-altitude; // distance to zenith
+    CONST float dMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA+distToHorizon;
+    CONST float d=distanceToAtmosphereBorder(cosVZA,altitude);
+    CONST float s=unitRangeToTexCoord((d-dMin)/(dMax-dMin), transmittanceTextureSize.s);
     return vec2(s,t);
 }
 
 // Output: vec2(cos(sunZenithAngle), altitude)
 IrradianceTexVars irradianceTexCoordToTexVars(const vec2 texCoord)
 {
-    const float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
-    const float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
+    CONST float cosSZA=2*texCoordToUnitRange(texCoord.s, irradianceTextureSize.s)-1;
+    CONST float alt=atmosphereHeight*texCoordToUnitRange(texCoord.t, irradianceTextureSize.t);
     return IrradianceTexVars(cosSZA,alt);
 }
 
 vec2 irradianceTexVarsToTexCoord(const float cosSunZenithAngle, const float altitude)
 {
-    const float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
-    const float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
+    CONST float s=unitRangeToTexCoord((cosSunZenithAngle+1)/2, irradianceTextureSize.s);
+    CONST float t=unitRangeToTexCoord(altitude/atmosphereHeight, irradianceTextureSize.t);
     return vec2(s,t);
 }
 
 float cosSZAToUnitRangeTexCoord(const float cosSunZenithAngle)
 {
     // Distance to top atmosphere border along the ray groundUnderCamera-sun: (altitude, cosSunZenithAngle)
-    const float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distFromGroundToTopAtmoBorder=distanceToAtmosphereBorder(cosSunZenithAngle, 0.);
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name
-    const float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
+    CONST float a=(distFromGroundToTopAtmoBorder-distMin)/(distMax-distMin);
     // TODO: choose a more descriptive name
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     return max(0.,1-a/A)/(a+1);
 }
 
 float unitRangeTexCoordToCosSZA(const float texCoord)
 {
-    const float distMin=atmosphereHeight;
-    const float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distMin=atmosphereHeight;
+    CONST float distMax=LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float A=2*earthRadius/(distMax-distMin);
+    CONST float A=2*earthRadius/(distMax-distMin);
     // TODO: choose a more descriptive name, same as in cosSZAToUnitRangeTexCoord()
-    const float a=(A-A*texCoord)/(1+A*texCoord);
-    const float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
+    CONST float a=(A-A*texCoord)/(1+A*texCoord);
+    CONST float distFromGroundToTopAtmoBorder=distMin+min(a,A)*(distMax-distMin);
     return distFromGroundToTopAtmoBorder==0 ? 1 :
         clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distFromGroundToTopAtmoBorder)) /
                     (2*earthRadius*distFromGroundToTopAtmoBorder));
@@ -292,24 +303,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
                                                const float dotViewSun, const float altitude,
                                                const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -317,24 +328,24 @@ Scattering4DCoords scatteringTexVarsTo4DCoords(const float cosSunZenithAngle, co
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float dotVSCoord=(dotViewSun+1)/2;
+    CONST float dotVSCoord=(dotViewSun+1)/2;
 
     // ------------------------------------
-    const float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
+    CONST float cosSZACoord=cosSZAToUnitRangeTexCoord(cosSunZenithAngle);
 
     return Scattering4DCoords(cosSZACoord, cosVZACoord, dotVSCoord, altCoord, viewRayIntersectsGround);
 }
 
 TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
@@ -342,16 +353,16 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture coordinates we combine into a single sampler3D coordinate.
-    const float texW = scatteringTextureSize[1];
-    const float texH = scatteringTextureSize[2];
-    const float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
-    const vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
+    CONST float texW = scatteringTextureSize[1];
+    CONST float texH = scatteringTextureSize[2];
+    CONST float cosSZAIndex=coords.cosSunZenithAngle*(texH-1);
+    CONST vec2 combiCoordUnitRange=vec2(floor(cosSZAIndex)*texW+coords.dotViewSun*(texW-1),
                                         ceil (cosSZAIndex)*texW+coords.dotViewSun*(texW-1)) / (texW*texH-1);
-    const vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
+    CONST vec2 combinedCoord=unitRangeToTexCoord(combiCoordUnitRange, texW*texH);
 
-    const float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
+    CONST float altitude = unitRangeToTexCoord(coords.altitude, scatteringTextureSize[3]);
 
-    const float alphaUpper=fract(cosSZAIndex);
+    CONST float alphaUpper=fract(cosSZAIndex);
     return TexCoordPair(vec3(cosVZAtc, combinedCoord.x, altitude), float(1-alphaUpper),
                         vec3(cosVZAtc, combinedCoord.y, altitude), float(alphaUpper));
 }
@@ -359,9 +370,9 @@ TexCoordPair scattering4DCoordsToTexCoords(const Scattering4DCoords coords)
 vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
+    CONST TexCoordPair texCoords=scattering4DCoordsToTexCoords(coords4d);
     return texture(tex, texCoords.lower) * texCoords.alphaLower +
            texture(tex, texCoords.upper) * texCoords.alphaUpper;
 }
@@ -369,17 +380,17 @@ vec4 sample4DTexture(const sampler3D tex, const float cosSunZenithAngle, const f
 // 3D texture is the 3D single-altitude slice of a 4D texture
 vec3 scattering4DCoordsToTex3DCoords(const Scattering4DCoords coords)
 {
-    const float cosVZAtc = coords.viewRayIntersectsGround ?
+    CONST float cosVZAtc = coords.viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, scatteringTextureSize[0]/2);
 
-    const float dvsSize = scatteringTextureSize[1];
-    const float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
+    CONST float dvsSize = scatteringTextureSize[1];
+    CONST float dotVStc = unitRangeToTexCoord(coords.dotViewSun, dvsSize);
 
-    const float cszaSize = scatteringTextureSize[2];
-    const float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
+    CONST float cszaSize = scatteringTextureSize[2];
+    CONST float cosSZAtc = unitRangeToTexCoord(coords.cosSunZenithAngle, cszaSize);
 
     return vec3(cosVZAtc, dotVStc, cosSZAtc);
 }
@@ -394,39 +405,39 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along dotViewSun coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[1];
-    const float posOfRow = indices[1];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[2], scatteringTextureSize[2]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[1];
+    CONST float posOfRow = indices[1];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         indexToTexCoord(currRow, numRows-1),
                                                         texCoordVerbatim));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               indexToTexCoord(currRow, numRows-1),
                                                               texCoordVerbatim));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          indexToTexCoord(currRow, numRows-1),
                                          texCoordVerbatim));
@@ -434,14 +445,14 @@ float findGuide01Angle(const sampler3D guides, const vec3 indices)
 vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolationGuides01Tex,
                                  const vec3 indices)
 {
-    const float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
+    CONST float interpAngle = findGuide01Angle(interpolationGuides01Tex, indices);
 
-    const float cosVZAIndex = indices[0];
-    const float dotVSIndex = indices[1];
-    const float currRow = floor(dotVSIndex);
-    const float posBetweenRows = dotVSIndex - currRow;
-    const float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cosVZAIndex = indices[0];
+    CONST float dotVSIndex = indices[1];
+    CONST float currRow = floor(dotVSIndex);
+    CONST float posBetweenRows = dotVSIndex - currRow;
+    CONST float cvzaPosInCurrRow = cosVZAIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cosVZAIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -449,14 +460,14 @@ vec4 sample3DTextureGuided01_log(const sampler3D tex, const sampler3D interpolat
     indicesCurrRow[1] =     currRow;
     indicesNextRow[1] = min(currRow+1, scatteringTextureSize[1]-1.);
 
-    const vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
-    const vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
+    CONST vec3 coordsNextRow = indicesToTexCoords(indicesNextRow, scatteringTextureSize.stp);
+    CONST vec3 coordsCurrRow = indicesToTexCoords(indicesCurrRow, scatteringTextureSize.stp);
 
-    const vec4 valueCurrRow = texture(tex, coordsCurrRow);
-    const vec4 valueNextRow = texture(tex, coordsNextRow);
-    const float epsilon = 1e-37; // Prevents passing zero to log
-    const vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
-    const vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
+    CONST vec4 valueCurrRow = texture(tex, coordsCurrRow);
+    CONST vec4 valueNextRow = texture(tex, coordsNextRow);
+    CONST float epsilon = 1e-37; // Prevents passing zero to log
+    CONST vec4 logValNextRow = log(max(valueNextRow, vec4(epsilon)));
+    CONST vec4 logValCurrRow = log(max(valueCurrRow, vec4(epsilon)));
     return (logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow;
 }
 
@@ -465,37 +476,37 @@ float findGuide02Angle(const sampler3D guides, const vec3 indices)
     // Row is the line along VZA coordinate.
     // Position between rows means the position along SZA coordinate.
 
-    const float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
-    const float rowLen = scatteringTextureSize[0];
-    const float numRows = scatteringTextureSize[2];
-    const float posOfRow = indices[2];
-    const float posInRow = indices[0];
-    const float currRow = floor(posOfRow);
-    const float posBetweenRows = posOfRow - currRow;
+    CONST float texCoordVerbatim = indexToTexCoord(indices[1], scatteringTextureSize[1]);
+    CONST float rowLen = scatteringTextureSize[0];
+    CONST float numRows = scatteringTextureSize[2];
+    CONST float posOfRow = indices[2];
+    CONST float posInRow = indices[0];
+    CONST float currRow = floor(posOfRow);
+    CONST float posBetweenRows = posOfRow - currRow;
 
     // A & B are the endpoints of binary search inside the row
     float posInRow_A = 0;
     float posInRow_B = rowLen-1;
 
-    const float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
+    CONST float angle_A = PI/2*sampleGuide(guides, vec3(indexToTexCoord(posInRow_A, rowLen),
                                                         texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-    const float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
+    CONST float posInRowAtPosBetweenRows_A = posInRow_A + (posBetweenRows-0.5) * tan(angle_A);
     if(posInRowAtPosBetweenRows_A > posInRow)
     {
         swap(posInRow_A, posInRow_B);
     }
     for(int n=0; n<8; ++n)
     {
-        const float currPosInRow = (posInRow_A + posInRow_B)/2;
-        const float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
+        CONST float currPosInRow = (posInRow_A + posInRow_B)/2;
+        CONST float currAngle = PI/2*sampleGuide(guides, vec3(indexToTexCoord(currPosInRow, rowLen),
                                                               texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
-        const float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
+        CONST float currPosInRowAtPosBetweenRows = currPosInRow + (posBetweenRows-0.5) * tan(currAngle);
         if(currPosInRowAtPosBetweenRows < posInRow)
             posInRow_A = currPosInRow;
         else
             posInRow_B = currPosInRow;
     }
-    const float finalPosInRow = (posInRow_A + posInRow_B)/2;
+    CONST float finalPosInRow = (posInRow_A + posInRow_B)/2;
     return PI/2*sampleGuide(guides, vec3(indexToTexCoord(finalPosInRow, rowLen),
                                          texCoordVerbatim, indexToTexCoord(currRow, numRows-1)));
 }
@@ -505,19 +516,19 @@ vec4 sample3DTextureGuided(const sampler3D tex,
                            const float cosSunZenithAngle, const float cosViewZenithAngle,
                            const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle, cosViewZenithAngle,
                                                                     dotViewSun, altitude, viewRayIntersectsGround);
     // Handle the external interpolation guides: the guides between a pair of VZA-dotViewSun 2D "pictures".
-    const vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
-    const vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
-    const float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
+    CONST vec3 tc = scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 indices = texCoordsToIndices(tc, scatteringTextureSize.stp);
+    CONST float interpAngle = findGuide02Angle(interpolationGuides02Tex, indices);
 
-    const float cvzaIndex = indices[0];
-    const float cszaIndex = indices[2];
-    const float currRow = floor(cszaIndex);
-    const float posBetweenRows = cszaIndex - currRow;
-    const float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
-    const float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
+    CONST float cvzaIndex = indices[0];
+    CONST float cszaIndex = indices[2];
+    CONST float currRow = floor(cszaIndex);
+    CONST float posBetweenRows = cszaIndex - currRow;
+    CONST float cvzaPosInCurrRow = cvzaIndex - posBetweenRows*tan(interpAngle);
+    CONST float cvzaPosInNextRow = cvzaIndex + (1-posBetweenRows)*tan(interpAngle);
 
     vec3 indicesCurrRow = indices, indicesNextRow = indices;
     indicesCurrRow[0] = clamp(cvzaPosInCurrRow, 0., scatteringTextureSize[0]-1.);
@@ -526,58 +537,58 @@ vec4 sample3DTextureGuided(const sampler3D tex,
     indicesNextRow[2] = min(currRow+1, scatteringTextureSize[2]-1);
 
     // The caller will handle the internal interpolation guides: the ones between rows in each 2D "picture".
-    const vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
-    const vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
+    CONST vec4 logValCurrRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesCurrRow);
+    CONST vec4 logValNextRow = sample3DTextureGuided01_log(tex, interpolationGuides01Tex, indicesNextRow);
     return exp((logValNextRow-logValCurrRow) * posBetweenRows + logValCurrRow);
 }
 
 vec4 sample3DTexture(const sampler3D tex, const float cosSunZenithAngle, const float cosViewZenithAngle,
                      const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
+    CONST Scattering4DCoords coords4d = scatteringTexVarsTo4DCoords(cosSunZenithAngle,cosViewZenithAngle,
                                                                     dotViewSun,altitude,viewRayIntersectsGround);
-    const vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
+    CONST vec3 texCoords=scattering4DCoordsToTex3DCoords(coords4d);
     return texture(tex, texCoords);
 }
 
 ScatteringTexVars scatteringTex4DCoordsToTexVars(const Scattering4DCoords coords)
 {
-    const float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float distToHorizon = coords.altitude*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
     // ------------------------------------
     float cosViewZenithAngle;
     if(coords.viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=coords.cosViewZenithAngle*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
     // ------------------------------------
-    const float dotViewSun=coords.dotViewSun*2-1;
+    CONST float dotViewSun=coords.dotViewSun*2-1;
 
     // ------------------------------------
-    const float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
+    CONST float cosSunZenithAngle=unitRangeTexCoordToCosSZA(coords.cosSunZenithAngle);
 
     return ScatteringTexVars(cosSunZenithAngle, cosViewZenithAngle, dotViewSun, altitude, coords.viewRayIntersectsGround);
 }
 
 Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 {
-    const vec4 indexMax=scatteringTextureSize-vec4(1);
+    CONST vec4 indexMax=scatteringTextureSize-vec4(1);
     Scattering4DCoords coords4d;
     coords4d.viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
     // The following formulas assume that scatteringTextureSize[0] is even. For odd sizes they would change.
@@ -593,8 +604,8 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
     // Width and height of the 2D subspace of the 4D texture - the subspace spanned by
     // the texture indices we combine into a single sampler3D coordinate.
-    const float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
-    const float combinedIndex=texIndices[1];
+    CONST float texW=scatteringTextureSize[1], texH=scatteringTextureSize[2];
+    CONST float combinedIndex=texIndices[1];
     coords4d.dotViewSun=mod(combinedIndex,texW)/(texW-1);
     coords4d.cosSunZenithAngle=floor(combinedIndex/texW)/(texH-1);
 
@@ -608,11 +619,11 @@ Scattering4DCoords scatteringTexIndicesTo4DCoords(const vec3 texIndices)
 
 ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 {
-    const Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
+    CONST Scattering4DCoords coords4d=scatteringTexIndicesTo4DCoords(texIndices);
     ScatteringTexVars vars=scatteringTex4DCoordsToTexVars(coords4d);
     // Clamp dotViewSun to its valid range of values, given cosViewZenithAngle and cosSunZenithAngle. This is
     // needed to prevent NaNs when computing the scattering texture.
-    const float cosVZA=vars.cosViewZenithAngle,
+    CONST float cosVZA=vars.cosViewZenithAngle,
                 cosSZA=vars.cosSunZenithAngle;
     vars.dotViewSun=clamp(vars.dotViewSun,
                           cosVZA*cosSZA-safeSqrt((1-sqr(cosVZA))*(1-sqr(cosSZA))),
@@ -622,54 +633,54 @@ ScatteringTexVars scatteringTexIndicesToTexVars(const vec3 texIndices)
 
 EclipseScatteringTexVars eclipseTexCoordsToTexVars(const vec2 texCoords, const float altitude)
 {
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
-    const bool viewRayIntersectsGround = texCoords.t<0.5;
+    CONST bool viewRayIntersectsGround = texCoords.t<0.5;
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(1-2*texCoords.t, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
+        CONST float cosVZACoord = texCoordToUnitRange(2*texCoords.t-1, eclipsedSingleScatteringTextureSize.t/2);
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosVZACoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
     }
 
-    const float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
+    CONST float azimuthRelativeToSun = 2*PI*(texCoords.s - 1/(2*eclipsedSingleScatteringTextureSize.s));
     return EclipseScatteringTexVars(azimuthRelativeToSun, cosViewZenithAngle, viewRayIntersectsGround);
 }
 
 EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                                    const float altitude, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon    = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -677,13 +688,13 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
-    const float azimuthCoord = azimuthRelativeToSun/(2*PI);
+    CONST float azimuthCoord = azimuthRelativeToSun/(2*PI);
 
     return EclipseScattering2DCoords(azimuthCoord, cosVZACoord);
 }
@@ -691,14 +702,14 @@ EclipseScattering2DCoords eclipseTexVarsTo2DCoords(const float azimuthRelativeTo
 vec2 eclipseTexVarsToTexCoords(const float azimuthRelativeToSun, const float cosViewZenithAngle,
                                const float altitude, const bool viewRayIntersectsGround, const vec2 texSize)
 {
-    const EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
+    CONST EclipseScattering2DCoords coords=eclipseTexVarsTo2DCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude,
                                                                     viewRayIntersectsGround);
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize.t/2);
-    const float azimuthTC = coords.azimuth + 1/(2*texSize.s);
+    CONST float azimuthTC = coords.azimuth + 1/(2*texSize.s);
 
     return vec2(azimuthTC, cosVZAtc);
 }
@@ -707,42 +718,42 @@ vec4 sampleEclipseDoubleScattering3DTexture(const sampler3D tex, const float cos
                                             const float cosViewZenithAngle, const float azimuthRelativeToSun,
                                             const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
+    CONST vec2 coords2d=eclipseTexVarsToTexCoords(azimuthRelativeToSun, cosViewZenithAngle, altitude, viewRayIntersectsGround,
                                                   eclipsedDoubleScatteringTextureSize.st);
-    const float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
-    const vec3 texCoords=vec3(coords2d, cosSZACoord);
+    CONST float cosSZACoord=unitRangeToTexCoord(cosSZAToUnitRangeTexCoord(cosSunZenithAngle), eclipsedDoubleScatteringTextureSize[2]);
+    CONST vec3 texCoords=vec3(coords2d, cosSZACoord);
 
     return texture(tex, texCoords);
 }
 
 LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 texIndices)
 {
-    const vec2 indexMax=lightPollutionTextureSize-vec2(1);
+    CONST vec2 indexMax=lightPollutionTextureSize-vec2(1);
 
-    const float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
-    const float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altitudeURCoord = texIndices[1] / (indexMax[1]-1);
+    CONST float distToHorizon = altitudeURCoord*LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
     // Rounding errors can result in altitude>max, breaking the code after this calculation, so we have to clamp.
-    const float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
+    CONST float altitude=clampAltitude(sqrt(sqr(distToHorizon)+sqr(earthRadius))-earthRadius);
 
-    const bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
-    const float cosViewZenithAngleCoord = viewRayIntersectsGround ?
+    CONST bool viewRayIntersectsGround = texIndices[0] < indexMax[0]/2;
+    CONST float cosViewZenithAngleCoord = viewRayIntersectsGround ?
                                    1-2*texIndices[0]/(indexMax[0]-1) :
                                    2*(texIndices[0]-1)/(indexMax[0]-1)-1;
     // ------------------------------------
     float cosViewZenithAngle;
     if(viewRayIntersectsGround)
     {
-        const float distMin=altitude;
-        const float distMax=distToHorizon;
-        const float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=altitude;
+        CONST float distMax=distToHorizon;
+        CONST float distToGround=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToGround==0 ? -1 :
             clampCosine(-(sqr(distToHorizon)+sqr(distToGround)) / (2*distToGround*(altitude+earthRadius)));
     }
     else
     {
-        const float distMin=atmosphereHeight-altitude;
-        const float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
-        const float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
+        CONST float distMin=atmosphereHeight-altitude;
+        CONST float distMax=distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder=cosViewZenithAngleCoord*(distMax-distMin)+distMin;
         cosViewZenithAngle = distToTopAtmoBorder==0 ? 1 :
             clampCosine((sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA)-sqr(distToHorizon)-sqr(distToTopAtmoBorder)) /
                         (2*distToTopAtmoBorder*(altitude+earthRadius)));
@@ -753,23 +764,23 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 
 LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
 
-    const float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
+    CONST float distToHorizon = sqrt(sqr(altitude)+2*altitude*earthRadius);
 
     // ------------------------------------
     float cosVZACoord; // Coordinate for cos(viewZenithAngle)
-    const float rCvza=r*cosViewZenithAngle;
+    CONST float rCvza=r*cosViewZenithAngle;
     // Discriminant of the quadratic equation for the intersections of the ray (altitiude, cosViewZenithAngle) with the ground.
-    const float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
+    CONST float discriminant=sqr(rCvza)-sqr(r)+sqr(earthRadius);
     if(viewRayIntersectsGround)
     {
         // Distance from camera to the ground along the view ray (altitude, cosViewZenithAngle)
-        const float distToGround = -rCvza-safeSqrt(discriminant);
+        CONST float distToGround = -rCvza-safeSqrt(discriminant);
         // Minimum possible value of distToGround
-        const float distMin = altitude;
+        CONST float distMin = altitude;
         // Maximum possible value of distToGround
-        const float distMax = distToHorizon;
+        CONST float distMax = distToHorizon;
         cosVZACoord = distMax==distMin ? 0. : (distToGround-distMin)/(distMax-distMin);
     }
     else
@@ -777,27 +788,27 @@ LightPollution2DCoords lightPollutionTexVarsTo2DCoords(const float altitude, con
         // Distance from camera to the atmosphere border along the view ray (altitude, cosViewZenithAngle)
         // sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA) added to sqr(earthRadius) term in discriminant changes
         // sqr(earthRadius) to sqr(earthRadius+atmosphereHeight), so that we target the top atmosphere boundary instead of bottom.
-        const float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
-        const float distMin = atmosphereHeight-altitude;
-        const float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+        CONST float distToTopAtmoBorder = -rCvza+safeSqrt(discriminant+sqr(LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA));
+        CONST float distMin = atmosphereHeight-altitude;
+        CONST float distMax = distToHorizon+LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
         cosVZACoord = distMax==distMin ? 0. : (distToTopAtmoBorder-distMin)/(distMax-distMin);
     }
 
     // ------------------------------------
-    const float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
+    CONST float altCoord = distToHorizon / LENGTH_OF_HORIZ_RAY_FROM_GROUND_TO_TOA;
 
     return LightPollution2DCoords(cosVZACoord, altCoord);
 }
 
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
-    const vec2 texSize = lightPollutionTextureSize;
-    const float cosVZAtc = viewRayIntersectsGround ?
+    CONST LightPollution2DCoords coords = lightPollutionTexVarsTo2DCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 texSize = lightPollutionTextureSize;
+    CONST float cosVZAtc = viewRayIntersectsGround ?
                             // Coordinate is in ~[0,0.5]
                             0.5-0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2) :
                             // Coordinate is in ~[0.5,1]
                             0.5+0.5*unitRangeToTexCoord(coords.cosViewZenithAngle, texSize[0]/2);
-    const float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
+    CONST float altitudeTC = unitRangeToTexCoord(coords.altitude, texSize[1]);
     return vec2(cosVZAtc, altitudeTC);
 }

--- a/atmosphere/default/shaders/zero-order-scattering/3/texture-sampling-functions.frag
+++ b/atmosphere/default/shaders/zero-order-scattering/3/texture-sampling-functions.frag
@@ -1,7 +1,18 @@
 #version 330
-#extension GL_ARB_shading_language_420pack : require
+#line 1 1 // version.h.glsl
+#ifndef INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
+#define INCLUDE_ONCE_EF4160B0_E881_42C8_BB48_A408AF2E4354
 
-#line 1 1 // const.h.glsl
+#extension GL_ARB_shading_language_420pack : enable
+#ifdef GL_ARB_shading_language_420pack
+# define CONST const
+#else
+# define CONST
+#endif
+
+#endif
+#line 3 0 // texture-sampling-functions.frag
+#line 1 2 // const.h.glsl
 #ifndef INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 #define INCLUDE_ONCE_2B59AE86_E78B_4D75_ACDF_5DA644F8E9A3
 const float earthRadius=6.371e+06; // must be in meters
@@ -34,13 +45,13 @@ const vec4 lightPollutionRelativeRadiance=vec4(3.80500001e-06,4.31499984e-06,4.9
 const vec4 wavelengths=vec4(736,767.333313,798.666687,830);
 const int wlSetIndex=3;
 #endif
-#line 5 0 // texture-sampling-functions.frag
-#line 1 2 // phase-functions.h.glsl
+#line 4 0 // texture-sampling-functions.frag
+#line 1 3 // phase-functions.h.glsl
 vec4 phaseFunction_molecules(float dotViewSun);
 vec4 phaseFunction_aerosols(float dotViewSun);
 vec4 currentPhaseFunction(float dotViewSun);
-#line 6 0 // texture-sampling-functions.frag
-#line 1 3 // common-functions.h.glsl
+#line 5 0 // texture-sampling-functions.frag
+#line 1 4 // common-functions.h.glsl
 #ifndef INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 #define INCLUDE_ONCE_B0879E51_5608_481B_9832_C7D601BD6AB1
 float distanceToAtmosphereBorder(const float cosZenithAngle, const float observerAltitude);
@@ -72,8 +83,8 @@ void setDebugData(float a,float b);
 void setDebugData(float a,float b,float c);
 void setDebugData(float a,float b,float c,float d);
 #endif
-#line 7 0 // texture-sampling-functions.frag
-#line 1 4 // texture-coordinates.h.glsl
+#line 6 0 // texture-sampling-functions.frag
+#line 1 5 // texture-coordinates.h.glsl
 #ifndef INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 #define INCLUDE_ONCE_72E237D7_42B6_462B_90E4_73AB6B6E4DE4
 
@@ -142,7 +153,7 @@ LightPollutionTexVars scatteringTexIndicesToLightPollutionTexVars(const vec2 tex
 vec2 lightPollutionTexVarsToTexCoords(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround);
 
 #endif
-#line 8 0 // texture-sampling-functions.frag
+#line 7 0 // texture-sampling-functions.frag
 
 uniform sampler2D transmittanceTexture;
 uniform sampler2D irradianceTexture;
@@ -154,13 +165,13 @@ uniform sampler2D lightPollutionScatteringTexture;
 
 vec4 irradiance(const float cosSunZenithAngle, const float altitude)
 {
-    const vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
+    CONST vec2 texCoords=irradianceTexVarsToTexCoord(cosSunZenithAngle, altitude);
     return texture(irradianceTexture, texCoords);
 }
 
 vec4 opticalDepthToAtmosphereBorder(const float cosViewZenithAngle, const float altitude)
 {
-    const vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
+    CONST vec2 texCoords=transmittanceTexVarsToTexCoord(cosViewZenithAngle, altitude);
     // We don't use mip mapping here, but for some reason, on my NVidia GTX 750 Ti with Linux-x86 driver 390.116 I get
     // an artifact when looking into nadir from TOA at some values of texture sizes (in particular, size of
     // transmittance texture for altitude being 4096). This happens when I simply call texture(eclipsedScatteringTexture,
@@ -178,11 +189,11 @@ vec4 transmittanceToAtmosphereBorder(const float cosViewZenithAngle, const float
 vec4 transmittance(const float cosViewZenithAngle, const float altitude, const float dist,
                    const bool viewRayIntersectsGround)
 {
-    const float r=earthRadius+altitude;
+    CONST float r=earthRadius+altitude;
     // Clamping only guards against rounding errors here, we don't try to handle view ray endpoint
     // in space here.
-    const float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
-    const float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
+    CONST float altAtDist=clampAltitude(sqrt(sqr(dist)+sqr(r)+2*r*dist*cosViewZenithAngle)-earthRadius);
+    CONST float cosViewZenithAngleAtDist=clampCosine((r*cosViewZenithAngle+dist)/(earthRadius+altAtDist));
 
     vec4 depth;
     if(viewRayIntersectsGround)
@@ -201,7 +212,7 @@ vec4 transmittance(const float cosViewZenithAngle, const float altitude, const f
 vec4 calcFirstScattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
                          const float dotViewSun, const float altitude, const bool viewRayIntersectsGround)
 {
-    const vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
+    CONST vec4 scattering = sample4DTexture(firstScatteringTexture, cosSunZenithAngle, cosViewZenithAngle,
                                           dotViewSun, altitude, viewRayIntersectsGround);
     return scattering*currentPhaseFunction(dotViewSun);
 }
@@ -220,6 +231,6 @@ vec4 scattering(const float cosSunZenithAngle, const float cosViewZenithAngle,
 
 vec4 lightPollutionScattering(const float altitude, const float cosViewZenithAngle, const bool viewRayIntersectsGround)
 {
-    const vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
+    CONST vec2 coords = lightPollutionTexVarsToTexCoords(altitude, cosViewZenithAngle, viewRayIntersectsGround);
     return texture(lightPollutionScatteringTexture, coords);
 }


### PR DESCRIPTION
This PR just updates the version of CalcMySky fetched in the CI, and also updates the default atmosphere model to conform to this version.

The main changes to CalcMySky is support for OpenGL@macOS. Now the problem remains for Stellarium to support GL Core profile.