### PR TITLE
Work around too much stretching of close button icon on Qt 5.12.8

### DIFF
--- a/src/gui/StelCloseButton.cpp
+++ b/src/gui/StelCloseButton.cpp
@@ -27,6 +27,15 @@ StelCloseButton::StelCloseButton(QWidget* parent)
 {
 	// Qt 5.15 regression: QBushButton without borders does not respond to clicks
 	setStyleSheet("border: 1px solid rgba(0, 0, 0, 0); background: none;");
+
+	// In Qt 5.12.8 the icon stretches too much for some reason, so let's
+	// simply make it the expected size. This will break high-DPI scaled mode,
+	// but I think such high-end systems should use newer Qt anyway.
+#if QT_VERSION < QT_VERSION_CHECK(5, 13, 0)
+	iconNormal = QIcon(iconNormal.pixmap(16,16));
+	iconHover  = QIcon(iconHover.pixmap(16,16));
+#endif
+
 	setIcon(iconNormal);
 }
 


### PR DESCRIPTION
In Qt 5.12 after #2660 the close button's icon appears to be overly stretched, like in the screenshot below. This happens in both scaled and unscaled UI.
![](https://user-images.githubusercontent.com/6376882/191136419-86581adf-9153-47d0-9d1a-71225cfca17b.png)

This patch works around this by requesting a downsampled 16×16 pixmap from the original icon and rendering from it—only on Qt<5.13. This works fine for unscaled UI, but still looks ugly for scaled one:

![close-bad-remains](https://user-images.githubusercontent.com/6376882/191282436-7898a176-9b4f-4364-aaca-48fd8bde4d7e.png)

I think this might be acceptable if we assume that Qt 5.12 is only going to be used on low-end systems which will not have high-DPI monitors anyway.