### PR TITLE
Add support for anisotropic filtering of StelTexture

### DIFF
--- a/guide/app_config_ini.tex
+++ b/guide/app_config_ini.tex
@@ -851,7 +851,9 @@ screen\_y        & int    & Vertical   position of the top-left corner in window
 viewport\_effect & string & This is used when the spheric mirror display mode is activated. Values include \emph{none} and \emph{sphericMirrorDistorter}.\\%\midrule
 minimum\_fps     & int    & Sets the minimum number of frames per second to display at (hardware performance permitting)\\%\midrule
 maximum\_fps     & int    & Sets the maximum number of frames per second to display at. This is useful to reduce power consumption in laptops.\\%\midrule
-multisampling    & int    & Sets the number of samples to use for multisampling antialiasing. \emph{0} disables antialiasing, \emph{1} is no-op (single sample per pixel), higher values increase smoothness and degrade performance. Too high a value may result in excessive blurriness of the GUI. A good starting value to try is \emph{4}.\\\bottomrule
+multisampling    & int    & Sets the number of samples to use for multisampling antialiasing. \emph{0} disables antialiasing, \emph{1} is no-op (single sample per pixel), higher values increase smoothness and degrade performance. Too high a value may result in excessive blurriness of the GUI. A good starting value to try is \emph{4}.\\
+	anisotropic\_filtering & int & Improves quality of rendering of inclined textured surfaces like e.g. planetary surface near the limb. Modern (and even quite old, like from 2010) GPUs can handle high anisotropy with no noticeable performance drop, so it should be fine to set this value as high as 16. If this setting value is higher than the GPU is capable of, the maximum value supported is used. The default is 16. To disable anisotropic filtering, set this value to 0.\\
+\bottomrule
 \end{tabularx}
 
 \subsection{\big[viewing\big]}

--- a/src/StelMainView.cpp
+++ b/src/StelMainView.cpp
@@ -77,6 +77,10 @@ Q_LOGGING_CATEGORY(mainview, "stel.MainView")
 
 #include <clocale>
 
+#ifndef GL_MAX_TEXTURE_MAX_ANISOTROPY
+# define GL_MAX_TEXTURE_MAX_ANISOTROPY 0x84FF
+#endif
+
 // Initialize static variables
 StelMainView* StelMainView::singleton = Q_NULLPTR;
 
@@ -868,6 +872,32 @@ void StelMainView::init()
 	glInfo.isGLES = format.renderableType()==QSurfaceFormat::OpenGLES;
 	qDebug().nospace() << "Luminance textures are " << (glInfo.supportsLuminanceTextures ? "" : "not ") << "supported";
 	glInfo.isCoreProfile = format.profile() == QSurfaceFormat::CoreProfile;
+	if(format.majorVersion() * 1000 + format.minorVersion() >= 4006 ||
+	   glInfo.mainContext->hasExtension("GL_EXT_texture_filter_anisotropic") ||
+	   glInfo.mainContext->hasExtension("GL_ARB_texture_filter_anisotropic"))
+	{
+		StelOpenGL::clearGLErrors();
+		auto& gl = *QOpenGLContext::currentContext()->functions();
+		gl.glGetIntegerv(GL_MAX_TEXTURE_MAX_ANISOTROPY, &glInfo.maxAnisotropy);
+		const auto error = gl.glGetError();
+		if(error != GL_NO_ERROR)
+		{
+			qDebug() << "Failed to get maximum texture anisotropy:" << StelOpenGL::getGLErrorText(error);
+		}
+		else if(glInfo.maxAnisotropy > 0)
+		{
+			qDebug() << "Maximum texture anisotropy:" << glInfo.maxAnisotropy;
+		}
+		else
+		{
+			qDebug() << "Maximum texture anisotropy is not positive:" << glInfo.maxAnisotropy;
+			glInfo.maxAnisotropy = 0;
+		}
+	}
+	else
+	{
+		qDebug() << "Anisotropic filtering is not supported!";
+	}
 
 	gui = new StelGui();
 

--- a/src/StelMainView.hpp
+++ b/src/StelMainView.hpp
@@ -72,6 +72,7 @@ public:
 		QSurface* surface;
 		QOpenGLContext* mainContext;
 		QOpenGLFunctions* functions;
+		GLint maxAnisotropy = 0;
 		bool supportsLuminanceTextures = false;
 		bool isCoreProfile = false;
 		bool isGLES = false;


### PR DESCRIPTION
### Description

Highly detailed surfaces of planet-like objects, e.g. the Moon, suffer from over-blurring of the limbs due to isotropic mip mapping. This patch adds an option to use anisotropic filtering.

The default state is off. It might be OK to enable by default, since I haven't seen a GPU that suffers from performance drops with it, but this needs testing with e.g. software rendering or ANGLE.

### Screenshots:

Default (anisotropy disabled):

![Screenshot_2022-11-29_02-21-54](https://user-images.githubusercontent.com/6376882/204373538-2ea064f1-8d2c-4774-8aa7-4f63e6d4867d.png)

Anisotropy 16×:

![Screenshot_2022-11-29_02-21-12](https://user-images.githubusercontent.com/6376882/204373583-6d78fb8b-effc-4f10-bd10-68baab5abb62.png)

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] This change requires a documentation update

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system: Ubuntu 20.04
* Graphics Card: Intel UHD Graphics 620

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [x] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules