### PR TITLE
Add contact times of global solar eclipse in AstroCal

### DIFF
--- a/src/gui/AstroCalcDialog.cpp
+++ b/src/gui/AstroCalcDialog.cpp
@@ -4151,7 +4151,6 @@ void AstroCalcDialog::selectCurrentSolarEclipse(const QModelIndex& modelIndex)
 						else
 						{
 							eclipseTypeStr = qc_("Partial", "eclipse type");
-							
 						}
 						pathWidthStr = dash;
 						durationStr = dash;

--- a/src/gui/AstroCalcDialog.cpp
+++ b/src/gui/AstroCalcDialog.cpp
@@ -127,8 +127,11 @@ AstroCalcDialog::AstroCalcDialog(QObject* parent)
 	Q_ASSERT(wutHeader.isEmpty());
 	Q_ASSERT(rtsHeader.isEmpty());
 	Q_ASSERT(lunareclipseHeader.isEmpty());
+	Q_ASSERT(lunareclipsecontactsHeader.isEmpty());
 	Q_ASSERT(solareclipseHeader.isEmpty());
+	Q_ASSERT(solareclipsecontactsHeader.isEmpty());
 	Q_ASSERT(solareclipselocalHeader.isEmpty());
+	Q_ASSERT(transitHeader.isEmpty());
 }
 
 AstroCalcDialog::~AstroCalcDialog()
@@ -170,6 +173,7 @@ void AstroCalcDialog::retranslate()
 		setLunarEclipseHeaderNames();
 		setLunarEclipseContactsHeaderNames();
 		setSolarEclipseHeaderNames();
+		setSolarEclipseContactsHeaderNames();
 		setSolarEclipseLocalHeaderNames();
 		setTransitHeaderNames();
 		populateCelestialBodyList();
@@ -344,6 +348,7 @@ void AstroCalcDialog::createDialogContent()
 	connect(ui->lunareclipsesCalculateButton, SIGNAL(clicked()), this, SLOT(generateLunarEclipses()));
 	connect(ui->lunareclipsesCleanupButton, SIGNAL(clicked()), this, SLOT(cleanupLunarEclipses()));
 	connect(ui->lunareclipsesSaveButton, SIGNAL(clicked()), this, SLOT(saveLunarEclipses()));
+	initListLunarEclipseContact();
 	connect(ui->lunareclipsescontactsSaveButton, SIGNAL(clicked()), this, SLOT(saveLunarEclipseCircumstances()));
 	connect(ui->lunareclipseTreeWidget, SIGNAL(clicked(QModelIndex)), this, SLOT(selectCurrentLunarEclipse(QModelIndex)));
 	connect(ui->lunareclipseTreeWidget, SIGNAL(doubleClicked(QModelIndex)), this, SLOT(selectCurrentLunarEclipseDate(QModelIndex)));
@@ -352,7 +357,11 @@ void AstroCalcDialog::createDialogContent()
 	connect(ui->solareclipsesCalculateButton, SIGNAL(clicked()), this, SLOT(generateSolarEclipses()));
 	connect(ui->solareclipsesCleanupButton, SIGNAL(clicked()), this, SLOT(cleanupSolarEclipses()));
 	connect(ui->solareclipsesSaveButton, SIGNAL(clicked()), this, SLOT(saveSolarEclipses()));
-	connect(ui->solareclipseTreeWidget, SIGNAL(doubleClicked(QModelIndex)), this, SLOT(selectCurrentSolarEclipse(QModelIndex)));
+	initListSolarEclipseContact();
+	connect(ui->solareclipsescontactsSaveButton, SIGNAL(clicked()), this, SLOT(saveSolarEclipseCircumstances()));
+	connect(ui->solareclipseTreeWidget, SIGNAL(clicked(QModelIndex)), this, SLOT(selectCurrentSolarEclipse(QModelIndex)));
+	connect(ui->solareclipseTreeWidget, SIGNAL(doubleClicked(QModelIndex)), this, SLOT(selectCurrentSolarEclipseDate(QModelIndex)));
+	connect(ui->solareclipsecontactsTreeWidget, SIGNAL(doubleClicked(QModelIndex)), this, SLOT(selectCurrentSolarEclipseContact(QModelIndex)));
 	initListSolarEclipseLocal();
 	connect(ui->solareclipseslocalCalculateButton, SIGNAL(clicked()), this, SLOT(generateSolarEclipsesLocal()));
 	connect(ui->solareclipseslocalCleanupButton, SIGNAL(clicked()), this, SLOT(cleanupSolarEclipsesLocal()));
@@ -3053,7 +3062,7 @@ void AstroCalcDialog::selectCurrentLunarEclipse(const QModelIndex& modelIndex)
 			}
 			treeItem->setText(LunarEclipseContactPA, positionAngleStr);
 			treeItem->setData(LunarEclipseContactPA, Qt::UserRole, positionAngle);
-			treeItem->setToolTip(LunarEclipseContactPA, q_("Position angle of the Earth's shadow with respect to center of the Moon measured counter-clockwise from celestial north"));
+			treeItem->setToolTip(LunarEclipseContactPA, q_("Position angle of contact point with respect to center of the Moon measured counter-clockwise from celestial north"));
 			treeItem->setText(LunarEclipseContactDistance, distanceStr);
 			treeItem->setData(LunarEclipseContactDistance, Qt::UserRole, axisDistance);
 			treeItem->setToolTip(LunarEclipseContactDistance, q_("Geocentric angular distance of center of the Moon from the axis or center of the Earth's shadow"));
@@ -3294,6 +3303,22 @@ void AstroCalcDialog::setSolarEclipseHeaderNames()
 	}
 }
 
+void AstroCalcDialog::setSolarEclipseContactsHeaderNames()
+{
+	solareclipsecontactsHeader.clear();
+	solareclipsecontactsHeader << qc_("Circumstances", "column name");
+	solareclipsecontactsHeader << q_("Date and Time");
+	solareclipsecontactsHeader << q_("Latitude");
+	solareclipsecontactsHeader << q_("Longitude");
+	ui->solareclipsecontactsTreeWidget->setHeaderLabels(solareclipsecontactsHeader);
+
+	// adjust the column width
+	for (int i = 0; i < SolarEclipseContactCount; ++i)
+	{
+		ui->solareclipsecontactsTreeWidget->resizeColumnToContents(i);
+	}
+}
+
 void AstroCalcDialog::initListSolarEclipse()
 {
 	ui->solareclipseTreeWidget->clear();
@@ -3301,6 +3326,16 @@ void AstroCalcDialog::initListSolarEclipse()
 	setSolarEclipseHeaderNames();
 	ui->solareclipseTreeWidget->header()->setSectionsMovable(false);
 	ui->solareclipseTreeWidget->header()->setDefaultAlignment(Qt::AlignCenter);
+	initListSolarEclipseContact();
+}
+
+void AstroCalcDialog::initListSolarEclipseContact()
+{
+	ui->solareclipsecontactsTreeWidget->clear();
+	ui->solareclipsecontactsTreeWidget->setColumnCount(SolarEclipseContactCount);
+	setSolarEclipseContactsHeaderNames();
+	ui->solareclipsecontactsTreeWidget->header()->setSectionsMovable(false);
+	ui->solareclipsecontactsTreeWidget->header()->setDefaultAlignment(Qt::AlignCenter);
 }
 
 // Local solar eclipse parameters
@@ -3338,39 +3373,23 @@ LocalSEparams localSolarEclipse(double JD,int contact,bool central) {
 	core->setJD(JD);
 	core->update(0);
 
+	double xdot,ydot,ddot,mudot,etadot;
+	BesselParameters(xdot,ydot,ddot,mudot,etadot);
 	double x,y,d,tf1,tf2,L1,L2,mu;
 	SolarEclipseBessel(x,y,d,tf1,tf2,L1,L2,mu);
-
-	core->setJD(JD - 5./1440.);
-	core->update(0);
-	double x1,y1,d1,bestf1,bestf2,besL1,besL2,mu1;
-	SolarEclipseBessel(x1,y1,d1,bestf1,bestf2,besL1,besL2,mu1);
-
-	core->setJD(JD + 5./1440.);
-	core->update(0);
-	double x2,y2,d2,mu2;
-	SolarEclipseBessel(x2,y2,d2,bestf1,bestf2,besL1,besL2,mu2);
-
-	// Hourly rate of changes
-	const double xdot = (x2 - x1) * 6.;
-	const double ydot = (y2 - y1) * 6.;
-	const double ddot = (d2 - d1) * 6.;
-	double mudot = mu2 - mu1;
-	if (mudot < 0.) mudot += 360.; // make sure it is positive in case mu2 < mu1
-	mudot = mudot * 6. * M_PI_180;
 	double theta = (mu + lon) * M_PI_180;
 	theta = StelUtils::fmodpos(theta, 2.*M_PI);
-	const double xi = rc*sin(theta);
-	const double eta = rs*cos(d)-rc*sin(d)*cos(theta);
-	const double zeta = rs*sin(d)+rc*cos(d)*cos(theta);
-	const double xidot = mudot * rc * cos(theta);
-	const double etadot = mudot*xi*sin(d)-zeta*ddot;
+	const double xi = rc*std::sin(theta);
+	const double eta = rs*std::cos(d)-rc*std::sin(d)*std::cos(theta);
+	const double zeta = rs*std::sin(d)+rc*std::cos(d)*std::cos(theta);
+	const double xidot = mudot*rc*std::cos(theta);
+	etadot = mudot*xi*std::sin(d)-zeta*ddot;
 	const double u = x - xi;
 	const double v = y - eta;
 	const double udot = xdot - xidot;
 	const double vdot = ydot - etadot;
 	const double n2 = udot * udot + vdot * vdot;
-	const double delta = (u * vdot - udot * v) / sqrt(n2);
+	const double delta = (u*vdot - udot*v)/std::sqrt(n2);
 	L1 = L1 - zeta * tf1;
 	L2 = L2 - zeta * tf2;
 	double L = L1;
@@ -3379,11 +3398,11 @@ LocalSEparams localSolarEclipse(double JD,int contact,bool central) {
 	const double ce = 1.- sfi*sfi;
 	double cfi = 0.; 
 	if (ce > 0.)
-		cfi = contact * sqrt(ce);
+		cfi = contact * std::sqrt(ce);
 	const double m = sqrt(u * u + v * v);
 	const double magnitude = (L1 - m) / (L1 + L2);
-	const double altitude = asin(rc*cos(d)*cos(theta)+rs*sin(d)) / M_PI_180;
-	const double dt = (L * cfi / sqrt(udot * udot + vdot * vdot)) - (u * udot + v * vdot) / n2;
+	const double altitude = std::asin(rc*std::cos(d)*std::cos(theta)+rs*std::sin(d))*M_180_PI;
+	const double dt = (L * cfi / std::sqrt(udot*udot + vdot*vdot)) - (u*udot + v*vdot)/n2;
 
 	result.dt = dt;
 	result.L1 = L1;
@@ -3393,6 +3412,83 @@ LocalSEparams localSolarEclipse(double JD,int contact,bool central) {
 	result.altitude = altitude;
 
 	return result;
+}
+
+double AstroCalcDialog::getDeltaTofContact(double JD, bool beginning, bool penumbra, bool external)
+{
+	StelCore* core = StelApp::getInstance().getCore();
+	static SolarSystem* ssystem = GETSTELMODULE(SolarSystem);
+	static const double f = 1.0 - ssystem->getEarth()->getOneMinusOblateness(); // flattening
+	static const double e2 = f*(2.-f);
+	core->setJD(JD);
+	core->update(0);
+	double xdot,ydot,ddot,mudot,etadot;
+	BesselParameters(xdot,ydot,ddot,mudot,etadot);
+	double x,y,d,tf1,tf2,L1,L2,mu,L=0.;
+	SolarEclipseBessel(x,y,d,tf1,tf2,L1,L2,mu);
+	double rho1 = std::sqrt(1.-e2*std::cos(d)*std::cos(d));
+	double s,dt;
+	if (!penumbra)
+		ydot = ydot/rho1;
+	double n = std::sqrt(xdot*xdot+ydot*ydot);
+	double y1 = y/rho1;
+	double m = std::sqrt(x*x+y*y);
+	double m1 = std::sqrt(x*x+y1*y1);
+	double rho = m/m1;
+	if (penumbra)
+		L = L1;
+	else
+		L = L2;
+
+	if (external)
+	{
+		s = (x*ydot-y*xdot)/(n*(L+rho));
+	}
+	else
+	{
+		s = (x*ydot-xdot*y1)/n;
+	}
+	double cs = std::sqrt(1.-s*s);
+	if (beginning)
+		cs *= -1.;
+	if (external)
+		dt = (L+rho)*cs/n-((x*xdot+y*ydot)/(n*n));
+	else
+		dt = cs/n-((x*xdot+y1*ydot)/(n*n));
+	return dt;
+}
+
+double AstroCalcDialog::getJDofContact(double JD, bool beginning, bool penumbra, bool external)
+{
+	double dt = 1.;
+	int iterations = 0;
+	while (std::abs(dt)>(0.1/86400.) && (iterations < 10))
+	{
+		dt = getDeltaTofContact(JD,beginning,penumbra,external);
+		JD += dt/24.;
+		iterations++;
+	}
+	return JD;
+}
+
+double AstroCalcDialog::getJDofMinimumDistance(double JD)
+{
+	double dt = 1.;
+	int iterations = 0;
+	double xdot,ydot,ddot,mudot,etadot;
+	double x,y,d,tf1,tf2,L1,L2,mu;
+	while (std::abs(dt)>(0.1/86400.) && (iterations < 20)) // 0.1 second of accuracy
+	{
+		core->setJD(JD);
+		core->update(0);
+		BesselParameters(xdot,ydot,ddot,mudot,etadot);
+		SolarEclipseBessel(x,y,d,tf1,tf2,L1,L2,mu);
+		double n2 = xdot*xdot + ydot*ydot;
+		dt = -(x*xdot + y*ydot)/n2;
+		JD += dt/24.;
+		iterations++;
+	}
+	return JD;
 }
 
 void AstroCalcDialog::generateSolarEclipses()
@@ -3435,43 +3531,12 @@ void AstroCalcDialog::generateSolarEclipses()
 				core->update(0);
 
 				// Find exact time of minimum distance between axis of lunar shadow cone to the center of Earth
-				double dt = 1.;
-				int iteration = 0;
-				while (abs(dt)>(0.1/86400.) && (iteration < 20)) // 0.1 second of accuracy
-				{
-					core->setJD(JD);
-					core->update(0);
-					double x,y,d,tf1,tf2,L1,L2,mu;
-					SolarEclipseBessel(x,y,d,tf1,tf2,L1,L2,mu);
-
-					core->setJD(JD - 5./1440.);
-					core->update(0);
-					double x1,y1;
-					SolarEclipseBessel(x1,y1,d,tf1,tf2,L1,L2,mu);
-
-					core->setJD(JD + 5./1440.);
-					core->update(0);
-					double x2,y2;
-					SolarEclipseBessel(x2,y2,d,tf1,tf2,L1,L2,mu);
-
-					double xdot1 = (x - x1) * 12.;
-					double xdot2 = (x2 - x) * 12.;
-					double xdot = (xdot1 + xdot2) / 2.;
-					double ydot1 = (y - y1) * 12.;
-					double ydot2 = (y2 - y) * 12.;
-					double ydot = (ydot1 + ydot2) / 2.;
-					double n2 = xdot * xdot + ydot * ydot;
-					dt  = -(x * xdot + y * ydot) / n2;
-					JD += dt / 24.;
-					iteration += 1;
-				}
-
+				JD = getJDofMinimumDistance(JD);
 				core->setJD(JD);
 				core->update(0);
 
 				double x,y,d,tf1,tf2,L1,L2,mu;
 				SolarEclipseBessel(x,y,d,tf1,tf2,L1,L2,mu);
-
 				double gamma = sqrt(x * x + y * y);
 				if (y<0.) gamma = -(gamma);
 				double dRatio,latDeg,lngDeg,altitude,pathWidth,duration,magnitude;
@@ -3701,44 +3766,13 @@ void AstroCalcDialog::generateSolarEclipsesLocal()
 				core->update(0);
 
 				// Find exact time of minimum distance between axis of lunar shadow cone to the center of Earth
-				double dt = 1.;
-				int iteration = 0;
-				while (abs(dt)>(0.1/86400.) && (iteration < 20)) // 0.1 second of accuracy
-				{
-					core->setJD(JD);
-					core->update(0);
-					double x,y,d,tf1,tf2,L1,L2,mu;
-					SolarEclipseBessel(x,y,d,tf1,tf2,L1,L2,mu);
-
-					core->setJD(JD - 5./1440.);
-					core->update(0);
-					double x1,y1;
-					SolarEclipseBessel(x1,y1,d,tf1,tf2,L1,L2,mu);
-
-					core->setJD(JD + 5./1440.);
-					core->update(0);
-					double x2,y2;
-					SolarEclipseBessel(x2,y2,d,tf1,tf2,L1,L2,mu);
-
-					double xdot1 = (x - x1) * 12.;
-					double xdot2 = (x2 - x) * 12.;
-					double xdot = (xdot1 + xdot2) / 2.;
-					double ydot1 = (y - y1) * 12.;
-					double ydot2 = (y2 - y) * 12.;
-					double ydot = (ydot1 + ydot2) / 2.;
-					double n2 = xdot * xdot + ydot * ydot;
-					dt  = -(x * xdot + y * ydot) / n2;
-					JD += dt / 24.;
-					iteration += 1;
-				}
-
+				JD = getJDofMinimumDistance(JD);
 				core->setJD(JD);
 				core->update(0);
 				double x,y,d,tf1,tf2,L1,L2,mu;
 				SolarEclipseBessel(x,y,d,tf1,tf2,L1,L2,mu);
 				double gamma = sqrt(x * x + y * y);
-				if (y<0.) gamma = -(gamma);
-
+				if (y<0.) gamma *= -1.;
 				if (abs(gamma) <= (1.5433 + L2)) // Solar eclipse occurs on this date
 				{
 					double magLocal = 0., altitudeMideclipse = 0.;
@@ -3973,27 +4007,134 @@ void AstroCalcDialog::generateSolarEclipsesLocal()
 void AstroCalcDialog::cleanupSolarEclipses()
 {
 	ui->solareclipseTreeWidget->clear();
+	ui->solareclipsecontactsTreeWidget->clear();
 }
 
 void AstroCalcDialog::selectCurrentSolarEclipse(const QModelIndex& modelIndex)
 {
-	// Find the Sun
-	QString name = "Sun";
-	double JD = modelIndex.sibling(modelIndex.row(), SolarEclipseDate).data(Qt::UserRole).toDouble();
-	float lat = modelIndex.sibling(modelIndex.row(), SolarEclipseLatitude).data(Qt::UserRole).toFloat();
-	float lon = modelIndex.sibling(modelIndex.row(), SolarEclipseLongitude).data(Qt::UserRole).toFloat();
+	initListSolarEclipseContact();
+	const bool saveTopocentric = core->getUseTopocentricCoordinates();
+	double currentJD = core->getJD();
+	const bool withDecimalDegree = StelApp::getInstance().getFlagShowDecimalDegrees();
+	QPair<QString, QString> coordStrings;
+	QString altitudeStr, azimuthStr, latitudeStr, longitudeStr, JDStr;
+	double JDMid = modelIndex.sibling(modelIndex.row(), SolarEclipseDate).data(Qt::UserRole).toDouble();
+	double JD = JDMid;
+
+	// Compute time and other data of contacts
+	double dRatio,latDeg,lngDeg,altitude,pathWidth,duration,magnitude;
+	bool event = false;
+	bool nonCentralEclipse = false;
+	core->setJD(JD);
+	core->update(0);
+	double x,y,d,tf1,tf2,L1,L2,mu;
+	SolarEclipseBessel(x,y,d,tf1,tf2,L1,L2,mu);
+	double gamma = std::sqrt(x*x+y*y);
+	if ((gamma > 0.9972) && (gamma < (1.5433 + L2)))
+		nonCentralEclipse = true;
+
+	for (int i = 0; i < 5; i++)
+	{
+		if (i==0) // P1
+		{
+			JD = getJDofContact(JDMid,true,true,true);
+			SolarEclipseData(JD,dRatio,latDeg,lngDeg,altitude,pathWidth,duration,magnitude);
+			event = true;
+		}
+		if (i==1 && !nonCentralEclipse) // C1
+		{
+			JD = getJDofContact(JDMid,true,false,false);
+			SolarEclipseData(JD,dRatio,latDeg,lngDeg,altitude,pathWidth,duration,magnitude);
+			event = true;
+		}
+		else if (i==2) // Greatest Eclipse
+		{
+			JD = JDMid;
+			SolarEclipseData(JD,dRatio,latDeg,lngDeg,altitude,pathWidth,duration,magnitude);
+			event = true;
+		}
+		else if (i==3 && !nonCentralEclipse) // C2
+		{
+			JD = getJDofContact(JDMid,false,false,false);
+			SolarEclipseData(JD,dRatio,latDeg,lngDeg,altitude,pathWidth,duration,magnitude);
+			event = true;
+		}
+		else if (i==4) // P4
+		{
+			JD = getJDofContact(JDMid,false,true,true);
+			SolarEclipseData(JD,dRatio,latDeg,lngDeg,altitude,pathWidth,duration,magnitude);
+			event = true;
+		}	
+		if (event)
+		{
+			ACSolarEclipseContactsTreeWidgetItem* treeItem = new ACSolarEclipseContactsTreeWidgetItem(ui->solareclipsecontactsTreeWidget);
+			switch (i)
+			{
+				case 0:
+					treeItem->setText(SolarEclipseContact, QString(q_("Eclipse begins; first contact with Earth")));
+					break;
+				case 1:
+					treeItem->setText(SolarEclipseContact, QString(q_("Beginning of center line; central eclipse begins")));
+					break;
+				case 2:
+					treeItem->setText(SolarEclipseContact, QString(q_("Greatest eclipse")));
+					break;
+				case 3:
+					treeItem->setText(SolarEclipseContact, QString(q_("End of center line; central eclipse ends")));
+					break;
+				case 4:
+					treeItem->setText(SolarEclipseContact, QString(q_("Eclipse ends; last contact with Earth")));
+					break;
+			}
+			treeItem->setText(SolarEclipseContactDate, QString("%1 %2").arg(localeMgr->getPrintableDateLocal(JD), localeMgr->getPrintableTimeLocal(JD)));
+			treeItem->setData(SolarEclipseContactDate, Qt::UserRole, JD);
+			latitudeStr = StelUtils::decDegToLatitudeStr(latDeg, !withDecimalDegree);
+			longitudeStr = StelUtils::decDegToLongitudeStr(lngDeg, true, false, !withDecimalDegree);
+			treeItem->setText(SolarEclipseContactLatitude, latitudeStr);
+			treeItem->setData(SolarEclipseContactLatitude, Qt::UserRole, latDeg);
+			treeItem->setToolTip(SolarEclipseContactLatitude, q_("Geographic latitude of contact point"));
+			treeItem->setText(SolarEclipseContactLongitude, longitudeStr);
+			treeItem->setData(SolarEclipseContactLongitude, Qt::UserRole, lngDeg);
+			treeItem->setToolTip(SolarEclipseContactLongitude, q_("Geographic longitude of contact point"));
+			treeItem->setTextAlignment(SolarEclipseContact, Qt::AlignLeft);
+			treeItem->setTextAlignment(SolarEclipseContactDate, Qt::AlignRight);
+			treeItem->setTextAlignment(SolarEclipseContactLatitude, Qt::AlignRight);
+			treeItem->setTextAlignment(SolarEclipseContactLongitude, Qt::AlignRight);
+		}
+		ui->solareclipsecontactsTreeWidget->setColumnHidden(4,true);
+		event = false;
+	}
+	core->setJD(currentJD);
+	core->setUseTopocentricCoordinates(saveTopocentric);
+	core->update(0);
+
+	// adjust the column width
+	for (int i = 0; i < SolarEclipseContactCount; ++i)
+	{
+		ui->solareclipsecontactsTreeWidget->resizeColumnToContents(i);
+	}
+
+	// sort-by-date
+	ui->solareclipsecontactsTreeWidget->sortItems(SolarEclipseContactDate, Qt::AscendingOrder);
+}
+
+void AstroCalcDialog::selectCurrentSolarEclipseContact(const QModelIndex& modelIndex)
+{
+	double JD = modelIndex.sibling(modelIndex.row(), SolarEclipseContactDate).data(Qt::UserRole).toDouble();
+	float lat = modelIndex.sibling(modelIndex.row(), SolarEclipseContactLatitude).data(Qt::UserRole).toFloat();
+	float lon = modelIndex.sibling(modelIndex.row(), SolarEclipseContactLongitude).data(Qt::UserRole).toFloat();
 
 	StelLocation loc;
 	loc.latitude = lat;
 	loc.longitude = lon;
 	loc.altitude = 10; // 10 meters above sea level
-	loc.name = q_("Greatest eclipse’s point");
+	loc.name = q_("Eclipse’s contact point");
 	loc.planetName = "Earth";
 	loc.ianaTimeZone = "LMST";
 	// NOTE: A small time is needed to update the GUI after change the coordinates without changing the name of location
 	core->moveObserverTo(loc, 0.1);
 
-	if (objectMgr->findAndSelectI18n(name) || objectMgr->findAndSelect(name))
+	if (objectMgr->findAndSelectI18n("Sun") || objectMgr->findAndSelect("Sun"))
 	{
 		core->setJD(JD);
 		const QList<StelObjectP> newSelected = objectMgr->getSelectedObject();
@@ -4081,6 +4222,138 @@ void AstroCalcDialog::saveSolarEclipses()
 		delete[] width;
 		xlsx.saveAs(filePath);
 	}
+}
+
+void AstroCalcDialog::saveSolarEclipseCircumstances()
+{
+	QString filter = q_("Microsoft Excel Open XML Spreadsheet");
+	filter.append(" (*.xlsx);;");
+	filter.append(q_("CSV (Comma delimited)"));
+	filter.append(" (*.csv)");
+	QString defaultFilter("(*.xlsx)");
+	QString filePath = QFileDialog::getSaveFileName(Q_NULLPTR,
+							q_("Save solar eclipse circumstances as..."),
+							QDir::homePath() + "/solareclipse-circumstances.xlsx",
+							filter,
+							&defaultFilter);
+
+	if (defaultFilter.contains(".csv", Qt::CaseInsensitive))
+		saveTableAsCSV(filePath, ui->solareclipsecontactsTreeWidget, solareclipsecontactsHeader);
+	else
+	{
+		int count = ui->solareclipsecontactsTreeWidget->topLevelItemCount();
+		int columns = solareclipsecontactsHeader.size();
+		int *width = new int[static_cast<unsigned int>(columns)];
+		QString sData;
+
+		QXlsx::Document xlsx;
+		xlsx.setDocumentProperty("title", q_("Circumstances of Solar Eclipse"));
+		xlsx.setDocumentProperty("creator", StelUtils::getApplicationName());
+		xlsx.addSheet("Circumstances of Solar Eclipse", AbstractSheet::ST_WorkSheet);
+
+		QXlsx::Format header;
+		header.setHorizontalAlignment(QXlsx::Format::AlignHCenter);
+		header.setPatternBackgroundColor(Qt::yellow);
+		header.setBorderStyle(QXlsx::Format::BorderThin);
+		header.setBorderColor(Qt::black);
+		header.setFontBold(true);
+		for (int i = 0; i < columns; i++)
+		{
+			// Row 1: Names of columns
+			sData = solareclipsecontactsHeader.at(i).trimmed();
+			xlsx.write(1, i + 1, sData, header);
+			width[i] = sData.size();
+		}
+
+		QXlsx::Format data;
+		data.setHorizontalAlignment(QXlsx::Format::AlignRight);
+		for (int i = 0; i < count; i++)
+		{
+			for (int j = 0; j < columns; j++)
+			{
+				// Row 2 and next: the data
+				sData = ui->solareclipsecontactsTreeWidget->topLevelItem(i)->text(j).trimmed();
+				xlsx.write(i + 2, j + 1, sData, data);
+				int w = sData.size();
+				if (w > width[j])
+				{
+					width[j] = w;
+				}
+			}
+		}
+
+		xlsx.write(count+3, 1, q_("Note: Path of eclipses during thousands of years in the past and future are not reliable due to uncertainty in ΔT which is caused by fluctuations in Earth's rotation."));
+		
+		for (int i = 0; i < columns; i++)
+		{
+			xlsx.setColumnWidth(i+1, width[i]+2);
+		}
+
+		delete[] width;
+		xlsx.saveAs(filePath);
+	}
+}
+
+void AstroCalcDialog::selectCurrentSolarEclipseDate(const QModelIndex& modelIndex)
+{
+	double JD = modelIndex.sibling(modelIndex.row(), SolarEclipseDate).data(Qt::UserRole).toDouble();
+	float lat = modelIndex.sibling(modelIndex.row(), SolarEclipseLatitude).data(Qt::UserRole).toFloat();
+	float lon = modelIndex.sibling(modelIndex.row(), SolarEclipseLongitude).data(Qt::UserRole).toFloat();
+
+	StelLocation loc;
+	loc.latitude = lat;
+	loc.longitude = lon;
+	loc.altitude = 10; // 10 meters above sea level
+	loc.name = q_("Greatest eclipse’s point");
+	loc.planetName = "Earth";
+	loc.ianaTimeZone = "LMST";
+	// NOTE: A small time is needed to update the GUI after change the coordinates without changing the name of location
+	core->moveObserverTo(loc, 0.1);
+	if (objectMgr->findAndSelectI18n("Sun") || objectMgr->findAndSelect("Sun"))
+	{
+		core->setJD(JD);
+		const QList<StelObjectP> newSelected = objectMgr->getSelectedObject();
+		if (!newSelected.empty())
+		{
+			// Can't point to home planet
+			if (newSelected[0]->getEnglishName() != core->getCurrentLocation().planetName)
+			{
+				mvMgr->moveToObject(newSelected[0], mvMgr->getAutoMoveDuration());
+				mvMgr->setFlagTracking(true);
+			}
+			else
+			{
+				GETSTELMODULE(StelObjectMgr)->unSelect();
+			}
+		}
+	}
+}
+
+BesselParameters::BesselParameters(double &xdot, double &ydot, double &ddot, double &mudot, double &etadot)
+{
+	StelCore* core = StelApp::getInstance().getCore();
+	double JD = core->getJD();
+	double tf1,tf2;
+	core->setJD(JD - 5./1440.);
+	core->update(0);
+	double x1,y1,d1,mu1,L11,L21;
+	SolarEclipseBessel(x1,y1,d1,tf1,tf2,L11,L21,mu1);
+	core->setJD(JD + 5./1440.);
+	core->update(0);
+	double x2,y2,d2,mu2,L12,L22;
+	SolarEclipseBessel(x2,y2,d2,tf1,tf2,L12,L22,mu2);
+
+	xdot = (x2-x1)*6.;
+	ydot = (y2-y1)*6.;
+	ddot = (d2-d1)*6.*M_PI_180;
+	mudot = (mu2-mu1);
+	if (mudot<0.) mudot += 360.; // make sure it is positive in case mu2 < mu1
+	mudot = mudot*6.* M_PI_180;
+	core->setJD(JD);
+	core->update(0);
+	double x,y,d,L1,L2,mu;
+	SolarEclipseBessel(x,y,d,tf1,tf2,L1,L2,mu);
+	etadot = mudot*x*std::sin(d);
 }
 
 void AstroCalcDialog::cleanupSolarEclipsesLocal()

--- a/src/gui/AstroCalcDialog.hpp
+++ b/src/gui/AstroCalcDialog.hpp
@@ -190,7 +190,7 @@ public:
 	//! @enum LunarEclipseContactColumns
 	enum LunarEclipseContactColumns {
 		LunarEclipseContact,		//! circumstance of lunar eclipse
-		LunarEclipseContactDate,	//! date and time
+		LunarEclipseContactDate,	//! date and time of circumstance
 		LunarEclipseContactAltitude,	//! altitude of the Moon
 		LunarEclipseContactAzimuth,	//! azimuth of the Moon
 		LunarEclipseContactLatitude,	//! latitude where the Moon appears in the zenith
@@ -214,6 +214,16 @@ public:
 		SolarEclipsePathwidth,	//! pathwidth of total or annular solar eclipse
 		SolarEclipseDuration,		//! central duration of total or annular solar eclipse
 		SolarEclipseCount		//! total number of columns
+	};
+
+	//! Defines the number and the order of the columns in the global solar eclipse contact table
+	//! @enum SolarEclipseContactColumns
+	enum SolarEclipseContactColumns {
+		SolarEclipseContact,		//! circumstance of solar eclipse
+		SolarEclipseContactDate,	//! date and time of circumstance
+		SolarEclipseContactLatitude,	//! latitude at contact time
+		SolarEclipseContactLongitude,	//! longitude at contact time
+		SolarEclipseContactCount	//! total number of columns
 	};
 
 	//! Defines the number and the order of the columns in the local solar eclipse table
@@ -313,7 +323,10 @@ private slots:
 	void generateSolarEclipses();
 	void cleanupSolarEclipses();
 	void selectCurrentSolarEclipse(const QModelIndex &modelIndex);
+	void selectCurrentSolarEclipseDate(const QModelIndex &modelIndex);
+	void selectCurrentSolarEclipseContact(const QModelIndex &modelIndex);
 	void saveSolarEclipses();
+	void saveSolarEclipseCircumstances();
 
 	//! Calculating local solar eclipses to fill the list.
 	//! Algorithm taken from calculating the rises, transits and sets.
@@ -474,6 +487,8 @@ private:
 	void setLunarEclipseContactsHeaderNames();
 	//! update header names for solar eclipse table
 	void setSolarEclipseHeaderNames();
+	//! update header names for solar eclipse contact table
+	void setSolarEclipseContactsHeaderNames();
 	//! update header names for local solar eclipse table
 	void setSolarEclipseLocalHeaderNames();
 	//! update header names for transit table
@@ -497,6 +512,14 @@ private:
 	void initListLunarEclipseContact();
 	//! Init header and list of solar eclipse
 	void initListSolarEclipse();
+	//! Init header and list of solar eclipse contact
+	void initListSolarEclipseContact();
+	//! Iteration to calculate minimum distance from Besselian elements
+	double getJDofMinimumDistance(double JD);
+	//! Iteration to calculate JD of solar eclipse contacts
+	double getJDofContact(double JD, bool beginning, bool penumbral, bool external);
+	//! Iteration to calculate contact times of solar eclipse
+	double getDeltaTofContact(double JD, bool beginning, bool penumbra, bool external);
 	//! Init header and list of local solar eclipse
 	void initListSolarEclipseLocal();
 	//! Init header and list of transit
@@ -585,7 +608,7 @@ private:
 	// Signal that a plot has to be redone
 	bool plotAltVsTime, plotAltVsTimeSun, plotAltVsTimeMoon, plotAltVsTimePositive, plotMonthlyElevation, plotMonthlyElevationPositive, plotDistanceGraph, plotLunarElongationGraph, plotAziVsTime;
 	int altVsTimePositiveLimit, monthlyElevationPositiveLimit, graphsDuration, graphsStep;
-	QStringList ephemerisHeader, phenomenaHeader, positionsHeader, hecPositionsHeader, wutHeader, rtsHeader, lunareclipseHeader, lunareclipsecontactsHeader, solareclipseHeader, solareclipselocalHeader, transitHeader;
+	QStringList ephemerisHeader, phenomenaHeader, positionsHeader, hecPositionsHeader, wutHeader, rtsHeader, lunareclipseHeader, lunareclipsecontactsHeader, solareclipseHeader, solareclipsecontactsHeader, solareclipselocalHeader, transitHeader;
 	static double brightLimit;
 	static const QString dash, delimiter;
 
@@ -913,6 +936,37 @@ private:
 			return text(column).toLower() < other.text(column).toLower();
 		}
 	}
+};
+
+class ACSolarEclipseContactsTreeWidgetItem : public QTreeWidgetItem
+{
+public:
+	ACSolarEclipseContactsTreeWidgetItem(QTreeWidget* parent)
+		: QTreeWidgetItem(parent)
+	{
+	}
+
+private:
+	bool operator < (const QTreeWidgetItem &other) const Q_DECL_OVERRIDE
+	{
+		int column = treeWidget()->sortColumn();
+
+		if (column == AstroCalcDialog::SolarEclipseContactDate)
+		{
+			return data(column, Qt::UserRole).toFloat() < other.data(column, Qt::UserRole).toFloat();
+		}
+		else
+		{
+			return text(column).toLower() < other.text(column).toLower();
+		}
+	}
+};
+
+// Class to compute parameters from Besselian elements
+class BesselParameters
+{
+public:
+	BesselParameters(double &xdot, double &ydot, double &ddot, double &mudot, double &etadot);
 };
 
 // Reimplements the QTreeWidgetItem class to fix the sorting bug

--- a/src/gui/AstroCalcDialog.hpp
+++ b/src/gui/AstroCalcDialog.hpp
@@ -223,6 +223,9 @@ public:
 		SolarEclipseContactDate,	//! date and time of circumstance
 		SolarEclipseContactLatitude,	//! latitude at contact time
 		SolarEclipseContactLongitude,	//! longitude at contact time
+		SolarEclipseContactPathwidth,	//! pathwidth of total or annular solar eclipse
+		SolarEclipseContactDuration,	//! central duration of total or annular solar eclipse
+		SolarEclipseContactType,	//! type of solar eclipse
 		SolarEclipseContactCount	//! total number of columns
 	};
 

--- a/src/gui/astroCalcDialog.ui
+++ b/src/gui/astroCalcDialog.ui
@@ -2574,7 +2574,7 @@
               <string>All Solar Eclipses</string>
              </attribute>
              <layout class="QGridLayout" name="gridLayout_20">
-              <item row="4" column="0">
+              <item row="5" column="0">
                <layout class="QHBoxLayout" name="horizontalLayout_40">
                 <item>
                  <widget class="QPushButton" name="solareclipsesCleanupButton">
@@ -2587,6 +2587,13 @@
                  <widget class="QPushButton" name="solareclipsesSaveButton">
                   <property name="text">
                    <string>Export solar eclipses...</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QPushButton" name="solareclipsescontactsSaveButton">
+                  <property name="text">
+                   <string>Export circumstances of eclipse...</string>
                   </property>
                  </widget>
                 </item>
@@ -2624,7 +2631,7 @@
                 </attribute>
                </widget>
               </item>
-              <item row="3" column="0">
+              <item row="4" column="0">
                <widget class="QLabel" name="gammaNoteSolarEclipseLabel">
                 <property name="text">
                  <string>Notes: The quantity gamma is the minimum distance from the axis of lunar shadow cone to the center of Earth, in units of Earth’s equatorial radius. This distance is positive or negative, depending on whether the axis of the shadow cone passes north or south of the Earth's center. Path of solar eclipses during thousands of years in the past and future are not reliable due to uncertainty in ΔT which is caused by fluctuations in Earth's rotation.</string>
@@ -2632,6 +2639,31 @@
                 <property name="wordWrap">
                  <bool>true</bool>
                 </property>
+               </widget>
+              </item>
+              <item row="3" column="0" alignment="Qt::AlignBottom">
+               <widget class="QTreeWidget" name="solareclipsecontactsTreeWidget">
+                <property name="rootIsDecorated">
+                 <bool>false</bool>
+                </property>
+                <property name="uniformRowHeights">
+                 <bool>true</bool>
+                </property>
+                <property name="itemsExpandable">
+                 <bool>false</bool>
+                </property>
+                <property name="sortingEnabled">
+                 <bool>false</bool>
+                </property>
+                <property name="expandsOnDoubleClick">
+                 <bool>false</bool>
+                </property>
+                <property name="columnCount">
+                 <number>0</number>
+                </property>
+                <attribute name="headerShowSortIndicator" stdset="0">
+                 <bool>true</bool>
+                </attribute>
                </widget>
               </item>
              </layout>


### PR DESCRIPTION
### Description
The main contact times, including latitude/longitude of each contact point.

Note: Minor fix in lunar eclipse - description of 'position angle' in contact table is incorrect for some circumstances. The new one should be better.

### Screenshots (if appropriate):
![solareclipse-circumstances](https://user-images.githubusercontent.com/41257965/190345894-239c5591-d773-47db-a34b-646c291f2874.png)

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system: Manjaro 22.0.0
* Graphics Card: -

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
