### PR TITLE
Add support for projection computations on GPU, make MilkyWay and ZodiacalLight use this

### DIFF
--- a/src/StelMainView.cpp
+++ b/src/StelMainView.cpp
@@ -856,6 +856,7 @@ void StelMainView::init()
 	const auto format = glInfo.mainContext->format();
 	glInfo.supportsLuminanceTextures = format.profile() == QSurfaceFormat::CompatibilityProfile ||
 									   format.majorVersion() < 3;
+	glInfo.isGLES = format.renderableType()==QSurfaceFormat::OpenGLES;
 	qDebug().nospace() << "Luminance textures are " << (glInfo.supportsLuminanceTextures ? "" : "not ") << "supported";
 	glInfo.isCoreProfile = format.profile() == QSurfaceFormat::CoreProfile;
 

--- a/src/StelMainView.hpp
+++ b/src/StelMainView.hpp
@@ -74,6 +74,7 @@ public:
 		QOpenGLFunctions* functions;
 		bool supportsLuminanceTextures = false;
 		bool isCoreProfile = false;
+		bool isGLES = false;
 	};
 
 	StelMainView(QSettings* settings);

--- a/src/core/RefractionExtinction.cpp
+++ b/src/core/RefractionExtinction.cpp
@@ -25,6 +25,8 @@
 #include "RefractionExtinction.hpp"
 #include "StelUtils.hpp"
 
+#include <QOpenGLShaderProgram>
+
 Extinction::Extinction() : ext_coeff(50), undergroundExtinctionMode(UndergroundExtinctionMirror)
 {
 }
@@ -57,6 +59,52 @@ float Extinction::airmass(float cosZ, const bool apparent_z) const
 		const float denum=((cosZ+0.149864f)*cosZ+0.0102963f)*cosZ+0.000303978f;
 		return nom/denum;
 	}
+}
+
+QByteArray Extinction::getForwardTransformShader() const
+{
+	return QByteArray(1+R"(
+uniform int EXTINCTION_undergroundExtinctionMode;
+float EXTINCTION_airmass(float cosZ, bool apparent_z)
+{
+	if(cosZ<-0.035) // about -2 degrees. Here, RozenbergZ>574 and climbs fast!
+	{
+		if(EXTINCTION_undergroundExtinctionMode == UndergroundExtinctionZero)
+			return 0.;
+		else if(EXTINCTION_undergroundExtinctionMode == UndergroundExtinctionMax)
+			return 42.;
+		else if(EXTINCTION_undergroundExtinctionMode == UndergroundExtinctionMirror)
+			cosZ = min(1., -0.035 - (cosZ+0.035));
+	}
+
+	if(apparent_z)
+	{
+		// Rozenberg 1966, reported by Schaefer (1993-2000).
+		return 1.0/(cosZ+0.025*exp(-11.*cosZ));
+	}
+	else
+	{
+		//Young 1994
+		float nom=(1.002432*cosZ+0.148386)*cosZ+0.0096467;
+		float denum=((cosZ+0.149864)*cosZ+0.0102963)*cosZ+0.000303978;
+		return nom/denum;
+	}
+}
+
+uniform float EXTINCTION_ext_coeff;
+float extinctionMagnitude(vec3 altAzPos)
+{
+	return EXTINCTION_airmass(altAzPos[2], false) * EXTINCTION_ext_coeff;
+}
+)").replace("UndergroundExtinctionZero", std::to_string(int(UndergroundExtinctionZero)).c_str())
+   .replace("UndergroundExtinctionMax", std::to_string(int(UndergroundExtinctionMax)).c_str())
+   .replace("UndergroundExtinctionMirror", std::to_string(int(UndergroundExtinctionMirror)).c_str());
+}
+
+void Extinction::setForwardTransformUniforms(QOpenGLShaderProgram& program) const
+{
+	program.setUniformValue("EXTINCTION_undergroundExtinctionMode", int(undergroundExtinctionMode));
+	program.setUniformValue("EXTINCTION_ext_coeff", GLfloat(ext_coeff));
 }
 
 /* ***************************************************************************************************** */
@@ -228,6 +276,88 @@ void Refraction::backward(Vec3f& altAzPos) const
 	innerRefractionBackward(vf);
 	altAzPos.set(static_cast<float>(vf[0]), static_cast<float>(vf[1]), static_cast<float>(vf[2]));
 	altAzPos.transfo4d(invertPreTransfoMatf);
+}
+
+QByteArray Refraction::getForwardTransformShader() const
+{
+	return QByteArray(1+R"(
+uniform float REFRACTION_press_temp_corr;
+vec3 innerRefractionForward(vec3 altAzPos)
+{
+	const float PI = 3.14159265;
+	const float M_180_PI = 180./PI;
+	const float M_PI_180 = PI/180.;
+	const float MIN_GEO_ALTITUDE_DEG=@MIN_GEO_ALTITUDE_DEG@;
+	const float TRANSITION_WIDTH_GEO_DEG=@TRANSITION_WIDTH_GEO_DEG@;
+
+	float press_temp_corr = REFRACTION_press_temp_corr;
+
+	float len = length(altAzPos);
+	if (len==0.0)
+	{
+		// Under some circumstances there are zero coordinates. Just leave them alone.
+		return altAzPos;
+	}
+
+	float sinGeo = altAzPos[2]/len;
+	float geom_alt_rad = asin(sinGeo);
+	float geom_alt_deg = M_180_PI*geom_alt_rad;
+	if (geom_alt_deg > MIN_GEO_ALTITUDE_DEG)
+	{
+		// refraction from Saemundsson, S&T1986 p70 / in Meeus, Astr.Alg.
+		float r=press_temp_corr * ( 1.02 / tan((geom_alt_deg+10.3/(geom_alt_deg+5.11))*M_PI_180) + 0.0019279);
+		geom_alt_deg += r;
+		if (geom_alt_deg > 90.)
+			geom_alt_deg=90.;
+	}
+	else if(geom_alt_deg>MIN_GEO_ALTITUDE_DEG-TRANSITION_WIDTH_GEO_DEG)
+	{
+		// Avoids the jump below -5 by interpolating linearly between MIN_GEO_ALTITUDE_DEG and bottom of transition zone
+		float r_m5=press_temp_corr * ( 1.02 / tan((MIN_GEO_ALTITUDE_DEG+10.3/(MIN_GEO_ALTITUDE_DEG+5.11))*M_PI_180) + 0.0019279);
+		geom_alt_deg += r_m5*(geom_alt_deg-(MIN_GEO_ALTITUDE_DEG-TRANSITION_WIDTH_GEO_DEG))/TRANSITION_WIDTH_GEO_DEG;
+	}
+	else return altAzPos;
+	// At this point we have corrected geometric altitude. Note that if we just change altAzPos[2], we would change vector length, so this would change our angles.
+	// We have to shorten X,Y components of the vector as well by the change in cosines of altitude, or (sqrt(1-sin(alt))
+
+	float refr_alt_rad=geom_alt_deg*M_PI_180;
+	float sinRef=sin(refr_alt_rad);
+
+	// FIXME: do we really need double's mantissa length here as a comment in the C++ code says?
+	float shortenxy = abs(sinGeo)>=1.0 ? 1.0 : sqrt((1.-sinRef*sinRef)/(1.-sinGeo*sinGeo));
+
+	altAzPos[0]*=shortenxy;
+	altAzPos[1]*=shortenxy;
+	altAzPos[2]=sinRef*len;
+
+	return altAzPos;
+}
+
+uniform mat4 REFRACTION_preTransfoMat;
+uniform mat4 REFRACTION_postTransfoMat;
+
+vec3 vertexToAltAzPos(vec3 v)
+{
+	vec3 altAzPosNotRefracted = (REFRACTION_preTransfoMat * vec4(v,1)).xyz;
+	return innerRefractionForward(altAzPosNotRefracted);
+}
+
+vec3 modelViewForwardTransform(vec3 v)
+{
+	vec3 altAzPos = vertexToAltAzPos(v);
+	return (REFRACTION_postTransfoMat * vec4(altAzPos, 1)).xyz;
+}
+
+#define HAVE_REFRACTION
+)").replace("@MIN_GEO_ALTITUDE_DEG@", std::to_string(MIN_GEO_ALTITUDE_DEG).c_str())
+   .replace("@TRANSITION_WIDTH_GEO_DEG@", std::to_string(TRANSITION_WIDTH_GEO_DEG).c_str());
+}
+
+void Refraction::setForwardTransformUniforms(QOpenGLShaderProgram& program) const
+{
+	program.setUniformValue("REFRACTION_press_temp_corr", GLfloat(press_temp_corr));
+	program.setUniformValue("REFRACTION_preTransfoMat", preTransfoMatf.toQMatrix());
+	program.setUniformValue("REFRACTION_postTransfoMat", postTransfoMatf.toQMatrix());
 }
 
 void Refraction::setPressure(float p)

--- a/src/core/RefractionExtinction.hpp
+++ b/src/core/RefractionExtinction.hpp
@@ -156,6 +156,8 @@ public:
 
 	QByteArray getForwardTransformShader() const override;
 	void setForwardTransformUniforms(QOpenGLShaderProgram& program) const override;
+	QByteArray getBackwardTransformShader() const override;
+	void setBackwardTransformUniforms(QOpenGLShaderProgram& program) const override;
 
 	StelProjector::ModelViewTranformP clone() const Q_DECL_OVERRIDE {Refraction* refr = new Refraction(); *refr=*this; return StelProjector::ModelViewTranformP(refr);}
 

--- a/src/core/RefractionExtinction.hpp
+++ b/src/core/RefractionExtinction.hpp
@@ -101,6 +101,9 @@ public:
 	//! Rozenberg is infinite at Z=92.17 deg, Young at Z=93.6 deg, so this function RETURNS SUBHORIZONTAL_AIRMASS BELOW -2 DEGREES!
 	float airmass(float cosZ, const bool apparent_z=true) const;
 
+	QByteArray getForwardTransformShader() const;
+	void setForwardTransformUniforms(QOpenGLShaderProgram& program) const;
+
 private:
 	//! k, magnitudes/airmass, in [0.00, ... 1.00], (default 0.20).
 	float ext_coeff;
@@ -150,6 +153,9 @@ public:
 	}
 
 	Mat4d getApproximateLinearTransfo() const Q_DECL_OVERRIDE {return postTransfoMat*preTransfoMat;}
+
+	QByteArray getForwardTransformShader() const override;
+	void setForwardTransformUniforms(QOpenGLShaderProgram& program) const override;
 
 	StelProjector::ModelViewTranformP clone() const Q_DECL_OVERRIDE {Refraction* refr = new Refraction(); *refr=*this; return StelProjector::ModelViewTranformP(refr);}
 

--- a/src/core/StelCore.cpp
+++ b/src/core/StelCore.cpp
@@ -2919,10 +2919,23 @@ QByteArray StelCore::getAberrationShader() const
 {
 	return 1+R"(
 uniform vec3 STELCORE_currentPlanetHeliocentricEclipticVelocity;
+// objectDir points to the object as viewed from its comoving frame.
+// Return value represents the apparent direction to this object from a frame
+// that moves with respect to the object at slightly relativistic speeds (v<0.1c).
+// Relative error in aberration angle is about 0.5v/c.
 vec3 applyAberrationToObject(vec3 objectDir)
 {
 	vec3 velocity = STELCORE_currentPlanetHeliocentricEclipticVelocity;
 	return normalize(objectDir + velocity);
+}
+// viewDir is the direction where the object appears to be when viewed from a
+// frame that moves with respect to it at slightly relativistic speeds (v<0.1c).
+// Return value represents the direction to the object as viewed from its comoving frame.
+// Relative error in aberration angle is about 0.5v/c.
+vec3 applyAberrationToViewDir(vec3 viewDir)
+{
+	vec3 velocity = STELCORE_currentPlanetHeliocentricEclipticVelocity;
+	return normalize(viewDir - velocity);
 }
 )";
 }

--- a/src/core/StelCore.cpp
+++ b/src/core/StelCore.cpp
@@ -534,7 +534,7 @@ void StelCore::updateMaximumFov()
 {
 	const float savedFov = currentProjectorParams.fov;
 	currentProjectorParams.fov = 0.0001f;	// Avoid crash
-	const float newMaxFov = getProjection(StelProjector::ModelViewTranformP(new StelProjector::Mat4dTransform(Mat4d::identity())))->getMaxFov();
+	const float newMaxFov = getProjection(StelProjector::ModelViewTranformP(new StelProjector::Mat4dTransform(Mat4d::identity(),Mat4d::identity())))->getMaxFov();
 	movementMgr->setMaxFov(static_cast<double>(newMaxFov));
 	currentProjectorParams.fov = qMin(newMaxFov, savedFov);
 }
@@ -688,7 +688,7 @@ QString StelCore::getDefaultLocationID() const
 QString StelCore::projectionTypeKeyToNameI18n(const QString& key) const
 {
 	const QMetaEnum& en = metaObject()->enumerator(metaObject()->indexOfEnumerator("ProjectionType"));
-	QString s(getProjection(StelProjector::ModelViewTranformP(new StelProjector::Mat4dTransform(Mat4d::identity())), static_cast<ProjectionType>(en.keyToValue(key.toLatin1())))->getNameI18());
+	QString s(getProjection(StelProjector::ModelViewTranformP(new StelProjector::Mat4dTransform(Mat4d::identity(),Mat4d::identity())), static_cast<ProjectionType>(en.keyToValue(key.toLatin1())))->getNameI18());
 	return s;
 }
 
@@ -697,7 +697,7 @@ QString StelCore::projectionNameI18nToTypeKey(const QString& nameI18n) const
 	const QMetaEnum& en = metaObject()->enumerator(metaObject()->indexOfEnumerator("ProjectionType"));
 	for (int i=0;i<en.keyCount();++i)
 	{
-		if (getProjection(StelProjector::ModelViewTranformP(new StelProjector::Mat4dTransform(Mat4d::identity())), static_cast<ProjectionType>(i))->getNameI18()==nameI18n)
+		if (getProjection(StelProjector::ModelViewTranformP(new StelProjector::Mat4dTransform(Mat4d::identity(),Mat4d::identity())), static_cast<ProjectionType>(i))->getNameI18()==nameI18n)
 			return en.valueToKey(i);
 	}
 	// Unknown translated name
@@ -857,7 +857,7 @@ Vec3d StelCore::heliocentricEclipticToEarthPosEquinoxEqu(const Vec3d& v) const
 StelProjector::ModelViewTranformP StelCore::getHeliocentricEclipticModelViewTransform(RefractionMode refMode) const
 {
 	if (refMode==RefractionOff || skyDrawer==Q_NULLPTR || (refMode==RefractionAuto && skyDrawer->getFlagHasAtmosphere()==false))
-		return StelProjector::ModelViewTranformP(new StelProjector::Mat4dTransform(matAltAzModelView*matHeliocentricEclipticJ2000ToAltAz));
+		return StelProjector::ModelViewTranformP(new StelProjector::Mat4dTransform(matAltAzModelView,matHeliocentricEclipticJ2000ToAltAz));
 	Refraction* refr = new Refraction(skyDrawer->getRefraction());
 	// The pretransform matrix will convert from input coordinates to AltAz needed by the refraction function.
 	refr->setPreTransfoMat(matHeliocentricEclipticJ2000ToAltAz);
@@ -869,7 +869,7 @@ StelProjector::ModelViewTranformP StelCore::getHeliocentricEclipticModelViewTran
 StelProjector::ModelViewTranformP StelCore::getObservercentricEclipticJ2000ModelViewTransform(RefractionMode refMode) const
 {
 	if (refMode==RefractionOff || skyDrawer==Q_NULLPTR || (refMode==RefractionAuto && skyDrawer->getFlagHasAtmosphere()==false))
-		return StelProjector::ModelViewTranformP(new StelProjector::Mat4dTransform(matAltAzModelView*matJ2000ToAltAz*matVsop87ToJ2000));
+		return StelProjector::ModelViewTranformP(new StelProjector::Mat4dTransform(matAltAzModelView,matJ2000ToAltAz*matVsop87ToJ2000));
 	Refraction* refr = new Refraction(skyDrawer->getRefraction());
 	// The pretransform matrix will convert from input coordinates to AltAz needed by the refraction function.
 	refr->setPreTransfoMat(matJ2000ToAltAz*matVsop87ToJ2000);
@@ -882,7 +882,7 @@ StelProjector::ModelViewTranformP StelCore::getObservercentricEclipticOfDateMode
 {
 	double eps_A=getPrecessionAngleVondrakCurrentEpsilonA();
 	if (refMode==RefractionOff || skyDrawer==Q_NULLPTR || (refMode==RefractionAuto && skyDrawer->getFlagHasAtmosphere()==false))
-		return StelProjector::ModelViewTranformP(new StelProjector::Mat4dTransform(matAltAzModelView*matEquinoxEquToAltAz* Mat4d::xrotation(eps_A)));
+		return StelProjector::ModelViewTranformP(new StelProjector::Mat4dTransform(matAltAzModelView,matEquinoxEquToAltAz* Mat4d::xrotation(eps_A)));
 	Refraction* refr = new Refraction(skyDrawer->getRefraction());
 	// The pretransform matrix will convert from input coordinates to AltAz needed by the refraction function.
 	refr->setPreTransfoMat(matEquinoxEquToAltAz* Mat4d::xrotation(eps_A));
@@ -894,7 +894,7 @@ StelProjector::ModelViewTranformP StelCore::getObservercentricEclipticOfDateMode
 StelProjector::ModelViewTranformP StelCore::getEquinoxEquModelViewTransform(RefractionMode refMode) const
 {
 	if (refMode==RefractionOff || skyDrawer==Q_NULLPTR || (refMode==RefractionAuto && skyDrawer->getFlagHasAtmosphere()==false))
-		return StelProjector::ModelViewTranformP(new StelProjector::Mat4dTransform(matAltAzModelView*matEquinoxEquToAltAz));
+		return StelProjector::ModelViewTranformP(new StelProjector::Mat4dTransform(matAltAzModelView,matEquinoxEquToAltAz));
 	Refraction* refr = new Refraction(skyDrawer->getRefraction());
 	// The pretransform matrix will convert from input coordinates to AltAz needed by the refraction function.
 	refr->setPreTransfoMat(matEquinoxEquToAltAz);
@@ -906,7 +906,7 @@ StelProjector::ModelViewTranformP StelCore::getEquinoxEquModelViewTransform(Refr
 StelProjector::ModelViewTranformP StelCore::getFixedEquatorialModelViewTransform(RefractionMode refMode) const
 {
 	if (refMode==RefractionOff || skyDrawer==Q_NULLPTR || (refMode==RefractionAuto && skyDrawer->getFlagHasAtmosphere()==false))
-		return StelProjector::ModelViewTranformP(new StelProjector::Mat4dTransform(matAltAzModelView*matFixedEquatorialToAltAz));
+		return StelProjector::ModelViewTranformP(new StelProjector::Mat4dTransform(matAltAzModelView,matFixedEquatorialToAltAz));
 	Refraction* refr = new Refraction(skyDrawer->getRefraction());
 	// The pretransform matrix will convert from input coordinates to AltAz needed by the refraction function.
 	refr->setPreTransfoMat(matFixedEquatorialToAltAz);
@@ -921,7 +921,7 @@ StelProjector::ModelViewTranformP StelCore::getAltAzModelViewTransform(Refractio
 	{
 		// Catch problem with improperly initialized matAltAzModelView
 		Q_ASSERT(matAltAzModelView[0]==matAltAzModelView[0]);
-		return StelProjector::ModelViewTranformP(new StelProjector::Mat4dTransform(matAltAzModelView));
+		return StelProjector::ModelViewTranformP(new StelProjector::Mat4dTransform(matAltAzModelView,Mat4d::identity()));
 	}
 	Refraction* refr = new Refraction(skyDrawer->getRefraction());
 	// The pretransform matrix will convert from input coordinates to AltAz needed by the refraction function.
@@ -933,7 +933,7 @@ StelProjector::ModelViewTranformP StelCore::getAltAzModelViewTransform(Refractio
 StelProjector::ModelViewTranformP StelCore::getJ2000ModelViewTransform(RefractionMode refMode) const
 {
 	if (refMode==RefractionOff || skyDrawer==Q_NULLPTR || (refMode==RefractionAuto && skyDrawer->getFlagHasAtmosphere()==false))
-		return StelProjector::ModelViewTranformP(new StelProjector::Mat4dTransform(matAltAzModelView*matEquinoxEquToAltAz*matJ2000ToEquinoxEqu));
+		return StelProjector::ModelViewTranformP(new StelProjector::Mat4dTransform(matAltAzModelView,matEquinoxEquToAltAz*matJ2000ToEquinoxEqu));
 	Refraction* refr = new Refraction(skyDrawer->getRefraction());
 	// The pretransform matrix will convert from input coordinates to AltAz needed by the refraction function.
 	refr->setPreTransfoMat(matEquinoxEquToAltAz*matJ2000ToEquinoxEqu);
@@ -945,7 +945,7 @@ StelProjector::ModelViewTranformP StelCore::getJ2000ModelViewTransform(Refractio
 StelProjector::ModelViewTranformP StelCore::getGalacticModelViewTransform(RefractionMode refMode) const
 {
 	if (refMode==RefractionOff || skyDrawer==Q_NULLPTR || (refMode==RefractionAuto && skyDrawer->getFlagHasAtmosphere()==false))
-		return StelProjector::ModelViewTranformP(new StelProjector::Mat4dTransform(matAltAzModelView*matEquinoxEquToAltAz*matJ2000ToEquinoxEqu*matGalacticToJ2000));
+		return StelProjector::ModelViewTranformP(new StelProjector::Mat4dTransform(matAltAzModelView,matEquinoxEquToAltAz*matJ2000ToEquinoxEqu*matGalacticToJ2000));
 	Refraction* refr = new Refraction(skyDrawer->getRefraction());
 	// The pretransform matrix will convert from input coordinates to AltAz needed by the refraction function.
 	refr->setPreTransfoMat(matEquinoxEquToAltAz*matJ2000ToEquinoxEqu*matGalacticToJ2000);
@@ -957,7 +957,7 @@ StelProjector::ModelViewTranformP StelCore::getGalacticModelViewTransform(Refrac
 StelProjector::ModelViewTranformP StelCore::getSupergalacticModelViewTransform(RefractionMode refMode) const
 {
 	if (refMode==RefractionOff || skyDrawer==Q_NULLPTR || (refMode==RefractionAuto && skyDrawer->getFlagHasAtmosphere()==false))
-		return StelProjector::ModelViewTranformP(new StelProjector::Mat4dTransform(matAltAzModelView*matEquinoxEquToAltAz*matJ2000ToEquinoxEqu*matSupergalacticToJ2000));
+		return StelProjector::ModelViewTranformP(new StelProjector::Mat4dTransform(matAltAzModelView,matEquinoxEquToAltAz*matJ2000ToEquinoxEqu*matSupergalacticToJ2000));
 	Refraction* refr = new Refraction(skyDrawer->getRefraction());
 	// The pretransform matrix will convert from input coordinates to AltAz needed by the refraction function.
 	refr->setPreTransfoMat(matEquinoxEquToAltAz*matJ2000ToEquinoxEqu*matSupergalacticToJ2000);

--- a/src/core/StelCore.hpp
+++ b/src/core/StelCore.hpp
@@ -537,6 +537,9 @@ public slots:
 	//! Set aberration factor. Values are clamped to 0...5. (Values above 5 cause graphical problems.)
 	void setAberrationFactor(double factor) { if (!fuzzyEquals(aberrationFactor, factor)) { aberrationFactor=qBound(0.,factor, 5.); emit aberrationFactorChanged(factor); }}
 
+	QByteArray getAberrationShader() const;
+	void setAberrationUniforms(QOpenGLShaderProgram& program) const;
+
 	//! @return whether topocentric coordinates are currently used.
 	bool getUseTopocentricCoordinates() const {return flagUseTopocentricCoordinates;}
 	//! Set whether you want computation and simulation of nutation (a slight wobble of Earth's axis, just a few arcseconds).

--- a/src/core/StelMovementMgr.cpp
+++ b/src/core/StelMovementMgr.cpp
@@ -1738,7 +1738,7 @@ void StelMovementMgr::setUserMaxFov(double max)
 		setMaxFov(userMaxFov);
 	else
 	{
-		const float prjMaxFov = StelApp::getInstance().getCore()->getProjection(StelProjector::ModelViewTranformP(new StelProjector::Mat4dTransform(Mat4d::identity())))->getMaxFov();
+		const float prjMaxFov = StelApp::getInstance().getCore()->getProjection(StelProjector::ModelViewTranformP(new StelProjector::Mat4dTransform(Mat4d::identity(),Mat4d::identity())))->getMaxFov();
 		setMaxFov(qMin(userMaxFov, static_cast<double>(prjMaxFov)));
 	}
 	emit userMaxFovChanged(userMaxFov);

--- a/src/core/StelOpenGL.cpp
+++ b/src/core/StelOpenGL.cpp
@@ -126,6 +126,8 @@ out vec4 FRAG_COLOR;
 #define textureCube_3(a,b,c) textureCube(a,b,c)
 #line 1
 )";
+		if(glInfo.isGLES)
+			return "precision mediump float;\n" + prefix;
 		return prefix;
 	}
 }

--- a/src/core/StelOpenGLArray.hpp
+++ b/src/core/StelOpenGLArray.hpp
@@ -29,6 +29,7 @@
 #include <QVector>
 
 class StelOBJ;
+struct StelVertexArray;
 class QOpenGLFunctions;
 
 Q_DECLARE_LOGGING_CATEGORY(stelOpenGLArray)
@@ -80,6 +81,7 @@ public:
 	//! @param useTangents Whether to also load tangent/bitangent data, or skip it to save GL memory
 	//! @note Requires a valid bound GL context
 	bool load(const StelOBJ* obj, bool useTangents = true);
+	bool load(const StelVertexArray& array);
 
 	//! Binds this array for drawing/manipulating with OpenGL
 	//! @note Requires a valid bound GL context

--- a/src/core/StelProjector.cpp
+++ b/src/core/StelProjector.cpp
@@ -550,3 +550,10 @@ StelProjector::StelProjectorMaskType StelProjector::getMaskType(void) const
 {
 	return maskType;
 }
+
+bool StelProjector::isSameProjection(const StelProjector& other) const
+{
+	// *this defines the projection type, modelViewTransform defines how refraction is handled.
+	return typeid(*this) == typeid(other) &&
+		   typeid(*modelViewTransform) == typeid(*other.modelViewTransform);
+}

--- a/src/core/StelProjector.cpp
+++ b/src/core/StelProjector.cpp
@@ -25,11 +25,12 @@
 #include <QDebug>
 #include <QString>
 
-StelProjector::Mat4dTransform::Mat4dTransform(const Mat4d& m)
-    : transfoMat(m),
-      transfoMatf(toMat4f(m))
+StelProjector::Mat4dTransform::Mat4dTransform(const Mat4d& altAzToWorld, const Mat4d& vertexToAltAzPos)
+    : transfoMat(altAzToWorld*vertexToAltAzPos)
+    , transfoMatf(toMat4f(transfoMat))
+	, vertexToAltAzPos(toMat4f(vertexToAltAzPos))
 {
-	Q_ASSERT(m[0]==m[0]); // prelude to assert later in Atmosphere rendering... still investigating
+	Q_ASSERT(transfoMat[0]==transfoMat[0]); // prelude to assert later in Atmosphere rendering... still investigating
 }
 
 void StelProjector::Mat4dTransform::forward(Vec3d& v) const

--- a/src/core/StelProjector.hpp
+++ b/src/core/StelProjector.hpp
@@ -65,6 +65,8 @@ public:
 
 		virtual QByteArray getForwardTransformShader() const = 0;
 		virtual void setForwardTransformUniforms(QOpenGLShaderProgram& program) const = 0;
+		virtual QByteArray getBackwardTransformShader() const = 0;
+		virtual void setBackwardTransformUniforms(QOpenGLShaderProgram& program) const = 0;
 	};
 
 	class Mat4dTransform: public ModelViewTranform
@@ -80,6 +82,8 @@ public:
 	ModelViewTranformP clone() const Q_DECL_OVERRIDE;
 	QByteArray getForwardTransformShader() const Q_DECL_OVERRIDE;
 	void setForwardTransformUniforms(QOpenGLShaderProgram& program) const Q_DECL_OVERRIDE;
+	QByteArray getBackwardTransformShader() const Q_DECL_OVERRIDE;
+	void setBackwardTransformUniforms(QOpenGLShaderProgram& program) const Q_DECL_OVERRIDE;
 
 	private:
 		Mat4dTransform(const Mat4dTransform& src) = default;
@@ -90,6 +94,8 @@ public:
 		Mat4f transfoMatf;
 		//! Transforms a vertex from model space to coordinates where Z is zenith, so zenith angle can easily be computed.
 		Mat4f vertexToAltAzPos;
+		//! Transforms view direction from the projector's frame to coordinates where Z is zenith, so zenith angle can easily be computed.
+		Mat4f worldPosToAltAzPos;
 	};
 
 	//! @enum StelProjectorMaskType
@@ -163,6 +169,10 @@ public:
 	virtual QByteArray getForwardTransformShader() const = 0;
 	//! Sets the necessary uniforms so that the shader returned by getForwardTransformShader can work
 	virtual void setForwardTransformUniforms(QOpenGLShaderProgram& program) const;
+	//! Returns GLSL code that can be used in a shader to implement backward transformation
+	virtual QByteArray getBackwardTransformShader() const = 0;
+	//! Sets the necessary uniforms so that the shader returned by getBackwardTransformShader can work
+	virtual void setBackwardTransformUniforms(QOpenGLShaderProgram& program) const;
 
 	//! Determine whether a great circle connection p1 and p2 intersects with a projection discontinuity.
 	//! For many projections without discontinuity, this should return always false, but for other like
@@ -293,6 +303,9 @@ public:
 
 	QByteArray getProjectShader() const;
 	void setProjectUniforms(QOpenGLShaderProgram& program) const;
+
+	QByteArray getUnProjectShader() const;
+	void setUnProjectUniforms(QOpenGLShaderProgram& program) const;
 
 	//! Get the current model view matrix.
 	ModelViewTranformP getModelViewTransform() const;

--- a/src/core/StelProjector.hpp
+++ b/src/core/StelProjector.hpp
@@ -309,6 +309,14 @@ public:
 	//! Get the current type of the mask if any.
 	StelProjectorMaskType getMaskType(void) const;
 
+	//! Check whether the projection represented by \p other is the same as this.
+	//!
+	//! This check is intended to tell whether the shaders returned by #getProjectShader and #getUnProjectShader are
+	//! the same for this and \p other.
+	//! The parameters compared include projection type and whether refraction is on. Numerical
+	//  parameters of the transform like rotation angles, stretch factors etc. (that are passed as uniforms) are ignored.
+	bool isSameProjection(const StelProjector& other) const;
+
 protected:
 	//! Private constructor. Only StelCore can create instances of StelProjector.
 	StelProjector(ModelViewTranformP amodelViewTransform)

--- a/src/core/StelProjector.hpp
+++ b/src/core/StelProjector.hpp
@@ -65,7 +65,7 @@ public:
 	class Mat4dTransform: public ModelViewTranform
 	{
 	public:
-        Mat4dTransform(const Mat4d& m);
+        Mat4dTransform(const Mat4d& altAzToWorld, const Mat4d& vertexToAltAzPos);
 	void forward(Vec3d& v) const Q_DECL_OVERRIDE;
 	void backward(Vec3d& v) const Q_DECL_OVERRIDE;
 	void forward(Vec3f& v) const Q_DECL_OVERRIDE;
@@ -81,6 +81,8 @@ public:
 		//! transfo matrix and invert
 		Mat4d transfoMat;
 		Mat4f transfoMatf;
+		//! Transforms a vertex from model space to coordinates where Z is zenith, so zenith angle can easily be computed.
+		Mat4f vertexToAltAzPos;
 	};
 
 	//! @enum StelProjectorMaskType

--- a/src/core/StelProjector.hpp
+++ b/src/core/StelProjector.hpp
@@ -24,6 +24,8 @@
 #include "VecMath.hpp"
 #include "StelSphereGeometry.hpp"
 
+class QOpenGLShaderProgram;
+
 //! @class StelProjector
 //! Provide the main interface to all operations of projecting coordinates from sky to screen.
 //! The StelProjector also defines the viewport size and position.
@@ -60,6 +62,9 @@ public:
 		virtual ModelViewTranformP clone() const=0;
 
 		virtual Mat4d getApproximateLinearTransfo() const=0;
+
+		virtual QByteArray getForwardTransformShader() const = 0;
+		virtual void setForwardTransformUniforms(QOpenGLShaderProgram& program) const = 0;
 	};
 
 	class Mat4dTransform: public ModelViewTranform
@@ -73,6 +78,8 @@ public:
 	void combine(const Mat4d& m) Q_DECL_OVERRIDE;
 	Mat4d getApproximateLinearTransfo() const Q_DECL_OVERRIDE;
 	ModelViewTranformP clone() const Q_DECL_OVERRIDE;
+	QByteArray getForwardTransformShader() const Q_DECL_OVERRIDE;
+	void setForwardTransformUniforms(QOpenGLShaderProgram& program) const Q_DECL_OVERRIDE;
 
 	private:
 		Mat4dTransform(const Mat4dTransform& src) = default;
@@ -152,6 +159,10 @@ public:
 	virtual bool backward(Vec3d& v) const = 0;
 	//! Return the small zoom increment to use at the given FOV for nice movements
 	virtual float deltaZoom(float fov) const = 0;
+	//! Returns GLSL code that can be used in a shader to implement forward transformation
+	virtual QByteArray getForwardTransformShader() const = 0;
+	//! Sets the necessary uniforms so that the shader returned by getForwardTransformShader can work
+	virtual void setForwardTransformUniforms(QOpenGLShaderProgram& program) const;
 
 	//! Determine whether a great circle connection p1 and p2 intersects with a projection discontinuity.
 	//! For many projections without discontinuity, this should return always false, but for other like
@@ -279,6 +290,9 @@ public:
 	//! @param win2 the second projected vector in the viewport 2D frame.
 	//! @return true if at least one of the projected vector is within the viewport.
 	bool projectLineCheck(const Vec3d& v1, Vec3d& win1, const Vec3d& v2, Vec3d& win2) const;
+
+	QByteArray getProjectShader() const;
+	void setProjectUniforms(QOpenGLShaderProgram& program) const;
 
 	//! Get the current model view matrix.
 	ModelViewTranformP getModelViewTransform() const;

--- a/src/core/StelProjectorClasses.hpp
+++ b/src/core/StelProjectorClasses.hpp
@@ -34,6 +34,7 @@ public:
 	virtual float fovToViewScalingFactor(float fov) const Q_DECL_OVERRIDE;
 	virtual float viewScalingFactorToFov(float vsf) const Q_DECL_OVERRIDE;
 	virtual float deltaZoom(float fov) const Q_DECL_OVERRIDE;
+	virtual QByteArray getForwardTransformShader() const Q_DECL_OVERRIDE;
 protected:
 	virtual bool hasDiscontinuity() const  Q_DECL_OVERRIDE {return false;}
 	virtual bool intersectViewportDiscontinuityInternal(const Vec3d&, const Vec3d&) const  Q_DECL_OVERRIDE {return false;}
@@ -52,6 +53,7 @@ public:
 	virtual float fovToViewScalingFactor(float fov) const Q_DECL_OVERRIDE;
 	virtual float viewScalingFactorToFov(float vsf) const Q_DECL_OVERRIDE;
 	virtual float deltaZoom(float fov) const Q_DECL_OVERRIDE;
+	virtual QByteArray getForwardTransformShader() const Q_DECL_OVERRIDE;
 protected:
 	virtual bool hasDiscontinuity() const  Q_DECL_OVERRIDE{return false;}
 	virtual bool intersectViewportDiscontinuityInternal(const Vec3d&, const Vec3d&) const  Q_DECL_OVERRIDE {return false;}
@@ -70,6 +72,7 @@ public:
 	virtual float fovToViewScalingFactor(float fov) const Q_DECL_OVERRIDE;
 	virtual float viewScalingFactorToFov(float vsf) const Q_DECL_OVERRIDE;
 	virtual float deltaZoom(float fov) const Q_DECL_OVERRIDE;
+	virtual QByteArray getForwardTransformShader() const Q_DECL_OVERRIDE;
 protected:
 	virtual bool hasDiscontinuity() const Q_DECL_OVERRIDE {return false;}
 	virtual bool intersectViewportDiscontinuityInternal(const Vec3d&, const Vec3d&) const Q_DECL_OVERRIDE {return false;}
@@ -88,6 +91,7 @@ public:
 	virtual float fovToViewScalingFactor(float fov) const Q_DECL_OVERRIDE;
 	virtual float viewScalingFactorToFov(float vsf) const Q_DECL_OVERRIDE;
 	virtual float deltaZoom(float fov) const Q_DECL_OVERRIDE;
+	virtual QByteArray getForwardTransformShader() const Q_DECL_OVERRIDE;
 protected:
 	virtual bool hasDiscontinuity() const Q_DECL_OVERRIDE {return false;}
 	virtual bool intersectViewportDiscontinuityInternal(const Vec3d&, const Vec3d&) const Q_DECL_OVERRIDE {return false;}
@@ -106,6 +110,7 @@ public:
 	virtual float fovToViewScalingFactor(float fov) const Q_DECL_OVERRIDE;
 	virtual float viewScalingFactorToFov(float vsf) const Q_DECL_OVERRIDE;
 	virtual float deltaZoom(float fov) const Q_DECL_OVERRIDE;
+	virtual QByteArray getForwardTransformShader() const Q_DECL_OVERRIDE;
 protected:
 	virtual bool hasDiscontinuity() const Q_DECL_OVERRIDE {return true;}
 	virtual bool intersectViewportDiscontinuityInternal(const Vec3d& p1, const Vec3d& p2) const Q_DECL_OVERRIDE {return p1[0]*p2[0]<0 && !(p1[2]<0 && p2[2]<0);}
@@ -131,6 +136,7 @@ public:
 	virtual float fovToViewScalingFactor(float fov) const Q_DECL_OVERRIDE;
 	virtual float viewScalingFactorToFov(float vsf) const Q_DECL_OVERRIDE;
 	virtual float deltaZoom(float fov) const Q_DECL_OVERRIDE;
+	virtual QByteArray getForwardTransformShader() const Q_DECL_OVERRIDE;
 protected:
 	virtual bool hasDiscontinuity() const Q_DECL_OVERRIDE {return true;}
 	virtual bool intersectViewportDiscontinuityInternal(const Vec3d& p1, const Vec3d& p2) const Q_DECL_OVERRIDE
@@ -159,6 +165,7 @@ public:
 	virtual float fovToViewScalingFactor(float fov) const Q_DECL_OVERRIDE;
 	virtual float viewScalingFactorToFov(float vsf) const Q_DECL_OVERRIDE;
 	virtual float deltaZoom(float fov) const Q_DECL_OVERRIDE;
+	virtual QByteArray getForwardTransformShader() const Q_DECL_OVERRIDE;
 protected:
 	virtual bool hasDiscontinuity() const Q_DECL_OVERRIDE {return true;}
 	virtual bool intersectViewportDiscontinuityInternal(const Vec3d& p1, const Vec3d& p2) const Q_DECL_OVERRIDE
@@ -187,6 +194,7 @@ public:
 	virtual float fovToViewScalingFactor(float fov) const Q_DECL_OVERRIDE;
 	virtual float viewScalingFactorToFov(float vsf) const Q_DECL_OVERRIDE;
 	virtual float deltaZoom(float fov) const Q_DECL_OVERRIDE;
+	virtual QByteArray getForwardTransformShader() const Q_DECL_OVERRIDE;
 protected:
 	virtual bool hasDiscontinuity() const Q_DECL_OVERRIDE {return false;}
 	virtual bool intersectViewportDiscontinuityInternal(const Vec3d&, const Vec3d&) const Q_DECL_OVERRIDE {return false;}
@@ -201,6 +209,7 @@ public:
 	virtual QString getDescriptionI18() const Q_DECL_OVERRIDE;
 	virtual bool forward(Vec3f &win) const Q_DECL_OVERRIDE;
 	virtual bool backward(Vec3d &v) const Q_DECL_OVERRIDE;
+	virtual QByteArray getForwardTransformShader() const Q_DECL_OVERRIDE;
 };
 
 class StelProjectorMiller : public StelProjectorMercator
@@ -212,6 +221,7 @@ public:
 	virtual float getMaxFov() const Q_DECL_OVERRIDE {return 270.f; }
 	virtual bool forward(Vec3f &win) const Q_DECL_OVERRIDE;
 	virtual bool backward(Vec3d &v) const Q_DECL_OVERRIDE;
+	virtual QByteArray getForwardTransformShader() const Q_DECL_OVERRIDE;
 };
 
 class StelProjector2d : public StelProjector
@@ -226,6 +236,8 @@ public:
 	virtual float fovToViewScalingFactor(float fov) const Q_DECL_OVERRIDE;
 	virtual float viewScalingFactorToFov(float vsf) const Q_DECL_OVERRIDE;
 	virtual float deltaZoom(float fov) const Q_DECL_OVERRIDE;
+	virtual QByteArray getForwardTransformShader() const Q_DECL_OVERRIDE;
+	virtual void setForwardTransformUniforms(QOpenGLShaderProgram& program) const Q_DECL_OVERRIDE;
 protected:
 	virtual bool hasDiscontinuity() const Q_DECL_OVERRIDE {return false;}
 	virtual bool intersectViewportDiscontinuityInternal(const Vec3d&, const Vec3d&) const Q_DECL_OVERRIDE {Q_ASSERT(0); return false;}

--- a/src/core/StelProjectorClasses.hpp
+++ b/src/core/StelProjectorClasses.hpp
@@ -217,7 +217,7 @@ public:
 class StelProjector2d : public StelProjector
 {
 public:
-	StelProjector2d() : StelProjector(ModelViewTranformP(new StelProjector::Mat4dTransform(Mat4d::identity()))) {}
+	StelProjector2d() : StelProjector(ModelViewTranformP(new StelProjector::Mat4dTransform(Mat4d::identity(),Mat4d::identity()))) {}
 	virtual QString getNameI18() const Q_DECL_OVERRIDE;
 	virtual QString getDescriptionI18() const Q_DECL_OVERRIDE;
 	virtual float getMaxFov() const Q_DECL_OVERRIDE {return 360.f;}

--- a/src/core/StelProjectorClasses.hpp
+++ b/src/core/StelProjectorClasses.hpp
@@ -35,6 +35,7 @@ public:
 	virtual float viewScalingFactorToFov(float vsf) const Q_DECL_OVERRIDE;
 	virtual float deltaZoom(float fov) const Q_DECL_OVERRIDE;
 	virtual QByteArray getForwardTransformShader() const Q_DECL_OVERRIDE;
+	virtual QByteArray getBackwardTransformShader() const Q_DECL_OVERRIDE;
 protected:
 	virtual bool hasDiscontinuity() const  Q_DECL_OVERRIDE {return false;}
 	virtual bool intersectViewportDiscontinuityInternal(const Vec3d&, const Vec3d&) const  Q_DECL_OVERRIDE {return false;}
@@ -54,6 +55,7 @@ public:
 	virtual float viewScalingFactorToFov(float vsf) const Q_DECL_OVERRIDE;
 	virtual float deltaZoom(float fov) const Q_DECL_OVERRIDE;
 	virtual QByteArray getForwardTransformShader() const Q_DECL_OVERRIDE;
+	virtual QByteArray getBackwardTransformShader() const Q_DECL_OVERRIDE;
 protected:
 	virtual bool hasDiscontinuity() const  Q_DECL_OVERRIDE{return false;}
 	virtual bool intersectViewportDiscontinuityInternal(const Vec3d&, const Vec3d&) const  Q_DECL_OVERRIDE {return false;}
@@ -73,6 +75,7 @@ public:
 	virtual float viewScalingFactorToFov(float vsf) const Q_DECL_OVERRIDE;
 	virtual float deltaZoom(float fov) const Q_DECL_OVERRIDE;
 	virtual QByteArray getForwardTransformShader() const Q_DECL_OVERRIDE;
+	virtual QByteArray getBackwardTransformShader() const Q_DECL_OVERRIDE;
 protected:
 	virtual bool hasDiscontinuity() const Q_DECL_OVERRIDE {return false;}
 	virtual bool intersectViewportDiscontinuityInternal(const Vec3d&, const Vec3d&) const Q_DECL_OVERRIDE {return false;}
@@ -92,6 +95,7 @@ public:
 	virtual float viewScalingFactorToFov(float vsf) const Q_DECL_OVERRIDE;
 	virtual float deltaZoom(float fov) const Q_DECL_OVERRIDE;
 	virtual QByteArray getForwardTransformShader() const Q_DECL_OVERRIDE;
+	virtual QByteArray getBackwardTransformShader() const Q_DECL_OVERRIDE;
 protected:
 	virtual bool hasDiscontinuity() const Q_DECL_OVERRIDE {return false;}
 	virtual bool intersectViewportDiscontinuityInternal(const Vec3d&, const Vec3d&) const Q_DECL_OVERRIDE {return false;}
@@ -111,6 +115,7 @@ public:
 	virtual float viewScalingFactorToFov(float vsf) const Q_DECL_OVERRIDE;
 	virtual float deltaZoom(float fov) const Q_DECL_OVERRIDE;
 	virtual QByteArray getForwardTransformShader() const Q_DECL_OVERRIDE;
+	virtual QByteArray getBackwardTransformShader() const Q_DECL_OVERRIDE;
 protected:
 	virtual bool hasDiscontinuity() const Q_DECL_OVERRIDE {return true;}
 	virtual bool intersectViewportDiscontinuityInternal(const Vec3d& p1, const Vec3d& p2) const Q_DECL_OVERRIDE {return p1[0]*p2[0]<0 && !(p1[2]<0 && p2[2]<0);}
@@ -137,6 +142,7 @@ public:
 	virtual float viewScalingFactorToFov(float vsf) const Q_DECL_OVERRIDE;
 	virtual float deltaZoom(float fov) const Q_DECL_OVERRIDE;
 	virtual QByteArray getForwardTransformShader() const Q_DECL_OVERRIDE;
+	virtual QByteArray getBackwardTransformShader() const Q_DECL_OVERRIDE;
 protected:
 	virtual bool hasDiscontinuity() const Q_DECL_OVERRIDE {return true;}
 	virtual bool intersectViewportDiscontinuityInternal(const Vec3d& p1, const Vec3d& p2) const Q_DECL_OVERRIDE
@@ -166,6 +172,7 @@ public:
 	virtual float viewScalingFactorToFov(float vsf) const Q_DECL_OVERRIDE;
 	virtual float deltaZoom(float fov) const Q_DECL_OVERRIDE;
 	virtual QByteArray getForwardTransformShader() const Q_DECL_OVERRIDE;
+	virtual QByteArray getBackwardTransformShader() const Q_DECL_OVERRIDE;
 protected:
 	virtual bool hasDiscontinuity() const Q_DECL_OVERRIDE {return true;}
 	virtual bool intersectViewportDiscontinuityInternal(const Vec3d& p1, const Vec3d& p2) const Q_DECL_OVERRIDE
@@ -195,6 +202,7 @@ public:
 	virtual float viewScalingFactorToFov(float vsf) const Q_DECL_OVERRIDE;
 	virtual float deltaZoom(float fov) const Q_DECL_OVERRIDE;
 	virtual QByteArray getForwardTransformShader() const Q_DECL_OVERRIDE;
+	virtual QByteArray getBackwardTransformShader() const Q_DECL_OVERRIDE;
 protected:
 	virtual bool hasDiscontinuity() const Q_DECL_OVERRIDE {return false;}
 	virtual bool intersectViewportDiscontinuityInternal(const Vec3d&, const Vec3d&) const Q_DECL_OVERRIDE {return false;}
@@ -210,6 +218,7 @@ public:
 	virtual bool forward(Vec3f &win) const Q_DECL_OVERRIDE;
 	virtual bool backward(Vec3d &v) const Q_DECL_OVERRIDE;
 	virtual QByteArray getForwardTransformShader() const Q_DECL_OVERRIDE;
+	virtual QByteArray getBackwardTransformShader() const Q_DECL_OVERRIDE;
 };
 
 class StelProjectorMiller : public StelProjectorMercator
@@ -222,6 +231,7 @@ public:
 	virtual bool forward(Vec3f &win) const Q_DECL_OVERRIDE;
 	virtual bool backward(Vec3d &v) const Q_DECL_OVERRIDE;
 	virtual QByteArray getForwardTransformShader() const Q_DECL_OVERRIDE;
+	virtual QByteArray getBackwardTransformShader() const Q_DECL_OVERRIDE;
 };
 
 class StelProjector2d : public StelProjector
@@ -238,6 +248,8 @@ public:
 	virtual float deltaZoom(float fov) const Q_DECL_OVERRIDE;
 	virtual QByteArray getForwardTransformShader() const Q_DECL_OVERRIDE;
 	virtual void setForwardTransformUniforms(QOpenGLShaderProgram& program) const Q_DECL_OVERRIDE;
+	virtual QByteArray getBackwardTransformShader() const Q_DECL_OVERRIDE;
+	virtual void setBackwardTransformUniforms(QOpenGLShaderProgram& program) const Q_DECL_OVERRIDE;
 protected:
 	virtual bool hasDiscontinuity() const Q_DECL_OVERRIDE {return false;}
 	virtual bool intersectViewportDiscontinuityInternal(const Vec3d&, const Vec3d&) const Q_DECL_OVERRIDE {Q_ASSERT(0); return false;}

--- a/src/core/modules/MilkyWay.hpp
+++ b/src/core/modules/MilkyWay.hpp
@@ -26,6 +26,7 @@
 #include "StelTextureTypes.hpp"
 
 class QOpenGLShaderProgram;
+class QOpenGLVertexArrayObject;
 //! @class MilkyWay 
 //! Manages the displaying of the Milky Way.
 class MilkyWay : public StelModule
@@ -104,6 +105,11 @@ signals:
 	void colorChanged(Vec3f color);
 
 private:
+	void setupCurrentVAO();
+	void bindVAO();
+	void releaseVAO();
+
+private:
 	StelTextureSP mainTex;
 	Vec3f color; // global color
 	double intensity;
@@ -120,12 +126,13 @@ private:
 		int saturation;
 		int rgbMaxValue;
 		int ditherPattern;
-		int projectionMatrix;
 		int bortleIntensity;
 		int extinctionEnabled;
+		int projectionMatrixInverse;
 	} shaderVars;
 
-	std::unique_ptr<class StelOpenGLArray> vertexArray;
+	std::unique_ptr<QOpenGLVertexArrayObject> vao;
+	std::unique_ptr<QOpenGLBuffer> vbo;
 	StelTextureSP ditherPatternTex;
 	StelProjectorP prevProjector;
 	std::unique_ptr<QOpenGLShaderProgram> renderProgram;

--- a/src/core/modules/MilkyWay.hpp
+++ b/src/core/modules/MilkyWay.hpp
@@ -22,8 +22,10 @@
 
 #include "StelModule.hpp"
 #include "VecMath.hpp"
+#include "StelCore.hpp"
 #include "StelTextureTypes.hpp"
 
+class QOpenGLShaderProgram;
 //! @class MilkyWay 
 //! Manages the displaying of the Milky Way.
 class MilkyWay : public StelModule
@@ -102,7 +104,7 @@ signals:
 	void colorChanged(Vec3f color);
 
 private:
-	StelTextureSP tex;
+	StelTextureSP mainTex;
 	Vec3f color; // global color
 	double intensity;
 	double intensityFovScale; // like for constellations: reduce brightness when zooming in.
@@ -111,8 +113,22 @@ private:
 	class LinearFader* fader;
 	double saturation = 1.0;
 
-	struct StelVertexArray* vertexArray;
-	struct StelVertexArray* vertexArrayNoAberration;
+	struct
+	{
+		int mainTex;
+		int brightness;
+		int saturation;
+		int rgbMaxValue;
+		int ditherPattern;
+		int projectionMatrix;
+		int bortleIntensity;
+		int extinctionEnabled;
+	} shaderVars;
+
+	std::unique_ptr<class StelOpenGLArray> vertexArray;
+	StelTextureSP ditherPatternTex;
+	StelProjectorP prevProjector;
+	std::unique_ptr<QOpenGLShaderProgram> renderProgram;
 };
 
 #endif // MILKYWAY_HPP


### PR DESCRIPTION
### Description
This PR makes it possible to perform projection on the GPU rather than CPU. This functionality will be needed in the future to render dense meshes like e.g. lunar surface.

An additional benefit is that some modules like MilkyWay and ZodiacalLight can be rendered without broken polygons at the borders of the projection area, and without the mesh effect near the horizon (see screenshots below). Landscape should also be converted, but hasn't been yet.

### Screenshots:

#### Zodiacal light, extinction

Old:
![](https://user-images.githubusercontent.com/6376882/202058538-d5f9171b-02da-4846-826c-ef15992d5fc3.png)

New:
![](https://user-images.githubusercontent.com/6376882/202058580-b5c97daa-7e49-43e1-99ad-8dc1dd27baef.png)

#### ZL & MW, borders of projection area (Miller cylindrical for example)

Old:
![9a](https://user-images.githubusercontent.com/6376882/202156313-58c1eb3d-7629-4f0e-81fb-f032d46d0d33.png)

New:
![9b](https://user-images.githubusercontent.com/6376882/202156354-ba0d18b1-4e54-4d72-8a75-b59005b5e27f.png)

#### MilkyWay, positioning of the texels in highly-stretched regions (stereographic for example)

Old:
![2a](https://user-images.githubusercontent.com/6376882/202157003-38546b29-6bc9-4135-8c11-08990a746b0a.png)

New:
![2b](https://user-images.githubusercontent.com/6376882/202157028-ed19df76-326b-4074-a5d3-4395aab5fa4d.png)

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### How Has This Been Tested?

**Test Configuration**:
* Operating system: Linux From Scratch
* Graphics Card: NVIDIA GeForce GTX 750Ti, `nvidia` driver
* Qt6 in desktop OpenGL and GLES2 modes

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
