### PR TITLE
Load Planet textures synchronously

### DIFF
--- a/src/core/modules/Planet.cpp
+++ b/src/core/modules/Planet.cpp
@@ -282,7 +282,7 @@ Planet::Planet(const QString& englishName,
 		QString texMapFile = StelFileMgr::findFile("textures/"+texMapName, StelFileMgr::File);
 		if (!texMapFile.isEmpty())
 		{
-			texMap = texMan.createTextureThread(texMapFile, StelTexture::StelTextureParams(true, GL_LINEAR, GL_REPEAT));
+			texMap = texMan.createTextureThread(texMapFile, StelTexture::StelTextureParams(true, GL_LINEAR, GL_REPEAT), false);
 			texMapFileOrig = texMapFile;
 		}
 		else
@@ -296,7 +296,7 @@ Planet::Planet(const QString& englishName,
 		QString normalMapFile = StelFileMgr::findFile("textures/"+normalMapName, StelFileMgr::File);
 		if (!normalMapFile.isEmpty())
 		{
-			normalMap = texMan.createTextureThread(normalMapFile, StelTexture::StelTextureParams(true, GL_LINEAR, GL_REPEAT));
+			normalMap = texMan.createTextureThread(normalMapFile, StelTexture::StelTextureParams(true, GL_LINEAR, GL_REPEAT), false);
 			normalMapFileOrig = normalMapFile;
 		}
 	}
@@ -306,7 +306,7 @@ Planet::Planet(const QString& englishName,
 		QString horizonMapFile = StelFileMgr::findFile("textures/"+horizonMapName, StelFileMgr::File);
 		if (!horizonMapFile.isEmpty())
 		{
-			horizonMap = texMan.createTextureThread(horizonMapFile, StelTexture::StelTextureParams(true, GL_LINEAR, GL_REPEAT));
+			horizonMap = texMan.createTextureThread(horizonMapFile, StelTexture::StelTextureParams(true, GL_LINEAR, GL_REPEAT), false);
 			horizonMapFileOrig = horizonMapFile;
 		}
 	}


### PR DESCRIPTION
Currently, if we launch Stellarium and point it to a planet, e.g. Jupiter, right away, and zoom in to see it, we'll find that the halo turns into emptiness. Only after several seconds will we see the actual planet.

All planets are created at two places: in SolarSystem::init() and in SolarSystemEditor. The former is only called at startup, so we don't lose FPS this way. The latter can tolerate a small lag before the reload is complete, since at least it's somewhat expected.

Besides, I haven't noticed any real delay on startup, it seems the "solar system objects" line doesn't even appear in the splash screen—so fast does it load.

### How Has This Been Tested?
**Test Configuration**:
* Operating system: Linux From Scratch, Ubuntu 20.04
* Graphics Card: NVIDIA GeForce GTX 750Ti, Intel UHD Graphics 620

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
