### PR TITLE
Add abort telescope slew signals to LX200 and NexStar telescopes

### DIFF
--- a/plugins/TelescopeControl/src/ASCOM/TelescopeClientASCOM.hpp
+++ b/plugins/TelescopeControl/src/ASCOM/TelescopeClientASCOM.hpp
@@ -37,6 +37,7 @@ public:
 	void telescopeSync(const Vec3d& j2000Pos, StelObjectP selectObject) override;
 	bool isTelescopeSyncSupported() const override {return true;}
 	void telescopeAbortSlew() override;
+	bool isAbortSlewSupported() const override {return true;}
 	bool isConnected() const override;
 	bool hasKnownPosition() const override;
 	static bool useJNow(ASCOMDevice::ASCOMEquatorialCoordinateType coordinateType, bool ascomUseDeviceEqCoordType, TelescopeControl::Equinox equinox);

--- a/plugins/TelescopeControl/src/Lx200/Lx200Connection.cpp
+++ b/plugins/TelescopeControl/src/Lx200/Lx200Connection.cpp
@@ -350,3 +350,18 @@ void Lx200Connection::sendCommand(Lx200Command *command)
 	}
 }
 
+void Lx200Connection::sendAbort()
+{
+		#ifdef DEBUG4
+		*log_file << Now()
+			  << "Lx200Connection::sendAbort()"
+			  << StelUtils::getEndLineChar();
+		#endif
+		command_list.clear();
+		read_buff_end = read_buff;
+		write_buff_end = write_buff;
+		command_list.push_back(new Lx200CommandStopSlew(server));
+		flushCommandList();
+		//*log_file << Now() << "Lx200Connection::sendAbort() end"
+		//          << StelUtils::getEndLineChar();
+}

--- a/plugins/TelescopeControl/src/Lx200/Lx200Connection.cpp
+++ b/plugins/TelescopeControl/src/Lx200/Lx200Connection.cpp
@@ -352,16 +352,22 @@ void Lx200Connection::sendCommand(Lx200Command *command)
 
 void Lx200Connection::sendAbort()
 {
-		#ifdef DEBUG4
-		*log_file << Now()
-			  << "Lx200Connection::sendAbort()"
-			  << StelUtils::getEndLineChar();
-		#endif
-		command_list.clear();
-		read_buff_end = read_buff;
-		write_buff_end = write_buff;
-		command_list.push_back(new Lx200CommandStopSlew(server));
-		flushCommandList();
-		//*log_file << Now() << "Lx200Connection::sendAbort() end"
-		//          << StelUtils::getEndLineChar();
+#ifdef DEBUG4
+	*log_file << Now()
+		  << "Lx200Connection::sendAbort()"
+		  << StelUtils::getEndLineChar();
+#endif
+	// Remove queued commands (pointers, so delete their objects!)
+	while (!command_list.empty())
+	{
+		delete command_list.front();
+		command_list.pop_front();
+	}
+
+	read_buff_end = read_buff;
+	write_buff_end = write_buff;
+	command_list.push_back(new Lx200CommandStopSlew(server));
+	flushCommandList();
+	//*log_file << Now() << "Lx200Connection::sendAbort() end"
+	//          << StelUtils::getEndLineChar();
 }

--- a/plugins/TelescopeControl/src/Lx200/Lx200Connection.hpp
+++ b/plugins/TelescopeControl/src/Lx200/Lx200Connection.hpp
@@ -39,6 +39,8 @@ public:
 	void sendGoto(unsigned int ra_int, int dec_int);
 	void sendSync(unsigned int ra_int, int dec_int);
 	void sendCommand(Lx200Command * command);
+	//! Delete pending commands and send abort signal.
+	void sendAbort();
 	void setTimeBetweenCommands(long long int micro_seconds)
 	{
 		time_between_commands = micro_seconds;

--- a/plugins/TelescopeControl/src/Lx200/TelescopeClientDirectLx200.cpp
+++ b/plugins/TelescopeControl/src/Lx200/TelescopeClientDirectLx200.cpp
@@ -151,6 +151,13 @@ void TelescopeClientDirectLx200::telescopeSync(const Vec3d &j2000Pos, StelObject
 	syncReceived(ra_int, dec_int);
 }
 
+void TelescopeClientDirectLx200::telescopeAbortSlew()
+{
+	if (!isConnected())
+		return;
+	lx200->sendAbort();
+}
+
 void TelescopeClientDirectLx200::gotoReceived(unsigned int ra_int, int dec_int)
 {
 	lx200->sendGoto(ra_int, dec_int);

--- a/plugins/TelescopeControl/src/Lx200/TelescopeClientDirectLx200.cpp
+++ b/plugins/TelescopeControl/src/Lx200/TelescopeClientDirectLx200.cpp
@@ -93,6 +93,7 @@ TelescopeClientDirectLx200::TelescopeClientDirectLx200 (const QString &name, con
 	}
 	
 	// lx200 will be deleted in the destructor of Server
+	// TODO: GZ2024: Server destructor is empty. Who deletes lx200 in version 24.2? Someone please clarify and fix documentation, then delete this note.
 	addConnection(lx200);
 	
 	long_format_used = false; // unknown

--- a/plugins/TelescopeControl/src/Lx200/TelescopeClientDirectLx200.hpp
+++ b/plugins/TelescopeControl/src/Lx200/TelescopeClientDirectLx200.hpp
@@ -73,6 +73,7 @@ private:
 	void telescopeSync(const Vec3d &j2000Pos, StelObjectP selectObject) override;
 	bool isTelescopeSyncSupported() const override {return true;}
 	void telescopeAbortSlew() override;
+	bool isAbortSlewSupported() const override {return true;}
 	bool isInitialized(void) const override;
 	
 	//======================================================================

--- a/plugins/TelescopeControl/src/Lx200/TelescopeClientDirectLx200.hpp
+++ b/plugins/TelescopeControl/src/Lx200/TelescopeClientDirectLx200.hpp
@@ -72,6 +72,7 @@ private:
 	void telescopeGoto(const Vec3d &j2000Pos, StelObjectP selectObject) override;
 	void telescopeSync(const Vec3d &j2000Pos, StelObjectP selectObject) override;
 	bool isTelescopeSyncSupported() const override {return true;}
+	void telescopeAbortSlew() override;
 	bool isInitialized(void) const override;
 	
 	//======================================================================

--- a/plugins/TelescopeControl/src/NexStar/NexStarCommand.cpp
+++ b/plugins/TelescopeControl/src/NexStar/NexStarCommand.cpp
@@ -192,6 +192,46 @@ void NexStarCommandSync::print(QTextStream &o) const
 	  << ra << "," << dec <<')';
 }
 
+bool NexStarCommandAbort::writeCommandToBuffer(char *&p,char *end)
+{
+	#ifdef DEBUG5
+	char *b = p;
+	#endif
+
+	if (end-p < 1)
+		return false;
+	// Only one char:
+	*p = 'M';
+
+	has_been_written_to_buffer = true;
+	#ifdef DEBUG5
+	*log_file << Now() << "NexStarCommandAbort::writeCommandToBuffer:"
+		  << b << StelUtils::getEndLineChar();
+	#endif
+
+	return true;
+}
+
+int NexStarCommandAbort::readAnswerFromBuffer(const char *&buff, const char *end) const
+{
+	if (buff >= end)
+		return 0;
+
+#ifdef DEBUG4
+	if (*buff=='#')
+		*log_file << Now() << "NexStarCommandAbort::readAnswerFromBuffer: answer ok" << StelUtils::getEndLineChar();
+	else
+		*log_file << Now() << "NexStarCommandSync::readAnswerFromBuffer: abort failed." << StelUtils::getEndLineChar();
+#endif
+	buff++;
+	return 1;
+}
+
+void NexStarCommandAbort::print(QTextStream &o) const
+{
+	o << "NexStarCommandAbort()";
+}
+
 bool NexStarCommandGetRaDec::writeCommandToBuffer(char *&p, char *end)
 {
 	if (end-p < 1)

--- a/plugins/TelescopeControl/src/NexStar/NexStarCommand.hpp
+++ b/plugins/TelescopeControl/src/NexStar/NexStarCommand.hpp
@@ -80,6 +80,16 @@ private:
 	int ra, dec;
 };
 
+//! Celestron NexStar command: abort a slew.
+class NexStarCommandAbort : public NexStarCommand
+{
+public:
+	NexStarCommandAbort(Server &server) : NexStarCommand(server){};
+	bool writeCommandToBuffer(char *&buff, char *end) override;
+	int readAnswerFromBuffer(const char *&buff, const char *end) const override;
+	void print(QTextStream &o) const override;
+};
+
 //! Celestron NexStar command: Get the current position.
 class NexStarCommandGetRaDec : public NexStarCommand
 {

--- a/plugins/TelescopeControl/src/NexStar/NexStarConnection.cpp
+++ b/plugins/TelescopeControl/src/NexStar/NexStarConnection.cpp
@@ -59,6 +59,12 @@ void NexStarConnection::sendSync(unsigned int ra_int, int dec_int)
 	sendCommand(new NexStarCommandSync(server, ra_int, dec_int));
 }
 
+void NexStarConnection::sendAbort()
+{
+	command_list.clear(); // remove any queued commands
+	sendCommand(new NexStarCommandAbort(server));
+}
+
 void NexStarConnection::dataReceived(const char *&p,const char *read_buff_end)
 {
 	if (isClosed())

--- a/plugins/TelescopeControl/src/NexStar/NexStarConnection.cpp
+++ b/plugins/TelescopeControl/src/NexStar/NexStarConnection.cpp
@@ -61,7 +61,18 @@ void NexStarConnection::sendSync(unsigned int ra_int, int dec_int)
 
 void NexStarConnection::sendAbort()
 {
-	command_list.clear(); // remove any queued commands
+#ifdef DEBUG4
+	*log_file << Now()
+		  << "NexStarConnection::sendAbort()"
+		  << StelUtils::getEndLineChar();
+#endif
+	// Remove queued commands (pointers, so delete their objects!)
+	while (!command_list.empty())
+	{
+		delete command_list.front();
+		command_list.pop_front();
+	}
+
 	sendCommand(new NexStarCommandAbort(server));
 }
 

--- a/plugins/TelescopeControl/src/NexStar/NexStarConnection.hpp
+++ b/plugins/TelescopeControl/src/NexStar/NexStarConnection.hpp
@@ -39,6 +39,8 @@ public:
 	~NexStarConnection(void) override { resetCommunication(); }
 	void sendGoto(unsigned int ra_int, int dec_int);
 	void sendSync(unsigned int ra_int, int dec_int);
+	//! Delete pending commands and send abort signal.
+	void sendAbort();
 	void sendCommand(NexStarCommand * command);
 	
 private:

--- a/plugins/TelescopeControl/src/NexStar/TelescopeClientDirectNexStar.cpp
+++ b/plugins/TelescopeControl/src/NexStar/TelescopeClientDirectNexStar.cpp
@@ -146,6 +146,10 @@ void TelescopeClientDirectNexStar::telescopeSync(const Vec3d &j2000Pos, StelObje
 	syncReceived(ra_int, dec_int);
 }
 
+void TelescopeClientDirectNexStar::telescopeAbortSlew()
+{
+	nexstar->sendAbort();
+}
 
 void TelescopeClientDirectNexStar::gotoReceived(unsigned int ra_int, int dec_int)
 {

--- a/plugins/TelescopeControl/src/NexStar/TelescopeClientDirectNexStar.cpp
+++ b/plugins/TelescopeControl/src/NexStar/TelescopeClientDirectNexStar.cpp
@@ -90,6 +90,7 @@ TelescopeClientDirectNexStar::TelescopeClientDirectNexStar(const QString &name, 
 	}
 	
 	//This connection will be deleted in the destructor of Server
+	// TODO: GZ2024: Server destructor is empty. Who deletes nexstar in version 24.2? Someone please clarify and fix documentation, then delete this note.
 	addConnection(nexstar);
 	
 	last_ra = 0;

--- a/plugins/TelescopeControl/src/NexStar/TelescopeClientDirectNexStar.hpp
+++ b/plugins/TelescopeControl/src/NexStar/TelescopeClientDirectNexStar.hpp
@@ -71,6 +71,7 @@ private:
 	void telescopeGoto(const Vec3d &j2000Pos, StelObjectP selectObject) override;
 	void telescopeSync(const Vec3d &j2000Pos, StelObjectP selectObject) override;
 	bool isTelescopeSyncSupported() const override {return true;}
+	void telescopeAbortSlew() override;
 	bool isInitialized(void) const override;
 	
 	//======================================================================

--- a/plugins/TelescopeControl/src/NexStar/TelescopeClientDirectNexStar.hpp
+++ b/plugins/TelescopeControl/src/NexStar/TelescopeClientDirectNexStar.hpp
@@ -72,6 +72,7 @@ private:
 	void telescopeSync(const Vec3d &j2000Pos, StelObjectP selectObject) override;
 	bool isTelescopeSyncSupported() const override {return true;}
 	void telescopeAbortSlew() override;
+	bool isAbortSlewSupported() const override {return true;}
 	bool isInitialized(void) const override;
 	
 	//======================================================================

--- a/plugins/TelescopeControl/src/TelescopeClient.cpp
+++ b/plugins/TelescopeControl/src/TelescopeClient.cpp
@@ -31,6 +31,7 @@
 #include "INDI/TelescopeClientINDI.hpp"
 #include "StelTranslator.hpp"
 #include "StelCore.hpp"
+#include "StelMainView.hpp"
 
 #include <cmath>
 
@@ -41,6 +42,7 @@
 #include <QString>
 #include <QTcpSocket>
 #include <QTextStream>
+#include <QMessageBox>
 
 #ifdef Q_OS_WIN
 	#include "ASCOM/TelescopeClientASCOM.hpp"
@@ -140,6 +142,12 @@ QString TelescopeClient::getInfoString(const StelCore* core, const InfoStringGro
 	postProcessInfoString(str, flags);
 
 	return str;
+}
+
+void TelescopeClient::telescopeAbortSlew()
+{
+	qWarning() << "Telescope" << getID() << "does not support AbortSlew()!";
+	QMessageBox::critical(&StelMainView::getInstance(), q_("QUICK!"), q_("This Telescope does not support Abort command!"));
 }
 
 void TelescopeClient::move(double angle, double speed)

--- a/plugins/TelescopeControl/src/TelescopeClient.hpp
+++ b/plugins/TelescopeControl/src/TelescopeClient.hpp
@@ -92,7 +92,9 @@ public:
 	//! report whether this client can respond to sync commands.
 	//! Can be used for GUI tweaks
 	virtual bool isTelescopeSyncSupported() const {return false;}
-	virtual void telescopeAbortSlew() { qWarning() << "Telescope" << getID() << "does not support AbortSlew()!"; }
+	//! Send command to abort slew. Not all telescopes support this, base implementation only gives a warning.
+	//! After abort, the current position should be retrieved and displayed.
+	virtual void telescopeAbortSlew();
 
 	//!
 	//! \brief move

--- a/plugins/TelescopeControl/src/TelescopeClient.hpp
+++ b/plugins/TelescopeControl/src/TelescopeClient.hpp
@@ -95,6 +95,9 @@ public:
 	//! Send command to abort slew. Not all telescopes support this, base implementation only gives a warning.
 	//! After abort, the current position should be retrieved and displayed.
 	virtual void telescopeAbortSlew();
+	//! report whether this client can abort a running slew.
+	//! Can be used for GUI tweaks
+	virtual bool isAbortSlewSupported() const {return false;}
 
 	//!
 	//! \brief move

--- a/plugins/TelescopeControl/src/TelescopeClient.hpp
+++ b/plugins/TelescopeControl/src/TelescopeClient.hpp
@@ -180,6 +180,7 @@ public:
 		desired_pos=XYZ;
 		qDebug() << "Telescope" << getID() << "Slew aborted";
 	}
+	bool isAbortSlewSupported() const override {return true;}
 	bool hasKnownPosition(void) const override
 	{
 		return true;

--- a/plugins/TelescopeControl/src/TelescopeControl.hpp
+++ b/plugins/TelescopeControl/src/TelescopeControl.hpp
@@ -361,9 +361,10 @@ public slots:
 	void slewTelescopeToViewDirection(const int idx);
 
 	//! abort the current slew command of a telescope at slot idx.
+	//! @note ATTENTION! Not all telescopes support this call! A warning panel may be shown instead. Then it's jump and run to prevent damage.
 	//! @code
 	//! // example of usage in scripts
-	//! TelescopeControl.syncTelescopeToSelectedObject(1);
+	//! TelescopeControl.abortTelescopeSlew(1);
 	//! @endcode
 	void abortTelescopeSlew(const int idx);
 

--- a/plugins/TelescopeControl/src/common/Socket.cpp
+++ b/plugins/TelescopeControl/src/common/Socket.cpp
@@ -40,7 +40,7 @@ long long int GetNow(void)
 		qint64 t;
 	} tmp;
 	GetSystemTimeAsFileTime(&tmp.file_time);
-	t = (tmp.t/10) - 86400000000LL*(369*365+89);
+	t = (tmp.t/10) - 86400000000LL*(369*365+89); // TODO: Explain this magic please!
 #else
 	struct timeval tv;
 	gettimeofday(&tv, 0);

--- a/plugins/TelescopeControl/src/common/Socket.hpp
+++ b/plugins/TelescopeControl/src/common/Socket.hpp
@@ -77,6 +77,8 @@ static inline int SetNonblocking(int s)
 
 #endif //Q_OS_WIN
 
+// retrieve system time in milliseconds
+// TODO: Specify epoch?
 long long int GetNow(void);
 
 class Server;

--- a/plugins/TelescopeControl/src/gui/SlewDialog.cpp
+++ b/plugins/TelescopeControl/src/gui/SlewDialog.cpp
@@ -367,6 +367,7 @@ void SlewDialog::onCurrentTelescopeChanged()
 		return;
 
 	ui->pushButtonSync->setEnabled(telescope->isTelescopeSyncSupported());
+	ui->pushButtonAbort->setEnabled(telescope->isAbortSlewSupported());
 	auto controlWidget = telescope->createControlWidget(telescope);
 	if (!controlWidget)
 		return;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Please include a summary of the change and which issue is fixed. -->
<!--- Please also include relevant motivation and context. -->
<!--- List any dependencies that are required for this change. -->

I found that most telescopes are missing the AbortSlew implementation. This is severely bad. This PR should add the signals at least for LX200 and NexStar. 

However, I cannot test it, so this needs external help. I unassigned myself for now in the hope one of our active observers steps in. It may just take a rainy weekend or two. Of course, support for a Big Red Button (emergency switch, separate hardware) would also be nice!

Fixes # (issue)

- [x] Add AbortSlew to LX200
- [x] Add AbortSlew to NexStar
- [ ] Add graceful recovery (put back marker) to LX200
- [ ] Add graceful recovery (put back marker) to NexStar

### Screenshots (if appropriate):

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] This change requires a documentation update

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system: Windows 10 or any other
* Graphics Card: irrelevant

- [ ] Tested AbortSlew for LX200
- [ ] Tested AbortSlew for NexStar

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
