### PR TITLE
Paint version on the fly on the splash screen instead of rasterizing it into a pixmap

### DIFF
--- a/src/StelSplashScreen.cpp
+++ b/src/StelSplashScreen.cpp
@@ -27,31 +27,13 @@ SplashScreen::SplashScreenWidget* SplashScreen::instance;
 static QPixmap makePixmap()
 {
 	QPixmap pixmap(StelFileMgr::findFile("data/splash.png"));
-	QPainter p(&pixmap);
-	p.setRenderHint(QPainter::Antialiasing);
-	p.setPen(Qt::white);
-	#if defined(GIT_REVISION)
-	QFontMetrics metrics(p.font());
-	p.drawText(QPointF(metrics.averageCharWidth(), 1.3*metrics.height()), QString("%1 (v%2)").arg(StelUtils::getApplicationPublicVersion(), StelUtils::getApplicationVersion()));
-	#else
-	QFont versionFont;
-	QString version = StelUtils::getApplicationPublicVersion();
-	versionFont.setPixelSize(25);
-	versionFont.setBold(true);
-	QFontMetrics versionMetrics(versionFont);
-	p.setFont(versionFont);
-	p.drawText(365 - versionMetrics.horizontalAdvance(version), 290, version);
-	#endif
 	return pixmap;
 }
 
 void SplashScreen::present()
 {
-	QFont splashFont;
-	splashFont.setPixelSize(11);
 	Q_ASSERT(!instance);
 	instance=new SplashScreenWidget(makePixmap());
-	instance->setFont(splashFont);
 	instance->show();
 	instance->ensureFirstPaint();
 }
@@ -74,4 +56,46 @@ void SplashScreen::clearMessage()
 {
 	Q_ASSERT(instance);
 	instance->clearMessage();
+}
+
+SplashScreen::SplashScreenWidget::SplashScreenWidget(QPixmap const& pixmap)
+	: QSplashScreen(pixmap)
+{
+	splashFont.setPixelSize(11);
+
+	// Fix concrete font family and rendering mode, so that even if default
+	// application font changes, we still render app version in the same font
+	// on each repaint.
+	QFontInfo info(splashFont);
+	splashFont.setFamily(info.family());
+	splashFont.setHintingPreference(QFont::PreferFullHinting);
+	splashFont.setStyleHint(QFont::AnyStyle, QFont::PreferAntialias);
+
+	setFont(splashFont);
+}
+
+void SplashScreen::SplashScreenWidget::paintEvent(QPaintEvent* event)
+{
+	QSplashScreen::paintEvent(event);
+
+	// Add version text
+	QPainter p(this);
+	p.setRenderHint(QPainter::Antialiasing);
+	p.setPen(Qt::white);
+#if defined(GIT_REVISION)
+	QFontMetrics metrics(splashFont);
+	p.drawText(QPointF(metrics.averageCharWidth(), 1.3*metrics.height()),
+			   QString("%1 (v%2)").arg(StelUtils::getApplicationPublicVersion(),
+									   StelUtils::getApplicationVersion()));
+#else
+	QFont versionFont(splashFont);
+	QString version = StelUtils::getApplicationPublicVersion();
+	versionFont.setPixelSize(25);
+	versionFont.setBold(true);
+	QFontMetrics versionMetrics(versionFont);
+	p.setFont(versionFont);
+	p.drawText(365 - versionMetrics.horizontalAdvance(version), 290, version);
+#endif
+
+	painted=true;
 }

--- a/src/StelSplashScreen.hpp
+++ b/src/StelSplashScreen.hpp
@@ -27,16 +27,10 @@ class SplashScreen
 {
 	class SplashScreenWidget : public QSplashScreen
 	{
+		QFont splashFont;
 		bool painted=false;
-		void paintEvent(QPaintEvent* e) override
-		{
-			QSplashScreen::paintEvent(e);
-			painted=true;
-		}
 	public:
-		SplashScreenWidget(QPixmap const& pixmap)
-			: QSplashScreen(pixmap)
-		{}
+		SplashScreenWidget(QPixmap const& pixmap);
 		void ensureFirstPaint() const
 		{
 			while(!painted)
@@ -45,6 +39,9 @@ class SplashScreen
 				qApp->processEvents();
 			}
 		}
+
+	protected:
+		void paintEvent(QPaintEvent*) override;
 	};
 
 	static SplashScreenWidget* instance;


### PR DESCRIPTION
This makes high-DPI splash screen a bit nicer. See the screenshots below.

## Scaling factor 100%

Before
![1a](https://user-images.githubusercontent.com/6376882/191129195-7e550bd4-1611-4bd5-b5c1-019c9a952214.png)

After
![2a](https://user-images.githubusercontent.com/6376882/191129297-b2cc04f4-eeb1-497e-a5dd-d63b119bc611.png)

## Scaling factor 150%

Before
![1b](https://user-images.githubusercontent.com/6376882/191129228-3362cebc-ebb0-476b-b14e-2ca600428b8d.png)

After
![2b](https://user-images.githubusercontent.com/6376882/191129307-c218db21-989e-434e-bc74-ad66289f314c.png)
