### PR TITLE
Enable dithering by default

### DIFF
--- a/src/core/StelPainter.cpp
+++ b/src/core/StelPainter.cpp
@@ -149,7 +149,14 @@ StelPainter::StelPainter(const StelProjectorP& proj) : QOpenGLFunctions(QOpenGLC
 	setProjector(proj);
 
 	QSettings*const conf = StelApp::getInstance().getSettings();
-	ditheringMode = parseDitheringMode(conf->value("video/dithering_mode").toString());
+	QVariant selectedDitherFormat = conf->value("video/dithering_mode");
+	if(!selectedDitherFormat.isValid())
+	{
+		constexpr char defaultValue[] = "color888";
+		selectedDitherFormat = defaultValue;
+		conf->setValue("video/dithering_mode", defaultValue);
+	}
+	ditheringMode = parseDitheringMode(selectedDitherFormat.toString());
 }
 
 void StelPainter::setProjector(const StelProjectorP& p)


### PR DESCRIPTION
With the new dithering algorithm there's no reason to avoid it. If a user has 10 bpc monitor, this will just result in a bit more noise than required (and can be changed as needed), and no other detrimental effects.
