### PR TITLE
Rename vectors methods length and lengthSquared into norm and normSquared

### DIFF
--- a/plugins/AngleMeasure/src/AngleMeasure.cpp
+++ b/plugins/AngleMeasure/src/AngleMeasure.cpp
@@ -273,7 +273,7 @@ void AngleMeasure::drawOne(StelCore *core, const StelCore::FrameType frameType, 
 //! Draw any parts on the screen which are for our module
 void AngleMeasure::draw(StelCore* core)
 {
-	if (startPoint.lengthSquared()==0.0) // avoid crash on switch-on, lp:#1455839
+	if (startPoint.normSquared()==0.0) // avoid crash on switch-on, lp:#1455839
 		return;
 	if (lineVisible.getInterstate() < 0.000001f && messageFader.getInterstate() < 0.000001f)
 		return;
@@ -426,7 +426,7 @@ void AngleMeasure::handleMouseClicks(class QMouseEvent* event)
 				prj->project(endPoint, e1);
 				prj->project(startPoint, s1);
 				// Move the point closest to the mouse
-				if ((c1-e1).length() > (c1-s1).length())
+				if ((c1-e1).norm() > (c1-s1).norm())
 				{
 					startPoint = endPoint;
 					startPointHor = endPointHor;
@@ -445,7 +445,7 @@ void AngleMeasure::handleMouseClicks(class QMouseEvent* event)
 					const StelProjectorP prjHor = StelApp::getInstance().getCore()->getProjection(StelCore::FrameAltAz, StelCore::RefractionOff);
 					prjHor->unProject(x,y,endPointHor);
 				}
-				if (!startPoint.length())
+				if (!startPoint.norm())
 				{
 					startPoint = endPoint;
 					startPointHor = endPointHor;
@@ -487,13 +487,13 @@ void AngleMeasure::calculateEnds(void)
 void AngleMeasure::calculateEndsOneLine(const Vec3d &start, const Vec3d &end, Vec3d &perp1Start, Vec3d &perp1End, Vec3d &perp2Start, Vec3d &perp2End, double &angle)
 {
 	Vec3d v0 = end - start;
-	Vec3d v1 = start / end.length();
+	Vec3d v1 = start / end.norm();
 	Vec3d p = v0 ^ v1;
 	p *= 0.08;  // end width
 	perp1Start.set(start[0]-p[0],start[1]-p[1],start[2]-p[2]);
 	perp1End.set(start[0]+p[0],start[1]+p[1],start[2]+p[2]);
 
-	v1 = end / start.length();
+	v1 = end / start.norm();
 	p = v0 ^ v1;
 	p *= 0.08;  // end width
 	perp2Start.set(end[0]-p[0],end[1]-p[1],end[2]-p[2]);

--- a/plugins/ArchaeoLines/src/ArchaeoLines.cpp
+++ b/plugins/ArchaeoLines/src/ArchaeoLines.cpp
@@ -1588,7 +1588,7 @@ void ArchaeoLine::draw(StelCore *core, float intensity) const
 			// Draw the arc in 2 sub-arcs to avoid lengths > 180 deg
 			Vec3d middlePoint = p1-rotCenter+p2-rotCenter;
 			middlePoint.normalize();
-			middlePoint*=(p1-rotCenter).length();
+			middlePoint*=(p1-rotCenter).norm();
 			middlePoint+=rotCenter;
 			if (!viewPortSphericalCap.contains(middlePoint))
 			{

--- a/plugins/Satellites/src/Satellites.cpp
+++ b/plugins/Satellites/src/Satellites.cpp
@@ -2843,7 +2843,7 @@ void Satellites::drawCircles(StelCore* core, StelPainter &painter)
 	satDistance += earth->getEquatorialRadius();
 	texCross->bind();
 	const float shift = 8.f;
-	const double earthDistance=earth->getHeliocentricEclipticPos().length(); // Earth distance [AU]
+	const double earthDistance=earth->getHeliocentricEclipticPos().norm(); // Earth distance [AU]
 	const double sunHP = asin(earth->getEquatorialRadius()/earthDistance) * M_180_PI*3600.; // arcsec.
 	const double satHP = asin(earth->getEquatorialRadius()/satDistance) * M_180_PI*3600.; // arcsec.
 	const double sunSD = atan(sun->getEquatorialRadius()/earthDistance) * M_180_PI*3600.; // arcsec.

--- a/plugins/Satellites/src/gSatWrapper.cpp
+++ b/plugins/Satellites/src/gSatWrapper.cpp
@@ -173,7 +173,7 @@ void  gSatWrapper::getSlantRange(double &ao_slantRange, double &ao_slantRangeRat
 	Vec3d slantRange		= satECIPos - observerECIPos;
 	Vec3d slantRangeVelocity = satECIVel - observerECIVel;
 
-	ao_slantRange		= slantRange.length();
+	ao_slantRange		= slantRange.norm();
 	ao_slantRangeRate	= slantRange.dot(slantRangeVelocity)/ao_slantRange;
 }
 

--- a/plugins/Scenery3d/src/S3DRenderer.cpp
+++ b/plugins/Scenery3d/src/S3DRenderer.cpp
@@ -275,8 +275,8 @@ static Vec3f zSortValue;
 bool zSortFunction(const StelOBJ::MaterialGroup* const & mLeft, const StelOBJ::MaterialGroup* const & mRight)
 {
 	//we can avoid taking the sqrt here
-	float dist1 = (mLeft->centroid - zSortValue).lengthSquared();
-	float dist2 = (mRight->centroid - zSortValue).lengthSquared();
+	float dist1 = (mLeft->centroid - zSortValue).normSquared();
+	float dist2 = (mRight->centroid - zSortValue).normSquared();
 	return dist1>dist2;
 }
 

--- a/plugins/Scenery3d/src/Scenery3d.cpp
+++ b/plugins/Scenery3d/src/Scenery3d.cpp
@@ -202,7 +202,7 @@ void Scenery3d::update(double deltaTime)
 
 		//perform movement
 		//when zoomed in more than 5°, we slow down movement
-		if(movementKeyInput.lengthSquared() > 0.00001)
+		if(movementKeyInput.normSquared() > 0.00001)
 			currentScene->moveViewer(movementKeyInput * deltaTime * 0.01 * std::max(5.0, mvMgr->getCurrentFov()));
 
 		//update material fade info, if necessary

--- a/plugins/TelescopeControl/src/ASCOM/TelescopeClientASCOM.cpp
+++ b/plugins/TelescopeControl/src/ASCOM/TelescopeClientASCOM.cpp
@@ -89,7 +89,7 @@ void TelescopeClientASCOM::performCommunication()
 	}
 
 	mInterpolatedPosition = mInterpolatedPosition * 10 + mCurrentTargetPosition;
-	const double lq = mInterpolatedPosition.lengthSquared();
+	const double lq = mInterpolatedPosition.normSquared();
 	if (lq > 0.0)
 		mInterpolatedPosition *= (1.0 / std::sqrt(lq));
 	else

--- a/plugins/TelescopeControl/src/TelescopeClient.hpp
+++ b/plugins/TelescopeControl/src/TelescopeClient.hpp
@@ -149,7 +149,7 @@ public:
 	bool prepareCommunication(void) override
 	{
 		XYZ = XYZ * 31.0 + desired_pos;
-		const double lq = XYZ.lengthSquared();
+		const double lq = XYZ.normSquared();
 		if (lq > 0.0)
 			XYZ *= (1.0/std::sqrt(lq));
 		else

--- a/plugins/TelescopeControl/src/common/InterpolatedPosition.cpp
+++ b/plugins/TelescopeControl/src/common/InterpolatedPosition.cpp
@@ -82,7 +82,7 @@ Vec3d InterpolatedPosition::get(qint64 now) const
 			if (pp->client_micros != p->client_micros)
 			{
 				Vec3d rval = p->pos * static_cast<double>(now - pp->client_micros) + pp->pos * static_cast<double>(p->client_micros - now);
-				double f = rval.lengthSquared();
+				double f = rval.normSquared();
 				if (f > 0.0)
 				{
 					return (1.0/std::sqrt(f))*rval;

--- a/src/core/RefractionExtinction.cpp
+++ b/src/core/RefractionExtinction.cpp
@@ -117,7 +117,7 @@ void Refraction::updatePrecomputed()
 
 void Refraction::innerRefractionForward(Vec3d& altAzPos) const
 {
-	const double length = altAzPos.length();
+	const double length = altAzPos.norm();
 	if (length==0.0)
 	{
 		// Under some circumstances there are zero coordinates. Just leave them alone.
@@ -162,7 +162,7 @@ void Refraction::innerRefractionForward(Vec3d& altAzPos) const
 // going from observed position to geometrical position.
 void Refraction::innerRefractionBackward(Vec3d& altAzPos) const
 {
-	const double length = altAzPos.length();
+	const double length = altAzPos.norm();
 	if (length==0.0)
 	{
 		// Under some circumstances there are zero coordinates. Just leave them alone.

--- a/src/core/SphericMirrorCalculator.cpp
+++ b/src/core/SphericMirrorCalculator.cpp
@@ -38,7 +38,7 @@ SphericMirrorCalculator::SphericMirrorCalculator(const QSettings& conf)
 				conf.value("spheric_mirror/projector_position_y",1.0).toFloat(),
 				conf.value("spheric_mirror/projector_position_z",-0.2).toFloat());
 	P = (projector_position - mirror_position) * (1.0f/mirror_radius);
-	PP = P.lengthSquared();
+	PP = P.normSquared();
 	lP = std::sqrt(PP);
 	p = P * (1.0f/lP);
 	float image_distance_div_height = conf.value("spheric_mirror/image_distance_div_height",-1e38f).toFloat();
@@ -127,12 +127,12 @@ void SphericMirrorCalculator::initRotMatrix(float alpha, float delta, float phi)
 
 bool SphericMirrorCalculator::transform(const Vec3f &v, float &xb,float &yb) const
 {
-	const Vec3f S = DomeCenter + (v * (DomeRadius/v.length()));
+	const Vec3f S = DomeCenter + (v * (DomeRadius/v.norm()));
 	const Vec3f SmP = S - P;
 	const float P_SmP = P.dot(SmP);
 	const bool rval = ( (PP-1.0f)*SmP.dot(SmP) > P_SmP*P_SmP );
 
-	const float lS = S.length();
+	const float lS = S.norm();
 	const Vec3f s(S/lS);
 	float t_min = 0;
 	float t_max = 1;

--- a/src/core/StelMovementMgr.cpp
+++ b/src/core/StelMovementMgr.cpp
@@ -656,7 +656,7 @@ void StelMovementMgr::handleMouseClicks(QMouseEvent* event)
 						{
 							const double deltaT = timeDragHistory.last().runTime-timeDragHistory.first().runTime;
 							Vec2f d(timeDragHistory.last().x-timeDragHistory.first().x, timeDragHistory.last().y-timeDragHistory.first().y);
-							if (d.length()/static_cast<float>(deltaT) < dragTriggerDistance)
+							if (d.norm()/static_cast<float>(deltaT) < dragTriggerDistance)
 							{
 								core->setTimeRate(StelCore::JD_SECOND);
 							}

--- a/src/core/StelPainter.cpp
+++ b/src/core/StelPainter.cpp
@@ -896,7 +896,7 @@ void StelPainter::drawSmallCircleArc(const Vec3d& start, const Vec3d& stop, cons
 	tessArc.push_back(win1);
 
 
-	if (rotCenter.lengthSquared()<1e-11)
+	if (rotCenter.normSquared()<1e-11)
 	{
 		// Great circle
 		// Perform the tesselation of the arc in small segments in a way so that the lines look smooth
@@ -904,8 +904,8 @@ void StelPainter::drawSmallCircleArc(const Vec3d& start, const Vec3d& stop, cons
 	}
 	else
 	{
-		Vec3d tmp = (rotCenter^start)/rotCenter.length();
-		const double radius = fabs(tmp.length());
+		Vec3d tmp = (rotCenter^start)/rotCenter.norm();
+		const double radius = fabs(tmp.norm());
 		// Perform the tesselation of the arc in small segments in a way so that the lines look smooth
 		fIter(prj, start-rotCenter, stop-rotCenter, win1, win2, tessArc, tessArc.insert(tessArc.end(), win2), radius, rotCenter);
 	}
@@ -1007,9 +1007,9 @@ void StelPainter::projectSphericalTriangle(const SphericalCap* clippingCap, cons
         const Vec2f* texturePos, QVarLengthArray<Vec2f, 4096>* outTexturePos, const Vec3f *colors, QVarLengthArray<Vec3f, 4096> *outColors,
         double maxSqDistortion, int nbI, bool checkDisc1, bool checkDisc2, bool checkDisc3) const
 {
-	Q_ASSERT(fabs(vertices[0].length()-1.)<0.00001);
-	Q_ASSERT(fabs(vertices[1].length()-1.)<0.00001);
-	Q_ASSERT(fabs(vertices[2].length()-1.)<0.00001);
+	Q_ASSERT(fabs(vertices[0].norm()-1.)<0.00001);
+	Q_ASSERT(fabs(vertices[1].norm()-1.)<0.00001);
+	Q_ASSERT(fabs(vertices[2].norm()-1.)<0.00001);
 	if (clippingCap && clippingCap->containsTriangle(vertices))
 		clippingCap = Q_NULLPTR;
 	if (clippingCap && !clippingCap->intersectsTriangle(vertices))
@@ -1603,7 +1603,7 @@ void StelPainter::drawStelVertexArray(const StelVertexArray& arr, bool checkDisc
 		QVector<Vec3d> aberredVertex(arr.vertex.size());
 		for (int i=0; i<arr.vertex.size(); i++)
 		{
-			Q_ASSERT(qFuzzyCompare(arr.vertex.at(i).lengthSquared(), 1.0));
+			Q_ASSERT(qFuzzyCompare(arr.vertex.at(i).normSquared(), 1.0));
 			Vec3d vec=arr.vertex.at(i)+aberration;
 			vec.normalize();
 			aberredVertex[i]=vec;
@@ -1710,8 +1710,8 @@ void StelPainter::drawCircle(float x, float y, float r)
 		return;
 	const Vec2f center(x,y);
 	const Vec2f v_center(0.5f*prj->viewportXywh[2],0.5f*prj->viewportXywh[3]);
-	const float R = v_center.length();
-	const float d = (v_center-center).length();
+	const float R = v_center.norm();
+	const float d = (v_center-center).norm();
 	if (d > r+R || d < r-R)
 		return;
 	const int segments = 180;

--- a/src/core/StelProjector.cpp
+++ b/src/core/StelProjector.cpp
@@ -404,8 +404,8 @@ void StelProjector::computeBoundingCap()
 	bool ok = unProject(static_cast<double>(viewportXywh[0]+0.5f*viewportXywh[2]), static_cast<double>(viewportXywh[1]+0.5f*viewportXywh[3]), boundingCap.n);
 	// The central point should be at a valid position by definition.
 	// When center is offset, this assumption may not hold however.
-	Q_ASSERT(ok || (viewportCenterOffset.lengthSquared()>0) );
-	const bool needNormalization = fabs(boundingCap.n.lengthSquared()-1.)>0.00000001;
+	Q_ASSERT(ok || (viewportCenterOffset.normSquared()>0) );
+	const bool needNormalization = fabs(boundingCap.n.normSquared()-1.)>0.00000001;
 
 	// Now need to determine the aperture
 	Vec3d e0,e1,e2,e3,e4,e5;

--- a/src/core/StelSphereGeometry.cpp
+++ b/src/core/StelSphereGeometry.cpp
@@ -472,8 +472,8 @@ bool SphericalCap::intersectionPoints(const SphericalCap& h1, const SphericalCap
 	const double& b2 = n2[1];
 	const double& c2 = n2[2];
 
-	Q_ASSERT(fabs(n1.lengthSquared()-1.)<0.000001);
-	Q_ASSERT(fabs(n2.lengthSquared()-1.)<0.000001);
+	Q_ASSERT(fabs(n1.normSquared()-1.)<0.000001);
+	Q_ASSERT(fabs(n2.normSquared()-1.)<0.000001);
 
 	// Compute the parametric equation of the line at the intersection of the 2 planes
 	Vec3d u = n1^n2;
@@ -521,7 +521,7 @@ bool SphericalCap::intersectionPoints(const SphericalCap& h1, const SphericalCap
 	// The points are on the unit sphere x^2+y^2+z^2=1, replace x, y and z by the parametric equation to get something of the form at^2+b*t+c=0
 	// const double a = 1.;
 	const double b = p0*u*2.;
-	const double c = p0.lengthSquared()-1.;
+	const double c = p0.normSquared()-1.;
 
 	// If discriminant <=0, zero or 1 real solution
 	const double D = b*b-4.*c;
@@ -534,8 +534,8 @@ bool SphericalCap::intersectionPoints(const SphericalCap& h1, const SphericalCap
 	p1 = p0+u*t1;
 	p2 = p0+u*t2;
 
-	Q_ASSERT(fabs(p1.lengthSquared()-1.)<0.000001);
-	Q_ASSERT(fabs(p2.lengthSquared()-1.)<0.000001);
+	Q_ASSERT(fabs(p1.normSquared()-1.)<0.000001);
+	Q_ASSERT(fabs(p2.normSquared()-1.)<0.000001);
 
 	return true;
 }
@@ -592,7 +592,7 @@ QVector<Vec3d> SphericalCap::getClosedOutlineContour() const
 	QVector<Vec3d> contour;
 	Vec3d p(n);
 	Vec3d axis = n^Vec3d(1,0,0);
-	if (axis.lengthSquared()<0.1)
+	if (axis.normSquared()<0.1)
 		axis = n^Vec3d(0,1,0);	// Improve precision
 	p.transfo4d(Mat4d::rotation(axis, std::acos(d)));
 	const Mat4d& rot = Mat4d::rotation(n, -2.*M_PI/nbStep);
@@ -876,7 +876,7 @@ StelVertexArray SphericalConvexPolygon::getFillVertexArray(const Vec3d &observer
 		aberratedContour.clear();
 		for (const Vec3d &v: qAsConst(contour))
 		{
-			Q_ASSERT(qAbs(v.lengthSquared()-1.0)<0.0001);
+			Q_ASSERT(qAbs(v.normSquared()-1.0)<0.0001);
 			Vec3d vec=v+observerVelocityForAberration;
 			aberratedContour.append(vec);
 		}
@@ -899,7 +899,7 @@ StelVertexArray SphericalConvexPolygon::getOutlineVertexArray(Vec3d observerVelo
 		aberratedContour.clear();
 		for (const Vec3d &v: qAsConst(contour))
 		{
-			Q_ASSERT(qAbs(v.lengthSquared()-1.0)<0.0001);
+			Q_ASSERT(qAbs(v.normSquared()-1.0)<0.0001);
 			Vec3d vec=v+observerVelocityForAberration;
 			aberratedContour.append(vec);
 		}
@@ -1111,7 +1111,7 @@ StelVertexArray SphericalTexturedConvexPolygon::getFillVertexArray(const Vec3d &
 		aberratedContour.clear();
 		for (const Vec3d &v: qAsConst(contour))
 		{
-			Q_ASSERT(qAbs(v.lengthSquared()-1.0)<0.0001);
+			Q_ASSERT(qAbs(v.normSquared()-1.0)<0.0001);
 			Vec3d vec=v+observerVelocityForAberration;
 			aberratedContour.append(vec);
 		}
@@ -1180,11 +1180,11 @@ Vec3d greatCircleIntersection(const Vec3d& p1, const Vec3d& p2, const Vec3d& n2,
 		return p1;
 	}
 	Vec3d n1 = p1^p2;
-	Q_ASSERT(std::fabs(n2.lengthSquared()-1.)<0.00000001);
+	Q_ASSERT(std::fabs(n2.normSquared()-1.)<0.00000001);
 	n1.normalize();
 	// Compute the parametric equation of the line at the intersection of the 2 planes
 	Vec3d u = n1^n2;
-	if (u.length()<1e-7)
+	if (u.norm()<1e-7)
 	{
 		// The planes are parallel
 		ok = false;

--- a/src/core/StelSphereGeometry.hpp
+++ b/src/core/StelSphereGeometry.hpp
@@ -302,7 +302,7 @@ public:
 	//! @param an a unit vector indicating the direction.
 	//! @param ar cosinus of the aperture.
 	SphericalCap(const Vec3d& an, double ar) : SphericalRegion(), n(an), d(ar) {//n.normalize();
-		Q_ASSERT(d==0 || qFuzzyCompare(n.lengthSquared(),1.));}
+		Q_ASSERT(d==0 || qFuzzyCompare(n.normSquared(),1.));}
 	// FIXME: GZ reports 2013-03-02: apparently the Q_ASSERT is here because n should be normalized at this point, but
 	// for efficiency n.normalize() should not be called at this point.
 	// However, when zooming in a bit in Hammer-Aitoff and Mercator projections, this Assertion fires.
@@ -333,8 +333,8 @@ public:
 	virtual SphericalCap getBoundingCap() const Q_DECL_OVERRIDE {return *this;}
 
 	// Contain and intersect	
-	virtual bool contains(const Vec3d &v) const Q_DECL_OVERRIDE {Q_ASSERT(d==0 || std::fabs(v.lengthSquared()-1.)<0.0000002);return (v*n>=d);}
-	virtual bool contains(const Vec3f &v) const {Q_ASSERT(d==0 || std::fabs(v.lengthSquared()-1.f)<0.000002f);return (v.toVec3d()*n>=d);}
+	virtual bool contains(const Vec3d &v) const Q_DECL_OVERRIDE {Q_ASSERT(d==0 || std::fabs(v.normSquared()-1.)<0.0000002);return (v*n>=d);}
+	virtual bool contains(const Vec3f &v) const {Q_ASSERT(d==0 || std::fabs(v.normSquared()-1.f)<0.000002f);return (v.toVec3d()*n>=d);}
 	virtual bool contains(const SphericalConvexPolygon& r) const Q_DECL_OVERRIDE;
 	virtual bool contains(const SphericalCap& h) const Q_DECL_OVERRIDE
 	{
@@ -449,7 +449,7 @@ inline bool sideHalfSpaceIntersects(const Vec3d& v1, const Vec3d& v2, const Sphe
 class SphericalPoint : public SphericalRegion
 {
 public:
-	SphericalPoint(const Vec3d& an) : n(an) {Q_ASSERT(std::fabs(1.-n.length())<0.0000001);}
+	SphericalPoint(const Vec3d& an) : n(an) {Q_ASSERT(std::fabs(1.-n.norm())<0.0000001);}
 	SphericalPoint(const SphericalPoint &other): n(other.n){}
 	inline SphericalPoint& operator=(const SphericalPoint &other){n=other.n; return *this;}
 	virtual ~SphericalPoint() Q_DECL_OVERRIDE {;}

--- a/src/core/StelToast.cpp
+++ b/src/core/StelToast.cpp
@@ -151,7 +151,7 @@ void ToastTile::prepareDraw(Vec3f color)
 		for (int i=0; i<originalVertexArray.size(); i++)
 		{
 			Vec3d vert=originalVertexArray.at(i);
-			Q_ASSERT_X(fabs(vert.lengthSquared()-1.0)<0.0001, "StelToast aberration", "vertex length not unity");
+			Q_ASSERT_X(fabs(vert.normSquared()-1.0)<0.0001, "StelToast aberration", "vertex length not unity");
 			vert+=vel;
 			vert.normalize();
 
@@ -173,7 +173,7 @@ void ToastTile::prepareDraw(Vec3f color)
 		for (int i=0; i<vertexArray.size(); ++i)
 		{
 			Vec3d vertAltAz=core->j2000ToAltAz(vertexArray.at(i), StelCore::RefractionOn);
-			Q_ASSERT(fabs(vertAltAz.lengthSquared()-1.0) < 0.001);
+			Q_ASSERT(fabs(vertAltAz.normSquared()-1.0) < 0.001);
 
 			float oneMag=0.0f;
 			extinction.forward(vertAltAz, &oneMag);

--- a/src/core/StelUtils.hpp
+++ b/src/core/StelUtils.hpp
@@ -259,7 +259,7 @@ namespace StelUtils
 	//! @param lat double* to store latitude in radian
 	//! @param v the input 3D vector
 	inline void rectToSphe(double *lng, double *lat, const Vec3d& v){
-		double r = v.length();
+		double r = v.norm();
 		*lat = asin(v[2]/r);
 		*lng = atan2(v[1],v[0]);
 	}
@@ -269,7 +269,7 @@ namespace StelUtils
 	//! @param lat float* to store latitude in radian
 	//! @param v the input 3D vector
 	inline void rectToSphe(float *lng, float *lat, const Vec3d& v){
-		double r = v.length();
+		double r = v.norm();
 		*lat = static_cast<float>(asin(v[2]/r));
 		*lng = static_cast<float>(atan2(v[1],v[0]));
 	}
@@ -280,7 +280,7 @@ namespace StelUtils
 	//! @param lat float* to store latitude in radian
 	//! @param v the input 3D vector
 	inline void rectToSphe(float *lng, float *lat, const Vec3f& v){
-		float r = v.length();
+		float r = v.norm();
 		*lat = asinf(v[2]/r);
 		*lng = atan2f(v[1],v[0]);
 	}
@@ -290,7 +290,7 @@ namespace StelUtils
 	//! @param lat double* to store latitude in radian
 	//! @param v the input 3D vector
 	inline void rectToSphe(double *lng, double *lat, const Vec3f &v){
-		double r = static_cast<double>(v.length());
+		double r = static_cast<double>(v.norm());
 		*lat = asin(static_cast<double>(v[2])/r);
 		*lng = atan2(static_cast<double>(v[1]),static_cast<double>(v[0]));
 	}
@@ -311,7 +311,7 @@ namespace StelUtils
 	//! @param r double*   length of radius vector (distance)
 	//! @param v the input 3D vector
 	inline void rectToSphe(double *lng, double *lat, double *r, const Vec3d& v){
-		*r = v.length();
+		*r = v.norm();
 		*lat = asin(v[2] / *r);
 		*lng = atan2(v[1],v[0]);
 	}

--- a/src/core/StelViewportEffect.cpp
+++ b/src/core/StelViewportEffect.cpp
@@ -144,7 +144,7 @@ StelViewportDistorterFisheyeToSphericMirror::StelViewportDistorterFisheyeToSpher
 				rc &= prj->forward(v);
 				const float x = static_cast<float>(newProjectorParams.viewportCenter[0]) + v[0] * view_scaling_factor;
 				const float y = static_cast<float>(newProjectorParams.viewportCenter[1]) + v[1] * view_scaling_factor;
-				vertex_point.h = rc ? static_cast<double>((vX^vY).length()) : 0.0;
+				vertex_point.h = rc ? static_cast<double>((vX^vY).norm()) : 0.0;
 
 				// sharp image up to the border of the fisheye image, at the cost of
 				// accepting clamping artefacts. You can get rid of the clamping

--- a/src/core/VecMath.hpp
+++ b/src/core/VecMath.hpp
@@ -154,8 +154,16 @@ public:
 
 	inline T dot(const Vector2<T>&) const;
 
-	inline T length() const;
-	inline T lengthSquared() const;
+	T length() const = delete; // Use norm()
+	T lengthSquared() const = delete; // Use normSquared()
+	//! Norm of the vector, also known as length
+	//
+	// The name "length" is not used to avoid mistakes when porting C++ code to
+	// GLSL, where length() method returns number of elements instead of the
+	// norm (and actual norm is computed by a free function called length).
+	inline T norm() const;
+	//! Square of the norm of the vector, same as dot product with itself
+	inline T normSquared() const;
 	inline void normalize();
 
 	//! Formatted string with brackets
@@ -243,8 +251,16 @@ public:
 	inline T angle(const Vector3<T>&) const;
 	inline T angleNormalized(const Vector3<T>&) const;
 
-	inline T length() const;
-	inline T lengthSquared() const;
+	T length() const = delete; // Use norm()
+	T lengthSquared() const = delete; // Use normSquared()
+	//! Norm of the vector, also known as length
+	//
+	// The name "length" is not used to avoid mistakes when porting C++ code to
+	// GLSL, where length() method returns number of elements instead of the
+	// norm (and actual norm is computed by a free function called length).
+	inline T norm() const;
+	//! Square of the norm of the vector, same as dot product with itself
+	inline T normSquared() const;
 	inline void normalize();
 
 	inline void transfo4d(const Mat4d&);
@@ -334,8 +350,16 @@ public:
 
 	inline T dot(const Vector4<T>&) const;
 
-	inline T length() const;
-	inline T lengthSquared() const;
+	T length() const = delete; // Use norm()
+	T lengthSquared() const = delete; // Use normSquared()
+	//! Norm of the vector, also known as length
+	//
+	// The name "length" is not used to avoid mistakes when porting C++ code to
+	// GLSL, where length() method returns number of elements instead of the
+	// norm (and actual norm is computed by a free function called length).
+	inline T norm() const;
+	//! Square of the norm of the vector, same as dot product with itself
+	inline T normSquared() const;
 	inline void normalize();
 
 	inline void transfo4d(const Mat4d&);
@@ -661,12 +685,12 @@ template<class T> T Vector2<T>::dot(const Vector2<T>& b) const
 }
 
 
-template<class T> T Vector2<T>::length() const
+template<class T> T Vector2<T>::norm() const
 {
 	return static_cast<T>(std::sqrt(v[0] * v[0] + v[1] * v[1]));
 }
 
-template<class T> T Vector2<T>::lengthSquared() const
+template<class T> T Vector2<T>::normSquared() const
 {
 	return v[0] * v[0] + v[1] * v[1];
 }
@@ -839,7 +863,7 @@ template<class T> Vector3<T> Vector3<T>::operator^(const Vector3<T>& b) const
 // Angle in radian between two vectors
 template<class T> T Vector3<T>::angle(const Vector3<T>& b) const
 {
-	const T cosAngle = dot(b)/std::sqrt(lengthSquared()*b.lengthSquared());
+	const T cosAngle = dot(b)/std::sqrt(normSquared()*b.normSquared());
 	return cosAngle>=1 ? 0 : (cosAngle<=-1 ? M_PI : std::acos(cosAngle));
 }
 
@@ -850,12 +874,12 @@ template<class T> T Vector3<T>::angleNormalized(const Vector3<T>& b) const
 	return cosAngle>=1 ? 0 : (cosAngle<=-1 ? M_PI : std::acos(cosAngle));
 }
 
-template<class T> T Vector3<T>::length() const
+template<class T> T Vector3<T>::norm() const
 {
 	return static_cast<T>(std::sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2]));
 }
 
-template<class T> T Vector3<T>::lengthSquared() const
+template<class T> T Vector3<T>::normSquared() const
 {
 	return v[0] * v[0] + v[1] * v[1] + v[2] * v[2];
 }
@@ -899,7 +923,7 @@ template<class T> Vec3d Vector3<T>::toVec3d() const
 // Return latitude in rad
 template<class T> T Vector3<T>::latitude() const
 {
-	return std::asin(v[2]/length());
+	return std::asin(v[2]/norm());
 }
 
 // Return longitude in rad
@@ -1050,12 +1074,12 @@ template<class T> T Vector4<T>::dot(const Vector4<T>& b) const
 	return v[0] * b.v[0] + v[1] * b.v[1] + v[2] * b.v[2] + v[3] * b.v[3];
 }
 
-template<class T> T Vector4<T>::length() const
+template<class T> T Vector4<T>::norm() const
 {
 	return static_cast<T>(std::sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2] + v[3] * v[3]));
 }
 
-template<class T> T Vector4<T>::lengthSquared() const
+template<class T> T Vector4<T>::normSquared() const
 {
 	return v[0] * v[0] + v[1] * v[1] + v[2] * v[2] + v[3] * v[3];
 }

--- a/src/core/modules/AtmospherePreetham.cpp
+++ b/src/core/modules/AtmospherePreetham.cpp
@@ -235,7 +235,7 @@ void AtmospherePreetham::computeColor(StelCore* core, const double JD, const Pla
 	}
 
 	auto sunPos  =  sun.getAltAzPosAuto(core);
-	if (qIsNaN(sunPos.length()))
+	if (qIsNaN(sunPos.norm()))
 		sunPos.set(0.,0.,-1.);
 
 	Vec3d moonPos = sunPos;
@@ -249,13 +249,13 @@ void AtmospherePreetham::computeColor(StelCore* core, const double JD, const Pla
 	if (moon)
 	{
 		moonPos = moon->getAltAzPosAuto(core);
-		if (qIsNaN(moonPos.length()))
+		if (qIsNaN(moonPos.norm()))
 			moonPos.set(0.,0.,-1.);
 
 		// Update the eclipse intensity factor to apply on atmosphere model
 		// these are for radii
-		const double sun_angular_radius = atan(sun.getEquatorialRadius()/sunPos.length());
-		const double moon_angular_radius = atan(moon->getEquatorialRadius()/moonPos.length());
+		const double sun_angular_radius = atan(sun.getEquatorialRadius()/sunPos.norm());
+		const double moon_angular_radius = atan(moon->getEquatorialRadius()/moonPos.norm());
 		const double touch_angle = sun_angular_radius + moon_angular_radius;
 
 		// determine luminance falloff during solar eclipses
@@ -340,7 +340,7 @@ void AtmospherePreetham::computeColor(StelCore* core, const double JD, const Pla
 		const Vec2f &v(posGrid[i]);
 		prj->unProject(static_cast<double>(v[0]),static_cast<double>(v[1]),point);
 
-		Q_ASSERT(fabs(point.lengthSquared()-1.0) < 1e-10);
+		Q_ASSERT(fabs(point.normSquared()-1.0) < 1e-10);
 
 		Vec3f pointF=point.toVec3f();
 		if (!noScatter)

--- a/src/core/modules/AtmosphereShowMySky.cpp
+++ b/src/core/modules/AtmosphereShowMySky.cpp
@@ -740,13 +740,13 @@ bool AtmosphereShowMySky::dynamicResolution(StelProjectorP prj, Vec3d &currPos, 
 	prj->project(currPos,currSun);
 	const auto dFad=1e3*(currFad-prevFad);				// per thousand of the fader
 	const auto dFov=2e3*(currFov-prevFov)/(currFov+prevFov);	// per thousand of the field of view
-	const auto dPos=1e3*(currPos-prevPos).length();			// milli-AU :)
-	const auto dSun=(currSun-prevSun).length();			// pixel
+	const auto dPos=1e3*(currPos-prevPos).norm();			// milli-AU :)
+	const auto dSun=(currSun-prevSun).norm();			// pixel
 	const auto changeOfView=Vec4d(dFad,dFov,dPos,dSun);
 	const auto allowedChange=eclipseFactor<1?10e-3:1;		// for solar eclipses, prioritize speed over resolution
 	const auto hysteresis=atmoRes==1?1:200e-3;			// hysteresis avoids frequent changing of the resolution
 	const auto allowedChangeOfView=allowedChange*hysteresis;
-	const auto changed=changeOfView.length()>allowedChangeOfView;	// change is too big
+	const auto changed=changeOfView.norm()>allowedChangeOfView;	// change is too big
 	const auto timeout=dynResTimer<=0;				// do we have a timeout?
 	// if we don't have a timeout or too much change, we skip the frame
 	if (!changed && !timeout)
@@ -763,7 +763,7 @@ bool AtmosphereShowMySky::dynamicResolution(StelProjectorP prj, Vec3d &currPos, 
 		resizeRenderTarget(width, height);
 		bool verbose=qApp->property("verbose").toBool();
 		if (verbose)
-			qDebug() << "dynResTimer" << dynResTimer << "atmoRes" << atmoRes << "changeOfView" << changeOfView.length() << changeOfView;
+			qDebug() << "dynResTimer" << dynResTimer << "atmoRes" << atmoRes << "changeOfView" << changeOfView.norm() << changeOfView;
 	}
 	// At reduced resolution, we hurry to redraw - at full resolution, we have time.
 	dynResTimer=timeout?17:5;
@@ -810,15 +810,15 @@ void AtmosphereShowMySky::computeColor(StelCore* core, const double JD, const Pl
 		}
 
 		auto sunPos  =  sun.getAltAzPosAuto(core);
-		if (std::isnan(sunPos.length()))
+		if (std::isnan(sunPos.norm()))
 			sunPos.set(0, 0, -1);
 
 		// if we run dynamic resolution mode and don't have a timeout or too much change, we skip the frame
 		if (dynamicResolution(prj, sunPos, width, height))
 			return;
 
-		const auto sunDir = sunPos / sunPos.length();
-		const double sunAngularRadius = atan(sun.getEquatorialRadius()/sunPos.length());
+		const auto sunDir = sunPos / sunPos.norm();
+		const double sunAngularRadius = atan(sun.getEquatorialRadius()/sunPos.norm());
 
 		// If we have no moon, just put it into nadir
 		Vec3d moonDir{0.,0.,-1.};
@@ -828,11 +828,11 @@ void AtmosphereShowMySky::computeColor(StelCore* core, const double JD, const Pl
 		if (moon)
 		{
 			auto moonPos = moon->getAltAzPosAuto(core);
-			if (std::isnan(moonPos.length()))
+			if (std::isnan(moonPos.norm()))
 				moonPos.set(0, 0, -1);
-			moonDir = moonPos / moonPos.length();
+			moonDir = moonPos / moonPos.norm();
 
-			const double moonAngularRadius = atan(moon->getEquatorialRadius()/moonPos.length());
+			const double moonAngularRadius = atan(moon->getEquatorialRadius()/moonPos.norm());
 			const double separationAngle = std::acos(sunDir.dot(moonDir));  // angle between them
 
 			sunVisibility_ = sunVisibilityDueToMoon(sunAngularRadius, moonAngularRadius, separationAngle);
@@ -841,7 +841,7 @@ void AtmosphereShowMySky::computeColor(StelCore* core, const double JD, const Pl
 
 			const Vec3d earthGeomPos = currentPlanet.getAltAzPosGeometric(core);
 			const Vec3d moonGeomPos = moon->getAltAzPosGeometric(core);
-			earthMoonDistance = (earthGeomPos - moonGeomPos).length() * (AU*1000);
+			earthMoonDistance = (earthGeomPos - moonGeomPos).norm() * (AU*1000);
 		}
 		else
 		{

--- a/src/core/modules/GridLinesMgr.cpp
+++ b/src/core/modules/GridLinesMgr.cpp
@@ -553,7 +553,7 @@ void SkyGrid::draw(const StelCore* core) const
 		// Draw the arc in 2 sub-arcs to avoid lengths > 180 deg
 		Vec3d middlePoint = p1-rotCenter+p2-rotCenter;
 		middlePoint.normalize();
-		middlePoint*=(p1-rotCenter).length();
+		middlePoint*=(p1-rotCenter).norm();
 		middlePoint+=rotCenter;
 		if (!viewPortSphericalCap.contains(middlePoint))
 		{
@@ -607,7 +607,7 @@ void SkyGrid::draw(const StelCore* core) const
 			// Draw the arc in 2 sub-arcs to avoid lengths > 180 deg
 			Vec3d middlePoint = p1-rotCenter+p2-rotCenter;
 			middlePoint.normalize();
-			middlePoint*=(p1-rotCenter).length();
+			middlePoint*=(p1-rotCenter).norm();
 			middlePoint+=rotCenter;
 			if (!viewPortSphericalCap.contains(middlePoint))
 			{
@@ -834,7 +834,7 @@ void SkyLine::draw(StelCore *core) const
 			StelUtils::rectToSphe(&lambda, &beta, dir);
 			const QPair<Vec3d, Vec3d> radii=GETSTELMODULE(SolarSystem)->getEarthShadowRadiiAtLunarDistance();
 			const double radius=(line_type==EARTH_UMBRA ? radii.first[1] : radii.second[1]);
-			const double dist=moon->getEclipticPos().length();  // geocentric Lunar distance [AU]
+			const double dist=moon->getEclipticPos().norm();  // geocentric Lunar distance [AU]
 			const Mat4d rot=Mat4d::zrotation(lambda)*Mat4d::yrotation(-beta);
 
 			StelVertexArray circle(StelVertexArray::LineLoop);
@@ -885,7 +885,7 @@ void SkyLine::draw(StelCore *core) const
 				// Draw the arc in 2 sub-arcs to avoid lengths > 180 deg
 				Vec3d middlePoint = p1-rotCenter+p2-rotCenter;
 				middlePoint.normalize();
-				middlePoint*=(p1-rotCenter).length();
+				middlePoint*=(p1-rotCenter).norm();
 				middlePoint+=rotCenter;
 				if (!viewPortSphericalCap.contains(middlePoint))
 				{
@@ -1484,7 +1484,7 @@ void SkyPoint::updateLabel()
 			QSharedPointer<Planet> planet=core->getCurrentObserver()->getHomePlanet();
 			Q_ASSERT(planet);
 			const Vec3d dir=planet->getHeliocentricEclipticVelocity();
-			const double speed=dir.length()*(AU/86400.0);
+			const double speed=dir.norm()*(AU/86400.0);
 			// In some cases we don't have a valid speed vector
 			if (speed>0.)
 			{
@@ -1592,7 +1592,7 @@ void SkyPoint::draw(StelCore *core) const
 			const Vec3d dir= - sun->getAberrationPush() + pos;
 			double lambda, beta;
 			StelUtils::rectToSphe(&lambda, &beta, dir);
-			const double dist=GETSTELMODULE(SolarSystem)->getMoon()->getEclipticPos().length();
+			const double dist=GETSTELMODULE(SolarSystem)->getMoon()->getEclipticPos().norm();
 			const Mat4d rot=Mat4d::zrotation(lambda)*Mat4d::yrotation(-beta);
 
 			Vec3d point(dist, 0.0, 0.0);
@@ -1609,7 +1609,7 @@ void SkyPoint::draw(StelCore *core) const
 			Q_ASSERT(planet);
 			const Vec3d dir=planet->getHeliocentricEclipticVelocity();
 			// In some cases we don't have a valid speed vector
-			if (dir.lengthSquared()>0.)
+			if (dir.normSquared()>0.)
 			{
 				sPainter.drawSprite2dMode(dir, 5.f);
 				sPainter.drawText(dir, northernLabel, 0, shift, shift, false);

--- a/src/core/modules/Meteor.cpp
+++ b/src/core/modules/Meteor.cpp
@@ -110,7 +110,7 @@ void Meteor::init(const float& radiantAlpha, const float& radiantDelta,
 	positionAltAz.transfo4d(m_matAltAzToRadiant);
 
 	// find the angle from horizon to meteor
-	float meteorAlt = static_cast<float>(std::asin(positionAltAz[2] / positionAltAz.length()));
+	float meteorAlt = static_cast<float>(std::asin(positionAltAz[2] / positionAltAz.norm()));
 
 	// this meteor should not be visible if it is above the maximum altitude
 	// or if it's below the horizon!
@@ -212,7 +212,7 @@ bool Meteor::update(double deltaTime)
 	}
 
 	// update apparent magnitude based on distance to observer
-	float scale = std::pow(m_minDist / static_cast<float>(m_position.length()), 2);
+	float scale = std::pow(m_minDist / static_cast<float>(m_position.norm()), 2);
 	m_aptMag = m_absMag * qMin(scale, 1.f);
 	m_aptMag = qMax(m_aptMag, 0.f);
 

--- a/src/core/modules/MilkyWay.cpp
+++ b/src/core/modules/MilkyWay.cpp
@@ -133,7 +133,7 @@ void MilkyWay::draw(StelCore* core)
 		for (int i=0; i<vertexArrayNoAberration->vertex.size(); ++i)
 		{
 			Vec3d vert=vertexArrayNoAberration->vertex.at(i);
-			Q_ASSERT_X(fabs(vert.lengthSquared()-1.0)<0.0001, "Milky Way aberration", "vertex length not unity");
+			Q_ASSERT_X(fabs(vert.normSquared()-1.0)<0.0001, "Milky Way aberration", "vertex length not unity");
 			vert+=vel;
 			vert.normalize();
 
@@ -218,7 +218,7 @@ void MilkyWay::draw(StelCore* core)
 		for (int i=0; i<vertexArray->vertex.size(); ++i)
 		{
 			Vec3d vertAltAz=core->j2000ToAltAz(vertexArray->vertex.at(i), StelCore::RefractionOn);
-			Q_ASSERT(fabs(vertAltAz.lengthSquared()-1.0) < 0.001);
+			Q_ASSERT(fabs(vertAltAz.normSquared()-1.0) < 0.001);
 
 			float mag=0.0f;
 			extinction.forward(vertAltAz, &mag);

--- a/src/core/modules/MinorPlanet.cpp
+++ b/src/core/modules/MinorPlanet.cpp
@@ -215,10 +215,10 @@ float MinorPlanet::getVMagnitude(const StelCore* core) const
 	//(Code copied from Planet::getVMagnitude())
 	//(this is actually vector subtraction + the cosine theorem :))
 	const Vec3d& observerHelioPos = core->getObserverHeliocentricEclipticPos();
-	const float observerRq = static_cast<float>(observerHelioPos.lengthSquared());
+	const float observerRq = static_cast<float>(observerHelioPos.normSquared());
 	const Vec3d& planetHelioPos = getHeliocentricEclipticPos();
-	const float planetRq = static_cast<float>(planetHelioPos.lengthSquared());
-	const float observerPlanetRq = static_cast<float>((observerHelioPos - planetHelioPos).lengthSquared());
+	const float planetRq = static_cast<float>(planetHelioPos.normSquared());
+	const float observerPlanetRq = static_cast<float>((observerHelioPos - planetHelioPos).normSquared());
 	const float cos_chi = (observerPlanetRq + planetRq - observerRq)/(2.0f*std::sqrt(observerPlanetRq*planetRq));
 	const float phaseAngle = std::acos(cos_chi);
 

--- a/src/core/modules/Nebula.cpp
+++ b/src/core/modules/Nebula.cpp
@@ -1013,7 +1013,7 @@ void Nebula::readDSO(QDataStream &in)
 	if (VdBHa_nb > 0) designations << QString("vdB-Ha %1").arg(VdBHa_nb);
 
 	StelUtils::spheToRect(ra,dec,XYZ);
-	Q_ASSERT(fabs(XYZ.lengthSquared()-1.)<1e-9);
+	Q_ASSERT(fabs(XYZ.normSquared()-1.)<1e-9);
 	nType = static_cast<Nebula::NebulaType>(oType);
 	pointRegion = SphericalRegionP(new SphericalPoint(getJ2000EquatorialPos(Q_NULLPTR)));
 }
@@ -1424,7 +1424,7 @@ Vec3d Nebula::getJ2000EquatorialPos(const StelCore* core) const
 	if ((core) && (core->getUseAberration()) && (core->getCurrentPlanet()))
 	{
 		Vec3d pos=XYZ;
-		Q_ASSERT_X(fabs(pos.lengthSquared()-1.0)<0.0001, "Nebula aberration", "vertex length not unity");
+		Q_ASSERT_X(fabs(pos.normSquared()-1.0)<0.0001, "Nebula aberration", "vertex length not unity");
 		//pos.normalize(); // Yay - not required!
 		Vec3d vel=core->getCurrentPlanet()->getHeliocentricEclipticVelocity();
 		vel=StelCore::matVsop87ToJ2000*vel*core->getAberrationFactor()*(AU/(86400.0*SPEED_OF_LIGHT));

--- a/src/core/modules/NomenclatureItem.cpp
+++ b/src/core/modules/NomenclatureItem.cpp
@@ -158,7 +158,7 @@ float NomenclatureItem::getSelectPriority(const StelCore* core) const
 
 	// Exclude if the planet is too faint for view (in deep shadow for example),
 	// or if feature is on far-side of the planet
-	if (planet->getVMagnitude(core)>=20.f || (planet->getJ2000EquatorialPos(core).lengthSquared() < getJ2000EquatorialPos(core).lengthSquared()))
+	if (planet->getVMagnitude(core)>=20.f || (planet->getJ2000EquatorialPos(core).normSquared() < getJ2000EquatorialPos(core).normSquared()))
 		return 1.e12f;
 
 	// Start with a priority just slightly lower than the carrier planet,
@@ -342,7 +342,7 @@ Vec3d NomenclatureItem::getJ2000EquatorialPos(const StelCore* core) const
 // Return apparent semidiameter
 double NomenclatureItem::getAngularRadius(const StelCore* core) const
 {
-	return std::atan2(0.5*size*planet->getSphereScale()/AU, getJ2000EquatorialPos(core).length()) * M_180_PI;
+	return std::atan2(0.5*size*planet->getSphereScale()/AU, getJ2000EquatorialPos(core).norm()) * M_180_PI;
 }
 
 float NomenclatureItem::getAngularDiameterRatio(const StelCore *core) const
@@ -358,7 +358,7 @@ void NomenclatureItem::draw(StelCore* core, StelPainter *painter)
 	Vec3d XYZ = getJ2000EquatorialPos(core);
 
 	// In case we are located at a labeled site, don't show this label or any labels within 150 km. Else we have bad flicker...
-	if (XYZ.lengthSquared() < 150.*150.*AU_KM*AU_KM )
+	if (XYZ.normSquared() < 150.*150.*AU_KM*AU_KM )
 		return;
 
 	if (getFlagHideLocalNomenclature())
@@ -380,7 +380,7 @@ void NomenclatureItem::draw(StelCore* core, StelPainter *painter)
 			return;
 	}
 
-	if (painter->getProjector()->projectCheck(XYZ, srcPos) && (equPos.lengthSquared() >= XYZ.lengthSquared())
+	if (painter->getProjector()->projectCheck(XYZ, srcPos) && (equPos.normSquared() >= XYZ.normSquared())
 	    && (scale>0.04f && (scale<0.5f || niType>=NomenclatureItem::niSpecialPointPole )))
 	{
 		float brightness=(getSolarAltitude(core)<0. ? 0.25f : 1.0f);

--- a/src/core/modules/NomenclatureMgr.cpp
+++ b/src/core/modules/NomenclatureMgr.cpp
@@ -286,7 +286,7 @@ void NomenclatureMgr::draw(StelCore* core)
 		// Early exit if the planet is not visible or too small to render the labels.
 		const Vec3d equPos = p->getJ2000EquatorialPos(core);
 		const double r = p->getEquatorialRadius() * static_cast<double>(p->getSphereScale());
-		double angularSize = atan2(r, equPos.length());
+		double angularSize = atan2(r, equPos.norm());
 		double screenSize = angularSize * static_cast<double>(painter.getProjector()->getPixelPerRadAtCenter());
 		if (screenSize < 50)
 			continue;

--- a/src/core/modules/Planet.cpp
+++ b/src/core/modules/Planet.cpp
@@ -530,7 +530,7 @@ QString Planet::getInfoString(const StelCore* core, const InfoStringGroup& flags
 {
 	QString str;
 	QTextStream oss(&str);
-	const double distanceAu = getJ2000EquatorialPos(core).length();
+	const double distanceAu = getJ2000EquatorialPos(core).norm();
 
 	if (flags&Name)
 	{
@@ -649,7 +649,7 @@ QString Planet::getInfoString(const StelCore* core, const InfoStringGroup& flags
 
 	if (flags&Distance)
 	{
-		const double hdistanceAu = getHeliocentricEclipticPos().length();
+		const double hdistanceAu = getHeliocentricEclipticPos().norm();
 		const double hdistanceKm = AU * hdistanceAu;
 		// TRANSLATORS: Unit of measure for distance - astronomical unit
 		QString au = qc_("AU", "distance, astronomical unit");
@@ -701,12 +701,12 @@ QString Planet::getInfoString(const StelCore* core, const InfoStringGroup& flags
 		QString kms = qc_("km/s", "speed");
 
 		const Vec3d orbitalVel=getEclipticVelocity();
-		const double orbVel=orbitalVel.length();
+		const double orbVel=orbitalVel.norm();
 		if (orbVel>0.)
 		{ // AU/d * km/AU /24
 			const double orbVelKms=orbVel* AU/86400.;
 			oss << QString("%1: %2 %3<br/>").arg(q_("Orbital velocity")).arg(orbVelKms, 0, 'f', 3).arg(kms);
-			const double helioVel=getHeliocentricEclipticVelocity().length();
+			const double helioVel=getHeliocentricEclipticVelocity().norm();
 			if (!fuzzyEquals(helioVel, orbVel))
 				oss << QString("%1: %2 %3<br/>").arg(q_("Heliocentric velocity")).arg(helioVel* AU/86400., 0, 'f', 3).arg(kms);
 		}
@@ -927,10 +927,10 @@ SolarEclipseBessel::SolarEclipseBessel(double &besX, double &besY,
 	StelUtils::rectToSphe(&raSun, &deSun, ssystem->getSun()->getEquinoxEquatorialPos(core));
 	StelUtils::rectToSphe(&raMoon, &deMoon, ssystem->getMoon()->getEquinoxEquatorialPos(core));
 
-	double sdistanceAu = ssystem->getSun()->getEquinoxEquatorialPos(core).length();
+	double sdistanceAu = ssystem->getSun()->getEquinoxEquatorialPos(core).norm();
 	const double earthRadius = ssystem->getEarth()->getEquatorialRadius()*AU;
 	// Moon's distance in Earth's radius
-	double mdistanceER = ssystem->getMoon()->getEquinoxEquatorialPos(core).length() * AU / earthRadius;
+	double mdistanceER = ssystem->getMoon()->getEquinoxEquatorialPos(core).norm() * AU / earthRadius;
 	// Greenwich Apparent Sidereal Time
 	const double gast = get_apparent_sidereal_time(core->getJD(), core->getJDE());
 
@@ -1506,7 +1506,7 @@ QVariantMap Planet::getInfoMap(const StelCore *core) const
 	if (getEnglishName()!="Sun")
 	{
 		const Vec3d& observerHelioPos = core->getObserverHeliocentricEclipticPos();
-		map.insert("distance", getJ2000EquatorialPos(core).length());
+		map.insert("distance", getJ2000EquatorialPos(core).norm());
 		float phase=getPhase(observerHelioPos);
 		map.insert("phase", phase);
 		map.insert("illumination", 100.f*phase);
@@ -1519,9 +1519,9 @@ QVariantMap Planet::getInfoMap(const StelCore *core) const
 		map.insert("elongation-dms", StelUtils::radToDmsStr(elongation));
 		map.insert("elongation-deg", StelUtils::radToDecDegStr(elongation));
 		map.insert("velocity", getEclipticVelocity().toString());
-		map.insert("velocity-kms", QString::number(getEclipticVelocity().length()* AU/86400., 'f', 5));
+		map.insert("velocity-kms", QString::number(getEclipticVelocity().norm()* AU/86400., 'f', 5));
 		map.insert("heliocentric-velocity", getHeliocentricEclipticVelocity().toString());
-		map.insert("heliocentric-velocity-kms", QString::number(getHeliocentricEclipticVelocity().length()* AU/86400., 'f', 5));
+		map.insert("heliocentric-velocity-kms", QString::number(getHeliocentricEclipticVelocity().norm()* AU/86400., 'f', 5));
 		map.insert("scale", sphereScale);		
 		map.insert("albedo", getAlbedo());
 	}
@@ -1618,7 +1618,7 @@ QPair<double,double> Planet::getLunarEclipseMagnitudes() const
 	if (raDiff < 3.*M_PI_180 || raDiff > 357.*M_PI_180)
 	{
 		// Moon's semi-diameter
-		const double mSD=atan(getEquatorialRadius()/eclipticPos.length()) * M_180_PI*3600.; // arcsec
+		const double mSD=atan(getEquatorialRadius()/eclipticPos.norm()) * M_180_PI*3600.; // arcsec
 		const QPair<Vec3d,Vec3d>shadowRadii=ssystem->getEarthShadowRadiiAtLunarDistance();
 		const double f1 = shadowRadii.second[0]; // radius of penumbra at the distance of the Moon
 		const double f2 = shadowRadii.first[0];  // radius of umbra at the distance of the Moon
@@ -1667,16 +1667,16 @@ Vec3f Planet::getInfoColor(void) const
 
 double Planet::getCloseViewFov(const StelCore* core) const
 {
-	return std::atan(equatorialRadius*sphereScale*2./getEquinoxEquatorialPos(core).length())*M_180_PI * 4.;
+	return std::atan(equatorialRadius*sphereScale*2./getEquinoxEquatorialPos(core).norm())*M_180_PI * 4.;
 }
 
 double Planet::getSatellitesFov(const StelCore* core) const
 {
 	// TODO: calculate from satellite orbits rather than hard code
-	if (englishName=="Jupiter") return std::atan(0.005 /getEquinoxEquatorialPos(core).length())*M_180_PI * 4.;
-	if (englishName=="Saturn")  return std::atan(0.005 /getEquinoxEquatorialPos(core).length())*M_180_PI * 4.;
-	if (englishName=="Mars")    return std::atan(0.0001/getEquinoxEquatorialPos(core).length())*M_180_PI * 4.;
-	if (englishName=="Uranus")  return std::atan(0.002 /getEquinoxEquatorialPos(core).length())*M_180_PI * 4.;
+	if (englishName=="Jupiter") return std::atan(0.005 /getEquinoxEquatorialPos(core).norm())*M_180_PI * 4.;
+	if (englishName=="Saturn")  return std::atan(0.005 /getEquinoxEquatorialPos(core).norm())*M_180_PI * 4.;
+	if (englishName=="Mars")    return std::atan(0.0001/getEquinoxEquatorialPos(core).norm())*M_180_PI * 4.;
+	if (englishName=="Uranus")  return std::atan(0.002 /getEquinoxEquatorialPos(core).norm())*M_180_PI * 4.;
 	return -1.;
 }
 
@@ -1770,7 +1770,7 @@ static bool willCastShadow(const Planet* thisPlanet, const Planet* p, const Plan
 	const Vec3d planetPos = p->getHeliocentricEclipticPos();
 	
 	// If the planet p is farther from the sun than this planet, it can't cast shadow on it.
-	if (planetPos.lengthSquared()>thisPos.lengthSquared())
+	if (planetPos.normSquared()>thisPos.normSquared())
 		return false;
 
 	// Very tentative solution
@@ -1779,11 +1779,11 @@ static bool willCastShadow(const Planet* thisPlanet, const Planet* p, const Plan
 	
 	double shadowDistance = ppVector * thisPos;
 	static const double sunRadius = SUN_RADIUS/AU;
-	const double d = planetPos.length() / (p->getEquatorialRadius()/sunRadius+1);
+	const double d = planetPos.norm() / (p->getEquatorialRadius()/sunRadius+1);
 	double penumbraRadius = (shadowDistance-d)/d*sunRadius;
 	// TODO: Note that Earth's shadow should be enlarged a bit. (6-7% following Danjon?)
 	
-	double penumbraCenterToThisPlanetCenterDistance = (ppVector*shadowDistance-thisPos).length();
+	double penumbraCenterToThisPlanetCenterDistance = (ppVector*shadowDistance-thisPos).norm();
 	
 	if (penumbraCenterToThisPlanetCenterDistance<penumbraRadius+thisPlanet->getEquatorialRadius())
 		return true;
@@ -2155,7 +2155,7 @@ Vec3d Planet::getHeliocentricEclipticVelocity() const
 // This is called by SolarSystem::draw()
 double Planet::computeDistance(const Vec3d& obsHelioPos)
 {
-	distance = (obsHelioPos-getHeliocentricEclipticPos()).length();
+	distance = (obsHelioPos-getHeliocentricEclipticPos()).norm();
 	// improve fps by juggling updates for asteroids and other minor bodies. They must be fast if close to observer, but can be slow if further away.
 	if (pType >= Planet::isAsteroid)
 		deltaJDE=distance*StelCore::JD_SECOND;
@@ -2165,20 +2165,20 @@ double Planet::computeDistance(const Vec3d& obsHelioPos)
 // Get the phase angle (radians) for an observer at pos obsPos in heliocentric coordinates (dist in AU)
 double Planet::getPhaseAngle(const Vec3d& obsPos) const
 {
-	const double observerRq = obsPos.lengthSquared();
+	const double observerRq = obsPos.normSquared();
 	const Vec3d& planetHelioPos = getHeliocentricEclipticPos();
-	const double planetRq = planetHelioPos.lengthSquared();
-	const double observerPlanetRq = (obsPos - planetHelioPos).lengthSquared();
+	const double planetRq = planetHelioPos.normSquared();
+	const double observerPlanetRq = (obsPos - planetHelioPos).normSquared();
 	return std::acos((observerPlanetRq + planetRq - observerRq)/(2.0*std::sqrt(observerPlanetRq*planetRq)));
 }
 
 // Get the planet phase ([0..1] illuminated fraction of the planet disk) for an observer at pos obsPos in heliocentric coordinates (in AU)
 float Planet::getPhase(const Vec3d& obsPos) const
 {
-	const double observerRq = obsPos.lengthSquared();
+	const double observerRq = obsPos.normSquared();
 	const Vec3d& planetHelioPos = getHeliocentricEclipticPos();
-	const double planetRq = planetHelioPos.lengthSquared();
-	const double observerPlanetRq = (obsPos - planetHelioPos).lengthSquared();
+	const double planetRq = planetHelioPos.normSquared();
+	const double observerPlanetRq = (obsPos - planetHelioPos).normSquared();
 	const double cos_chi = (observerPlanetRq + planetRq - observerRq)/(2.0*std::sqrt(observerPlanetRq*planetRq));
 	return 0.5f * static_cast<float>(qAbs(1. + cos_chi));
 }
@@ -2245,7 +2245,7 @@ QPair<Vec4d, Vec3d> Planet::getSubSolarObserverPoints(const StelCore *core, bool
 	Vec3d n=PrecNut*Vec3d(cosd0*cosa0, cosd0*sina0, sind0);
 	// Rotation W is OK for all planets except Jupiter: return simple W_II to remove GRS adaptation shift.
 	const double W= ( ((englishName=="Jupiter") && !jupiterGraphical )  ?
-			re.W0+ remainder( (core->getJDE()-J2000 - Dr.length()*(AU/(SPEED_OF_LIGHT*86400.)))*re.W1, 360.) :
+			re.W0+ remainder( (core->getJDE()-J2000 - Dr.norm()*(AU/(SPEED_OF_LIGHT*86400.)))*re.W1, 360.) :
 			re.currentAxisW);
 	const double sinW=sin(W*M_PI_180);
 	const double sindw=sinW*cosd0;
@@ -2298,10 +2298,10 @@ QPair<Vec4d, Vec3d> Planet::getSubSolarObserverPoints(const StelCore *core, bool
 // Get the elongation angle (radians) for an observer at pos obsPos in heliocentric coordinates (dist in AU)
 double Planet::getElongation(const Vec3d& obsPos) const
 {
-	const double observerRq = obsPos.lengthSquared();
+	const double observerRq = obsPos.normSquared();
 	const Vec3d& planetHelioPos = getHeliocentricEclipticPos();
-	const double planetRq = planetHelioPos.lengthSquared();
-	const double observerPlanetRq = (obsPos - planetHelioPos).lengthSquared();
+	const double planetRq = planetHelioPos.normSquared();
+	const double observerPlanetRq = (obsPos - planetHelioPos).normSquared();
 	return std::acos((observerPlanetRq  + observerRq - planetRq)/(2.0*std::sqrt(observerPlanetRq*observerRq)));
 }
 
@@ -2357,7 +2357,7 @@ float Planet::getVMagnitude(const StelCore* core) const
 	{
 		// Sun, compute the apparent magnitude for the absolute mag (V: 4.83) and observer's distance
 		// Hint: Absolute Magnitude of the Sun in Several Bands: http://mips.as.arizona.edu/~cnaw/sun.html
-		const double distParsec = std::sqrt(core->getObserverHeliocentricEclipticPos().lengthSquared())*AU/PARSEC;
+		const double distParsec = std::sqrt(core->getObserverHeliocentricEclipticPos().normSquared())*AU/PARSEC;
 
 		// check how much of it is visible
 		const double shadowFactor = qMax(0.000128, GETSTELMODULE(SolarSystem)->getSolarEclipseFactor(core).first);
@@ -2369,10 +2369,10 @@ float Planet::getVMagnitude(const StelCore* core) const
 
 	// Compute the phase angle i. We need the intermediate results also below, therefore we don't just call getPhaseAngle.
 	const Vec3d& observerHelioPos = core->getObserverHeliocentricEclipticPos();
-	const double observerRq = observerHelioPos.lengthSquared();
+	const double observerRq = observerHelioPos.normSquared();
 	const Vec3d& planetHelioPos = getHeliocentricEclipticPos();
-	const double planetRq = planetHelioPos.lengthSquared();
-	const double observerPlanetRq = (observerHelioPos - planetHelioPos).lengthSquared();
+	const double planetRq = planetHelioPos.normSquared();
+	const double observerPlanetRq = (observerHelioPos - planetHelioPos).normSquared();
 	const double dr = std::sqrt(observerPlanetRq*planetRq);
 	const double cos_chi = (observerPlanetRq + planetRq - observerRq)/(2.0*dr);
 	const double phaseAngle = std::acos(cos_chi);
@@ -2382,7 +2382,7 @@ float Planet::getVMagnitude(const StelCore* core) const
 	if (parent->parent != Q_NULLPTR)
 	{
 		const Vec3d& parentHeliopos = parent->getHeliocentricEclipticPos();
-		const double parent_Rq = parentHeliopos.lengthSquared();
+		const double parent_Rq = parentHeliopos.normSquared();
 		const double pos_times_parent_pos = planetHelioPos * parentHeliopos;
 		if (pos_times_parent_pos > parent_Rq)
 		{
@@ -2392,7 +2392,7 @@ float Planet::getVMagnitude(const StelCore* core) const
 				static const double totalityFactor=2.710e-5; // defined previously by AW
 				const SolarSystem* ssm = GETSTELMODULE(SolarSystem);
 				const QPair<Vec3d,Vec3d>shadowRadii=ssm->getEarthShadowRadiiAtLunarDistance();
-				const double dist=getEclipticPos().length();  // Lunar distance [AU]
+				const double dist=getEclipticPos().norm();  // Lunar distance [AU]
 				const double u=shadowRadii.first[0]  / 3600.; // geocentric angle of earth umbra radius at lunar distance [degrees]
 				const double p=shadowRadii.second[0] / 3600.; // geocentric angle of earth penumbra radius at lunar distance [degrees]
 				const double r=atan(getEquatorialRadius()/dist) * M_180_PI; // geocentric angle of Lunar radius at lunar distance [degrees]
@@ -2400,10 +2400,10 @@ float Planet::getVMagnitude(const StelCore* core) const
 				// We must compute an elongation from the aberrated sun. The following is adapted from getElongation(), with a tweak to move the Sun to its apparent position.
 				PlanetP sun=ssm->getSun();
 				const Vec3d obsPos=parent->eclipticPos-sun->getAberrationPush();
-				const double observerRq = obsPos.lengthSquared();
+				const double observerRq = obsPos.normSquared();
 				const Vec3d& planetHelioPos = getHeliocentricEclipticPos() - sun->getAberrationPush();
-				const double planetRq = planetHelioPos.lengthSquared();
-				const double observerPlanetRq = dist*dist; // (obsPos - planetHelioPos).lengthSquared();
+				const double planetRq = planetHelioPos.normSquared();
+				const double observerPlanetRq = dist*dist; // (obsPos - planetHelioPos).normSquared();
 				double aberratedElongation = std::acos((observerPlanetRq  + observerRq - planetRq)/(2.0*std::sqrt(observerPlanetRq*observerRq)));
 				const double od = 180. - aberratedElongation * (180.0/M_PI); // opposition distance [degrees]
 
@@ -2473,8 +2473,8 @@ float Planet::getVMagnitude(const StelCore* core) const
 		fluxIll *= (lunarMeanDistSq/observerPlanetRq);
 
 		// compute flux of ashen light: Agrawal 2016.
-		const double beta=parent->equatorialRadius*parent->equatorialRadius/eclipticPos.lengthSquared();
-		const double gamma=equatorialRadius*equatorialRadius/eclipticPos.lengthSquared();
+		const double beta=parent->equatorialRadius*parent->equatorialRadius/eclipticPos.normSquared();
+		const double gamma=equatorialRadius*equatorialRadius/eclipticPos.normSquared();
 
 		const double slfoe=133100.; // https://www.allthingslighting.org/index.php/2019/02/15/solar-illumination/
 		const double LumEarth=slfoe * static_cast<double>(core->getCurrentObserver()->getHomePlanet()->albedo);
@@ -2840,13 +2840,13 @@ float Planet::getVMagnitude(const StelCore* core) const
 double Planet::getAngularRadius(const StelCore* core) const
 {
 	const double rad = (rings ? rings->getSize() : equatorialRadius);
-	return std::atan2(rad*sphereScale,getJ2000EquatorialPos(core).length()) * M_180_PI;
+	return std::atan2(rad*sphereScale,getJ2000EquatorialPos(core).norm()) * M_180_PI;
 }
 
 
 double Planet::getSpheroidAngularRadius(const StelCore* core) const
 {
-	return std::atan2(equatorialRadius*sphereScale,getJ2000EquatorialPos(core).length()) * M_180_PI;
+	return std::atan2(equatorialRadius*sphereScale,getJ2000EquatorialPos(core).norm()) * M_180_PI;
 }
 
 //the Planet and all the related infos : name, circle etc..
@@ -2925,7 +2925,7 @@ void Planet::draw(StelCore* core, float maxMagLabels, const QFont& planetNameFon
 	{
 		// Draw the name, and the circle if it's not too close from the body it's turning around
 		// this prevents name overlapping (e.g. for Jupiter's satellites)
-		float ang_dist = 300.f*static_cast<float>(atan(getEclipticPos().length()/getEquinoxEquatorialPos(core).length())/core->getMovementMgr()->getCurrentFov());
+		float ang_dist = 300.f*static_cast<float>(atan(getEclipticPos().norm()/getEquinoxEquatorialPos(core).norm())/core->getMovementMgr()->getCurrentFov());
 		if (ang_dist==0.f)
 			ang_dist = 1.f; // if ang_dist == 0, the Planet is sun..
 
@@ -3484,7 +3484,7 @@ void Planet::draw3dModel(StelCore* core, StelProjector::ModelViewTranformP trans
 		if(rings)
 			r+=rings->getSize()*sphereScale;
 
-		const double dist = getEquinoxEquatorialPos(core).length();
+		const double dist = getEquinoxEquatorialPos(core).norm();
 		const double z_near = qMax(0.00001, (dist - r)); //near Z should be as close as possible to the actual geometry
 		const double z_far  = (dist + 10*r); //far Z should be quite a bit further behind (Z buffer accuracy is worse near the far plane)
 		core->setClippingPlanes(z_near,z_far);
@@ -3778,8 +3778,8 @@ void Planet::computeModelMatrix(Mat4d &result, bool solarEclipseCase) const
 		PlanetP sun=GETSTELMODULE(SolarSystem)->getSun();
 		// in our program we have no aberration push for the moon. We must take that info from the Sun's push instead
 		// It seems that a distance proportional to the distance lunarDistance/solarDistance may be the right way (?)
-		const double earthSunDistance=parent->eclipticPos.length();
-		const double earthMoonDistance=eclipticPos.length();
+		const double earthSunDistance=parent->eclipticPos.norm();
+		const double earthMoonDistance=eclipticPos.norm();
 		const double factor=earthMoonDistance/earthSunDistance;
 		result = Mat4d::translation(factor*sun->getAberrationPush()) * result * Mat4d::zrotation(M_PI/180.*static_cast<double>(axisRotation + 90.f));
 	}
@@ -3859,7 +3859,7 @@ Planet::RenderData Planet::setCommonShaderUniforms(const StelPainter& painter, Q
 		GL(shader->setUniformValue(shaderVars.orenNayarParameters, vec));
 	}
 
-	float outgas_intensity_distanceScaled=static_cast<float>(static_cast<double>(outgas_intensity)/getHeliocentricEclipticPos().lengthSquared()); // ad-hoc function: assume square falloff by distance.
+	float outgas_intensity_distanceScaled=static_cast<float>(static_cast<double>(outgas_intensity)/getHeliocentricEclipticPos().normSquared()); // ad-hoc function: assume square falloff by distance.
 	GL(shader->setUniformValue(shaderVars.outgasParameters, QVector2D(outgas_intensity_distanceScaled, outgas_falloff)));
 
 	return data;
@@ -3976,15 +3976,15 @@ void Planet::drawSphere(StelPainter* painter, float screenRd, bool drawOnlyRing)
 			// Like in getVMagnitude() we must compute an elongation from the aberrated sun.
 			PlanetP sun=ssm->getSun();
 			const Vec3d obsPos=parent->eclipticPos-sun->getAberrationPush();
-			const double observerRq = obsPos.lengthSquared();
+			const double observerRq = obsPos.normSquared();
 			const Vec3d& planetHelioPos = getHeliocentricEclipticPos() - sun->getAberrationPush();
-			const double planetRq = planetHelioPos.lengthSquared();
-			const double observerPlanetRq = (obsPos - planetHelioPos).lengthSquared();
+			const double planetRq = planetHelioPos.normSquared();
+			const double observerPlanetRq = (obsPos - planetHelioPos).normSquared();
 			double aberratedElongation = std::acos((observerPlanetRq  + observerRq - planetRq)/(2.0*std::sqrt(observerPlanetRq*observerRq)));
 			const double od = 180. - aberratedElongation * (180.0/M_PI); // opposition distance [degrees]
 
 			// Compute umbra radius at lunar distance.
-			const double Lambda=getEclipticPos().length();                             // Lunar distance [AU]
+			const double Lambda=getEclipticPos().norm();                             // Lunar distance [AU]
 			const double sigma=ssm->getEarthShadowRadiiAtLunarDistance().first[0]/3600.;
 			const double tau=atan(getEquatorialRadius()/Lambda) * M_180_PI; // geocentric angle of Lunar radius [degrees]
 
@@ -4580,7 +4580,7 @@ bool Planet::drawObjShadowMap(StelPainter *painter, QMatrix4x4& shadowMatrix)
 	painter->setDepthMask(true);
 	painter->setCullFace(true);
 	gl->glCullFace(GL_BACK);
-	bool useOffset = !qFuzzyIsNull(shadowPolyOffset.lengthSquared());
+	bool useOffset = !qFuzzyIsNull(shadowPolyOffset.normSquared());
 
 	if(useOffset)
 	{

--- a/src/core/modules/SolarSystem.cpp
+++ b/src/core/modules/SolarSystem.cpp
@@ -1237,7 +1237,7 @@ void SolarSystem::computePositions(double dateJDE, PlanetP observerPlanet)
 		for (const auto& p : qAsConst(systemPlanets))
 		{
 			//p->setExtraInfoString(StelObject::DebugAid, "");
-			const double lightTimeDays = (p->getHeliocentricEclipticPos()-obsPosJDE).length() * (AU / (SPEED_OF_LIGHT * 86400.));
+			const double lightTimeDays = (p->getHeliocentricEclipticPos()-obsPosJDE).norm() * (AU / (SPEED_OF_LIGHT * 86400.));
 			Vec3d aberrationPush(0.);
 			if (withAberration && (observerPlanet->englishName!="Earth" || p->englishName!="Moon"))
 				aberrationPush=lightTimeDays*aberrationPushSpeed;
@@ -1247,7 +1247,7 @@ void SolarSystem::computePositions(double dateJDE, PlanetP observerPlanet)
 		for (const auto& p : qAsConst(systemPlanets))
 		{
 			//p->setExtraInfoString(StelObject::DebugAid, "");
-			const double lightTimeDays = (p->getHeliocentricEclipticPos()-obsPosJDE).length() * (AU / (SPEED_OF_LIGHT * 86400.));
+			const double lightTimeDays = (p->getHeliocentricEclipticPos()-obsPosJDE).norm() * (AU / (SPEED_OF_LIGHT * 86400.));
 			Vec3d aberrationPush(0.);
 			if (withAberration && (observerPlanet->englishName!="Earth" || p->englishName!="Moon"))
 				aberrationPush=lightTimeDays*aberrationPushSpeed;
@@ -1294,7 +1294,7 @@ void SolarSystem::computeTransMatrices(double dateJDE, const Vec3d& observerPos)
 	{
 		for (const auto& p : qAsConst(systemPlanets))
 		{
-			const double light_speed_correction = (p->getHeliocentricEclipticPos()-observerPos).length() * (AU / (SPEED_OF_LIGHT * 86400));
+			const double light_speed_correction = (p->getHeliocentricEclipticPos()-observerPos).norm() * (AU / (SPEED_OF_LIGHT * 86400));
 			p->computeTransMatrix(dateJD-light_speed_correction, dateJDE-light_speed_correction);
 		}
 	}
@@ -2023,14 +2023,14 @@ bool SolarSystem::nearLunarEclipse() const
 	// shadow location at earth + moon distance along earth vector from (aberrated) sun
 	Vec3d en = e-sun;
 	en.normalize();
-	Vec3d shadow = en * (e.length() + m.length());
+	Vec3d shadow = en * (e.norm() + m.norm());
 
 	// find shadow radii in AU
-	double r_penumbra = shadow.length()*702378.1/AU/e.length() - SUN_RADIUS/AU;
+	double r_penumbra = shadow.norm()*702378.1/AU/e.norm() - SUN_RADIUS/AU;
 
 	// modify shadow location for scaled moon
 	Vec3d mdist = shadow - mh;
-	if(mdist.length() > r_penumbra + 2000./AU) return false;   // not visible so don't bother drawing
+	if(mdist.norm() > r_penumbra + 2000./AU) return false;   // not visible so don't bother drawing
 
 	return true;
 }
@@ -3186,14 +3186,14 @@ QPair<double, PlanetP> SolarSystem::getSolarEclipseFactor(const StelCore* core) 
 
 		Vec3d v1 = Lp - P3;
 		Vec3d v2 = C - P3;
-		const double L = v1.length();
-		const double l = v2.length();
+		const double L = v1.norm();
+		const double l = v2.norm();
 		v1 /= L;
 		v2 /= l;
 
 		const double R = RS / L;
 		const double r = radius / l;
-		const double d = ( v1 - v2 ).length();
+		const double d = ( v1 - v2 ).norm();
 		double illumination;
 
 		if(d >= R + r) // distance too far
@@ -3245,8 +3245,8 @@ QPair<Vec3d,Vec3d> SolarSystem::getEarthShadowRadiiAtLunarDistance() const
 	PlanetP sun=getSun();
 	PlanetP moon=getMoon();
 	PlanetP earth=getEarth();
-	const double lunarDistance=moon->getEclipticPos().length(); // Lunar distance [AU]
-	const double earthDistance=earth->getHeliocentricEclipticPos().length(); // Earth distance [AU]
+	const double lunarDistance=moon->getEclipticPos().norm(); // Lunar distance [AU]
+	const double earthDistance=earth->getHeliocentricEclipticPos().norm(); // Earth distance [AU]
 	const double sunHP =asin(earth->getEquatorialRadius()/earthDistance) * M_180_PI*3600.; // arcsec.
 	const double moonHP=asin(earth->getEquatorialRadius()/lunarDistance) * M_180_PI*3600.; // arcsec.
 	const double sunSD  =atan(sun->getEquatorialRadius()/earthDistance)  * M_180_PI*3600.; // arcsec.

--- a/src/core/modules/StarMgr.cpp
+++ b/src/core/modules/StarMgr.cpp
@@ -1411,7 +1411,7 @@ QList<StelObjectP > StarMgr::searchAround(const Vec3d& vv, double limFov, const 
 	Vec3d e1 = v + h1;
 	Vec3d e2 = v - h0;
 	Vec3d e3 = v - h1;
-	f = 1.0/e0.length();
+	f = 1.0/e0.norm();
 	e0 *= f;
 	e1 *= f;
 	e2 *= f;

--- a/src/core/modules/ZodiacalLight.cpp
+++ b/src/core/modules/ZodiacalLight.cpp
@@ -248,14 +248,14 @@ void ZodiacalLight::draw(StelCore* core)
 		for (int i=0; i<vertexArray->vertex.size(); ++i)
 		{
 			Vec3d eclPos=vertexArray->vertex.at(i);
-			Q_ASSERT(fabs(eclPos.lengthSquared()-1.0) < 0.001);
+			Q_ASSERT(fabs(eclPos.normSquared()-1.0) < 0.001);
 			double ecLon, ecLat, ra, dec;
 			StelUtils::rectToSphe(&ecLon, &ecLat, eclPos);
 			StelUtils::eclToEqu(ecLon, ecLat, epsDate, &ra, &dec);
 			Vec3d eqPos;
 			StelUtils::spheToRect(ra, dec, eqPos);
 			Vec3d vertAltAz=core->equinoxEquToAltAz(eqPos, StelCore::RefractionOn);
-			Q_ASSERT(fabs(vertAltAz.lengthSquared()-1.0) < 0.001);
+			Q_ASSERT(fabs(vertAltAz.normSquared()-1.0) < 0.001);
 
 			float oneMag=0.0f;
 			extinction.forward(vertAltAz, &oneMag);

--- a/src/gui/AstroCalcDialog.cpp
+++ b/src/gui/AstroCalcDialog.cpp
@@ -1224,7 +1224,7 @@ void AstroCalcDialog::currentCelestialPositions()
 				else
 					coordStrings = getStringCoordinates(pos, horizon, useSouthAzimuth, withDecimalDegree);
 
-				QString extra = QString::number(pos.length(), 'f', 5); // A.U.
+				QString extra = QString::number(pos.norm(), 'f', 5); // A.U.
 
 				// Convert to arc-seconds the angular size of Solar system object (with rings, if any)
 				QString angularSize = QString::number(planet->getAngularRadius(core) * 120., 'f', 4);
@@ -1500,7 +1500,7 @@ void AstroCalcDialog::currentHECPositions()
 		if (!planet.isNull())
 		{
 			Vec3d pos = planet->getHeliocentricEclipticPos();
-			double distance = pos.length();
+			double distance = pos.norm();
 			double longitude, latitude;
 			StelUtils::rectToSphe(&longitude, &latitude, pos);
 			if (longitude<0) longitude+=2.0*M_PI;
@@ -1954,7 +1954,7 @@ void AstroCalcDialog::generateEphemeris()
 			treeItem->setTextAlignment(EphemerisMagnitude, Qt::AlignRight);
 			treeItem->setText(EphemerisPhase, phaseStr);
 			treeItem->setTextAlignment(EphemerisPhase, Qt::AlignRight);
-			treeItem->setText(EphemerisDistance, QString::number(obj->getJ2000EquatorialPos(core).length(), 'f', 6));
+			treeItem->setText(EphemerisDistance, QString::number(obj->getJ2000EquatorialPos(core).norm(), 'f', 6));
 			treeItem->setTextAlignment(EphemerisDistance, Qt::AlignRight);
 			treeItem->setToolTip(EphemerisDistance, QString("%1, %2").arg(distanceInfo, distanceUM));
 			treeItem->setText(EphemerisElongation, elongStr.replace("+","",Qt::CaseInsensitive)); // remove sign
@@ -2340,7 +2340,7 @@ LunarEclipseBessel::LunarEclipseBessel(double &besX, double &besY, double &besL1
 	const double raDiff = StelUtils::fmodpos(raMoon-raShadow, 2.*M_PI);
 	besX = std::cos(deMoon)*std::sin(raDiff)*3600.*M_180_PI;
 	besY = (std::cos(deShadow)*std::sin(deMoon)-std::sin(deShadow)*std::cos(deMoon)*std::cos(raDiff))*3600.* M_180_PI;
-	const double dist=moon->getEclipticPos().length();  // geocentric Lunar distance [AU]
+	const double dist=moon->getEclipticPos().norm();  // geocentric Lunar distance [AU]
 	const double mSD=atan(moon->getEquatorialRadius()/dist)*M_180_PI*3600.; // arcsec
 	const QPair<Vec3d,Vec3d>shadowRadii=ssystem->getEarthShadowRadiiAtLunarDistance();
 	const double f1 = shadowRadii.second[0]; // radius of penumbra at the distance of the Moon
@@ -2493,7 +2493,7 @@ void AstroCalcDialog::generateLunarEclipses()
 				// and the American Ephemeris and Nautical Almanac (1961)
 				// Algorithm taken from Planet::getLunarEclipseMagnitudes()
 
-				const double dist=moon->getEclipticPos().length();  // geocentric Lunar distance [AU]
+				const double dist=moon->getEclipticPos().norm();  // geocentric Lunar distance [AU]
 				const double mSD=atan(moon->getEquatorialRadius()/dist) * M_180_PI*3600.; // arcsec
 				double x,y,L1,L2,L3,latitude,longitude;
 				LunarEclipseBessel(x,y,L1,L2,L3,latitude,longitude);
@@ -5075,10 +5075,10 @@ TransitBessel::TransitBessel(PlanetP object, double &besX, double &besY,
 	StelUtils::rectToSphe(&raSun, &deSun, ssystem->getSun()->getEquinoxEquatorialPos(core));
 	StelUtils::rectToSphe(&raPlanet, &dePlanet, object->getEquinoxEquatorialPos(core));
 
-	const double sdistanceAu = ssystem->getSun()->getEquinoxEquatorialPos(core).length();
+	const double sdistanceAu = ssystem->getSun()->getEquinoxEquatorialPos(core).norm();
 	static const double earthRadius = ssystem->getEarth()->getEquatorialRadius()*AU;
 	// Planet's distance in Earth's radius
-	double pdistanceER = object->getEquinoxEquatorialPos(core).length() * AU / earthRadius;
+	double pdistanceER = object->getEquinoxEquatorialPos(core).norm() * AU / earthRadius;
 	// Greenwich Apparent Sidereal Time
 	const double gast = get_apparent_sidereal_time(core->getJD(), core->getJDE());
 	// Avoid bug for special cases happen around Vernal Equinox
@@ -6280,7 +6280,7 @@ double AstroCalcDialog::computeGraphValue(const PlanetP &ssObj, const AstroCalcC
 			break;
 		case AstroCalcChart::Distance1:
 		case AstroCalcChart::Distance2:
-			value =  ssObj->getJ2000EquatorialPos(core).length();
+			value =  ssObj->getJ2000EquatorialPos(core).norm();
 			if (ssObj->getEnglishName()=="Moon")
 				value*=(AU*0.001);
 			break;
@@ -6302,7 +6302,7 @@ double AstroCalcDialog::computeGraphValue(const PlanetP &ssObj, const AstroCalcC
 			break;
 		case AstroCalcChart::HeliocentricDistance1:
 		case AstroCalcChart::HeliocentricDistance2:
-			value =  ssObj->getHeliocentricEclipticPos().length();
+			value =  ssObj->getHeliocentricEclipticPos().norm();
 			break;
 		case AstroCalcChart::TransitAltitude1:
 		case AstroCalcChart::TransitAltitude2:
@@ -6873,7 +6873,7 @@ void AstroCalcDialog::calculatePhenomena()
 			StelObjectP mObj = qSharedPointerCast<StelObject>(sun);
 			if (quadrature)
 			{
-				if (planet->getHeliocentricEclipticPos().length()<core->getCurrentPlanet()->getHeliocentricEclipticPos().length())
+				if (planet->getHeliocentricEclipticPos().norm()<core->getCurrentPlanet()->getHeliocentricEclipticPos().norm())
 				{
 					// greatest elongations for inner planets
 					fillPhenomenaTable(findGreatestElongationApproach(planet, mObj, startJD, stopJD), planet, sun, PhenomenaTypeIndex::GreatestElongation);
@@ -6966,8 +6966,8 @@ void AstroCalcDialog::fillPhenomenaTable(const QMap<double, double> list, const 
 		bool occultation = false;
 		const double s1 = object1->getSpheroidAngularRadius(core);
 		const double s2 = object2->getSpheroidAngularRadius(core);
-		const double d1 = object1->getJ2000EquatorialPos(core).length();
-		const double d2 = object2->getJ2000EquatorialPos(core).length();
+		const double d1 = object1->getJ2000EquatorialPos(core).norm();
+		const double d2 = object2->getJ2000EquatorialPos(core).norm();
 		if (mode==PhenomenaTypeIndex::Shadows) // shadows
 		{
 			phenomenType = q_("Shadow transit");
@@ -7046,9 +7046,9 @@ void AstroCalcDialog::fillPhenomenaTable(const QMap<double, double> list, const 
 		}
 		else if (object1 == sun || object2 == sun) // this is may be superior of inferior conjunction for inner planet
 		{
-			double dcp = planet->getHeliocentricEclipticPos().length();
-			double dp  = (object1 == sun) ? object2->getHeliocentricEclipticPos().length() :
-							object1->getHeliocentricEclipticPos().length();
+			double dcp = planet->getHeliocentricEclipticPos().norm();
+			double dp  = (object1 == sun) ? object2->getHeliocentricEclipticPos().norm() :
+							object1->getHeliocentricEclipticPos().norm();
 			if (dp < dcp) // OK, it's inner planet
 			{
 				if (object1 == sun)
@@ -7231,8 +7231,8 @@ void AstroCalcDialog::fillPhenomenaTable(const QMap<double, double> list, const 
 		bool occultation = false;		
 		const double s1 = object1->getSpheroidAngularRadius(core);
 		const double s2 = object2->getAngularRadius(core);
-		const double d1 = object1->getJ2000EquatorialPos(core).length();
-		const double d2 = object2->getJ2000EquatorialPos(core).length();
+		const double d1 = object1->getJ2000EquatorialPos(core).norm();
+		const double d2 = object2->getJ2000EquatorialPos(core).norm();
 		if (mode==PhenomenaTypeIndex::Opposition)
 		{
 			phenomenType = q_("Opposition");
@@ -7264,12 +7264,12 @@ void AstroCalcDialog::fillPhenomenaTable(const QMap<double, double> list, const 
 		}
 		else if (object1 == sun || object2 == sun) // this is may be superior of inferior conjunction for inner planet
 		{
-			double dcp = (planet->getEquinoxEquatorialPos(core) - sun->getEquinoxEquatorialPos(core)).length();
+			double dcp = (planet->getEquinoxEquatorialPos(core) - sun->getEquinoxEquatorialPos(core)).norm();
 			double dp;
 			if (object1 == sun)
-				dp = (object2->getEquinoxEquatorialPos(core) - sun->getEquinoxEquatorialPos(core)).length();
+				dp = (object2->getEquinoxEquatorialPos(core) - sun->getEquinoxEquatorialPos(core)).norm();
 			else
-				dp = (object1->getEquinoxEquatorialPos(core) - sun->getEquinoxEquatorialPos(core)).length();
+				dp = (object1->getEquinoxEquatorialPos(core) - sun->getEquinoxEquatorialPos(core)).norm();
 			if (dp < dcp) // OK, it's inner planet
 			{
 				if (object1 == sun)
@@ -7833,7 +7833,7 @@ double AstroCalcDialog::findRightAscension(double JD, PlanetP object)
 	const double JDE=JD+core->computeDeltaT(JD)/86400.;
 	const Vec3d obs=core->getCurrentPlanet()->getHeliocentricEclipticPos(JDE);
 	Vec3d body=object->getHeliocentricEclipticPos(JDE);
-	const double distanceCorrection=(body-obs).length() * (AU / (SPEED_OF_LIGHT * 86400.));
+	const double distanceCorrection=(body-obs).norm() * (AU / (SPEED_OF_LIGHT * 86400.));
 	body=object->getHeliocentricEclipticPos(JDE-distanceCorrection);
 	Vec3d bodyJ2000=StelCore::matVsop87ToJ2000.multiplyWithoutTranslation(body - obs);
 	double ra, dec;
@@ -9155,7 +9155,7 @@ void AstroCalcDialog::computePlanetaryData()
 	PlanetP secondCBId = solarSystem->searchByEnglishName(secondCelestialBody);
 	Vec3d posSCB = secondCBId->getJ2000EquatorialPos(core);
 
-	const double distanceAu = (posFCB - posSCB).length();
+	const double distanceAu = (posFCB - posSCB).norm();
 	const double distanceKm = AU * distanceAu;
 	QString degree = QChar(0x00B0);
 	// TRANSLATORS: Unit of measure for distance - kilometers
@@ -9226,11 +9226,11 @@ void AstroCalcDialog::computePlanetaryData()
 	// TRANSLATORS: Unit of measure for speed - kilometers per second
 	QString kms = qc_("km/s", "speed");
 
-	double orbVelFCB = firstCBId->getEclipticVelocity().length();
+	double orbVelFCB = firstCBId->getEclipticVelocity().norm();
 	QString orbitalVelocityFCB = orbVelFCB<=0. ? dash : QString("%1 %2").arg(QString::number(orbVelFCB * AU/86400., 'f', 3), kms);
 	ui->labelOrbitalVelocityFCBValue->setText(orbitalVelocityFCB);
 
-	double orbVelSCB = secondCBId->getEclipticVelocity().length();
+	double orbVelSCB = secondCBId->getEclipticVelocity().norm();
 	QString orbitalVelocitySCB = orbVelSCB<=0. ? dash : QString("%1 %2").arg(QString::number(orbVelSCB * AU/86400., 'f', 3), kms);
 	ui->labelOrbitalVelocitySCBValue->setText(orbitalVelocitySCB);
 
@@ -9293,7 +9293,7 @@ void AstroCalcDialog::drawDistanceGraph()
 		core->update(0.0);
 		Vec3d posFCB = firstCBId->getJ2000EquatorialPos(core);
 		Vec3d posSCB = secondCBId->getJ2000EquatorialPos(core);
-		double distanceAu = (posFCB - posSCB).length();
+		double distanceAu = (posFCB - posSCB).norm();
 		pcChart->append(AstroCalcChart::pcDistanceAU, StelUtils::jdToQDateTime(JD+utcOffset, Qt::UTC).toMSecsSinceEpoch(), distanceAu);
 		if (firstCBId != currentPlanet && secondCBId != currentPlanet)
 		{

--- a/src/gui/AstroCalcDialog.hpp
+++ b/src/gui/AstroCalcDialog.hpp
@@ -630,7 +630,7 @@ private:
 	//! Calculation of perihelion and aphelion points
 	QMap<double, double> findOrbitalPointApproach(PlanetP& object1, double startJD, double stopJD);
 	bool findPreciseOrbitalPoint(QPair<double, double>* out, PlanetP object1, double JD, double stopJD, double step, bool minimal);
-	inline double findHeliocentricDistance(double JD, PlanetP object1) const {return object1->getHeliocentricEclipticPos(JD+core->computeDeltaT(JD)/86400.).length();}
+	inline double findHeliocentricDistance(double JD, PlanetP object1) const {return object1->getHeliocentricEclipticPos(JD+core->computeDeltaT(JD)/86400.).norm();}
 	bool isSecondObjectRight(double JD, PlanetP object1, StelObjectP object2);
 
 	// Signal that a plot has to be redone

--- a/src/tests/testStelSphereGeometry.cpp
+++ b/src/tests/testStelSphereGeometry.cpp
@@ -262,9 +262,9 @@ void TestStelSphericalGeometry::testPlaneIntersect2()
 	hx.d = std::sqrt(2.)/2.;
 	QVERIFY2(SphericalCap::intersectionPoints(hx, hz, p1, p2)==true, "Plane/convex intersect failed");
 	Vec3d res(p1-Vec3d(hx.d,-hx.d,0));
-	QVERIFY2(res.length()<0.0000001, QString("p1 wrong: %1").arg(p1.toString()).toUtf8());
+	QVERIFY2(res.norm()<0.0000001, QString("p1 wrong: %1").arg(p1.toString()).toUtf8());
 	res = p2-Vec3d(hx.d,hx.d,0);
-	QVERIFY2(res.length()<0.0000001, QString("p2 wrong: %1").arg(p2.toString()).toUtf8());
+	QVERIFY2(res.norm()<0.0000001, QString("p2 wrong: %1").arg(p2.toString()).toUtf8());
 }
 
 void TestStelSphericalGeometry::testGreatCircleIntersection()

--- a/src/tests/testVecMath.cpp
+++ b/src/tests/testVecMath.cpp
@@ -62,8 +62,8 @@ void TestVecMath::testVec2Math()
 	QVERIFY(vi.clamp(Vec2i(1,1),Vec2i(10,10))==Vec2i(5,5));
 	QVERIFY(vi.dot(Vec2i(5,5))==50);
 	vi.set(2,2);
-	QVERIFY(vi.length()==2);
-	QVERIFY(vi.lengthSquared()==8);
+	QVERIFY(vi.norm()==2);
+	QVERIFY(vi.normSquared()==8);
 	QVERIFY(vi.toString()==QString("[2, 2]"));
 	Vec2i vt(1,2);
 	QVERIFY(vt==Vec2i(1,2));
@@ -108,8 +108,8 @@ void TestVecMath::testVec2Math()
 	QVERIFY(vf.clamp(Vec2f(1.f,1.f),Vec2f(10.f,10.f))==Vec2f(5.f,5.f));
 	QVERIFY(qAbs(vf.dot(Vec2f(5.f,5.f)) - 50.f) <= ERROR_LIMIT);
 	vf.set(2.f,2.f);
-	QVERIFY(qAbs(vf.length() - 2.82843f) <= ERROR_LIMIT);
-	QVERIFY(qAbs(vf.lengthSquared() - 8.f) <= ERROR_LIMIT);
+	QVERIFY(qAbs(vf.norm() - 2.82843f) <= ERROR_LIMIT);
+	QVERIFY(qAbs(vf.normSquared() - 8.f) <= ERROR_LIMIT);
 	Vec2f vtf(1.f,2.f);
 	QVERIFY(vtf==Vec2f(1.f,2.f));
 	vf = vtf;
@@ -149,8 +149,8 @@ void TestVecMath::testVec2Math()
 	QVERIFY(vd.clamp(Vec2d(1.,1.),Vec2d(10.,10.))==Vec2d(5.,5.));
 	QVERIFY(qAbs(vd.dot(Vec2d(5.,5.)) - 50.) <= ERROR_LIMIT);
 	vd.set(2.,2.);
-	QVERIFY(qAbs(vd.length() - 2.82843) <= ERROR_LIMIT);
-	QVERIFY(qAbs(vd.lengthSquared() - 8.) <= ERROR_LIMIT);
+	QVERIFY(qAbs(vd.norm() - 2.82843) <= ERROR_LIMIT);
+	QVERIFY(qAbs(vd.normSquared() - 8.) <= ERROR_LIMIT);
 	Vec2d vtd(1.,2.);
 	QVERIFY(vtd==Vec2d(1.,2.));
 	vd = vtd;
@@ -219,8 +219,8 @@ void TestVecMath::testVec3Math()
 	vi.set(5,5,5);
 	QVERIFY(vi.dot(Vec3i(5,5,1))==55);
 	vi.set(2,2,2);
-	QVERIFY(vi.length()==3);
-	QVERIFY(vi.lengthSquared()==12);
+	QVERIFY(vi.norm()==3);
+	QVERIFY(vi.normSquared()==12);
 	QVERIFY(vi.toString()==QString("[2, 2, 2]"));
 	vi = Vec3i(1);
 	QVERIFY(vi.toVec3f()==Vec3f(1.f));
@@ -258,8 +258,8 @@ void TestVecMath::testVec3Math()
 	vf.set(5.f,5.f,5.f);
 	QVERIFY(qAbs(vf.dot(Vec3f(5.f,5.f,1.f)) - 55.f) <= ERROR_LIMIT);
 	vf.set(2.f,2.f,2.f);
-	QVERIFY(qAbs(vf.length() - 3.4641016f) <= ERROR_LIMIT);
-	QVERIFY(qAbs(vf.lengthSquared() - 12.f) <= ERROR_LIMIT);
+	QVERIFY(qAbs(vf.norm() - 3.4641016f) <= ERROR_LIMIT);
+	QVERIFY(qAbs(vf.normSquared() - 12.f) <= ERROR_LIMIT);
 	vf = Vec3f(10.f);
 	QVERIFY(vf/2.f==Vec3f(5.f));
 	vf.set(3.f,3.f,3.f);
@@ -302,8 +302,8 @@ void TestVecMath::testVec3Math()
 	vd.set(5.,5.,5.);
 	QVERIFY(qAbs(vd.dot(Vec3d(5.,5.,1.)) - 55.) <= ERROR_LIMIT);
 	vd.set(2.,2.,2.);
-	QVERIFY(qAbs(vd.length() - 3.4641016) <= ERROR_LIMIT);
-	QVERIFY(qAbs(vd.lengthSquared() - 12.) <= ERROR_LIMIT);
+	QVERIFY(qAbs(vd.norm() - 3.4641016) <= ERROR_LIMIT);
+	QVERIFY(qAbs(vd.normSquared() - 12.) <= ERROR_LIMIT);
 	vd = Vec3d(10.);
 	QVERIFY(vd/2.==Vec3d(5.));
 	vd.set(3.,3.,3.);
@@ -377,8 +377,8 @@ void TestVecMath::testVec4Math()
 	vi.set(5,5,5,5);
 	QVERIFY(vi.dot(Vec4i(5,5,1,1))==60);
 	vi.set(2,2,2,2);
-	QVERIFY(vi.length()==4);
-	QVERIFY(vi.lengthSquared()==16);
+	QVERIFY(vi.norm()==4);
+	QVERIFY(vi.normSquared()==16);
 	QVERIFY(vi.toString()==QString("[2, 2, 2, 2]"));
 	Vec4i vt(1,2,3,4);
 	QVERIFY(vt==Vec4i(1,2,3,4));
@@ -414,8 +414,8 @@ void TestVecMath::testVec4Math()
 	vf.set(5.f,5.f,5.f,5.f);
 	QVERIFY(qAbs(vf.dot(Vec4f(5.f,5.f,1.f,1.f))-60.f)<=ERROR_LIMIT);
 	vf.set(2.f,2.f,2.f,2.f);
-	QVERIFY(qAbs(vf.length()-4.f) <= ERROR_LIMIT);
-	QVERIFY(qAbs(vf.lengthSquared()-16.f) <= ERROR_LIMIT);
+	QVERIFY(qAbs(vf.norm()-4.f) <= ERROR_LIMIT);
+	QVERIFY(qAbs(vf.normSquared()-16.f) <= ERROR_LIMIT);
 	Vec4f vg(0.f);
 	QVERIFY2(vg==Vec4f(0.0f, 0.0f, 0.0f, 0.0f), "Vec4f constructor with single constant failed");
 
@@ -440,8 +440,8 @@ void TestVecMath::testVec4Math()
 	vd.set(5.,5.,5.,5.);
 	QVERIFY(qAbs(vd.dot(Vec4d(5.,5.,1.,1.))-60.)<=ERROR_LIMIT);
 	vd.set(2.,2.,2.,2.);
-	QVERIFY(qAbs(vd.length()-4.) <= ERROR_LIMIT);
-	QVERIFY(qAbs(vd.lengthSquared()-16.) <= ERROR_LIMIT);
+	QVERIFY(qAbs(vd.norm()-4.) <= ERROR_LIMIT);
+	QVERIFY(qAbs(vd.normSquared()-16.) <= ERROR_LIMIT);
 
 	QStringList li={"8", "4", "2", "1"};
 	vi=Vec4i(li);


### PR DESCRIPTION
When porting C++ code to GLSL the length() method can lead to hard to diagnose bugs (and I have been bitten by this), because this method in GLSL returns number of elements of a vector, while we supposed to get the norm of the vector. This patch renames the length() method of all VecMath's vectors, and for consistency also lengthSquared(), to say norm instead of length.

The old names are explicitly marked as deleted so that those who write new code don't get surprised by unavailability of these functions.