### PR TITLE
Projection: plate carree

### DIFF
--- a/src/core/StelCore.cpp
+++ b/src/core/StelCore.cpp
@@ -407,6 +407,9 @@ StelProjectorP StelCore::getProjection(StelProjector::ModelViewTranformP modelVi
 		case ProjectionCylinder:
 			prj = StelProjectorP(new StelProjectorCylinder(modelViewTransform));
 			break;
+		case ProjectionCylinderFill:
+			prj = StelProjectorP(new StelProjectorCylinderFill(modelViewTransform));
+			break;
 		case ProjectionMercator:
 			prj = StelProjectorP(new StelProjectorMercator(modelViewTransform));
 			break;

--- a/src/core/StelCore.cpp
+++ b/src/core/StelCore.cpp
@@ -558,16 +558,26 @@ void StelCore::setCurrentProjectionType(ProjectionType type)
 {
 	if(type!=currentProjectionType)
 	{
+		QSettings* conf = StelApp::getInstance().getSettings();
+
 		currentProjectionType=type;
 		updateMaximumFov();
 		if (currentProjectionType==ProjectionType::ProjectionCylinderFill)
 		{
+			// Save whatever stretch is present into config.ini. This value is saved just temporarily until switching back to another projection and will not be loaded on startup.
+			// (To configure a stretch at startup, use startup.ssc script.)
+			conf->setValue("projection/width_stretch", currentProjectorParams.widthStretch);
 			currentProjectorParams.fov=180.f;
 			currentProjectorParams.widthStretch=0.5*currentProjectorParams.viewportXywh[2]/currentProjectorParams.viewportXywh[3];
 			currentProjectorParams.viewportFovDiameter = currentProjectorParams.viewportXywh[3];
 			Q_ASSERT(movementMgr);
 			movementMgr->setViewportVerticalOffsetTarget(0.);
 			movementMgr->zoomTo(180., 0.5);
+		}
+		else
+		{
+			// reset to what is stored in config.ini
+			currentProjectorParams.widthStretch=conf->value("projection/width_stretch", 1.0).toDouble();
 		}
 
 		emit currentProjectionTypeChanged(type);

--- a/src/core/StelCore.cpp
+++ b/src/core/StelCore.cpp
@@ -505,11 +505,6 @@ void StelCore::update(double deltaTime)
 	movementMgr->updateMotion(deltaTime);
 
 	currentProjectorParams.fov = static_cast<float>(movementMgr->getCurrentFov());
-//	if (currentProjectionType==ProjectionType::ProjectionCylinderFill)
-//	{
-//		currentProjectorParams.widthStretch=0.5*currentProjectorParams.viewportXywh[2]/currentProjectorParams.viewportXywh[3];
-//		currentProjectorParams.viewportFovDiameter = currentProjectorParams.viewportXywh[3];
-//	}
 
 	skyDrawer->update(deltaTime);
 }

--- a/src/core/StelCore.cpp
+++ b/src/core/StelCore.cpp
@@ -482,6 +482,12 @@ void StelCore::windowHasBeenResized(qreal x, qreal y, qreal width, qreal height)
 	currentProjectorParams.viewportXywh.set(qRound(x), qRound(y), qRound(width), qRound(height));
 	currentProjectorParams.viewportCenter.set(x+(0.5+currentProjectorParams.viewportCenterOffset.v[0])*width, y+(0.5+currentProjectorParams.viewportCenterOffset.v[1])*height);
 	currentProjectorParams.viewportFovDiameter = qMin(width,height);
+
+	if (currentProjectionType==ProjectionType::ProjectionCylinderFill)
+	{
+		currentProjectorParams.widthStretch=0.5*width/height;
+		currentProjectorParams.viewportFovDiameter = height;
+	}
 }
 
 /*************************************************************************
@@ -499,6 +505,11 @@ void StelCore::update(double deltaTime)
 	movementMgr->updateMotion(deltaTime);
 
 	currentProjectorParams.fov = static_cast<float>(movementMgr->getCurrentFov());
+//	if (currentProjectionType==ProjectionType::ProjectionCylinderFill)
+//	{
+//		currentProjectorParams.widthStretch=0.5*currentProjectorParams.viewportXywh[2]/currentProjectorParams.viewportXywh[3];
+//		currentProjectorParams.viewportFovDiameter = currentProjectorParams.viewportXywh[3];
+//	}
 
 	skyDrawer->update(deltaTime);
 }
@@ -549,6 +560,15 @@ void StelCore::setCurrentProjectionType(ProjectionType type)
 	{
 		currentProjectionType=type;
 		updateMaximumFov();
+		if (currentProjectionType==ProjectionType::ProjectionCylinderFill)
+		{
+			currentProjectorParams.fov=180.f;
+			currentProjectorParams.widthStretch=0.5*currentProjectorParams.viewportXywh[2]/currentProjectorParams.viewportXywh[3];
+			currentProjectorParams.viewportFovDiameter = currentProjectorParams.viewportXywh[3];
+			Q_ASSERT(movementMgr);
+			movementMgr->setViewportVerticalOffsetTarget(0.);
+			movementMgr->zoomTo(180., 0.5);
+		}
 
 		emit currentProjectionTypeChanged(type);
 		emit currentProjectionTypeKeyChanged(getCurrentProjectionTypeKey());

--- a/src/core/StelCore.hpp
+++ b/src/core/StelCore.hpp
@@ -101,6 +101,7 @@ public:
 		ProjectionMercator,		//!< Mercator projection
 		ProjectionMiller,		//!< Miller cylindrical projection
 		ProjectionCylinder,		//!< Cylinder projection
+		ProjectionCylinderFill		//!< Cylinder projection, no zoom or movement allowed
 	};
 	Q_ENUM(ProjectionType)
 

--- a/src/core/StelMovementMgr.cpp
+++ b/src/core/StelMovementMgr.cpp
@@ -1545,7 +1545,15 @@ void StelMovementMgr::panView(const double deltaAz, const double deltaAlt)
 	if (core->getCurrentProjectionType()==StelCore::ProjectionCylinderFill) // Inhibit any motion in this projection!
 	{
 		Vec3d tmp;
-		StelUtils::spheToRect(0., 0, tmp);
+		switch (mountMode){
+			case MountEquinoxEquatorial:
+				StelUtils::spheToRect(M_PI, 0., tmp);
+				break;
+			default:
+				StelUtils::spheToRect(0., 0., tmp);
+				break;
+		}
+
 		setViewDirectionJ2000(mountFrameToJ2000(tmp));
 		setViewUpVector(Vec3d(0., 0., 1.));
 

--- a/src/core/StelMovementMgr.cpp
+++ b/src/core/StelMovementMgr.cpp
@@ -1542,6 +1542,16 @@ void StelMovementMgr::setViewDirectionJ2000(const Vec3d& v)
 
 void StelMovementMgr::panView(const double deltaAz, const double deltaAlt)
 {
+	if (core->getCurrentProjectionType()==StelCore::ProjectionCylinderFill) // Inhibit any motion in this projection!
+	{
+		Vec3d tmp;
+		StelUtils::spheToRect(0., 0, tmp);
+		setViewDirectionJ2000(mountFrameToJ2000(tmp));
+		setViewUpVector(Vec3d(0., 0., 1.));
+
+		return;
+	}
+
 	// DONE 2016-12 FIX UP VECTOR PROBLEM
 	// The function is called in update loops, so make a quick check for exit.
 	if ((deltaAz==0.) && (deltaAlt==0.))

--- a/src/core/StelMovementMgr.hpp
+++ b/src/core/StelMovementMgr.hpp
@@ -24,6 +24,7 @@
 #include "StelModule.hpp"
 #include "StelObjectType.hpp"
 #include "VecMath.hpp"
+#include "StelCore.hpp"
 #include <QTimeLine>
 #include <QTimer>
 #include <QCursor>
@@ -479,6 +480,9 @@ private:
 	double maxFov;     // Maximum FOV in degrees. Depends on projection.
 	double userMaxFov; // Custom setting. Can be useful in a planetarium context.
 	double deltaFov;   // requested change of FOV (degrees) used during zooming.
+	StelCore* core;          // The core on which the movement are applied
+	QSettings* conf;
+	class StelObjectMgr* objectMgr;
 	void setFov(double f)
 	{
 		if (core->getCurrentProjectionType()==StelCore::ProjectionCylinderFill)
@@ -497,9 +501,6 @@ private:
 	//! Make the first screen position correspond to the second (useful for mouse dragging and also time dragging.)
 	void dragView(int x1, int y1, int x2, int y2);
 
-	StelCore* core;          // The core on which the movement are applied
-	QSettings* conf;
-	class StelObjectMgr* objectMgr;
 	bool flagLockEquPos;     // Define if the equatorial position is locked
 	bool flagTracking;       // Define if the selected object is followed
 	bool flagInhibitAllAutomoves; // Required for special installations: If true, there is no automatic centering etc.

--- a/src/core/StelMovementMgr.hpp
+++ b/src/core/StelMovementMgr.hpp
@@ -481,7 +481,10 @@ private:
 	double deltaFov;   // requested change of FOV (degrees) used during zooming.
 	void setFov(double f)
 	{
-		currentFov=qBound(minFov, f, maxFov);
+		if (core->getCurrentProjectionType()==StelCore::ProjectionCylinderFill)
+			currentFov=180.0;
+		else
+			currentFov=qBound(minFov, f, maxFov);
 	}
 	// immediately add deltaFov argument to FOV - does not change private var.
 	void changeFov(double deltaFov);

--- a/src/core/StelProjector.cpp
+++ b/src/core/StelProjector.cpp
@@ -152,7 +152,7 @@ void StelProjector::init(const StelProjectorParams& params)
 	zNear = params.zNear;
 	oneOverZNearMinusZFar = 1./(zNear-params.zFar);
 	viewportCenterOffset = params.viewportCenterOffset;
-	viewportXywh = params.viewportXywh * static_cast<int>(devicePixelsPerPixel);
+	viewportXywh = params.viewportXywh * devicePixelsPerPixel;
 	viewportCenter = params.viewportCenter * devicePixelsPerPixel;
 	gravityLabels = params.gravityLabels;
 	defaultAngleForGravityText = params.defaultAngleForGravityText;

--- a/src/core/StelProjector.cpp
+++ b/src/core/StelProjector.cpp
@@ -152,19 +152,14 @@ void StelProjector::init(const StelProjectorParams& params)
 	zNear = params.zNear;
 	oneOverZNearMinusZFar = 1./(zNear-params.zFar);
 	viewportCenterOffset = params.viewportCenterOffset;
-	viewportXywh = params.viewportXywh;
-	viewportXywh[0] *= devicePixelsPerPixel;
-	viewportXywh[1] *= devicePixelsPerPixel;
-	viewportXywh[2] *= devicePixelsPerPixel;
-	viewportXywh[3] *= devicePixelsPerPixel;
-	viewportCenter = params.viewportCenter;
-	viewportCenter *= devicePixelsPerPixel;
+	viewportXywh = params.viewportXywh * static_cast<int>(devicePixelsPerPixel);
+	viewportCenter = params.viewportCenter * devicePixelsPerPixel;
 	gravityLabels = params.gravityLabels;
 	defaultAngleForGravityText = params.defaultAngleForGravityText;
 	flipHorz = params.flipHorz ? -1.f : 1.f;
 	flipVert = params.flipVert ? -1.f : 1.f;
 	viewportFovDiameter = params.viewportFovDiameter * devicePixelsPerPixel;
-	pixelPerRad = 0.5f * static_cast<float>(viewportFovDiameter) / fovToViewScalingFactor(params.fov*(static_cast<float>(M_PI)/360.f));
+	pixelPerRad = 0.5f * static_cast<float>(viewportFovDiameter) / fovToViewScalingFactor(params.fov*(static_cast<float>(M_PI/360.)));
 	widthStretch = params.widthStretch;
 	computeBoundingCap();
 }

--- a/src/core/StelProjector.cpp
+++ b/src/core/StelProjector.cpp
@@ -152,8 +152,13 @@ void StelProjector::init(const StelProjectorParams& params)
 	zNear = params.zNear;
 	oneOverZNearMinusZFar = 1./(zNear-params.zFar);
 	viewportCenterOffset = params.viewportCenterOffset;
-	viewportXywh = params.viewportXywh * devicePixelsPerPixel;
-	viewportCenter = params.viewportCenter * devicePixelsPerPixel;
+	viewportXywh = params.viewportXywh;
+	viewportXywh[0] *= devicePixelsPerPixel;
+	viewportXywh[1] *= devicePixelsPerPixel;
+	viewportXywh[2] *= devicePixelsPerPixel;
+	viewportXywh[3] *= devicePixelsPerPixel;
+	viewportCenter = params.viewportCenter;
+	viewportCenter *= devicePixelsPerPixel;
 	gravityLabels = params.gravityLabels;
 	defaultAngleForGravityText = params.defaultAngleForGravityText;
 	flipHorz = params.flipHorz ? -1.f : 1.f;

--- a/src/core/StelProjector.hpp
+++ b/src/core/StelProjector.hpp
@@ -73,17 +73,17 @@ public:
 	{
 	public:
         Mat4dTransform(const Mat4d& altAzToWorld, const Mat4d& vertexToAltAzPos);
-	void forward(Vec3d& v) const Q_DECL_OVERRIDE;
-	void backward(Vec3d& v) const Q_DECL_OVERRIDE;
-	void forward(Vec3f& v) const Q_DECL_OVERRIDE;
-	void backward(Vec3f& v) const Q_DECL_OVERRIDE;
-	void combine(const Mat4d& m) Q_DECL_OVERRIDE;
-	Mat4d getApproximateLinearTransfo() const Q_DECL_OVERRIDE;
-	ModelViewTranformP clone() const Q_DECL_OVERRIDE;
-	QByteArray getForwardTransformShader() const Q_DECL_OVERRIDE;
-	void setForwardTransformUniforms(QOpenGLShaderProgram& program) const Q_DECL_OVERRIDE;
-	QByteArray getBackwardTransformShader() const Q_DECL_OVERRIDE;
-	void setBackwardTransformUniforms(QOpenGLShaderProgram& program) const Q_DECL_OVERRIDE;
+	void forward(Vec3d& v) const override;
+	void backward(Vec3d& v) const override;
+	void forward(Vec3f& v) const override;
+	void backward(Vec3f& v) const override;
+	void combine(const Mat4d& m) override;
+	Mat4d getApproximateLinearTransfo() const override;
+	ModelViewTranformP clone() const override;
+	QByteArray getForwardTransformShader() const override;
+	void setForwardTransformUniforms(QOpenGLShaderProgram& program) const override;
+	QByteArray getBackwardTransformShader() const override;
+	void setBackwardTransformUniforms(QOpenGLShaderProgram& program) const override;
 
 	private:
 		Mat4dTransform(const Mat4dTransform& src) = default;
@@ -164,7 +164,7 @@ public:
 	//! Apply the transformation in the backward projection in place.
 	virtual bool backward(Vec3d& v) const = 0;
 	//! Return the small zoom increment to use at the given FOV for nice movements
-	virtual float deltaZoom(float fov) const = 0;
+	virtual float deltaZoom(float fov) const {return fov;}
 	//! Returns GLSL code that can be used in a shader to implement forward transformation
 	virtual QByteArray getForwardTransformShader() const = 0;
 	//! Sets the necessary uniforms so that the shader returned by getForwardTransformShader can work
@@ -181,9 +181,9 @@ public:
 	bool intersectViewportDiscontinuity(const SphericalCap& cap) const;
 
 	//! Convert a Field Of View radius value in radians in ViewScalingFactor (used internally)
-	virtual float fovToViewScalingFactor(float fov) const = 0;
+	virtual float fovToViewScalingFactor(float fov) const {return fov;}
 	//! Convert a ViewScalingFactor value (used internally) in Field Of View radius in radians
-	virtual float viewScalingFactorToFov(float vsf) const = 0;
+	virtual float viewScalingFactorToFov(float vsf) const { return vsf;}
 
 	//! Get the current state of the flag which decides whether to
 	//! arrage labels so that they are aligned with the bottom of a 2d

--- a/src/core/StelProjector.hpp
+++ b/src/core/StelProjector.hpp
@@ -347,14 +347,14 @@ protected:
 		  widthStretch(1.0) {}
 
 	//! Return whether the projection presents discontinuities. Used for optimization.
-	virtual bool hasDiscontinuity() const =0;
+	virtual bool hasDiscontinuity() const {return false;}
 	//! Determine whether a great circle connection p1 and p2 intersects with a projection discontinuity.
 	//! For many projections without discontinuity, this should return always false, but for other like
 	//! cylindrical projection it will return true if the line cuts the wrap-around line (i.e. at lon=180 if the observer look at lon=0).
-	virtual bool intersectViewportDiscontinuityInternal(const Vec3d& p1, const Vec3d& p2) const = 0;
+	virtual bool intersectViewportDiscontinuityInternal(const Vec3d& p1, const Vec3d& p2) const {return false;}
 
 	//! Determine whether a cap intersects with a projection discontinuity.
-	virtual bool intersectViewportDiscontinuityInternal(const Vec3d& capN, double capD) const = 0;
+	virtual bool intersectViewportDiscontinuityInternal(const Vec3d& capN, double capD) const {return false;}
 
 	//! Initialize the bounding cap.
 	virtual void computeBoundingCap();

--- a/src/core/StelProjector.hpp
+++ b/src/core/StelProjector.hpp
@@ -126,7 +126,7 @@ public:
 			, devicePixelsPerPixel(1)
 			, widthStretch(1) {}
 
-		Vector4<int> viewportXywh;       //! posX, posY, width, height
+		Vec4i viewportXywh;              //! posX, posY, width, height
 		float fov;                       //! FOV in degrees
 		bool gravityLabels;              //! the flag to use gravity labels or not
 		float defaultAngleForGravityText;//! a rotation angle to apply to gravity text (only if gravityLabels is set to false)
@@ -145,7 +145,7 @@ public:
 	virtual ~StelProjector() {}
 
 	///////////////////////////////////////////////////////////////////////////
-	// Methods which must be reimplemented by all instance of StelProjector
+	// Methods which must be reimplemented by all subclasses of StelProjector
 	//! Get a human-readable name for this projection type
 	virtual QString getNameI18() const = 0;
 	//! Get a human-readable short description for this projection type

--- a/src/core/StelProjector.hpp
+++ b/src/core/StelProjector.hpp
@@ -72,18 +72,18 @@ public:
 	class Mat4dTransform: public ModelViewTranform
 	{
 	public:
-        Mat4dTransform(const Mat4d& altAzToWorld, const Mat4d& vertexToAltAzPos);
-	void forward(Vec3d& v) const override;
-	void backward(Vec3d& v) const override;
-	void forward(Vec3f& v) const override;
-	void backward(Vec3f& v) const override;
-	void combine(const Mat4d& m) override;
-	Mat4d getApproximateLinearTransfo() const override;
-	ModelViewTranformP clone() const override;
-	QByteArray getForwardTransformShader() const override;
-	void setForwardTransformUniforms(QOpenGLShaderProgram& program) const override;
-	QByteArray getBackwardTransformShader() const override;
-	void setBackwardTransformUniforms(QOpenGLShaderProgram& program) const override;
+		Mat4dTransform(const Mat4d& altAzToWorld, const Mat4d& vertexToAltAzPos);
+		void forward(Vec3d& v) const override;
+		void backward(Vec3d& v) const override;
+		void forward(Vec3f& v) const override;
+		void backward(Vec3f& v) const override;
+		void combine(const Mat4d& m) override;
+		Mat4d getApproximateLinearTransfo() const override;
+		ModelViewTranformP clone() const override;
+		QByteArray getForwardTransformShader() const override;
+		void setForwardTransformUniforms(QOpenGLShaderProgram& program) const override;
+		QByteArray getBackwardTransformShader() const override;
+		void setBackwardTransformUniforms(QOpenGLShaderProgram& program) const override;
 
 	private:
 		Mat4dTransform(const Mat4dTransform& src) = default;
@@ -359,7 +359,7 @@ protected:
 	//! Initialize the bounding cap.
 	virtual void computeBoundingCap();
 
-	ModelViewTranformP modelViewTransform;	// Operator to apply (if not Q_NULLPTR) before the modelview projection step
+	ModelViewTranformP modelViewTransform;	// Operator to apply (if not nullptr) before the modelview projection step
 
 	float flipHorz,flipVert;            // Whether to flip in horizontal or vertical directions. Values only -1 (flip) or +1 (no flip).
 	float pixelPerRad;                  // pixel per rad at the center of the viewport disk

--- a/src/core/StelProjectorClasses.cpp
+++ b/src/core/StelProjectorClasses.cpp
@@ -57,7 +57,7 @@ bool StelProjectorPerspective::forward(Vec3f &v) const
 
 bool StelProjectorPerspective::backward(Vec3d &v) const
 {
-	v[0] /= static_cast<double>(widthStretch);
+	v[0] /= widthStretch;
 	v[2] = std::sqrt(1.0/(1.0+v[0]*v[0]+v[1]*v[1]));
 	v[0] *= v[2];
 	v[1] *= v[2];
@@ -158,7 +158,7 @@ bool StelProjectorEqualArea::forward(Vec3f &v) const
 
 bool StelProjectorEqualArea::backward(Vec3d &v) const
 {
-	v[0] /= static_cast<double>(widthStretch);
+	v[0] /= widthStretch;
 	// FIXME: for high FoV, return false but don't cause crash with Mouse Pointer Coordinates.
 	const double dq = v[0]*v[0] + v[1]*v[1];
 	double l = 1.0 - 0.25*dq;
@@ -272,7 +272,7 @@ bool StelProjectorStereographic::forward(Vec3f &v) const
 
 bool StelProjectorStereographic::backward(Vec3d &v) const
 {
-	v[0] /= static_cast<double>(widthStretch);
+	v[0] /= widthStretch;
 	const double lqq = 0.25*(v[0]*v[0] + v[1]*v[1]);
 	v[2] = lqq - 1.0;
 	v *= (1.0 / (lqq + 1.0));
@@ -378,7 +378,7 @@ bool StelProjectorFisheye::forward(Vec3f &v) const
 
 bool StelProjectorFisheye::backward(Vec3d &v) const
 {
-	v[0] /= static_cast<double>(widthStretch);
+	v[0] /= widthStretch;
 	const double a = std::sqrt(v[0]*v[0]+v[1]*v[1]);
 	const double f = (a > 0.0) ? (std::sin(a) / a) : 1.0;
 	v[0] *= f;
@@ -476,7 +476,7 @@ bool StelProjectorHammer::forward(Vec3f &v) const
 	const float alpha = std::atan2(v[0],-v[2]);
 	const float cosDelta = std::sqrt(1.f-v[1]*v[1]/(r*r));
 	float z = std::sqrt(1.f+cosDelta*cosf(alpha/2.f));
-	v[0] = 2.f*static_cast<float>(M_SQRT2)*cosDelta*std::sin(alpha/2.f)/z * widthStretch;
+	v[0] = 2.f*static_cast<float>(M_SQRT2)*cosDelta*std::sin(alpha*0.5f)/z * static_cast<float>(widthStretch);
 	v[1] = static_cast<float>(M_SQRT2)*v[1]/r/z;
 	v[2] = r;
 	return true;
@@ -484,7 +484,7 @@ bool StelProjectorHammer::forward(Vec3f &v) const
 
 bool StelProjectorHammer::backward(Vec3d &v) const
 {
-	v[0] /= static_cast<double>(widthStretch);
+	v[0] /= widthStretch;
 	const double zsq = 1.-0.25*0.25*v[0]*v[0]-0.5*0.5*v[1]*v[1];
 	const double z = zsq<0. ? 0. : std::sqrt(zsq);
 	const bool ret = 0.25*v[0]*v[0]+v[1]*v[1]<2.0; // This is stolen from glunatic
@@ -585,7 +585,7 @@ bool StelProjectorCylinder::forward(Vec3f &v) const
 
 bool StelProjectorCylinder::backward(Vec3d &v) const
 {
-	v[0] /= static_cast<double>(widthStretch);
+	v[0] /= widthStretch;
 	const bool rval = v[1]<M_PI_2 && v[1]>-M_PI_2 && v[0]>-M_PI && v[0]<M_PI;
 	const double cd = std::cos(v[1]);
 	const double alpha=v[0];
@@ -678,7 +678,7 @@ bool StelProjectorCylinderFill::forward(Vec3f &v) const
 
 bool StelProjectorCylinderFill::backward(Vec3d &v) const
 {
-	v[0] /= static_cast<double>(widthStretch);
+	v[0] /= widthStretch;
 	const bool rval = v[1]<M_PI_2 && v[1]>-M_PI_2 && v[0]>-M_PI && v[0]<M_PI;
 	const double cd = std::cos(v[1]);
 	const double alpha=v[0];
@@ -688,20 +688,20 @@ bool StelProjectorCylinderFill::backward(Vec3d &v) const
 	return rval;
 }
 
-float StelProjectorCylinderFill::fovToViewScalingFactor(float fov) const
-{
-	return fov;
-}
-
-float StelProjectorCylinderFill::viewScalingFactorToFov(float vsf) const
-{
-	return vsf;
-}
-
-float StelProjectorCylinderFill::deltaZoom(float fov) const
-{
-	return fov;
-}
+//float StelProjectorCylinderFill::fovToViewScalingFactor(float fov) const
+//{
+//	return fov;
+//}
+//
+//float StelProjectorCylinderFill::viewScalingFactorToFov(float vsf) const
+//{
+//	return vsf;
+//}
+//
+//float StelProjectorCylinderFill::deltaZoom(float fov) const
+//{
+//	return fov;
+//}
 
 
 
@@ -729,7 +729,7 @@ bool StelProjectorMercator::forward(Vec3f &v) const
 
 bool StelProjectorMercator::backward(Vec3d &v) const
 {
-	v[0] /= static_cast<double>(widthStretch);
+	v[0] /= widthStretch;
 	const bool rval = v[0]>-M_PI && v[0]<M_PI;
 	const double E = std::exp(v[1]);
 	const double h = E*E;
@@ -825,7 +825,7 @@ bool StelProjectorOrthographic::forward(Vec3f &v) const
 
 bool StelProjectorOrthographic::backward(Vec3d &v) const
 {
-	v[0] /= static_cast<double>(widthStretch);
+	v[0] /= widthStretch;
 	const double dq = v[0]*v[0] + v[1]*v[1];
 	double h = 1.0 - dq;
 	if (h < 0) {
@@ -923,7 +923,7 @@ bool StelProjectorSinusoidal::forward(Vec3f &v) const
 
 bool StelProjectorSinusoidal::backward(Vec3d &v) const
 {
-	v[0] /= static_cast<double>(widthStretch);
+	v[0] /= widthStretch;
 	const bool rval = v[1]<M_PI_2 && v[1]>-M_PI_2 && v[0]>-M_PI && v[0]<M_PI;
 	const double cd = std::cos(v[1]);
 	const double pcd = v[0]/cd;
@@ -1018,7 +1018,7 @@ bool StelProjectorMiller::forward(Vec3f &v) const
 
 bool StelProjectorMiller::backward(Vec3d &v) const
 {
-	v[0] /= static_cast<double>(widthStretch);
+	v[0] /= widthStretch;
 	const double yMax=1.25*asinh(tan(M_PI*2.0/5.0));
 	const bool rval = v[1]<yMax && v[1]>-yMax && v[0]>-M_PI && v[0]<M_PI;
 	const double lat = 1.25*atan(sinh(0.8*v[1]));

--- a/src/core/StelProjectorClasses.cpp
+++ b/src/core/StelProjectorClasses.cpp
@@ -606,12 +606,13 @@ vec3 projectorBackwardTransform(vec3 v, out bool ok)
 
 QString StelProjectorCylinderFill::getNameI18() const
 {
-	return q_("Cylinder fill");
+	return q_("Equirectangular");
 }
 
 QString StelProjectorCylinderFill::getDescriptionI18() const
 {
-	return q_("The full name of this projection mode is <i>plate carr&eacute;e</i>  (French, for 'flat square'). With this projection all parallels are equally spaced.");
+	return q_("The full name of this variant of the Cylindrical projection mode is <i>plate carr&eacute;e</i> (French, for 'flat square'). With this projection all parallels are equally spaced. "
+		  "The view is stretched to always show a 360x180° field of view in a fixed view direction. It is provided for specialized setups.");
 }
 
 bool StelProjectorCylinderFill::forward(Vec3f &v) const

--- a/src/core/StelProjectorClasses.cpp
+++ b/src/core/StelProjectorClasses.cpp
@@ -611,7 +611,7 @@ QString StelProjectorCylinderFill::getNameI18() const
 
 QString StelProjectorCylinderFill::getDescriptionI18() const
 {
-	return q_("The full name of this variant of the Cylindrical projection mode is <i>plate carr&eacute;e</i> (French, for 'flat square'). With this projection all parallels are equally spaced. "
+	return q_("Another name of this variant of the Cylindrical projection mode is <i>plate carr&eacute;e</i> (French, for 'flat square'). With this projection all parallels are equally spaced. "
 		  "The view is stretched to always show a 360x180° field of view in a fixed view direction. It is provided for specialized setups.");
 }
 

--- a/src/core/StelProjectorClasses.cpp
+++ b/src/core/StelProjectorClasses.cpp
@@ -653,6 +653,58 @@ vec3 projectorBackwardTransform(vec3 v, out bool ok)
 )";
 }
 
+
+QString StelProjectorCylinderFill::getNameI18() const
+{
+	return q_("Cylinder fill");
+}
+
+QString StelProjectorCylinderFill::getDescriptionI18() const
+{
+	return q_("The full name of this projection mode is <i>plate carr&eacute;e</i>  (French, for 'flat square'). With this projection all parallels are equally spaced.");
+}
+
+bool StelProjectorCylinderFill::forward(Vec3f &v) const
+{
+	const float r = std::sqrt(v[0]*v[0] + v[1]*v[1] + v[2]*v[2]);
+	const bool rval = (-r < v[1] && v[1] < r);
+	const float alpha = std::atan2(v[0],-v[2]);
+	const float delta = std::asin(v[1]/r);
+	v[0] = alpha*static_cast<float>(widthStretch);
+	v[1] = delta;
+	v[2] = r;
+	return rval;
+}
+
+bool StelProjectorCylinderFill::backward(Vec3d &v) const
+{
+	v[0] /= static_cast<double>(widthStretch);
+	const bool rval = v[1]<M_PI_2 && v[1]>-M_PI_2 && v[0]>-M_PI && v[0]<M_PI;
+	const double cd = std::cos(v[1]);
+	const double alpha=v[0];
+	v[2] = - cd * std::cos(alpha);
+	v[0] = cd * std::sin(alpha);
+	v[1] = std::sin(v[1]);
+	return rval;
+}
+
+float StelProjectorCylinderFill::fovToViewScalingFactor(float fov) const
+{
+	return fov;
+}
+
+float StelProjectorCylinderFill::viewScalingFactorToFov(float vsf) const
+{
+	return vsf;
+}
+
+float StelProjectorCylinderFill::deltaZoom(float fov) const
+{
+	return fov;
+}
+
+
+
 QString StelProjectorMercator::getNameI18() const
 {
 	return q_("Mercator");

--- a/src/core/StelProjectorClasses.cpp
+++ b/src/core/StelProjectorClasses.cpp
@@ -615,30 +615,6 @@ QString StelProjectorCylinderFill::getDescriptionI18() const
 		  "The view is stretched to always show a 360x180° field of view in a fixed view direction. It is provided for specialized setups.");
 }
 
-bool StelProjectorCylinderFill::forward(Vec3f &v) const
-{
-	const float r = std::sqrt(v[0]*v[0] + v[1]*v[1] + v[2]*v[2]);
-	const bool rval = (-r < v[1] && v[1] < r);
-	const float alpha = std::atan2(v[0],-v[2]);
-	const float delta = std::asin(v[1]/r);
-	v[0] = alpha*static_cast<float>(widthStretch);
-	v[1] = delta;
-	v[2] = r;
-	return rval;
-}
-
-bool StelProjectorCylinderFill::backward(Vec3d &v) const
-{
-	v[0] /= widthStretch;
-	const bool rval = v[1]<M_PI_2 && v[1]>-M_PI_2 && v[0]>-M_PI && v[0]<M_PI;
-	const double cd = std::cos(v[1]);
-	const double alpha=v[0];
-	v[2] = - cd * std::cos(alpha);
-	v[0] = cd * std::sin(alpha);
-	v[1] = std::sin(v[1]);
-	return rval;
-}
-
 QString StelProjectorMercator::getNameI18() const
 {
 	return q_("Mercator");
@@ -659,7 +635,6 @@ bool StelProjectorMercator::forward(Vec3f &v) const
 	v[2] = r;
 	return rval;
 }
-
 
 bool StelProjectorMercator::backward(Vec3d &v) const
 {

--- a/src/core/StelProjectorClasses.cpp
+++ b/src/core/StelProjectorClasses.cpp
@@ -189,11 +189,6 @@ float StelProjectorEqualArea::viewScalingFactorToFov(float vsf) const
 	return 2.f * std::asin(0.5f * vsf);
 }
 
-float StelProjectorEqualArea::deltaZoom(float fov) const
-{
-	return fov;
-}
-
 QByteArray StelProjectorEqualArea::getForwardTransformShader() const
 {
 	return modelViewTransform->getForwardTransformShader() + R"(
@@ -387,21 +382,6 @@ bool StelProjectorFisheye::backward(Vec3d &v) const
 	return (a < M_PI);
 }
 
-float StelProjectorFisheye::fovToViewScalingFactor(float fov) const
-{
-	return fov;
-}
-
-float StelProjectorFisheye::viewScalingFactorToFov(float vsf) const
-{
-	return vsf;
-}
-
-float StelProjectorFisheye::deltaZoom(float fov) const
-{
-	return fov;
-}
-
 QByteArray StelProjectorFisheye::getForwardTransformShader() const
 {
 	return modelViewTransform->getForwardTransformShader() + R"(
@@ -497,21 +477,6 @@ bool StelProjectorHammer::backward(Vec3d &v) const
 	return ret;
 }
 
-float StelProjectorHammer::fovToViewScalingFactor(float fov) const
-{
-	return fov;
-}
-
-float StelProjectorHammer::viewScalingFactorToFov(float vsf) const
-{
-	return vsf;
-}
-
-float StelProjectorHammer::deltaZoom(float fov) const
-{
-	return fov;
-}
-
 QByteArray StelProjectorHammer::getForwardTransformShader() const
 {
 	return modelViewTransform->getForwardTransformShader() + R"(
@@ -595,21 +560,6 @@ bool StelProjectorCylinder::backward(Vec3d &v) const
 	return rval;
 }
 
-float StelProjectorCylinder::fovToViewScalingFactor(float fov) const
-{
-	return fov;
-}
-
-float StelProjectorCylinder::viewScalingFactorToFov(float vsf) const
-{
-	return vsf;
-}
-
-float StelProjectorCylinder::deltaZoom(float fov) const
-{
-	return fov;
-}
-
 QByteArray StelProjectorCylinder::getForwardTransformShader() const
 {
 	return modelViewTransform->getForwardTransformShader() + R"(
@@ -688,23 +638,6 @@ bool StelProjectorCylinderFill::backward(Vec3d &v) const
 	return rval;
 }
 
-//float StelProjectorCylinderFill::fovToViewScalingFactor(float fov) const
-//{
-//	return fov;
-//}
-//
-//float StelProjectorCylinderFill::viewScalingFactorToFov(float vsf) const
-//{
-//	return vsf;
-//}
-//
-//float StelProjectorCylinderFill::deltaZoom(float fov) const
-//{
-//	return fov;
-//}
-
-
-
 QString StelProjectorMercator::getNameI18() const
 {
 	return q_("Mercator");
@@ -740,21 +673,6 @@ bool StelProjectorMercator::backward(Vec3d &v) const
 	v[0] = cos_delta * std::sin(v[0]);
 	v[1] = sin_delta;
 	return rval;
-}
-
-float StelProjectorMercator::fovToViewScalingFactor(float fov) const
-{
-	return fov;
-}
-
-float StelProjectorMercator::viewScalingFactorToFov(float vsf) const
-{
-	return vsf;
-}
-
-float StelProjectorMercator::deltaZoom(float fov) const
-{
-	return fov;
 }
 
 QByteArray StelProjectorMercator::getForwardTransformShader() const
@@ -847,11 +765,6 @@ float StelProjectorOrthographic::fovToViewScalingFactor(float fov) const
 float StelProjectorOrthographic::viewScalingFactorToFov(float vsf) const
 {
 	return std::asin(vsf);
-}
-
-float StelProjectorOrthographic::deltaZoom(float fov) const
-{
-	return fov;
 }
 
 QByteArray StelProjectorOrthographic::getForwardTransformShader() const

--- a/src/core/StelProjectorClasses.hpp
+++ b/src/core/StelProjectorClasses.hpp
@@ -26,50 +26,50 @@ class StelProjectorPerspective : public StelProjector
 {
 public:
 	StelProjectorPerspective(ModelViewTranformP func) : StelProjector(func) {}
-	virtual QString getNameI18() const Q_DECL_OVERRIDE;
-	virtual QString getDescriptionI18() const Q_DECL_OVERRIDE;
-	virtual float getMaxFov() const Q_DECL_OVERRIDE {return 120.f;}
-	virtual bool forward(Vec3f &v) const Q_DECL_OVERRIDE;
-	virtual bool backward(Vec3d &v) const Q_DECL_OVERRIDE;
-	virtual float fovToViewScalingFactor(float fov) const Q_DECL_OVERRIDE;
-	virtual float viewScalingFactorToFov(float vsf) const Q_DECL_OVERRIDE;
-	virtual float deltaZoom(float fov) const Q_DECL_OVERRIDE;
-	virtual QByteArray getForwardTransformShader() const Q_DECL_OVERRIDE;
-	virtual QByteArray getBackwardTransformShader() const Q_DECL_OVERRIDE;
+	QString getNameI18() const override;
+	QString getDescriptionI18() const override;
+	float getMaxFov() const override {return 120.f;}
+	bool forward(Vec3f &v) const override;
+	bool backward(Vec3d &v) const override;
+	float fovToViewScalingFactor(float fov) const override;
+	float viewScalingFactorToFov(float vsf) const override;
+	float deltaZoom(float fov) const override;
+	QByteArray getForwardTransformShader() const override;
+	QByteArray getBackwardTransformShader() const override;
 protected:
-	virtual bool hasDiscontinuity() const Q_DECL_OVERRIDE {return false;}
-	virtual bool intersectViewportDiscontinuityInternal(const Vec3d&, const Vec3d&) const  Q_DECL_OVERRIDE {return false;}
-	virtual bool intersectViewportDiscontinuityInternal(const Vec3d&, double) const Q_DECL_OVERRIDE {return false;}
+	bool hasDiscontinuity() const override {return false;}
+	bool intersectViewportDiscontinuityInternal(const Vec3d&, const Vec3d&) const  override {return false;}
+	bool intersectViewportDiscontinuityInternal(const Vec3d&, double) const override {return false;}
 };
 
 class StelProjectorEqualArea : public StelProjector
 {
 public:
 	StelProjectorEqualArea(ModelViewTranformP func) : StelProjector(func) {}
-	virtual QString getNameI18() const Q_DECL_OVERRIDE;
-	virtual QString getDescriptionI18() const Q_DECL_OVERRIDE;
-	virtual float getMaxFov() const Q_DECL_OVERRIDE{return 360.f;}
-	virtual bool forward(Vec3f &v) const Q_DECL_OVERRIDE;
-	virtual bool backward(Vec3d &v) const Q_DECL_OVERRIDE;
-	virtual float fovToViewScalingFactor(float fov) const Q_DECL_OVERRIDE;
-	virtual float viewScalingFactorToFov(float vsf) const Q_DECL_OVERRIDE;
-	virtual float deltaZoom(float fov) const Q_DECL_OVERRIDE;
-	virtual QByteArray getForwardTransformShader() const Q_DECL_OVERRIDE;
-	virtual QByteArray getBackwardTransformShader() const Q_DECL_OVERRIDE;
+	QString getNameI18() const override;
+	QString getDescriptionI18() const override;
+	float getMaxFov() const override{return 360.f;}
+	bool forward(Vec3f &v) const override;
+	bool backward(Vec3d &v) const override;
+	float fovToViewScalingFactor(float fov) const override;
+	float viewScalingFactorToFov(float vsf) const override;
+	// float deltaZoom(float fov) const override;
+	QByteArray getForwardTransformShader() const override;
+	QByteArray getBackwardTransformShader() const override;
 protected:
-	virtual bool hasDiscontinuity() const Q_DECL_OVERRIDE {return false;}
-	virtual bool intersectViewportDiscontinuityInternal(const Vec3d&, const Vec3d&) const  Q_DECL_OVERRIDE {return false;}
-	virtual bool intersectViewportDiscontinuityInternal(const Vec3d&, double) const  Q_DECL_OVERRIDE {return false;}
+	bool hasDiscontinuity() const override {return false;}
+	bool intersectViewportDiscontinuityInternal(const Vec3d&, const Vec3d&) const  override {return false;}
+	bool intersectViewportDiscontinuityInternal(const Vec3d&, double) const  override {return false;}
 };
 
 class StelProjectorStereographic : public StelProjector
 {
 public:
 	StelProjectorStereographic(ModelViewTranformP func) : StelProjector(func) {}
-	virtual QString getNameI18() const Q_DECL_OVERRIDE;
-	virtual QString getDescriptionI18() const Q_DECL_OVERRIDE;
-	virtual float getMaxFov() const  Q_DECL_OVERRIDE {return 235.f;}
-//	virtual void project(int n, const Vec3d* in, Vec3f* out) Q_DECL_OVERRIDE
+	QString getNameI18() const override;
+	QString getDescriptionI18() const override;
+	float getMaxFov() const  override {return 235.f;}
+//	void project(int n, const Vec3d* in, Vec3f* out) override
 //	{
 //		Vec3d v;
 //		for (int i = 0; i < n; ++i, ++out)
@@ -84,48 +84,48 @@ public:
 //		}
 //	}
 
-	virtual bool forward(Vec3f &v) const Q_DECL_OVERRIDE;
-	virtual bool backward(Vec3d &v) const Q_DECL_OVERRIDE;
-	virtual float fovToViewScalingFactor(float fov) const Q_DECL_OVERRIDE;
-	virtual float viewScalingFactorToFov(float vsf) const Q_DECL_OVERRIDE;
-	virtual float deltaZoom(float fov) const Q_DECL_OVERRIDE;
-	virtual QByteArray getForwardTransformShader() const Q_DECL_OVERRIDE;
-	virtual QByteArray getBackwardTransformShader() const Q_DECL_OVERRIDE;
+	bool forward(Vec3f &v) const override;
+	bool backward(Vec3d &v) const override;
+	float fovToViewScalingFactor(float fov) const override;
+	float viewScalingFactorToFov(float vsf) const override;
+	float deltaZoom(float fov) const override;
+	QByteArray getForwardTransformShader() const override;
+	QByteArray getBackwardTransformShader() const override;
 protected:
-	virtual bool hasDiscontinuity() const Q_DECL_OVERRIDE {return false;}
-	virtual bool intersectViewportDiscontinuityInternal(const Vec3d&, const Vec3d&) const Q_DECL_OVERRIDE {return false;}
-	virtual bool intersectViewportDiscontinuityInternal(const Vec3d&, double) const Q_DECL_OVERRIDE {return false;}
+	bool hasDiscontinuity() const override {return false;}
+	bool intersectViewportDiscontinuityInternal(const Vec3d&, const Vec3d&) const override {return false;}
+	bool intersectViewportDiscontinuityInternal(const Vec3d&, double) const override {return false;}
 };
 
 class StelProjectorFisheye : public StelProjector
 {
 public:
 	StelProjectorFisheye(ModelViewTranformP func) : StelProjector(func) {}
-	virtual QString getNameI18() const Q_DECL_OVERRIDE;
-	virtual QString getDescriptionI18() const Q_DECL_OVERRIDE;
-	virtual float getMaxFov() const Q_DECL_OVERRIDE {return 360.0f;}
-	virtual bool forward(Vec3f &v) const Q_DECL_OVERRIDE;
-	virtual bool backward(Vec3d &v) const Q_DECL_OVERRIDE;
-	virtual float fovToViewScalingFactor(float fov) const Q_DECL_OVERRIDE;
-	virtual float viewScalingFactorToFov(float vsf) const Q_DECL_OVERRIDE;
-	virtual float deltaZoom(float fov) const Q_DECL_OVERRIDE;
-	virtual QByteArray getForwardTransformShader() const Q_DECL_OVERRIDE;
-	virtual QByteArray getBackwardTransformShader() const Q_DECL_OVERRIDE;
+	QString getNameI18() const override;
+	QString getDescriptionI18() const override;
+	float getMaxFov() const override {return 360.0f;}
+	bool forward(Vec3f &v) const override;
+	bool backward(Vec3d &v) const override;
+	//float fovToViewScalingFactor(float fov) const override;
+	//float viewScalingFactorToFov(float vsf) const override;
+	//float deltaZoom(float fov) const override;
+	QByteArray getForwardTransformShader() const override;
+	QByteArray getBackwardTransformShader() const override;
 protected:
-	virtual bool hasDiscontinuity() const Q_DECL_OVERRIDE {return false;}
-	virtual bool intersectViewportDiscontinuityInternal(const Vec3d&, const Vec3d&) const Q_DECL_OVERRIDE {return false;}
-	virtual bool intersectViewportDiscontinuityInternal(const Vec3d&, double) const Q_DECL_OVERRIDE {return false;}
+	bool hasDiscontinuity() const override {return false;}
+	bool intersectViewportDiscontinuityInternal(const Vec3d&, const Vec3d&) const override {return false;}
+	bool intersectViewportDiscontinuityInternal(const Vec3d&, double) const override {return false;}
 };
 
 class StelProjectorHammer : public StelProjector
 {
 public:
 	StelProjectorHammer(ModelViewTranformP func) : StelProjector(func) {}
-	virtual QString getNameI18() const Q_DECL_OVERRIDE;
-	virtual QString getDescriptionI18() const Q_DECL_OVERRIDE;
-//	virtual float getMaxFov() const Q_DECL_OVERRIDE {return 185.f;}
-	virtual float getMaxFov() const Q_DECL_OVERRIDE {return 360.f;}
-//	virtual void project(int n, const Vec3d* in, Vec3f* out) Q_DECL_OVERRIDE
+	QString getNameI18() const override;
+	QString getDescriptionI18() const override;
+//	float getMaxFov() const override {return 185.f;}
+	float getMaxFov() const override {return 360.f;}
+//	void project(int n, const Vec3d* in, Vec3f* out) override
 //	{
 //		Vec3d v;
 //		for (int i = 0; i < n; ++i)
@@ -139,17 +139,17 @@ public:
 //			out[i][2] = (out[i][2] - static_cast<float>(zNear)) * static_cast<float>(oneOverZNearMinusZFar);
 //		}
 //	}
-	virtual bool forward(Vec3f &v) const Q_DECL_OVERRIDE;
-	virtual bool backward(Vec3d &v) const Q_DECL_OVERRIDE;
-	virtual float fovToViewScalingFactor(float fov) const Q_DECL_OVERRIDE;
-	virtual float viewScalingFactorToFov(float vsf) const Q_DECL_OVERRIDE;
-	virtual float deltaZoom(float fov) const Q_DECL_OVERRIDE;
-	virtual QByteArray getForwardTransformShader() const Q_DECL_OVERRIDE;
-	virtual QByteArray getBackwardTransformShader() const Q_DECL_OVERRIDE;
+	bool forward(Vec3f &v) const override;
+	bool backward(Vec3d &v) const override;
+	//float fovToViewScalingFactor(float fov) const override;
+	//float viewScalingFactorToFov(float vsf) const override;
+	//float deltaZoom(float fov) const override;
+	virtual QByteArray getForwardTransformShader() const override;
+	virtual QByteArray getBackwardTransformShader() const override;
 protected:
-	virtual bool hasDiscontinuity() const Q_DECL_OVERRIDE {return true;}
-	virtual bool intersectViewportDiscontinuityInternal(const Vec3d& p1, const Vec3d& p2) const Q_DECL_OVERRIDE {return p1[0]*p2[0]<0 && !(p1[2]<0 && p2[2]<0);}
-	virtual bool intersectViewportDiscontinuityInternal(const Vec3d& capN, double capD) const Q_DECL_OVERRIDE
+	bool hasDiscontinuity() const override {return true;}
+	bool intersectViewportDiscontinuityInternal(const Vec3d& p1, const Vec3d& p2) const override {return p1[0]*p2[0]<0 && !(p1[2]<0 && p2[2]<0);}
+	bool intersectViewportDiscontinuityInternal(const Vec3d& capN, double capD) const override
 	{
 		static const SphericalCap cap1(1,0,0);
 		static const SphericalCap cap2(-1,0,0);
@@ -163,24 +163,24 @@ class StelProjectorCylinder : public StelProjector
 {
 public:
 	StelProjectorCylinder(ModelViewTranformP func) : StelProjector(func) {}
-	virtual QString getNameI18() const Q_DECL_OVERRIDE;
-	virtual QString getDescriptionI18() const Q_DECL_OVERRIDE;
-//	virtual float getMaxFov() const Q_DECL_OVERRIDE {return 200.f;} // slight overshoot
-	virtual float getMaxFov() const Q_DECL_OVERRIDE {return 175.f * 4.f/3.f;} // assume aspect ration of 4/3 for getting a full 360 degree horizon
-	virtual bool forward(Vec3f &win) const Q_DECL_OVERRIDE;
-	virtual bool backward(Vec3d &v) const Q_DECL_OVERRIDE;
-	virtual float fovToViewScalingFactor(float fov) const Q_DECL_OVERRIDE;
-	virtual float viewScalingFactorToFov(float vsf) const Q_DECL_OVERRIDE;
-	virtual float deltaZoom(float fov) const Q_DECL_OVERRIDE;
-	virtual QByteArray getForwardTransformShader() const Q_DECL_OVERRIDE;
-	virtual QByteArray getBackwardTransformShader() const Q_DECL_OVERRIDE;
+	QString getNameI18() const override;
+	QString getDescriptionI18() const override;
+//	virtual float getMaxFov() const override {return 200.f;} // slight overshoot
+	float getMaxFov() const override {return 175.f * 4.f/3.f;} // assume aspect ration of 4/3 for getting a full 360 degree horizon
+	bool forward(Vec3f &win) const override;
+	bool backward(Vec3d &v) const override;
+	//float fovToViewScalingFactor(float fov) const override;
+	//float viewScalingFactorToFov(float vsf) const override;
+	//float deltaZoom(float fov) const override;
+	QByteArray getForwardTransformShader() const override;
+	QByteArray getBackwardTransformShader() const override;
 protected:
-	virtual bool hasDiscontinuity() const Q_DECL_OVERRIDE {return true;}
-	virtual bool intersectViewportDiscontinuityInternal(const Vec3d& p1, const Vec3d& p2) const Q_DECL_OVERRIDE
+	bool hasDiscontinuity() const override {return true;}
+	bool intersectViewportDiscontinuityInternal(const Vec3d& p1, const Vec3d& p2) const override
 	{
 		return p1[0]*p2[0]<0 && !(p1[2]<0 && p2[2]<0);
 	}
-	virtual bool intersectViewportDiscontinuityInternal(const Vec3d& capN, double capD) const Q_DECL_OVERRIDE
+	bool intersectViewportDiscontinuityInternal(const Vec3d& capN, double capD) const override
 	{
 		static const SphericalCap cap1(1,0,0);
 		static const SphericalCap cap2(-1,0,0);
@@ -195,21 +195,21 @@ class StelProjectorCylinderFill : public StelProjectorCylinder
 {
 public:
 	StelProjectorCylinderFill(ModelViewTranformP func) : StelProjectorCylinder(func) {;}
-	virtual QString getNameI18() const Q_DECL_OVERRIDE;
-	virtual QString getDescriptionI18() const Q_DECL_OVERRIDE;
-	virtual float getMaxFov() const Q_DECL_OVERRIDE {return 180.f;} // vertical fov always max 180.
-	virtual bool forward(Vec3f &win) const Q_DECL_OVERRIDE;
-	virtual bool backward(Vec3d &v) const Q_DECL_OVERRIDE;
-	//virtual float fovToViewScalingFactor(float fov) const Q_DECL_OVERRIDE;
-	//virtual float viewScalingFactorToFov(float vsf) const Q_DECL_OVERRIDE;
-	//virtual float deltaZoom(float fov) const Q_DECL_OVERRIDE;
+	QString getNameI18() const override;
+	QString getDescriptionI18() const override;
+	float getMaxFov() const override {return 180.f;} // vertical fov always max 180.
+	bool forward(Vec3f &win) const override;
+	bool backward(Vec3d &v) const override;
+	//float fovToViewScalingFactor(float fov) const override;
+	//float viewScalingFactorToFov(float vsf) const override;
+	//float deltaZoom(float fov) const override;
 protected:
-	//virtual bool hasDiscontinuity() const {return true;}
-	//virtual bool intersectViewportDiscontinuityInternal(const Vec3d& p1, const Vec3d& p2) const
+	//bool hasDiscontinuity() const {return true;}
+	//bool intersectViewportDiscontinuityInternal(const Vec3d& p1, const Vec3d& p2) const
 	//{
 	//	return p1[0]*p2[0]<0 && !(p1[2]<0 && p2[2]<0);
 	//}
-	//virtual bool intersectViewportDiscontinuityInternal(const Vec3d& capN, double capD) const
+	//bool intersectViewportDiscontinuityInternal(const Vec3d& capN, double capD) const
 	//{
 	//	static const SphericalCap cap1(1,0,0);
 	//	static const SphericalCap cap2(-1,0,0);
@@ -223,24 +223,24 @@ class StelProjectorMercator : public StelProjector
 {
 public:
 	StelProjectorMercator(ModelViewTranformP func) : StelProjector(func) {}
-	virtual QString getNameI18() const Q_DECL_OVERRIDE;
-	virtual QString getDescriptionI18() const Q_DECL_OVERRIDE;
-//	virtual float getMaxFov() const Q_DECL_OVERRIDE {return 270.f; }
-	virtual float getMaxFov() const Q_DECL_OVERRIDE {return 175.f * 4.f/3.f;} // assume aspect ration of 4/3 for getting a full 360 degree horizon
-	virtual bool forward(Vec3f &win) const Q_DECL_OVERRIDE;
-	virtual bool backward(Vec3d &v) const Q_DECL_OVERRIDE;
-	virtual float fovToViewScalingFactor(float fov) const Q_DECL_OVERRIDE;
-	virtual float viewScalingFactorToFov(float vsf) const Q_DECL_OVERRIDE;
-	virtual float deltaZoom(float fov) const Q_DECL_OVERRIDE;
-	virtual QByteArray getForwardTransformShader() const Q_DECL_OVERRIDE;
-	virtual QByteArray getBackwardTransformShader() const Q_DECL_OVERRIDE;
+	QString getNameI18() const override;
+	QString getDescriptionI18() const override;
+//	float getMaxFov() const override {return 270.f; }
+	float getMaxFov() const override {return 175.f * 4.f/3.f;} // assume aspect ration of 4/3 for getting a full 360 degree horizon
+	bool forward(Vec3f &win) const override;
+	bool backward(Vec3d &v) const override;
+	//float fovToViewScalingFactor(float fov) const override;
+	//float viewScalingFactorToFov(float vsf) const override;
+	//float deltaZoom(float fov) const override;
+	QByteArray getForwardTransformShader() const override;
+	QByteArray getBackwardTransformShader() const override;
 protected:
-	virtual bool hasDiscontinuity() const Q_DECL_OVERRIDE {return true;}
-	virtual bool intersectViewportDiscontinuityInternal(const Vec3d& p1, const Vec3d& p2) const Q_DECL_OVERRIDE
+	bool hasDiscontinuity() const override {return true;}
+	bool intersectViewportDiscontinuityInternal(const Vec3d& p1, const Vec3d& p2) const override
 	{
 		return p1[0]*p2[0]<0 && !(p1[2]<0 && p2[2]<0);
 	}
-	virtual bool intersectViewportDiscontinuityInternal(const Vec3d& capN, double capD) const Q_DECL_OVERRIDE
+	bool intersectViewportDiscontinuityInternal(const Vec3d& capN, double capD) const override
 	{
 		static const SphericalCap cap1(1,0,0);
 		static const SphericalCap cap2(-1,0,0);
@@ -254,69 +254,69 @@ class StelProjectorOrthographic : public StelProjector
 {
 public:
 	StelProjectorOrthographic(ModelViewTranformP func) : StelProjector(func) {}
-	virtual QString getNameI18() const Q_DECL_OVERRIDE;
-	virtual QString getDescriptionI18() const Q_DECL_OVERRIDE;
-	virtual float getMaxFov() const Q_DECL_OVERRIDE {return 179.9999f;}
-	virtual bool forward(Vec3f &win) const Q_DECL_OVERRIDE;
-	virtual bool backward(Vec3d &v) const Q_DECL_OVERRIDE;
-	virtual float fovToViewScalingFactor(float fov) const Q_DECL_OVERRIDE;
-	virtual float viewScalingFactorToFov(float vsf) const Q_DECL_OVERRIDE;
-	virtual float deltaZoom(float fov) const Q_DECL_OVERRIDE;
-	virtual QByteArray getForwardTransformShader() const Q_DECL_OVERRIDE;
-	virtual QByteArray getBackwardTransformShader() const Q_DECL_OVERRIDE;
+	QString getNameI18() const override;
+	QString getDescriptionI18() const override;
+	float getMaxFov() const override {return 179.9999f;}
+	bool forward(Vec3f &win) const override;
+	bool backward(Vec3d &v) const override;
+	float fovToViewScalingFactor(float fov) const override;
+	float viewScalingFactorToFov(float vsf) const override;
+	//float deltaZoom(float fov) const override;
+	QByteArray getForwardTransformShader() const override;
+	QByteArray getBackwardTransformShader() const override;
 protected:
-	virtual bool hasDiscontinuity() const Q_DECL_OVERRIDE {return false;}
-	virtual bool intersectViewportDiscontinuityInternal(const Vec3d&, const Vec3d&) const Q_DECL_OVERRIDE {return false;}
-	virtual bool intersectViewportDiscontinuityInternal(const Vec3d&, double) const Q_DECL_OVERRIDE {return false;}
+	bool hasDiscontinuity() const override {return false;}
+	bool intersectViewportDiscontinuityInternal(const Vec3d&, const Vec3d&) const override {return false;}
+	bool intersectViewportDiscontinuityInternal(const Vec3d&, double) const override {return false;}
 };
 
 class StelProjectorSinusoidal : public StelProjectorCylinder
 {
 public:
 	StelProjectorSinusoidal(ModelViewTranformP func) : StelProjectorCylinder(func) {}
-	virtual QString getNameI18() const Q_DECL_OVERRIDE;
-	virtual QString getDescriptionI18() const Q_DECL_OVERRIDE;
-	virtual bool forward(Vec3f &win) const Q_DECL_OVERRIDE;
-	virtual bool backward(Vec3d &v) const Q_DECL_OVERRIDE;
-	virtual QByteArray getForwardTransformShader() const Q_DECL_OVERRIDE;
-	virtual QByteArray getBackwardTransformShader() const Q_DECL_OVERRIDE;
+	QString getNameI18() const override;
+	QString getDescriptionI18() const override;
+	bool forward(Vec3f &win) const override;
+	bool backward(Vec3d &v) const override;
+	QByteArray getForwardTransformShader() const override;
+	QByteArray getBackwardTransformShader() const override;
 };
 
 class StelProjectorMiller : public StelProjectorMercator
 {
 public:
 	StelProjectorMiller(ModelViewTranformP func) : StelProjectorMercator(func) {}
-	virtual QString getNameI18() const Q_DECL_OVERRIDE;
-	virtual QString getDescriptionI18() const Q_DECL_OVERRIDE;
-//	virtual float getMaxFov() const Q_DECL_OVERRIDE {return 270.f; }
-	virtual float getMaxFov() const Q_DECL_OVERRIDE {return 175.f * 4.f/3.f;} // or 180?
-	virtual bool forward(Vec3f &win) const Q_DECL_OVERRIDE;
-	virtual bool backward(Vec3d &v) const Q_DECL_OVERRIDE;
-	virtual QByteArray getForwardTransformShader() const Q_DECL_OVERRIDE;
-	virtual QByteArray getBackwardTransformShader() const Q_DECL_OVERRIDE;
+	QString getNameI18() const override;
+	QString getDescriptionI18() const override;
+//	float getMaxFov() const override {return 270.f; }
+	float getMaxFov() const override {return 175.f * 4.f/3.f;} // or 180?
+	bool forward(Vec3f &win) const override;
+	bool backward(Vec3d &v) const override;
+	QByteArray getForwardTransformShader() const override;
+	QByteArray getBackwardTransformShader() const override;
 };
 
 class StelProjector2d : public StelProjector
 {
 public:
 	StelProjector2d() : StelProjector(ModelViewTranformP(new StelProjector::Mat4dTransform(Mat4d::identity(),Mat4d::identity()))) {}
-	virtual QString getNameI18() const Q_DECL_OVERRIDE;
-	virtual QString getDescriptionI18() const Q_DECL_OVERRIDE;
-	virtual float getMaxFov() const Q_DECL_OVERRIDE {return 360.f;}
-	virtual bool forward(Vec3f &win) const Q_DECL_OVERRIDE;
-	virtual bool backward(Vec3d &v) const Q_DECL_OVERRIDE;
-	virtual float fovToViewScalingFactor(float fov) const Q_DECL_OVERRIDE;
-	virtual float viewScalingFactorToFov(float vsf) const Q_DECL_OVERRIDE;
-	virtual float deltaZoom(float fov) const Q_DECL_OVERRIDE;
-	virtual QByteArray getForwardTransformShader() const Q_DECL_OVERRIDE;
-	virtual void setForwardTransformUniforms(QOpenGLShaderProgram& program) const Q_DECL_OVERRIDE;
-	virtual QByteArray getBackwardTransformShader() const Q_DECL_OVERRIDE;
-	virtual void setBackwardTransformUniforms(QOpenGLShaderProgram& program) const Q_DECL_OVERRIDE;
+	QString getNameI18() const override;
+	QString getDescriptionI18() const override;
+	float getMaxFov() const override {return 360.f;}
+	bool forward(Vec3f &win) const override;
+	bool backward(Vec3d &v) const override;
+	float fovToViewScalingFactor(float fov) const override;
+	float viewScalingFactorToFov(float vsf) const override;
+	float deltaZoom(float fov) const override;
+	QByteArray getForwardTransformShader() const override;
+	void setForwardTransformUniforms(QOpenGLShaderProgram& program) const override;
+	QByteArray getBackwardTransformShader() const override;
+	void setBackwardTransformUniforms(QOpenGLShaderProgram& program) const override;
 protected:
-	virtual bool hasDiscontinuity() const Q_DECL_OVERRIDE {return false;}
-	virtual bool intersectViewportDiscontinuityInternal(const Vec3d&, const Vec3d&) const Q_DECL_OVERRIDE {Q_ASSERT(0); return false;}
-	virtual bool intersectViewportDiscontinuityInternal(const Vec3d&, double) const Q_DECL_OVERRIDE {Q_ASSERT(0); return false;}
-	virtual void computeBoundingCap() Q_DECL_OVERRIDE {}
+	bool hasDiscontinuity() const override {return false;}
+	bool intersectViewportDiscontinuityInternal(const Vec3d&, const Vec3d&) const override {Q_ASSERT(0); return false;}
+	bool intersectViewportDiscontinuityInternal(const Vec3d&, double) const override {Q_ASSERT(0); return false;}
+	void computeBoundingCap() override {}
 };
 
 #endif // STELPROJECTIONS_HPP

--- a/src/core/StelProjectorClasses.hpp
+++ b/src/core/StelProjectorClasses.hpp
@@ -159,6 +159,35 @@ protected:
 	}
 };
 
+// A variant which fills the viewport with a plate carree, regardless of screen dimensions.
+class StelProjectorCylinderFill : public StelProjectorCylinder
+{
+public:
+	StelProjectorCylinderFill(ModelViewTranformP func) : StelProjectorCylinder(func) {;}
+	virtual QString getNameI18() const;
+	virtual QString getDescriptionI18() const;
+	virtual float getMaxFov() const {return 180.f;} // vertical fov always max 180.
+	bool forward(Vec3f &win) const;
+	bool backward(Vec3d &v) const;
+	float fovToViewScalingFactor(float fov) const;
+	float viewScalingFactorToFov(float vsf) const;
+	float deltaZoom(float fov) const;
+protected:
+	//virtual bool hasDiscontinuity() const {return true;}
+	//virtual bool intersectViewportDiscontinuityInternal(const Vec3d& p1, const Vec3d& p2) const
+	//{
+	//	return p1[0]*p2[0]<0 && !(p1[2]<0 && p2[2]<0);
+	//}
+	//virtual bool intersectViewportDiscontinuityInternal(const Vec3d& capN, double capD) const
+	//{
+	//	static const SphericalCap cap1(1,0,0);
+	//	static const SphericalCap cap2(-1,0,0);
+	//	static const SphericalCap cap3(0,0,-1);
+	//	SphericalCap cap(capN, capD);
+	//	return cap.intersects(cap1) && cap.intersects(cap2) && cap.intersects(cap3);
+	//}
+};
+
 class StelProjectorMercator : public StelProjector
 {
 public:

--- a/src/core/StelProjectorClasses.hpp
+++ b/src/core/StelProjectorClasses.hpp
@@ -36,10 +36,6 @@ public:
 	float deltaZoom(float fov) const override;
 	QByteArray getForwardTransformShader() const override;
 	QByteArray getBackwardTransformShader() const override;
-protected:
-	bool hasDiscontinuity() const override {return false;}
-	bool intersectViewportDiscontinuityInternal(const Vec3d&, const Vec3d&) const  override {return false;}
-	bool intersectViewportDiscontinuityInternal(const Vec3d&, double) const override {return false;}
 };
 
 class StelProjectorEqualArea : public StelProjector
@@ -56,10 +52,6 @@ public:
 	// float deltaZoom(float fov) const override;
 	QByteArray getForwardTransformShader() const override;
 	QByteArray getBackwardTransformShader() const override;
-protected:
-	bool hasDiscontinuity() const override {return false;}
-	bool intersectViewportDiscontinuityInternal(const Vec3d&, const Vec3d&) const  override {return false;}
-	bool intersectViewportDiscontinuityInternal(const Vec3d&, double) const  override {return false;}
 };
 
 class StelProjectorStereographic : public StelProjector
@@ -76,10 +68,6 @@ public:
 	float deltaZoom(float fov) const override;
 	QByteArray getForwardTransformShader() const override;
 	QByteArray getBackwardTransformShader() const override;
-protected:
-	bool hasDiscontinuity() const override {return false;}
-	bool intersectViewportDiscontinuityInternal(const Vec3d&, const Vec3d&) const override {return false;}
-	bool intersectViewportDiscontinuityInternal(const Vec3d&, double) const override {return false;}
 };
 
 class StelProjectorFisheye : public StelProjector
@@ -96,10 +84,6 @@ public:
 	//float deltaZoom(float fov) const override;
 	QByteArray getForwardTransformShader() const override;
 	QByteArray getBackwardTransformShader() const override;
-protected:
-	bool hasDiscontinuity() const override {return false;}
-	bool intersectViewportDiscontinuityInternal(const Vec3d&, const Vec3d&) const override {return false;}
-	bool intersectViewportDiscontinuityInternal(const Vec3d&, double) const override {return false;}
 };
 
 class StelProjectorHammer : public StelProjector
@@ -213,10 +197,6 @@ public:
 	//float deltaZoom(float fov) const override;
 	QByteArray getForwardTransformShader() const override;
 	QByteArray getBackwardTransformShader() const override;
-protected:
-	bool hasDiscontinuity() const override {return false;}
-	bool intersectViewportDiscontinuityInternal(const Vec3d&, const Vec3d&) const override {return false;}
-	bool intersectViewportDiscontinuityInternal(const Vec3d&, double) const override {return false;}
 };
 
 class StelProjectorSinusoidal : public StelProjectorCylinder
@@ -261,7 +241,6 @@ public:
 	QByteArray getBackwardTransformShader() const override;
 	void setBackwardTransformUniforms(QOpenGLShaderProgram& program) const override;
 protected:
-	bool hasDiscontinuity() const override {return false;}
 	bool intersectViewportDiscontinuityInternal(const Vec3d&, const Vec3d&) const override {Q_ASSERT(0); return false;}
 	bool intersectViewportDiscontinuityInternal(const Vec3d&, double) const override {Q_ASSERT(0); return false;}
 	void computeBoundingCap() override {}

--- a/src/core/StelProjectorClasses.hpp
+++ b/src/core/StelProjectorClasses.hpp
@@ -69,21 +69,6 @@ public:
 	QString getNameI18() const override;
 	QString getDescriptionI18() const override;
 	float getMaxFov() const  override {return 235.f;}
-//	void project(int n, const Vec3d* in, Vec3f* out) override
-//	{
-//		Vec3d v;
-//		for (int i = 0; i < n; ++i, ++out)
-//		{
-//			v = in[i];
-//			modelViewTransform->forward(v);
-//			out->set(static_cast<float>(v[0]), static_cast<float>(v[1]), static_cast<float>(v[2]));
-//			StelProjectorStereographic::forward(*out);
-//			out->set(static_cast<float>(viewportCenter[0]) + flipHorz * pixelPerRad * (*out)[0],
-//				static_cast<float>(viewportCenter[1]) + flipVert * pixelPerRad * (*out)[1],
-//				((*out)[2] - static_cast<float>(zNear)) * static_cast<float>(oneOverZNearMinusZFar));
-//		}
-//	}
-
 	bool forward(Vec3f &v) const override;
 	bool backward(Vec3d &v) const override;
 	float fovToViewScalingFactor(float fov) const override;
@@ -123,29 +108,14 @@ public:
 	StelProjectorHammer(ModelViewTranformP func) : StelProjector(func) {}
 	QString getNameI18() const override;
 	QString getDescriptionI18() const override;
-//	float getMaxFov() const override {return 185.f;}
-	float getMaxFov() const override {return 360.f;}
-//	void project(int n, const Vec3d* in, Vec3f* out) override
-//	{
-//		Vec3d v;
-//		for (int i = 0; i < n; ++i)
-//		{
-//			v = in[i];
-//			modelViewTransform->forward(v);
-//			out[i].set(static_cast<float>(v[0]), static_cast<float>(v[1]), static_cast<float>(v[2]));
-//			StelProjectorHammer::forward(out[i]);
-//			out[i][0] = static_cast<float>(viewportCenter[0]) + flipHorz * pixelPerRad * out[i][0];
-//			out[i][1] = static_cast<float>(viewportCenter[1]) + flipVert * pixelPerRad * out[i][1];
-//			out[i][2] = (out[i][2] - static_cast<float>(zNear)) * static_cast<float>(oneOverZNearMinusZFar);
-//		}
-//	}
+	float getMaxFov() const override {return 185.f;}
 	bool forward(Vec3f &v) const override;
 	bool backward(Vec3d &v) const override;
 	//float fovToViewScalingFactor(float fov) const override;
 	//float viewScalingFactorToFov(float vsf) const override;
 	//float deltaZoom(float fov) const override;
-	virtual QByteArray getForwardTransformShader() const override;
-	virtual QByteArray getBackwardTransformShader() const override;
+	QByteArray getForwardTransformShader() const override;
+	QByteArray getBackwardTransformShader() const override;
 protected:
 	bool hasDiscontinuity() const override {return true;}
 	bool intersectViewportDiscontinuityInternal(const Vec3d& p1, const Vec3d& p2) const override {return p1[0]*p2[0]<0 && !(p1[2]<0 && p2[2]<0);}
@@ -165,8 +135,7 @@ public:
 	StelProjectorCylinder(ModelViewTranformP func) : StelProjector(func) {}
 	QString getNameI18() const override;
 	QString getDescriptionI18() const override;
-//	virtual float getMaxFov() const override {return 200.f;} // slight overshoot
-	float getMaxFov() const override {return 175.f * 4.f/3.f;} // assume aspect ration of 4/3 for getting a full 360 degree horizon
+	virtual float getMaxFov() const override {return 185.f;} // slight overshoot
 	bool forward(Vec3f &win) const override;
 	bool backward(Vec3d &v) const override;
 	//float fovToViewScalingFactor(float fov) const override;
@@ -206,8 +175,7 @@ public:
 	StelProjectorMercator(ModelViewTranformP func) : StelProjector(func) {}
 	QString getNameI18() const override;
 	QString getDescriptionI18() const override;
-//	float getMaxFov() const override {return 270.f; }
-	float getMaxFov() const override {return 175.f * 4.f/3.f;} // assume aspect ration of 4/3 for getting a full 360 degree horizon
+	float getMaxFov() const override {return 270.f; } // Despite being named 270 degrees this does not even show the 180° VFoV.
 	bool forward(Vec3f &win) const override;
 	bool backward(Vec3d &v) const override;
 	//float fovToViewScalingFactor(float fov) const override;
@@ -269,8 +237,7 @@ public:
 	StelProjectorMiller(ModelViewTranformP func) : StelProjectorMercator(func) {}
 	QString getNameI18() const override;
 	QString getDescriptionI18() const override;
-//	float getMaxFov() const override {return 270.f; }
-	float getMaxFov() const override {return 175.f * 4.f/3.f;} // or 180?
+	float getMaxFov() const override {return 270.f; } // Show a slight overshoot of the full map.
 	bool forward(Vec3f &win) const override;
 	bool backward(Vec3d &v) const override;
 	QByteArray getForwardTransformShader() const override;

--- a/src/core/StelProjectorClasses.hpp
+++ b/src/core/StelProjectorClasses.hpp
@@ -28,7 +28,7 @@ public:
 	StelProjectorPerspective(ModelViewTranformP func) : StelProjector(func) {}
 	virtual QString getNameI18() const Q_DECL_OVERRIDE;
 	virtual QString getDescriptionI18() const Q_DECL_OVERRIDE;
-	virtual float getMaxFov() const  Q_DECL_OVERRIDE{return 120.f;}
+	virtual float getMaxFov() const Q_DECL_OVERRIDE {return 120.f;}
 	virtual bool forward(Vec3f &v) const Q_DECL_OVERRIDE;
 	virtual bool backward(Vec3d &v) const Q_DECL_OVERRIDE;
 	virtual float fovToViewScalingFactor(float fov) const Q_DECL_OVERRIDE;
@@ -37,7 +37,7 @@ public:
 	virtual QByteArray getForwardTransformShader() const Q_DECL_OVERRIDE;
 	virtual QByteArray getBackwardTransformShader() const Q_DECL_OVERRIDE;
 protected:
-	virtual bool hasDiscontinuity() const  Q_DECL_OVERRIDE {return false;}
+	virtual bool hasDiscontinuity() const Q_DECL_OVERRIDE {return false;}
 	virtual bool intersectViewportDiscontinuityInternal(const Vec3d&, const Vec3d&) const  Q_DECL_OVERRIDE {return false;}
 	virtual bool intersectViewportDiscontinuityInternal(const Vec3d&, double) const Q_DECL_OVERRIDE {return false;}
 };
@@ -48,7 +48,7 @@ public:
 	StelProjectorEqualArea(ModelViewTranformP func) : StelProjector(func) {}
 	virtual QString getNameI18() const Q_DECL_OVERRIDE;
 	virtual QString getDescriptionI18() const Q_DECL_OVERRIDE;
-	virtual float getMaxFov() const  Q_DECL_OVERRIDE{return 360.f;}
+	virtual float getMaxFov() const Q_DECL_OVERRIDE{return 360.f;}
 	virtual bool forward(Vec3f &v) const Q_DECL_OVERRIDE;
 	virtual bool backward(Vec3d &v) const Q_DECL_OVERRIDE;
 	virtual float fovToViewScalingFactor(float fov) const Q_DECL_OVERRIDE;
@@ -57,7 +57,7 @@ public:
 	virtual QByteArray getForwardTransformShader() const Q_DECL_OVERRIDE;
 	virtual QByteArray getBackwardTransformShader() const Q_DECL_OVERRIDE;
 protected:
-	virtual bool hasDiscontinuity() const  Q_DECL_OVERRIDE{return false;}
+	virtual bool hasDiscontinuity() const Q_DECL_OVERRIDE {return false;}
 	virtual bool intersectViewportDiscontinuityInternal(const Vec3d&, const Vec3d&) const  Q_DECL_OVERRIDE {return false;}
 	virtual bool intersectViewportDiscontinuityInternal(const Vec3d&, double) const  Q_DECL_OVERRIDE {return false;}
 };
@@ -69,6 +69,21 @@ public:
 	virtual QString getNameI18() const Q_DECL_OVERRIDE;
 	virtual QString getDescriptionI18() const Q_DECL_OVERRIDE;
 	virtual float getMaxFov() const  Q_DECL_OVERRIDE {return 235.f;}
+//	virtual void project(int n, const Vec3d* in, Vec3f* out) Q_DECL_OVERRIDE
+//	{
+//		Vec3d v;
+//		for (int i = 0; i < n; ++i, ++out)
+//		{
+//			v = in[i];
+//			modelViewTransform->forward(v);
+//			out->set(static_cast<float>(v[0]), static_cast<float>(v[1]), static_cast<float>(v[2]));
+//			StelProjectorStereographic::forward(*out);
+//			out->set(static_cast<float>(viewportCenter[0]) + flipHorz * pixelPerRad * (*out)[0],
+//				static_cast<float>(viewportCenter[1]) + flipVert * pixelPerRad * (*out)[1],
+//				((*out)[2] - static_cast<float>(zNear)) * static_cast<float>(oneOverZNearMinusZFar));
+//		}
+//	}
+
 	virtual bool forward(Vec3f &v) const Q_DECL_OVERRIDE;
 	virtual bool backward(Vec3d &v) const Q_DECL_OVERRIDE;
 	virtual float fovToViewScalingFactor(float fov) const Q_DECL_OVERRIDE;
@@ -108,7 +123,22 @@ public:
 	StelProjectorHammer(ModelViewTranformP func) : StelProjector(func) {}
 	virtual QString getNameI18() const Q_DECL_OVERRIDE;
 	virtual QString getDescriptionI18() const Q_DECL_OVERRIDE;
-	virtual float getMaxFov() const Q_DECL_OVERRIDE {return 185.f;}
+//	virtual float getMaxFov() const Q_DECL_OVERRIDE {return 185.f;}
+	virtual float getMaxFov() const Q_DECL_OVERRIDE {return 360.f;}
+//	virtual void project(int n, const Vec3d* in, Vec3f* out) Q_DECL_OVERRIDE
+//	{
+//		Vec3d v;
+//		for (int i = 0; i < n; ++i)
+//		{
+//			v = in[i];
+//			modelViewTransform->forward(v);
+//			out[i].set(static_cast<float>(v[0]), static_cast<float>(v[1]), static_cast<float>(v[2]));
+//			StelProjectorHammer::forward(out[i]);
+//			out[i][0] = static_cast<float>(viewportCenter[0]) + flipHorz * pixelPerRad * out[i][0];
+//			out[i][1] = static_cast<float>(viewportCenter[1]) + flipVert * pixelPerRad * out[i][1];
+//			out[i][2] = (out[i][2] - static_cast<float>(zNear)) * static_cast<float>(oneOverZNearMinusZFar);
+//		}
+//	}
 	virtual bool forward(Vec3f &v) const Q_DECL_OVERRIDE;
 	virtual bool backward(Vec3d &v) const Q_DECL_OVERRIDE;
 	virtual float fovToViewScalingFactor(float fov) const Q_DECL_OVERRIDE;
@@ -135,7 +165,8 @@ public:
 	StelProjectorCylinder(ModelViewTranformP func) : StelProjector(func) {}
 	virtual QString getNameI18() const Q_DECL_OVERRIDE;
 	virtual QString getDescriptionI18() const Q_DECL_OVERRIDE;
-	virtual float getMaxFov() const Q_DECL_OVERRIDE {return 200.f;} // slight overshoot
+//	virtual float getMaxFov() const Q_DECL_OVERRIDE {return 200.f;} // slight overshoot
+	virtual float getMaxFov() const Q_DECL_OVERRIDE {return 175.f * 4.f/3.f;} // assume aspect ration of 4/3 for getting a full 360 degree horizon
 	virtual bool forward(Vec3f &win) const Q_DECL_OVERRIDE;
 	virtual bool backward(Vec3d &v) const Q_DECL_OVERRIDE;
 	virtual float fovToViewScalingFactor(float fov) const Q_DECL_OVERRIDE;
@@ -164,14 +195,14 @@ class StelProjectorCylinderFill : public StelProjectorCylinder
 {
 public:
 	StelProjectorCylinderFill(ModelViewTranformP func) : StelProjectorCylinder(func) {;}
-	virtual QString getNameI18() const;
-	virtual QString getDescriptionI18() const;
-	virtual float getMaxFov() const {return 180.f;} // vertical fov always max 180.
-	bool forward(Vec3f &win) const;
-	bool backward(Vec3d &v) const;
-	float fovToViewScalingFactor(float fov) const;
-	float viewScalingFactorToFov(float vsf) const;
-	float deltaZoom(float fov) const;
+	virtual QString getNameI18() const Q_DECL_OVERRIDE;
+	virtual QString getDescriptionI18() const Q_DECL_OVERRIDE;
+	virtual float getMaxFov() const Q_DECL_OVERRIDE {return 180.f;} // vertical fov always max 180.
+	virtual bool forward(Vec3f &win) const Q_DECL_OVERRIDE;
+	virtual bool backward(Vec3d &v) const Q_DECL_OVERRIDE;
+	//virtual float fovToViewScalingFactor(float fov) const Q_DECL_OVERRIDE;
+	//virtual float viewScalingFactorToFov(float vsf) const Q_DECL_OVERRIDE;
+	//virtual float deltaZoom(float fov) const Q_DECL_OVERRIDE;
 protected:
 	//virtual bool hasDiscontinuity() const {return true;}
 	//virtual bool intersectViewportDiscontinuityInternal(const Vec3d& p1, const Vec3d& p2) const
@@ -194,7 +225,8 @@ public:
 	StelProjectorMercator(ModelViewTranformP func) : StelProjector(func) {}
 	virtual QString getNameI18() const Q_DECL_OVERRIDE;
 	virtual QString getDescriptionI18() const Q_DECL_OVERRIDE;
-	virtual float getMaxFov() const Q_DECL_OVERRIDE {return 270.f; }
+//	virtual float getMaxFov() const Q_DECL_OVERRIDE {return 270.f; }
+	virtual float getMaxFov() const Q_DECL_OVERRIDE {return 175.f * 4.f/3.f;} // assume aspect ration of 4/3 for getting a full 360 degree horizon
 	virtual bool forward(Vec3f &win) const Q_DECL_OVERRIDE;
 	virtual bool backward(Vec3d &v) const Q_DECL_OVERRIDE;
 	virtual float fovToViewScalingFactor(float fov) const Q_DECL_OVERRIDE;
@@ -256,7 +288,8 @@ public:
 	StelProjectorMiller(ModelViewTranformP func) : StelProjectorMercator(func) {}
 	virtual QString getNameI18() const Q_DECL_OVERRIDE;
 	virtual QString getDescriptionI18() const Q_DECL_OVERRIDE;
-	virtual float getMaxFov() const Q_DECL_OVERRIDE {return 270.f; }
+//	virtual float getMaxFov() const Q_DECL_OVERRIDE {return 270.f; }
+	virtual float getMaxFov() const Q_DECL_OVERRIDE {return 175.f * 4.f/3.f;} // or 180?
 	virtual bool forward(Vec3f &win) const Q_DECL_OVERRIDE;
 	virtual bool backward(Vec3d &v) const Q_DECL_OVERRIDE;
 	virtual QByteArray getForwardTransformShader() const Q_DECL_OVERRIDE;

--- a/src/core/StelProjectorClasses.hpp
+++ b/src/core/StelProjectorClasses.hpp
@@ -190,33 +190,14 @@ protected:
 	}
 };
 
-// A variant which fills the viewport with a plate carree, regardless of screen dimensions.
+// A variant which fills the viewport with a plate carrée, regardless of screen dimensions.
 class StelProjectorCylinderFill : public StelProjectorCylinder
 {
 public:
-	StelProjectorCylinderFill(ModelViewTranformP func) : StelProjectorCylinder(func) {;}
+	StelProjectorCylinderFill(ModelViewTranformP func) : StelProjectorCylinder(func) {}
 	QString getNameI18() const override;
 	QString getDescriptionI18() const override;
 	float getMaxFov() const override {return 180.f;} // vertical fov always max 180.
-	bool forward(Vec3f &win) const override;
-	bool backward(Vec3d &v) const override;
-	//float fovToViewScalingFactor(float fov) const override;
-	//float viewScalingFactorToFov(float vsf) const override;
-	//float deltaZoom(float fov) const override;
-protected:
-	//bool hasDiscontinuity() const {return true;}
-	//bool intersectViewportDiscontinuityInternal(const Vec3d& p1, const Vec3d& p2) const
-	//{
-	//	return p1[0]*p2[0]<0 && !(p1[2]<0 && p2[2]<0);
-	//}
-	//bool intersectViewportDiscontinuityInternal(const Vec3d& capN, double capD) const
-	//{
-	//	static const SphericalCap cap1(1,0,0);
-	//	static const SphericalCap cap2(-1,0,0);
-	//	static const SphericalCap cap3(0,0,-1);
-	//	SphericalCap cap(capN, capD);
-	//	return cap.intersects(cap1) && cap.intersects(cap2) && cap.intersects(cap3);
-	//}
 };
 
 class StelProjectorMercator : public StelProjector

--- a/src/tests/testStelProjector.cpp
+++ b/src/tests/testStelProjector.cpp
@@ -334,7 +334,7 @@ void TestStelProjector::testStelProjectorCylinder()
 	StelProjector::ModelViewTranformP modelViewTransform;
 	StelProjectorP projection = StelProjectorP(new StelProjectorCylinder(modelViewTransform));
 	float maxFov = projection->getMaxFov();
-	float expectedFov = 200.f;
+	float expectedFov = 185.f;
 	float actualError = qAbs(maxFov - expectedFov);
 	QVERIFY2(actualError <= ERROR_LIMIT, QString("Max. FOV=%1deg expected FOV=%2deg error=%3 acceptable=%4")
 						.arg(QString::number(maxFov, 'f', 3))
@@ -511,7 +511,7 @@ void TestStelProjector::testStelProjectorSinusoidal()
 	StelProjector::ModelViewTranformP modelViewTransform;
 	StelProjectorP projection = StelProjectorP(new StelProjectorSinusoidal(modelViewTransform));
 	float maxFov = projection->getMaxFov();
-	float expectedFov = 200.f;
+	float expectedFov = 185.f;
 	float actualError = qAbs(maxFov - expectedFov);
 	QVERIFY2(actualError <= ERROR_LIMIT, QString("Max. FOV=%1deg expected FOV=%2deg error=%3 acceptable=%4")
 						.arg(QString::number(maxFov, 'f', 3))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

Ruslan's shader implementation of Milky Way and ZL makes this finally interesting: A window-filling all-sky map. I can imagine an application using Spout where the result goes into another program, as live texture for some object, or just a printed all-sky map. 

Fixes #1120 

What currently still looks bad at the seam are of course all meshes which are projected before being sent to the GPU: 
- landscapes
- constellation artwork
- DSO textures
- DSS
- HiPS
- sky images (from scripting)
- An axis-aligned grid has flickering parts on the window edges.
- Points like NCP flicker as they should be plotted on the edge but may be projected to the other side by rounding.

Fixing the meshes is not part of this PR. For the time being the application is limited to mostly MW/ZL all-sky maps. 

### Screenshots (if appropriate):

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system: Windows 10
* Graphics Card: Geforce 960M

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
