### PR TITLE
Undo extraneous gamma encoded in moon_4k texture

### DIFF
--- a/data/shaders/planet.frag
+++ b/data/shaders/planet.frag
@@ -352,6 +352,14 @@ void main()
     //litColor.xyz = clamp( litColor.xyz + vec3(outgas), 0.0, 1.0);
 
     lowp vec4 texColor = texture2D(tex, texc);
+#ifdef IS_MOON
+    // Undo the extraneous gamma encoded in the texture.
+    // FIXME: ideally, we want all the calculations to be done in linear scale,
+    // and then *in the end* apply the exact sRGB transfer function. Currently
+    // though, we don't do actual physically-correct simulation here, so we
+    // just apply the approximate sRGB gamma.
+    texColor = pow(texColor, vec4(2.8/2.2));
+#endif
 
     mediump vec4 finalColor = texColor;
 	// apply (currently only Martian) pole caps. texc.t=0 at south pole, 1 at north pole. 


### PR DESCRIPTION
### Description

The Moon texture introduced in a5c14408e6e61ce73e032c932e5a68448e376389 was apparently taken from the SVS [CGI Moon Kit](https://svs.gsfc.nasa.gov/cgi-bin/details.cgi?aid=4720), where it's described thus:

> The red channel contains the 643 nm band, while green and blue were created from different linear combinations of the 566 and 415 nm bands to more nearly center them on 532 nm (green) and 472 nm (blue). A gamma of 2.8 was applied (the LROC data is linear), and the channels were multiplied by (0.935, 1.005, 1.04) to balance the color. The intensity range (0.16, 0.4) was mapped into the full (0, 255) 8-bit range per channel.

The colorimetric transformations I can't check currently, and the intensity remapping is not relevant for current state of Stellarium, but the gamma is definitely wrong for the monitors we are targeting.

This patch fixes the gamma to be closer to sRGB transfer function. As Stellarium doesn't fully support sRGB (whose transfer function should be applied to the linear RGB values at the end of the whole scene rendering), this patch simply reduces the encoding gamma of the texture of 2.8 to rendering gamma of 2.2. This is done on the fly, in the shader.

### Screenshots:

Old:

![Screenshot_2022-11-28_23-05-44](https://user-images.githubusercontent.com/6376882/204338620-dee0691f-1573-4241-b3ec-13eba97671dd.png)

New:

![Screenshot_2022-11-28_23-04-55](https://user-images.githubusercontent.com/6376882/204338708-893c6f8f-6a5f-42ca-bc2b-85e59ce90798.png)