### PR TITLE
Fix typos in the `src/` subdirectory

### DIFF
--- a/src/CLIProcessor.hpp
+++ b/src/CLIProcessor.hpp
@@ -79,8 +79,8 @@ public:
 	//! @exception runtime_error("optarg_type") the expected argument to
 	//! the option could not be converted. The longOpt value is appended
 	//! in parenthesis.
-	//! @return 1 if the argument to the specified opion is "yes", "y",
-	//! "true", "on" or 1; 0 if the argument to the specified opion is "no",
+	//! @return 1 if the argument to the specified option is "yes", "y",
+	//! "true", "on" or 1; 0 if the argument to the specified option is "no",
 	//! "n", "false", "off" or 0; the value of the defaultValue parameter if
 	//! the option was not found in the argument list before an element which
 	//! has the value "--".

--- a/src/StelLogger.hpp
+++ b/src/StelLogger.hpp
@@ -25,7 +25,7 @@
 #include <QMutex>
 
 //! @class StelLogger
-//! Class wit only static members used to manage logging for Stellarium.
+//! Class with only static members used to manage logging for Stellarium.
 //! The debugLogHandler() method allow to defined it as a standard Qt messages handler
 //! which is then used by qDebug, qWarning and qFatal.
 class StelLogger

--- a/src/StelMainView.cpp
+++ b/src/StelMainView.cpp
@@ -846,7 +846,7 @@ void StelMainView::init()
 			qWarning()<<"Failed to initialize OpenGL debug logger";
 
 		connect(QOpenGLContext::currentContext(),SIGNAL(aboutToBeDestroyed()),this,SLOT(contextDestroyed()));
-		//for easier debugging, print the adress of the main GL context
+		//for easier debugging, print the address of the main GL context
 		qDebug()<<"CurCtxPtr:"<<QOpenGLContext::currentContext();
 	}
 #endif
@@ -1450,7 +1450,7 @@ void StelMainView::setFlagCursorTimeout(bool b)
 
 void StelMainView::hideCursor()
 {
-	// timout fired...
+	// timeout fired...
 	// if the feature is not asked, do nothing
 	if (!flagCursorTimeout) return;
 

--- a/src/StelMainView.hpp
+++ b/src/StelMainView.hpp
@@ -240,7 +240,7 @@ signals:
 	//! @remark FS: is threaded access here even a possibility anymore, or a remnant of older code?
 	void screenshotRequested(void);
 	void fullScreenChanged(bool b);
-	//! Emitted when the "Reload shaders" action is perfomed
+	//! Emitted when the "Reload shaders" action is performed
 	//! Interested objects should subscribe to this signal and reload their shaders
 	//! when this is emitted
 	void reloadShadersRequested();

--- a/src/core/MultiLevelJsonBase.hpp
+++ b/src/core/MultiLevelJsonBase.hpp
@@ -55,13 +55,13 @@ public:
 	//! Return the short name for this image to be used in the loading bar.
 	virtual QString getShortName() const Q_DECL_OVERRIDE {return shortName;}
 
-	//! Return true if an error occured while loading the data.
+	//! Return true if an error occurred while loading the data.
 	bool hasErrorOccured() const {return errorOccured;}
 
 	//! Get the depth level in the tree.
 	int getLevel() const {return parent()==Q_NULLPTR ? 0 : (qobject_cast<MultiLevelJsonBase*>(parent()))->getLevel()+1;}
 
-	//! Convert the image informations to a map following the JSON structure.
+	//! Convert the image information to a map following the JSON structure.
 	//! It can be saved as JSON using the StelJsonParser methods.
 	QVariantMap toQVariantMap() const;
 
@@ -95,7 +95,7 @@ protected:
 	//! The list of all the created subtiles for this tile
 	QList<MultiLevelJsonBase*> subTiles;
 
-	//! Set to true if an error occured with this tile and it should not be displayed
+	//! Set to true if an error occurred with this tile and it should not be displayed
 	bool errorOccured;
 
 	void updatePercent(int tot, int numToBeLoaded);

--- a/src/core/SimbadSearcher.hpp
+++ b/src/core/SimbadSearcher.hpp
@@ -40,7 +40,7 @@ public:
 	enum SimbadLookupStatus
 	{
 		SimbadLookupQuerying,		//!< Simbad is still being queried.
-		SimbadLookupErrorOccured,	//!< An error occured while looking up Simbad. Call getErrorString() for a description of the error.
+		SimbadLookupErrorOccured,	//!< An error occurred while looking up Simbad. Call getErrorString() for a description of the error.
 		SimbadLookupFinished,		//!< The query is over. The reply can be deleted.
 		SimbadCoordinateLookupFinished  //!< A coordinate lookup is finished. The reply can be deleted.
 	};
@@ -59,7 +59,7 @@ public:
 	//! Get a I18n string describing the current status. It can be used e.g for reporting in widgets.
 	QString getCurrentStatusString() const;
 
-	//! Get the error description string. Return empty string if no error occured.
+	//! Get the error description string. Return empty string if no error occurred.
 	QString getErrorString() const {return errorString;}
 
 	//! Explicitly delete the internal QNetworkReply. Must not be called from a QNetworkReply signal.
@@ -91,7 +91,7 @@ private:
 	//! Current lookup status.
 	SimbadLookupStatus currentStatus;
 
-	//! The error description. Empty if no errors occured.
+	//! The error description. Empty if no errors occurred.
 	QString errorString;
 };
 
@@ -111,7 +111,7 @@ public:
 	//! @param objectName the possibly truncated object name.
 	//! @param maxNbResult the maximum number of returned result.
 	//! @param delayMs a delay in ms to wait for before actually triggering the lookup.
-	//! This used to group requests, e.g. send only one request when a used types a word insead of one per letter.
+	//! This used to group requests, e.g. send only one request when a used types a word instead of one per letter.
 	//! @return a new SimbadLookupReply which is owned by the caller.
 	SimbadLookupReply* lookup(const QString& serverUrl, const QString& objectName, int maxNbResult=1, int delayMs=500);
 	//! Lookup in Simbad for objects which have a position coordsJ2000

--- a/src/core/SpoutSender.cpp
+++ b/src/core/SpoutSender.cpp
@@ -117,7 +117,7 @@ void SpoutSender::captureAndSendFrame(GLuint fbo)
 
 		//manual calling of UpdateSender seems buggy, it creates a new sender name
 		//but we don't need to use it
-		//SendTexture will update the sender automaticallly if the size is wrong, without these bugs
+		//SendTexture will update the sender automatically if the size is wrong, without these bugs
 		//only possible drawback is the sent frame seems to be discarded, only next call will draw properly
 		//spoutLib->UpdateSender(name,width,height);
 		textureDirty = false;

--- a/src/core/SpoutSender.hpp
+++ b/src/core/SpoutSender.hpp
@@ -44,7 +44,7 @@ public slots:
 	//! Informs the sender about changed buffer dimensions.
 	//! Does not need a GL context.
 	void resize(uint width, uint height);
-	//! True if the sender has been successfuly created
+	//! True if the sender has been successfully created
 	bool isValid() { return valid; }
 private:
 	SPOUTLIBRARY* spoutLib;

--- a/src/core/StelApp.cpp
+++ b/src/core/StelApp.cpp
@@ -445,7 +445,7 @@ void StelApp::init(QSettings* conf)
 	if (!fuzzyEquals(saveProjW, -1.) && !fuzzyEquals(saveProjH, -1.))
 		core->windowHasBeenResized(0, 0, saveProjW, saveProjH);
 	
-	//Initializing locale at the begining to show all strings translated
+	//Initializing locale at the beginning to show all strings translated
 	localeMgr = new StelLocaleMgr();
 	localeMgr->init();
 	//SplashScreen::showMessage(q_("Initializing locales..."));
@@ -613,7 +613,7 @@ void StelApp::init(QSettings* conf)
 	custObj->init();
 	getModuleMgr().registerModule(custObj);
 
-	// Init hightlights
+	// Init highlights
 	SplashScreen::showMessage(q_("Initializing highlights..."));
 	HighlightMgr* hlMgr = new HighlightMgr();
 	hlMgr->init();

--- a/src/core/StelApp.hpp
+++ b/src/core/StelApp.hpp
@@ -64,7 +64,7 @@ class SpoutSender;
 //! This is the central class of Stellarium.  Only one singleton instance of
 //! this class is created and can be accessed from anywhere else.  This class
 //! is the access point to several "Manager" class which provide application-wide
-//! services for managment of font, textures, localization, sky culture, and in
+//! services for management of font, textures, localization, sky culture, and in
 //! theory all other services used by the other part of the program.
 //!
 //! The StelApp class is also the one managing the StelModule in a generic manner
@@ -326,7 +326,7 @@ public slots:
 	//! Return the scaled time for animated objects
 	static double getAnimationTime();
 
-	//! Report that a download occured. This is used for statistics purposes.
+	//! Report that a download occurred. This is used for statistics purposes.
 	//! Connect this slot to QNetworkAccessManager::finished() slot to obtain statistics at the end of the program.
 	void reportFileDownloadFinished(QNetworkReply* reply);
 
@@ -397,7 +397,7 @@ private:
 	// Sky cultures manager for the application
 	StelSkyCultureMgr* skyCultureMgr;
 
-	//Actions manager fot the application.  Will replace shortcutMgr.
+	//Actions manager for the application.  Will replace shortcutMgr.
 	StelActionMgr* actionMgr;
 
 	//Property manager for the application

--- a/src/core/StelCore.cpp
+++ b/src/core/StelCore.cpp
@@ -359,7 +359,7 @@ QString StelCore::getDefaultProjectionTypeKey() const
 }
 
 // Get the shared instance of StelGeodesicGrid.
-// The returned instance is garanteed to allow for at least maxLevel levels
+// The returned instance is guaranteed to allow for at least maxLevel levels
 const StelGeodesicGrid* StelCore::getGeodesicGrid(int maxLevel) const
 {
 	if (geodesicGrid==Q_NULLPTR)
@@ -1222,7 +1222,7 @@ void StelCore::moveObserverToSelected()
 	mmgr->setFlagTracking(false);
 }
 
-// Get the informations on the current location
+// Get the information on the current location
 const StelLocation& StelCore::getCurrentLocation() const
 {
 	return position->getCurrentLocation();
@@ -1476,7 +1476,7 @@ double StelCore::getSolutionEquationOfTime() const
 	double ra, dec;
 	StelUtils::rectToSphe(&ra, &dec, pos);
 
-	// covert radians to degrees and reduce the angle, so that 0 <= angle < 360
+	// convert radians to degrees and reduce the angle, so that 0 <= angle < 360
 	const double alpha = StelUtils::fmodpos(ra*M_180_PI, 360.);
 
 	double deltaPsi, deltaEps;

--- a/src/core/StelCore.hpp
+++ b/src/core/StelCore.hpp
@@ -196,7 +196,7 @@ public:
 	//! Get the current StelSkyDrawer used in the core.
 	const StelSkyDrawer* getSkyDrawer() const{return skyDrawer;}
 
-	//! Get an instance of StelGeodesicGrid which is garanteed to allow for at least maxLevel levels
+	//! Get an instance of StelGeodesicGrid which is guaranteed to allow for at least maxLevel levels
 	const StelGeodesicGrid* getGeodesicGrid(int maxLevel) const;
 
 	//! Get the instance of movement manager.
@@ -788,7 +788,7 @@ public slots:
 signals:
 	//! This signal is emitted when the observer location has changed.
 	void locationChanged(const StelLocation&);
-	//! This signal is emitted whenever the targetted location changes
+	//! This signal is emitted whenever the targeted location changes
 	void targetLocationChanged(const StelLocation&);
 	//! This signal is emitted when the current timezone name is changed.
 	void currentTimeZoneChanged(const QString& tz);
@@ -924,7 +924,7 @@ private:
 	double deltaTCustomNDot;
 	double deltaTCustomYear;
 	double deltaTnDot; // The currently applied nDot correction. (different per algorithm, and displayed in status line.)
-	bool  deltaTdontUseMoon; // true if the currenctly selected algorithm does not do a lunar correction (?????)
+	bool  deltaTdontUseMoon; // true if the currently selected algorithm does not do a lunar correction (?????)
 	double (*deltaTfunc)(const double JD); // This is a function pointer which must be set to a function which computes DeltaT(JD).
 	int deltaTstart;   // begin year of validity range for the selected DeltaT algorithm. (SET INT_MIN to mark infinite)
 	int deltaTfinish;  // end   year of validity range for the selected DeltaT algorithm. (Set INT_MAX to mark infinite)

--- a/src/core/StelFileMgr.hpp
+++ b/src/core/StelFileMgr.hpp
@@ -31,7 +31,7 @@ class QFileInfo;
 
 //! Provides utilities for locating and handling files.
 //! StelFileMgr provides functions for locating files.  It maintains a list of
-//! directories in which to look for files called the search path. Typcially this
+//! directories in which to look for files called the search path. Typically this
 //! includes the Stellarium installation directory, and a per-user settings
 //! directory (on platforms which support it).
 //! The concept is that the StelFileMgr will be asked for a named path, and it
@@ -217,8 +217,8 @@ private:
 	static QString installDir;
 	
 #ifdef Q_OS_WIN
-	//! For internal use - retreives windows special named directories.
-	//! @param csidlId identifier for directoy, e.g. CSIDL_APPDATA
+	//! For internal use - retrieves windows special named directories.
+	//! @param csidlId identifier for directory, e.g. CSIDL_APPDATA
 	static QString getWin32SpecialDirPath(int csidlId);
 #endif
 };

--- a/src/core/StelGuiBase.hpp
+++ b/src/core/StelGuiBase.hpp
@@ -49,7 +49,7 @@ public:
 	virtual void setVisible(bool b) =0;
 	//! Get the current visible status of the GUI.
 	virtual bool getVisible() const =0;
-	//! Show wether the Gui is currently used.
+	//! Show whether the Gui is currently used.
 	//! This can then be used to optimize the rendering to increase reactivity.
 	virtual bool isCurrentlyUsed() const =0;
 };

--- a/src/core/StelLocaleMgr.cpp
+++ b/src/core/StelLocaleMgr.cpp
@@ -165,7 +165,7 @@ double StelLocaleMgr::getJdFromISO8601TimeLocal(const QString& t, bool* ok) cons
 }
 
 
-// Return a string with the local date formated according to the dateFormat variable
+// Return a string with the local date formatted according to the dateFormat variable
 QString StelLocaleMgr::getPrintableDateLocal(double JD) const
 {
 	int year, month, day, dayOfWeek;
@@ -203,7 +203,7 @@ QString StelLocaleMgr::getPrintableDateLocal(double JD) const
 	return str;
 }
 
-// Return a string with the local time (according to timeZoneMode variable) formated
+// Return a string with the local time (according to timeZoneMode variable) formatted
 // according to the timeFormat variable
 QString StelLocaleMgr::getPrintableTimeLocal(double JD) const
 {

--- a/src/core/StelLocation.hpp
+++ b/src/core/StelLocation.hpp
@@ -26,7 +26,7 @@
 class Planet;
 
 //! @class StelLocation
-//! Store the informations for a location on a planet
+//! Store the information for a location on a planet
 class StelLocation
 {
 public:
@@ -40,7 +40,7 @@ public:
 	//! @arg alt altitude above mean sea level
 	//! @arg populationK population in thousands
 	//! @arg timeZone IANA timezone string like "Europe/Vienna" or "UT-7"
-	//! @arg bortleIndex light polution hint
+	//! @arg bortleIndex light pollution hint
 	//! @arg roleKey code for location role.
 	//! @arg landscapeID a fitting landscape
 	StelLocation(QString lName, QString lState, QString lRegion, float lng, float lat, int alt,

--- a/src/core/StelModule.hpp
+++ b/src/core/StelModule.hpp
@@ -86,7 +86,7 @@ public:
 	//! Get the name of the module author
 	virtual QString getAuthorName() const {return "Stellarium's Team";}
 
-	//! Get the email adress of the module author
+	//! Get the email address of the module author
 	virtual QString getAuthorEmail() const {return "stellarium@googlegroups.com";}
 
 	//! Handle mouse clicks. Please note that most of the interactions will be done through the GUI module.

--- a/src/core/StelMovementMgr.hpp
+++ b/src/core/StelMovementMgr.hpp
@@ -204,9 +204,9 @@ public slots:
 	//! @return the number of seconds it takes for an auto-move operation to complete.
 	float getAutoMoveDuration(void) const {return autoMoveDuration;}
 
-	//! Set whether auto zoom out will reset the viewing direction to the inital value
+	//! Set whether auto zoom out will reset the viewing direction to the initial value
 	void setFlagAutoZoomOutResetsDirection(bool b) {if (flagAutoZoomOutResetsDirection != b) { flagAutoZoomOutResetsDirection = b; emit flagAutoZoomOutResetsDirectionChanged(b);}}
-	//! Get whether auto zoom out will reset the viewing direction to the inital value
+	//! Get whether auto zoom out will reset the viewing direction to the initial value
 	bool getFlagAutoZoomOutResetsDirection(void) const {return flagAutoZoomOutResetsDirection;}
 
 	//! Get whether keys can control zoom
@@ -435,7 +435,7 @@ public slots:
 	//! this will avoid any unwanted tracking.
 	void setInhibitAllAutomoves(bool inhibit) { flagInhibitAllAutomoves=inhibit;}
 
-	//! Returns the targetted value of the viewport offset
+	//! Returns the targeted value of the viewport offset
 	Vec2d getViewportOffsetTarget() const { return targetViewportOffset; }
 	double getViewportHorizontalOffsetTarget() const { return targetViewportOffset[0]; }
 	double getViewportVerticalOffsetTarget() const { return targetViewportOffset[1]; }

--- a/src/core/StelOBJ.cpp
+++ b/src/core/StelOBJ.cpp
@@ -302,19 +302,19 @@ bool StelOBJ::parseFace(const ParseParams& params, const V3Vec& posList, const V
 
 	int vtxAmount = params.size()-1;
 
-	//parse each one seperately
+	//parse each one separately
 	int mode = 0;
 	bool ok = false;
 	//a macro for consistency check
 	#define CHK_MODE(a) if(mode && mode!=a) { qCCritical(stelOBJ)<<"Inconsistent face statement"<<params; return false; } else {mode = a;}
-	//a macro for checking number pasing
+	//a macro for checking number parsing
 	#define CHK_OK(a) do{ a; if(!ok) { qCCritical(stelOBJ)<<"Could not parse number in face statement"<<params; return false; } } while(0)
 	//negative indices indicate relative data, i.e. -1 would mean the last position/texture/normal that was parsed
 	//this macro fixes it up so that it always uses absolute numbers
 	//note: the indices start with 1, this is fixed up later
 	#define FIX_REL(a, list) if(a<0) {a += list.size()+1; }
 
-	//loop to parse each section seperately
+	//loop to parse each section separately
 	for(int i =0; i<vtxAmount;++i)
 	{
 		//split on slash

--- a/src/core/StelObject.hpp
+++ b/src/core/StelObject.hpp
@@ -288,7 +288,7 @@ public slots:
 	//! @note This should be used with caution. Usually you want to use addToExtraInfoString().
 	//! @note: If this breaks some const declaration, you can use StelObjectMgr::setExtraInfoString() instead.
 	virtual void setExtraInfoString(const InfoStringGroup& flags, const QString &str);
-	//! Add str to the extra string. This should be preferrable over hard setting.
+	//! Add str to the extra string. This should be preferable over hard setting.
 	//! Can be used by plugins to show extra info for the selected object, or for debugging.
 	//! The strings will be shown in the InfoString for the selected object, below the default fields per-flag.
 	//! Additional coordinates not fitting into one of the predefined coordinate sets should be flagged with OtherCoords,

--- a/src/core/StelObjectMgr.hpp
+++ b/src/core/StelObjectMgr.hpp
@@ -112,13 +112,13 @@ public:
 	//! Notify that we want to select the given object.
 	//! @param obj the StelObject to select
 	//! @param action action define whether to add to, replace, or remove from the existing selection
-	//! @return true if at least 1 object was sucessfully selected
+	//! @return true if at least 1 object was successfully selected
 	bool setSelectedObject(const StelObjectP obj, StelModule::StelModuleSelectAction action=StelModule::ReplaceSelection);
 
 	//! Notify that we want to select the given objects.
 	//! @param objs a vector of objects to select
 	//! @param action define whether to add to, replace, or remove from the existing selection
-	//! @return true if at least 1 object was sucessfully selected
+	//! @return true if at least 1 object was successfully selected
 	bool setSelectedObject(const QList<StelObjectP>& objs, StelModule::StelModuleSelectAction action=StelModule::ReplaceSelection);
 
 	//! Get the list of objects which was recently selected by the user.
@@ -181,7 +181,7 @@ public slots:
 	//! @note This should be used with caution. Usually you want to use addToExtraInfoString().
 	virtual void setExtraInfoString(const StelObject::InfoStringGroup& flags, const QString &str);
 
-	//! Add str to the extra string. This should be preferrable over hard setting.
+	//! Add str to the extra string. This should be preferable over hard setting.
 	//! Can be used by plugins to show extra info for the selected object, or for debugging.
 	//! The strings will be shown in the InfoString for the selected object, below the default fields per-flag.
 	//! Additional coordinates not fitting into one of the predefined coordinate sets should be flagged with OtherCoords,

--- a/src/core/StelObserver.hpp
+++ b/src/core/StelObserver.hpp
@@ -67,7 +67,7 @@ public:
 
 	virtual const QSharedPointer<Planet> getHomePlanet(void) const;
 
-	//! Get the informations on the current location
+	//! Get the information on the current location
 	virtual const StelLocation& getCurrentLocation() const {return currentLocation;}
 
 	//! Get whether the life of this observer is over, and therefore that it should be changed to the next one

--- a/src/core/StelPainter.cpp
+++ b/src/core/StelPainter.cpp
@@ -2007,7 +2007,7 @@ StelVertexArray StelPainter::computeSphereNoLight(double radius, double oneMinus
 	return result;
 }
 
-// Reimplementation of gluCylinder : glu is overrided for non standard projection
+// Reimplementation of gluCylinder : glu is overridden for non standard projection
 void StelPainter::sCylinder(double radius, double height, int slices, int orientInside)
 {
 	if (orientInside)

--- a/src/core/StelPainter.hpp
+++ b/src/core/StelPainter.hpp
@@ -280,7 +280,7 @@ public:
 	//! This method needs to be called once before exit.
 	static void deinitGLShaders();
 
-	// Thoses methods should eventually be replaced by a single setVertexArray
+	// These methods should eventually be replaced by a single setVertexArray
 	//! use instead of glVertexPointer
 	void setVertexPointer(int size, GLenum type, const void* pointer) {
 		vertexArray.size = size; vertexArray.type = type; vertexArray.pointer = pointer;

--- a/src/core/StelPluginInterface.hpp
+++ b/src/core/StelPluginInterface.hpp
@@ -66,7 +66,7 @@ public:
 	//! Get information about the plugin.
 	virtual StelPluginInfo getPluginInfo() const = 0;
 
-	//! A mechanism to provide abitrary QObjects to the StelModuleMgr.
+	//! A mechanism to provide arbitrary QObjects to the StelModuleMgr.
 	//! Introduced to provide some limited form of inter-plugin communication.
 	//! If you do not need this, return an empty list.
 	//!

--- a/src/core/StelProjector.hpp
+++ b/src/core/StelProjector.hpp
@@ -152,7 +152,7 @@ public:
 	virtual QString getDescriptionI18() const {return "No description";}
 	//! Get a HTML version of the short description for this projection type
 	QString getHtmlSummary() const;
-	//! Get the maximum FOV apperture in degree
+	//! Get the maximum FOV aperture in degree
 	virtual float getMaxFov() const = 0;
 	//! Apply the transformation in the forward direction in place.
 	//! After transformation v[2] will always contain the length of the original v: sqrt(v[0]*v[0]+v[1]*v[1]+v[2]*v[2])

--- a/src/core/StelPropertyMgr.hpp
+++ b/src/core/StelPropertyMgr.hpp
@@ -28,7 +28,7 @@ class StelProperty;
 //! Abstract base class for a StelProperty proxy implementation, which allow reacting to the
 //! StelProperty::changed event using a specific type instead of reacting to the QVariant version.
 //! This is required for some connections such as in the UI.
-//! The intented use is to subclass this class and implement the onPropertyChanged() slot,
+//! The intended use is to subclass this class and implement the onPropertyChanged() slot,
 //! re-emitting the "changed" event with a type-converted value.
 class StelPropertyProxy : public QObject
 {

--- a/src/core/StelSkyDrawer.cpp
+++ b/src/core/StelSkyDrawer.cpp
@@ -267,7 +267,7 @@ void StelSkyDrawer::update(double)
 
 	if (getFlagHasAtmosphere() && core->getJD()>2387627.5) // JD given is J1825.0; ignore Bortle scale index before that.
 	{
-        // GZ: Light pollution must take global atmosphere setting into acount!
+        // GZ: Light pollution must take global atmosphere setting into account!
         // moved parts from setBortleScale() here
         // This formula is a fit to a set of values calibrated by hand, looking at the faintest star in stellarium at around 40 deg FOV.
         // It should roughly match the scale described at http://en.wikipedia.org/wiki/Bortle_Dark-Sky_Scale

--- a/src/core/StelSkyDrawer.hpp
+++ b/src/core/StelSkyDrawer.hpp
@@ -217,7 +217,7 @@ public slots:
 	bool getFlagStarSpiky() const {return flagStarSpiky;}
 
 	//! Get the magnitude of the currently faintest visible point source
-	//! It depends on the zoom level, on the eye adapation and on the point source rendering parameters
+	//! It depends on the zoom level, on the eye adaptation and on the point source rendering parameters
 	//! @return the limit V mag at which a point source will be displayed
 	float getLimitMagnitude() const {return limitMagnitude;}
 
@@ -257,7 +257,7 @@ public slots:
 	void setCustomPlanetMagnitudeLimit(double limit) { customPlanetMagLimit=limit; emit customPlanetMagLimitChanged(limit);}
 
 	//! Get the luminance of the faintest visible object (e.g. RGB<0.05)
-	//! It depends on the zoom level, on the eye adapation and on the point source rendering parameters
+	//! It depends on the zoom level, on the eye adaptation and on the point source rendering parameters
 	//! @return the limit V luminance at which an object will be visible
 	float getLimitLuminance() const {return limitLuminance;}
 

--- a/src/core/StelSkyImageTile.cpp
+++ b/src/core/StelSkyImageTile.cpp
@@ -138,7 +138,7 @@ void StelSkyImageTile::getTilesToDraw(QMultiMap<double, StelSkyImageTile*>& resu
 	}
 #endif
 
-	// An error occured during loading
+	// An error occurred during loading
 	if (errorOccured)
 		return;
 
@@ -554,7 +554,7 @@ void StelSkyImageTile::loadFromQVariantMap(const QVariantMap& map)
 	withAberration = map.value("withAberration", true).toBool();
 }
 
-// Convert the image informations to a map following the JSON structure.
+// Convert the image information to a map following the JSON structure.
 QVariantMap StelSkyImageTile::toQVariantMap() const
 {
 	QVariantMap res;

--- a/src/core/StelSkyImageTile.hpp
+++ b/src/core/StelSkyImageTile.hpp
@@ -91,7 +91,7 @@ public:
 	//! Return true if the tile is fully loaded and can be displayed
 	bool isReadyToDisplay() const;
 
-	//! Convert the image informations to a map following the JSON structure.
+	//! Convert the image information to a map following the JSON structure.
 	//! It can be saved as JSON using the StelJsonParser methods.
 	QVariantMap toQVariantMap() const;
 

--- a/src/core/StelSkyLayerMgr.hpp
+++ b/src/core/StelSkyLayerMgr.hpp
@@ -157,7 +157,7 @@ private slots:
 	void loadCollection();
 
 private:
-	//! Store the informations needed for a graphical element layer.
+	//! Store the information needed for a graphical element layer.
 	class SkyLayerElem
 	{
 	public:

--- a/src/core/StelSphereGeometry.cpp
+++ b/src/core/StelSphereGeometry.cpp
@@ -456,7 +456,7 @@ bool SphericalCap::clipGreatCircle(Vec3d& v1, Vec3d& v2) const
 }
 
 //! Compute the intersection of the circles defined by the 2 caps on the sphere (usually on 2 points) and return it in p1 and p2.
-//! If the 2 SphericalCaps don't interesect or intersect only at 1 point, false is returned and p1 and p2 are undefined.
+//! If the 2 SphericalCaps don't intersect or intersect only at 1 point, false is returned and p1 and p2 are undefined.
 bool SphericalCap::intersectionPoints(const SphericalCap& h1, const SphericalCap& h2, Vec3d& p1, Vec3d& p2)
 {
 	if (!h1.intersects(h2))

--- a/src/core/StelSphericalIndex.hpp
+++ b/src/core/StelSphericalIndex.hpp
@@ -326,7 +326,7 @@ private:
 
 			//! The maximum number of objects per node.
 			int maxObjectsPerNode;
-			//! The maximum level of the grid. Prevents grid split into too small triangles if unecessary.
+			//! The maximum level of the grid. Prevents grid split into too small triangles if unnecessary.
 			int maxLevel;
 	};
 

--- a/src/core/StelTexture.cpp
+++ b/src/core/StelTexture.cpp
@@ -256,7 +256,7 @@ void StelTexture::onNetworkReply()
 }
 
 /*************************************************************************
- Return the width and heigth of the texture in pixels
+ Return the width and height of the texture in pixels
 *************************************************************************/
 bool StelTexture::getDimensions(int &awidth, int &aheight)
 {

--- a/src/core/StelTexture.hpp
+++ b/src/core/StelTexture.hpp
@@ -66,7 +66,7 @@ public:
 
 	//! Bind the texture so that it can be used for openGL drawing (calls glBindTexture).
 	//! If the texture is lazyly loaded, this starts the loading and return false immediately.
-	//! @return true if the binding successfully occured, false if the texture is not yet loaded.
+	//! @return true if the binding successfully occurred, false if the texture is not yet loaded.
 	bool bind(uint slot=0);
 
 	//! Releases the currently bound texture without testing if it is currently bound,
@@ -80,7 +80,7 @@ public:
 	//! Return whether the texture can be binded, i.e. it is fully loaded
 	bool canBind() const {return id!=0;}
 
-	//! Return the width and heigth of the texture in pixels
+	//! Return the width and height of the texture in pixels
 	bool getDimensions(int &width, int &height);
 
 	//! Returns whether the texture has an alpha channel (GL_RGBA or GL_LUMINANCE_ALPHA format)
@@ -88,7 +88,7 @@ public:
 	bool hasAlphaChannel() const { return alphaChannel ; }
 
 	//! Get the error message which caused the texture loading to fail
-	//! @return the human friendly error message or empty string if no errors occured
+	//! @return the human friendly error message or empty string if no errors occurred
 	const QString& getErrorMessage() const {return errorMessage;}
 
 	//! Returns true if a loading error occurred
@@ -106,9 +106,9 @@ public:
 
 signals:
 	//! Emitted when the texture is ready to be bind(), i.e. when downloaded, imageLoading and	glLoading is over
-	//! or when an error occured and the texture will never be available
+	//! or when an error occurred and the texture will never be available
 	//! In case of error, you can query what the problem was by calling getErrorMessage()
-	//! @param error is equal to true if an error occured while loading the texture
+	//! @param error is equal to true if an error occurred while loading the texture
 	void loadingProcessFinished(bool error);
 
 private slots:
@@ -149,7 +149,7 @@ private:
 
 	//! Load the texture already in the RAM to the openGL memory
 	//! This function uses openGL routines and must be called in the main thread
-	//! @return false if an error occured
+	//! @return false if an error occurred
 	bool glLoad(const QImage& image);
 	//! Same as glLoad(QImage), but with an image already in OpenGl format
 	bool glLoad(const GLData& data);

--- a/src/core/StelTextureTypes.hpp
+++ b/src/core/StelTextureTypes.hpp
@@ -28,7 +28,7 @@
 class StelTexture;
 
 //! @typedef StelTextureSP
-//! Use shared pointer to simplify memory managment.
+//! Use shared pointer to simplify memory management.
 typedef QSharedPointer<StelTexture> StelTextureSP;
 
 #endif // STELTEXTURETYPES_HPP

--- a/src/core/StelToneReproducer.hpp
+++ b/src/core/StelToneReproducer.hpp
@@ -69,7 +69,7 @@ public:
 	//! Constructor
 	StelToneReproducer();
 	
-	//! Desctructor
+	//! Destructor
 	virtual ~StelToneReproducer() Q_DECL_OVERRIDE;
 
 public slots:

--- a/src/core/StelTranslator.cpp
+++ b/src/core/StelTranslator.cpp
@@ -96,7 +96,7 @@ void StelTranslator::initSystemLanguage()
 }
 
 
-//! Convert from ISO639-1 2(+3) letters langage code to native language name
+//! Convert from ISO639-1 2(+3) letters language code to native language name
 QString StelTranslator::iso639_1CodeToNativeName(const QString& languageCode)
 {
 	if (languageCode=="C")
@@ -119,7 +119,7 @@ QString StelTranslator::iso639_1CodeToNativeName(const QString& languageCode)
 	return languageCode;
 }
 
-//! Convert from native language name to ISO639-1 2(+3) letters langage code
+//! Convert from native language name to ISO639-1 2(+3) letters language code
 QString StelTranslator::nativeNameToIso639_1Code(const QString& languageName)
 {
 	QMap<QString, QString>::ConstIterator iter;

--- a/src/core/StelTranslator.hpp
+++ b/src/core/StelTranslator.hpp
@@ -90,11 +90,11 @@ public:
 	//! Get available language name in native language from passed locales directory
 	QStringList getAvailableLanguagesNamesNative(const QString& localeDir="", const QString &section="") const;
 
-	//! Convert from ISO639-1 langage code to native language name
+	//! Convert from ISO639-1 language code to native language name
 	//! @param languageCode the code to look up
 	static QString iso639_1CodeToNativeName(const QString& languageCode);
 	
-	//! Convert from native language name to ISO639-1 2 letters langage code 
+	//! Convert from native language name to ISO639-1 2 letters language code 
 	static QString nativeNameToIso639_1Code(const QString& languageName);
 	
 	//! Initialize Translation
@@ -124,7 +124,7 @@ private:
 	//! Try to determine system language from system configuration
 	static void initSystemLanguage(void);
 	
-	//! Store the system default language name as taken from LANGUAGE environement variable
+	//! Store the system default language name as taken from LANGUAGE environment variable
 	static QString systemLangName;
 	
 	//! Contains the list of all iso639 languages codes

--- a/src/core/StelUtils.hpp
+++ b/src/core/StelUtils.hpp
@@ -804,7 +804,7 @@ namespace StelUtils
 	//! Get Delta-T estimation for a given date.
 	//! Implementation of algorithm by Reingold & Dershowitz (1997, 2001, 2002, 2007, 2018) for DeltaT computation.
 	//! This is again mostly a data fit based on the table in Meeus, Astronomical Algorithms (1991).
-	//! This is the version given in the 4rd edition ("the ultimate edition"; 2018) which added the fit
+	//! This is the version given in the 4th edition ("the ultimate edition"; 2018) which added the fit
 	//! for -500..1699 and 2006..2150 omitted from previous editions.
 	//! Calendrical Calculations: The Ultimate Edition / Edward M. Reingold, Nachum Dershowitz - 4th Edition,
 	//! Cambridge University Press, 2018. - 660p. ISBN: 9781107057623, DOI: 10.1017/9781107415058

--- a/src/core/StelViewportEffect.hpp
+++ b/src/core/StelViewportEffect.hpp
@@ -37,7 +37,7 @@ public:
 	//! The default implementation does nothing.
 	virtual void alterBuffer(QOpenGLFramebufferObject*) const {;}
 	//! Draw the viewport on the screen.
-	//! @param buf the GL frame buffer containing the Stellarium viewport alreay drawn.
+	//! @param buf the GL frame buffer containing the Stellarium viewport already drawn.
 	//! The default implementation paints the buffer on the fullscreen.
 	virtual void paintViewportBuffer(const QOpenGLFramebufferObject* buf) const;
 	//! Distort an x,y position according to the distortion.

--- a/src/core/VecMath.hpp
+++ b/src/core/VecMath.hpp
@@ -1473,7 +1473,7 @@ template<class T> Vector3<T> Matrix4<T>::multiplyWithoutTranslation(const Vector
 			  r[2]*a.v[0] + r[6]*a.v[1] + r[10]*a.v[2]);
 }
 
-// multiply column vector by a 4x4 matrix in homogeneous coordinate (considere a[3]=1)
+// multiply column vector by a 4x4 matrix in homogeneous coordinate (consider a[3]=1)
 template<class T> Vector4<T> Matrix4<T>::operator*(const Vector4<T>& a) const
 {
 	return Vector4<T>(r[0]*a.v[0] + r[4]*a.v[1] +  r[8]*a.v[2] + r[12]*a.v[3],

--- a/src/core/modules/AsterismMgr.hpp
+++ b/src/core/modules/AsterismMgr.hpp
@@ -214,7 +214,7 @@ public slots:
 	//! // example of usage in scripts: remove selection from the "Summer Triangle" asterism
 	//! AsterismMgr.deselectAsterism("Summer Triangle");
 	//! @endcode
-	//! @note all asterisms will be hided when list of selected asterisms will be empty
+	//! @note all asterisms will be hidden when list of selected asterisms will be empty
 	void deselectAsterism(const QString& englishName);
 
 	//! Remove asterisms from selected objects

--- a/src/core/modules/Comet.cpp
+++ b/src/core/modules/Comet.cpp
@@ -351,7 +351,7 @@ void Comet::update(int deltaTime)
 		// Not only correct the color values for extinction, but for twilight conditions, also make tail end less visible.
 		// I consider sky brightness over 1cd/m^2 as reason to shorten tail.
 		// Below this brightness, the tail brightness loss by this method is insignificant:
-		// Just counting through the vertices might make a spiral apperance. Maybe even better than stackwise? Let's see...
+		// Just counting through the vertices might make a spiral appearance. Maybe even better than stackwise? Let's see...
 		const float avgAtmLum=GETSTELMODULE(LandscapeMgr)->getAtmosphereAverageLuminance();
 		const float brightnessDecreasePerVertexFromHead=1.0f/(COMET_TAIL_SLICES*COMET_TAIL_STACKS)  * avgAtmLum;
 		float brightnessPerVertexFromHead=1.0f;

--- a/src/core/modules/Comet.hpp
+++ b/src/core/modules/Comet.hpp
@@ -73,7 +73,7 @@ public:
 	//! \todo Find better sources for the g,k system
 	virtual float getVMagnitude(const StelCore* core) const Q_DECL_OVERRIDE;
 	//! sets the nameI18 property with the appropriate translation.
-	//! Function overriden to handle the problem with name conflicts.
+	//! Function overridden to handle the problem with name conflicts.
 	virtual void translateName(const StelTranslator& trans) Q_DECL_OVERRIDE;
 	virtual QString getEnglishName(void) const Q_DECL_OVERRIDE {return englishName;}
 	virtual QString getNameI18n(void) const Q_DECL_OVERRIDE {return nameI18;}

--- a/src/core/modules/Constellation.hpp
+++ b/src/core/modules/Constellation.hpp
@@ -45,7 +45,7 @@ class StelPainter;
 //! boundary shape from file constellation_boundaries.dat and an (optional) artistic pictorial representation.
 //! GZ NEW: The nativeName should be accessible in a GUI option, so that e.g. original names as written in a
 //! concrete book where a skyculture has been taken from can be assured even when translation is available.
-//! TODO: There should be a distinction between constellations and asterisms, which are "inofficial" figures within a sky culture.
+//! TODO: There should be a distinction between constellations and asterisms, which are "unofficial" figures within a sky culture.
 //! For example, Western sky culture has a "Big Dipper", "Coathanger", etc. These would be nice to see, but in different style.
 class Constellation : public StelObject
 {

--- a/src/core/modules/ConstellationMgr.hpp
+++ b/src/core/modules/ConstellationMgr.hpp
@@ -302,7 +302,7 @@ public slots:
 	//! // example of usage in scripts: remove selection from the Orion constellation
 	//! ConstellationMgr.deselectConstellation("Orion");
 	//! @endcode
-	//! @note all constellations will be hided when list of selected constellations will be empty
+	//! @note all constellations will be hidden when list of selected constellations will be empty
 	void deselectConstellation(const QString& englishName);
 
 	//! Get the list of English names of all constellations for loaded sky culture

--- a/src/core/modules/GridLinesMgr.cpp
+++ b/src/core/modules/GridLinesMgr.cpp
@@ -624,7 +624,7 @@ void SkyGrid::draw(const StelCore* core) const
 	}
 
 	if (lineThickness>1)
-		sPainter.setLineWidth(1); // reset tickness of line
+		sPainter.setLineWidth(1); // reset thickness of line
 	sPainter.setLineSmooth(false);
 }
 

--- a/src/core/modules/Landscape.hpp
+++ b/src/core/modules/Landscape.hpp
@@ -99,7 +99,7 @@ public:
 	double getBrightness() const { return static_cast<double>(landscapeBrightness); }
 	//! Returns the lightscape brightness
 	double getLightscapeBrightness() const { return static_cast<double>(lightScapeBrightness); }
-	//! Returns the lightscape brighness modulated with the fader's target state (i.e. binary on/off)
+	//! Returns the lightscape brightness modulated with the fader's target state (i.e. binary on/off)
 	double getTargetLightscapeBrightness() const { return static_cast<double>(lightScapeBrightness * illumFader); }
 	//! Gets the currently effective lightscape brightness (modulated by the fader)
 	double getEffectiveLightscapeBrightness() const { return static_cast<double>(lightScapeBrightness * illumFader.getInterstate()); }

--- a/src/core/modules/LandscapeMgr.hpp
+++ b/src/core/modules/LandscapeMgr.hpp
@@ -384,7 +384,7 @@ public slots:
 	//! @return false if the new landscape could not be set (e.g. no landscape of that ID was found). True on success.
 	bool setDefaultLandscapeID(const QString& id);
 
-	//! Return a pseudo HTML formatted string with all informations on the current landscape
+	//! Return a pseudo HTML formatted string with all information on the current landscape
 	QString getCurrentLandscapeHtmlDescription() const;
 
 	//! Return a pseudo HTML formatted string with information from description or ini file

--- a/src/core/modules/MinorPlanet.hpp
+++ b/src/core/modules/MinorPlanet.hpp
@@ -91,7 +91,7 @@ public:
 	void setAbsoluteMagnitudeAndSlope(const float magnitude, const float slope);
 
 	//! renders the subscript in a minor planet provisional designation with HTML.
-	//! \returns an emtpy string if the source string is not a provisional
+	//! \returns an empty string if the source string is not a provisional
 	//! designation.
 	static QString renderProvisionalDesignationinHtml(QString plainText);
 

--- a/src/core/modules/Planet.cpp
+++ b/src/core/modules/Planet.cpp
@@ -4243,7 +4243,7 @@ void Planet::drawSurvey(StelCore* core, StelPainter* painter)
 		}
 	}
 
-	// Apply a rotation otherwize the hips surveys don't get rendered at the
+	// Apply a rotation otherwise the hips surveys don't get rendered at the
 	// proper position.  Not sure why...
 	painter->getProjector()->getModelViewTransform()->combine(Mat4d::zrotation(M_PI * 0.5));
 	painter->getProjector()->getModelViewTransform()->combine(Mat4d::scaling(Vec3d(1, 1, oneMinusOblateness)));

--- a/src/core/modules/Planet.hpp
+++ b/src/core/modules/Planet.hpp
@@ -716,7 +716,7 @@ protected:
 					 // To get heliocentric coordinates, use getHeliocentricEclipticPos()
 	Vec3d eclipticVelocity;          // Speed in AU/d in the rectangular ecliptic coordinate system (J2000) around the parent body.
 					 // NEW FEATURE in late 2017. For now, this may be 0/0/0 when we are not yet able to compute it.
-					 // to get velocity, preferrably read getEclipticVelocity() and getHeliocentricEclipticVelocity()
+					 // to get velocity, preferably read getEclipticVelocity() and getHeliocentricEclipticVelocity()
 					 // The "State Vector" [Heafner 1999] can be formed from (JDE, eclipticPos, eclipticVelocity)
 	Vec3d aberrationPush;            // 0.21.2+: a small displacement to be applied if aberred positions are requested.
 	Vec3d screenPos;                 // Used to store temporarily the 2D position on screen. We need double for moons. Observe Styx from Pluto w/o atmosphere to see that.

--- a/src/core/modules/RotationElements.hpp
+++ b/src/core/modules/RotationElements.hpp
@@ -127,7 +127,7 @@ public:
 		double E11;
 		double E12;
 		double E13;
-		double M1;  // Mars corrections. These are from WGCCRE2015.
+		double M1; // Mars corrections. These are from WGCCRE2015.
 		double M2;
 		double M3;
 		double M4;
@@ -142,7 +142,7 @@ public:
 		double Jc;
 		double Jd;
 		double Je;
-		double Na; // Neptune axix term
+		double Na; // Neptune axis term
 		double J1; // corrective terms for Jupiter' moons, Table 10.10
 		double J2;
 		double J3;

--- a/src/core/modules/SolarSystem.hpp
+++ b/src/core/modules/SolarSystem.hpp
@@ -280,7 +280,7 @@ public slots:
 
 	//! Set flag whether to use OBJ models for rendering, where available
 	void setFlagUseObjModels(bool b) { if(b!=flagUseObjModels) { flagUseObjModels = b; emit flagUseObjModelsChanged(b); } }
-	//! Get the current value of the flag which determines wether to use OBJ models for rendering, where available
+	//! Get the current value of the flag which determines whether to use OBJ models for rendering, where available
 	bool getFlagUseObjModels(void) const { return flagUseObjModels; }
 
 	//! Set flag whether OBJ models should render self-shadowing (using a shadow map)

--- a/src/core/modules/Star.hpp
+++ b/src/core/modules/Star.hpp
@@ -41,7 +41,7 @@ template <class Star> struct SpecialZoneData;
 // structs for storing the stars in binary form. The idea is
 // to store much data for bright stars (Star1), but only little or even
 // very little data for faints stars (Star3). Using only 6 bytes for Star3
-// makes it feasable to store hundreds of millions of them in main memory.
+// makes it feasible to store hundreds of millions of them in main memory.
 
 
 static inline float IndexToBV(int bV)

--- a/src/core/modules/StarMgr.cpp
+++ b/src/core/modules/StarMgr.cpp
@@ -62,7 +62,7 @@ static QStringList component_array;
 
 // This number must be incremented each time the content or file format of the stars catalogs change
 // It can also be incremented when the defaultStarsConfig.json file change.
-// It should always matchs the version field of the defaultStarsConfig.json file
+// It should always match the version field of the defaultStarsConfig.json file
 static const int StarCatalogFormatVersion = 12;
 
 // Initialise statics

--- a/src/core/modules/ZoneArray.cpp
+++ b/src/core/modules/ZoneArray.cpp
@@ -435,7 +435,7 @@ void SpecialZoneArray<Star>::draw(StelPainter* sPainter, int index, bool isInsid
 	const Star* lastStar = zoneToDraw->getStars() + zoneToDraw->size;
 	for (const Star* s=zoneToDraw->getStars();s<lastStar;++s)
 	{
-		// Artifical cutoff per magnitude
+		// Artificial cutoff per magnitude
 		if (s->getMag() > cutoffMagStep)
 			break;
     

--- a/src/core/planetsephems/elliptic_to_rectangular.c
+++ b/src/core/planetsephems/elliptic_to_rectangular.c
@@ -64,7 +64,7 @@ SOFTWARE.
    L = mean longitude = Omega + omega + M
    M = mean anomaly
    i = inclination
-   e = excentricity
+   e = eccentricity
 
    Units are suspected to be: Julian days, AU, rad
 */
@@ -87,7 +87,7 @@ EllipticToRectangular(const double a,const double n,
   for (;;) {
     const double cLe = cos(Le);
     const double sLe = sin(Le);
-      /* for excentricity < 1 we have denominator > 0 */
+      /* for eccentricity < 1 we have denominator > 0 */
     const double dLe = (L - Le + elem[2]*sLe - elem[3]*cLe)
                      / (1.0    - elem[2]*cLe - elem[3]*sLe);
     Le += dLe;

--- a/src/core/planetsephems/elliptic_to_rectangular.h
+++ b/src/core/planetsephems/elliptic_to_rectangular.h
@@ -62,7 +62,7 @@ extern "C" {
    L = mean longitude = Omega + omega + M
    M = mean anomaly
    i = inclination
-   e = excentricity
+   e = eccentricity
    
    Units are suspected to be: Julian days, AU, rad
 

--- a/src/core/planetsephems/jpleph.cpp
+++ b/src/core/planetsephems/jpleph.cpp
@@ -43,7 +43,7 @@ current platform,  and swaps bytes on-the-fly if needed.  (Yes,  this
 can result in a slowdown... sometimes as much as 1%.  The function is
 so mathematically intensive that the byte-swapping is the least of our
 troubles.)  You can also use DE-200, 403, 404, 405,  or 406 without
-recompiling (the constan() function now determines which ephemeris is
+recompiling (the constant() function now determines which ephemeris is
 in use and its byte order).
 
 Also,  I did some minor optimization of the interp() (Chebyshev

--- a/src/core/planetsephems/pluto.c
+++ b/src/core/planetsephems/pluto.c
@@ -3,7 +3,7 @@ Copyright (C) 2001 Liam Girdwood <liam@nova-ioe.org>
 Copyright (C) 2003 Fabien Chereau
 
 This program is free software; you can redistribute it and/or modify
-it under the terms of the GNU Libary General Public License as published by
+it under the terms of the GNU Library General Public License as published by
 the Free Software Foundation; either version 2 of the License, or
 (at your option) any later version.
 

--- a/src/core/planetsephems/pluto.h
+++ b/src/core/planetsephems/pluto.h
@@ -3,7 +3,7 @@ Copyright (C) 2001 Liam Girdwood <liam@nova-ioe.org>
 Copyright (C) 2003 Fabien Chereau
 
 This program is free software; you can redistribute it and/or modify
-it under the terms of the GNU Libary General Public License as published by
+it under the terms of the GNU Library General Public License as published by
 the Free Software Foundation; either version 2 of the License, or
 (at your option) any later version.
 

--- a/src/gui/AstroCalcDialog.hpp
+++ b/src/gui/AstroCalcDialog.hpp
@@ -598,11 +598,11 @@ private:
 	//! @note Ported from KStars, should be improved, because this feature calculates
 	//! angular separation ("conjunction" defined as equality of right ascension
 	//! of two bodies), and current solution is not accurate and slow.
-	//! @note modes: 0 - conjuction, 1 - opposition, 2 - greatest elongation
+	//! @note modes: 0 - conjunction, 1 - opposition, 2 - greatest elongation
 	QMap<double, double> findClosestApproach(PlanetP& object1, StelObjectP& object2, const double startJD, const double stopJD, const double maxSeparation, const int mode);
 	//! Finding the angular distance between two celestial bodies at some Julian date
 	double findDistance(double JD, PlanetP object1, StelObjectP object2, int mode);
-	//! Finding the initial time steps for interations
+	//! Finding the initial time steps for interactions
 	double findInitialStep(double startJD, double stopJD, QStringList objects);
 	//! Finding the celestial event
 	bool findPrecise(QPair<double, double>* out, PlanetP object1, StelObjectP object2, double JD, double step, int prevSign, int mode);
@@ -611,7 +611,7 @@ private:
 	//! Wrapper for filling the table of phenomena between planet and deep-sky object
 	void fillPhenomenaTable(const QMap<double, double> list, const PlanetP object1, const NebulaP object2);
 	//! Wrapper for filling the table of phenomena between two planets
-	//! @note modes: 0 - conjuction, 1 - opposition, 2 - greatest elongation
+	//! @note modes: 0 - conjunction, 1 - opposition, 2 - greatest elongation
 	void fillPhenomenaTable(const QMap<double, double> list, const PlanetP object1, const PlanetP object2, int mode);
 	//! Filling the table of phenomena
 	void fillPhenomenaTableVis(QString phenomenType, double JD, QString firstObjectName, float firstObjectMagnitude,

--- a/src/gui/HelpDialog.cpp
+++ b/src/gui/HelpDialog.cpp
@@ -193,7 +193,7 @@ void HelpDialog::downloadComplete(QNetworkReply *reply)
 	{
 		qWarning() << "Error: While trying to access"
 			   << reply->url().toString()
-			   << "the following error occured:"
+			   << "the following error occurred:"
 			   << reply->errorString();
 
 		reply->deleteLater();

--- a/src/gui/ObsListCreateEditDialog.hpp
+++ b/src/gui/ObsListCreateEditDialog.hpp
@@ -93,7 +93,7 @@ private:
 			 const QString &ra, const QString &dec, const QString &magnitude, const QString &constellation,
 			 const QString &date, const QString &location, const QString &landscapeID);
 
-	//! Save the object informations into json file
+	//! Save the object information into json file
 	void saveObservedObjectsInJsonFile();
 
 	//! Load the observing list in case of edit mode

--- a/src/gui/SearchDialog.cpp
+++ b/src/gui/SearchDialog.cpp
@@ -910,7 +910,7 @@ void SearchDialog::adjustMatchesResult(QStringList &allMatches, QStringList& rec
 	stringLengthCompare comparator;
 	std::sort(matches.begin(), matches.end(), comparator);
 
-	// Adjust recent matches to prefered max size
+	// Adjust recent matches to preferred max size
 	recentMatches = recentMatches.mid(0, recentObjectSearchesData.maxSize);
 
 	// Find total size of both matches
@@ -1482,7 +1482,7 @@ void SearchDialog::pasteAndGo()
 	// https://wiki.qt.io/Technical_FAQ#Why_does_the_memory_keep_increasing_when_repeatedly_pasting_text_and_calling_clear.28.29_in_a_QLineEdit.3F
 	ui->lineEditSearchSkyObject->setText(""); // clear current text
 	ui->lineEditSearchSkyObject->paste(); // paste text from clipboard
-	gotoObject(); // go to first finded object
+	gotoObject(); // go to first found object
 }
 
 void SearchDialog::setVisible(bool v)

--- a/src/gui/SearchDialog.hpp
+++ b/src/gui/SearchDialog.hpp
@@ -122,7 +122,7 @@ public:
 	~SearchDialog() override;
 	bool eventFilter(QObject *object, QEvent *event) override;
 
-	//! Replaces all occurences of substrings describing Greek letters (i.e. "alpha", "beta", ...)
+	//! Replaces all occurrences of substrings describing Greek letters (i.e. "alpha", "beta", ...)
 	//! with the actual Greek unicode characters.
 	static QString substituteGreek(const QString& keyString);
 	//! Returns the Greek unicode character for the specified letter string (i.e. "alpha", "beta", ...)

--- a/src/gui/ShortcutsDialog.cpp
+++ b/src/gui/ShortcutsDialog.cpp
@@ -509,7 +509,7 @@ void ShortcutsDialog::updateTreeData()
 			updateShortcutsItem(action);
 		}
 	}
-	// ajust columns
+	// adjust columns
 	for(int i=0; i<3; i++)
 		ui->shortcutsTreeView->resizeColumnToContents(i);
 }

--- a/src/gui/ShortcutsDialog.hpp
+++ b/src/gui/ShortcutsDialog.hpp
@@ -114,7 +114,7 @@ private:
 	QStandardItemModel* mainModel;
 	//! Initialize or reset the main model.
 	void resetModel();
-	//! Set the main model's column lables.
+	//! Set the main model's column labels.
 	void setModelHeader();
 };
 

--- a/src/gui/SkyGui.hpp
+++ b/src/gui/SkyGui.hpp
@@ -34,7 +34,7 @@ class StelButton;
 class BottomStelBar;
 class StelProgressController;
 
-//! The informations about the currently selected object
+//! The information about the currently selected object
 class InfoPanel : public QGraphicsTextItem
 {
 	public:

--- a/src/gui/StelGui.cpp
+++ b/src/gui/StelGui.cpp
@@ -763,7 +763,7 @@ void StelGui::setFlagShowFlipButtons(bool b)
 	}
 }
 
-// Define whether the button toggling nebulae backround images should be visible
+// Define whether the button toggling nebulae background images should be visible
 void StelGui::setFlagShowNebulaBackgroundButton(bool b)
 {
 	if (b!=flagShowNebulaBackgroundButton)

--- a/src/gui/StelGuiItems.hpp
+++ b/src/gui/StelGuiItems.hpp
@@ -32,7 +32,7 @@ class QTimer;
 class StelProgressController;
 class QProgressBar;
 
-// Progess bars in the lower right corner
+// Progress bars in the lower right corner
 class StelProgressBarMgr : public QGraphicsWidget
 {
 	Q_OBJECT

--- a/src/gui/astroCalcDialog.ui
+++ b/src/gui/astroCalcDialog.ui
@@ -381,7 +381,7 @@
                    <string>Use horizontal coordinates</string>
                   </property>
                   <property name="text">
-                   <string comment="horizonal coordinates">H.C.</string>
+                   <string comment="horizontal coordinates">H.C.</string>
                   </property>
                  </widget>
                 </item>
@@ -684,7 +684,7 @@
                <string>Use horizontal coordinates</string>
               </property>
               <property name="text">
-               <string comment="horizonal coordinates">H.C.</string>
+               <string comment="horizontal coordinates">H.C.</string>
               </property>
              </widget>
             </item>

--- a/src/scripting/ScreenImageMgr.cpp
+++ b/src/scripting/ScreenImageMgr.cpp
@@ -69,7 +69,7 @@ ScreenImage::ScreenImage(const QString& filename, qreal x, qreal y, bool show, q
 	ScreenImage::setFadeDuration(fadeDuration);
 	connect(fadeTimer, SIGNAL(valueChanged(qreal)), this, SLOT(setOpacity(qreal)));
 
-	// set inital displayed state
+	// set initial displayed state
 	if (show)
 		tex->setOpacity(maxAlpha);
 	else

--- a/src/tests/testStelSkyCultureMgr.cpp
+++ b/src/tests/testStelSkyCultureMgr.cpp
@@ -33,7 +33,7 @@ void TestStelSkyCultureMgr::testStelSkyCultureMgr()
 
 	StelSkyCultureMgr scMgr;
 
-	QVERIFY(scMgr.getDefaultSkyCultureID().isEmpty()); // Shoud be true, because sky culture is not set! (StelSkyCultureMgr::init() isn't called)
+	QVERIFY(scMgr.getDefaultSkyCultureID().isEmpty()); // Should be true, because sky culture is not set! (StelSkyCultureMgr::init() isn't called)
 	QVERIFY(scMgr.setCurrentSkyCultureID("arabic_al-sufi"));
 	QVERIFY(scMgr.getCurrentSkyCultureID()=="arabic_al-sufi");
 	QVERIFY(scMgr.setCurrentSkyCultureID("modern"));

--- a/src/tests/testStelSphereGeometry.cpp
+++ b/src/tests/testStelSphereGeometry.cpp
@@ -220,7 +220,7 @@ void TestStelSphericalGeometry::testContains()
 	QVERIFY2(square1.intersects(square2), "Square intersect square failure");
 	QVERIFY2(square2.intersects(square1), "Square intersect square failure");
 
-	// Check when the polygons are far appart
+	// Check when the polygons are far apart
 	QVERIFY(!square1.intersects(opositeSquare));
 	QVERIFY(!square2.intersects(opositeSquare));
 	QVERIFY(!holySquare.intersects(opositeSquare));


### PR DESCRIPTION
### Description

Fixes all comment or documentation typos in the `src/` subdir  
Found via `codespell -q 3 -S *.po,*.pot,*.utf8,ChangeLog,./src/external,./plugins/RemoteControl/webroot/js -L anonymus,dout,inout,lod,ned,ser,te,tht,ue`


### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [X] Housecleaning 

### How Has This Been Tested?

n/a

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
