### PR TITLE
Make QXlsx use the correct Qt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,9 @@ ELSE()
          SET(QT_VERSION_MAJOR 5)
      ENDIF()
 ENDIF()
+# This will tell QXlsx to use the same Qt version (5 vs 6) as we do.
+# https://github.com/Stellarium/stellarium/pull/2849
+LIST(PREPEND CMAKE_PREFIX_PATH ${Qt${QT_VERSION_MAJOR}_DIR})
 # TODO: Check real minimal supported version of GPSD API
 SET(MINIMAL_GPS_API_VERSION "6.0")
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Please include a summary of the change and which issue is fixed. -->
<!--- Please also include relevant motivation and context. -->
<!--- List any dependencies that are required for this change. -->

Fixes issue reported in #2838

### Screenshots (if appropriate):

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system: <Name, version number>
* Graphics Card: <Manufacturer (likely Intel, NVidia, AMD?), Model (HD, Geforce, Radeon..., with model number), driver version?>

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
