### PR TITLE
Make Date&Time dialog more usable for typing date

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -363,6 +363,7 @@ IF(STELLARIUM_GUI_MODE STREQUAL "Standard")
 	  gui/ContributorsList.hpp
           gui/StelCloseButton.hpp
           gui/StelCloseButton.cpp
+		  gui/ExternalStepSpinBox.hpp
      )
 
      ################# compiles .ui files ############

--- a/src/gui/DateTimeDialog.cpp
+++ b/src/gui/DateTimeDialog.cpp
@@ -75,6 +75,13 @@ void DateTimeDialog::createDialogContent()
 	ui->dateDelimiterLabel2->setText(delimiter);
 
 	connectSpinnerEvents();
+
+	connect(ui->spinner_second, &ExternalStepSpinBox::stepsRequested, this, [this](int steps){secondChanged(second+steps);});
+	connect(ui->spinner_minute, &ExternalStepSpinBox::stepsRequested, this, [this](int steps){minuteChanged(minute+steps);});
+	connect(ui->spinner_hour  , &ExternalStepSpinBox::stepsRequested, this, [this](int steps){  hourChanged(hour  +steps);});
+	connect(ui->spinner_day   , &ExternalStepSpinBox::stepsRequested, this, [this](int steps){   dayChanged(day   +steps);});
+	connect(ui->spinner_month , &ExternalStepSpinBox::stepsRequested, this, [this](int steps){ monthChanged(month +steps);});
+
 	StelGui* gui = dynamic_cast<StelGui*>(StelApp::getInstance().getGui());
 	if (gui)
 	{
@@ -226,14 +233,27 @@ double DateTimeDialog::newJd()
 void DateTimeDialog::pushToWidgets()
 {
 	disconnectSpinnerEvents();
-	ui->spinner_year->setValue(year);
-	ui->spinner_month->setValue(month);
-	ui->spinner_day->setValue(day);
-	ui->spinner_hour->setValue(hour);
-	ui->spinner_minute->setValue(minute);
-	ui->spinner_second->setValue(second);
+
+	// Don't touch spinboxes that don't change. Otherwise it interferes with
+	// typing (e.g. when starting a number with leading zero), and sometimes
+	// even with stepping (e.g. the user clicks an arrow, but the number
+	// remains the same, although the time did change).
+	if(ui->spinner_year->value() != year)
+		ui->spinner_year->setValue(year);
+	if(ui->spinner_month->value() != month)
+		ui->spinner_month->setValue(month);
+	if(ui->spinner_day->value() != day)
+		ui->spinner_day->setValue(day);
+	if(ui->spinner_hour->value() != hour)
+		ui->spinner_hour->setValue(hour);
+	if(ui->spinner_minute->value() != minute)
+		ui->spinner_minute->setValue(minute);
+	if(ui->spinner_second->value() != second)
+		ui->spinner_second->setValue(second);
+
 	ui->spinner_jd->setValue(jd);
 	ui->spinner_mjd->setValue(getMjd());
+
 	if (jd<2299161) // 1582-10-15
 	{
 		ui->dateTimeTab->setToolTip(q_("Date and Time in Julian calendar"));
@@ -244,6 +264,7 @@ void DateTimeDialog::pushToWidgets()
 		ui->dateTimeTab->setToolTip(q_("Date and Time in Gregorian calendar"));
 		ui->dateTimeTabWidget->setTabToolTip(0, q_("Date and Time in Gregorian calendar"));
 	}
+
 	connectSpinnerEvents();
 }
 

--- a/src/gui/ExternalStepSpinBox.hpp
+++ b/src/gui/ExternalStepSpinBox.hpp
@@ -1,0 +1,47 @@
+/*
+ * Stellarium
+ * Copyright (C) 2022 Ruslan Kabatsayev
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Suite 500, Boston, MA  02110-1335, USA.
+*/
+
+#ifndef EXTERNAL_STEP_SPINBOX_HPP
+#define EXTERNAL_STEP_SPINBOX_HPP
+
+#include <QSpinBox>
+
+/*!
+ * A spinbox whose stepBy commands are emitted as signals instead of changing the value.
+ */
+class ExternalStepSpinBox : public QSpinBox
+{
+	Q_OBJECT
+
+public:
+	ExternalStepSpinBox(QWidget*const parent = nullptr)
+		: QSpinBox(parent)
+	{
+		setWrapping(true); // enable step buttons even when at limits
+	}
+	void stepBy(const int steps) override
+	{
+		emit stepsRequested(steps);
+	}
+
+signals:
+	void stepsRequested(int steps);
+};
+
+#endif

--- a/src/gui/dateTimeDialogGui.ui
+++ b/src/gui/dateTimeDialogGui.ui
@@ -303,7 +303,7 @@
            </widget>
           </item>
           <item>
-           <widget class="QSpinBox" name="spinner_month">
+           <widget class="ExternalStepSpinBox" name="spinner_month">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
               <horstretch>0</horstretch>
@@ -323,10 +323,10 @@
              <set>Qt::AlignCenter</set>
             </property>
             <property name="minimum">
-             <number>0</number>
+             <number>1</number>
             </property>
             <property name="maximum">
-             <number>13</number>
+             <number>12</number>
             </property>
            </widget>
           </item>
@@ -353,7 +353,7 @@
            </widget>
           </item>
           <item>
-           <widget class="QSpinBox" name="spinner_day">
+           <widget class="ExternalStepSpinBox" name="spinner_day">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
               <horstretch>0</horstretch>
@@ -373,10 +373,10 @@
              <set>Qt::AlignCenter</set>
             </property>
             <property name="minimum">
-             <number>0</number>
+             <number>1</number>
             </property>
             <property name="maximum">
-             <number>32</number>
+             <number>31</number>
             </property>
            </widget>
           </item>
@@ -414,7 +414,7 @@
            <number>0</number>
           </property>
           <item>
-           <widget class="QSpinBox" name="spinner_hour">
+           <widget class="ExternalStepSpinBox" name="spinner_hour">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
               <horstretch>0</horstretch>
@@ -431,10 +431,10 @@
              <set>Qt::AlignCenter</set>
             </property>
             <property name="minimum">
-             <number>-1</number>
+             <number>0</number>
             </property>
             <property name="maximum">
-             <number>24</number>
+             <number>23</number>
             </property>
            </widget>
           </item>
@@ -461,7 +461,7 @@
            </widget>
           </item>
           <item>
-           <widget class="QSpinBox" name="spinner_minute">
+           <widget class="ExternalStepSpinBox" name="spinner_minute">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
               <horstretch>0</horstretch>
@@ -478,10 +478,10 @@
              <set>Qt::AlignCenter</set>
             </property>
             <property name="minimum">
-             <number>-1</number>
+             <number>0</number>
             </property>
             <property name="maximum">
-             <number>60</number>
+             <number>59</number>
             </property>
            </widget>
           </item>
@@ -511,7 +511,7 @@
            </widget>
           </item>
           <item>
-           <widget class="QSpinBox" name="spinner_second">
+           <widget class="ExternalStepSpinBox" name="spinner_second">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
               <horstretch>0</horstretch>
@@ -540,10 +540,10 @@
              <string/>
             </property>
             <property name="minimum">
-             <number>-1</number>
+             <number>0</number>
             </property>
             <property name="maximum">
-             <number>60</number>
+             <number>59</number>
             </property>
            </widget>
           </item>
@@ -716,6 +716,11 @@
    <class>StelCloseButton</class>
    <extends>QPushButton</extends>
    <header>gui/StelCloseButton.hpp</header>
+  </customwidget>
+  <customwidget>
+   <class>ExternalStepSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>ExternalStepSpinBox.hpp</header>
   </customwidget>
  </customwidgets>
  <resources/>


### PR DESCRIPTION
### Description

Dates are commonly represented in a format where month and day are two-digit, and if less than 10, they have leading zero. Same goes for time. If we were to type such a date or time into the current Date&Time dialog, we'll get an annoying result of decreasing value of the spinbox to the left of the current one and getting maximum value in the current spinbox.

This is due to the way carry from lower-order date-time elements (e.g. days) to the higher-order elements (e.g. months) is implemented: by using "overflow" values to catch a step and then fixing it up.

This patch makes the behavior closer to the expected one by catching the step event in a more natural way.

Fixes #2272

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

## Checklist:
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
