### PR TITLE
Update to INDI 2.0.0

### DIFF
--- a/src/external/CMakeLists.txt
+++ b/src/external/CMakeLists.txt
@@ -107,6 +107,17 @@ IF(USE_PLUGIN_TELESCOPECONTROL)
         configure_file(${indiclient_SOURCE_DIR}/libs/indicore/indidevapi.h.new
             ${indiclient_SOURCE_DIR}/libs/indicore/indidevapi.h COPYONLY)
 
+        # libastro.h doesn't need libnova/utility.h
+        file(READ
+            ${indiclient_SOURCE_DIR}/libs/indicore/libastro.h
+            LIBASTRO_H)
+        string(REGEX REPLACE "#include <libnova/utility.h>" "" LIBASTRO_H "${LIBASTRO_H}")
+        file(WRITE
+            ${indiclient_SOURCE_DIR}/libs/indicore/libastro.h.new
+           "${LIBASTRO_H}")
+        configure_file(${indiclient_SOURCE_DIR}/libs/indicore/libastro.h.new
+            ${indiclient_SOURCE_DIR}/libs/indicore/libastro.h COPYONLY)
+
         # Now copy the headers
         file(GLOB INDI_HEADERS "${indiclient_SOURCE_DIR}/libs/*/*.h")
         file(COPY ${INDI_HEADERS}

--- a/src/external/CMakeLists.txt
+++ b/src/external/CMakeLists.txt
@@ -85,15 +85,15 @@ IF(USE_PLUGIN_TELESCOPECONTROL)
         # Included CMakeLists.txt contains unrelated targets and dependencies of
         # them, therefore DOWNLOAD_ONLY and all the code below
         CPMAddPackage(NAME indiclient
-            URL https://github.com/indilib/indi/archive/v1.8.5.zip
-            URL_HASH SHA256=57b78afe6d338533e35725e94cf6a9e302e22348ab418811bd41997cddf13fd6
-            VERSION 1.8.5
+            URL https://github.com/indilib/indi/archive/v1.9.9.zip
+            URL_HASH SHA256=17cc4c0cb2559f373aabe1f6c0d76f00508c0608da34a2c5bdcffbc41e3dce01
+            VERSION 1.9.9
             DOWNLOAD_ONLY YES)
 
-        # Installed version has /usr/include/libindi, move these headers to
+        # Installed version has /usr/include/libindi, copy these headers to
         # such directory for a consistent #include
         file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/libindi)
-        file(GLOB INDI_HEADERS "${indiclient_SOURCE_DIR}/libs/indibase/*.h")
+        file(GLOB INDI_HEADERS "${indiclient_SOURCE_DIR}/libs/*/*.h")
         file(COPY ${INDI_HEADERS}
             DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/libindi)
 
@@ -142,29 +142,55 @@ IF(USE_PLUGIN_TELESCOPECONTROL)
 
         set(INDI_SOVERSION "1")
         set(CMAKE_INDI_VERSION_MAJOR 1)
-        set(CMAKE_INDI_VERSION_MINOR 8)
-        set(CMAKE_INDI_VERSION_RELEASE 5)
+        set(CMAKE_INDI_VERSION_MINOR 9)
+        set(CMAKE_INDI_VERSION_RELEASE 9)
         set(CMAKE_INDI_VERSION_STRING "${CMAKE_INDI_VERSION_MAJOR}.${CMAKE_INDI_VERSION_MINOR}.${CMAKE_INDI_VERSION_RELEASE}")
         set(INDI_VERSION ${CMAKE_INDI_VERSION_MAJOR}.${CMAKE_INDI_VERSION_MINOR}.${CMAKE_INDI_VERSION_RELEASE})
         set(DATA_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/share/indi/")
         configure_file(${indiclient_SOURCE_DIR}/config.h.cmake
             ${CMAKE_CURRENT_BINARY_DIR}/libindi/config.h )
+        configure_file(${indiclient_SOURCE_DIR}/libs/indicore/indiapi.h.in
+		    ${indiclient_SOURCE_DIR}/libs/indicore/indiapi.h)
         add_library(indiclient STATIC
-            ${indiclient_SOURCE_DIR}/libs/lilxml.c
-            ${indiclient_SOURCE_DIR}/base64.c
-            ${indiclient_SOURCE_DIR}/libs/indibase/basedevice.cpp
-            ${indiclient_SOURCE_DIR}/libs/indibase/baseclient.cpp
-            ${indiclient_SOURCE_DIR}/libs/indibase/indiproperty.cpp
-            ${indiclient_SOURCE_DIR}/libs/indibase/indistandardproperty.cpp
-            ${indiclient_SOURCE_DIR}/libs/indicom.c)
+            ${indiclient_SOURCE_DIR}/libs/indicore/lilxml.cpp
+            ${indiclient_SOURCE_DIR}/libs/indicore/base64.c
+            ${indiclient_SOURCE_DIR}/libs/indicore/indidevapi.c
+            ${indiclient_SOURCE_DIR}/libs/indicore/indicom.c
+            ${indiclient_SOURCE_DIR}/libs/indicore/userio.c
+            ${indiclient_SOURCE_DIR}/libs/indicore/indiuserio.c
+            ${indiclient_SOURCE_DIR}/libs/indiabstractclient/abstractbaseclient.cpp
+            ${indiclient_SOURCE_DIR}/libs/indiclient/baseclient.cpp
+            ${indiclient_SOURCE_DIR}/libs/indidevice/basedevice.cpp
+            ${indiclient_SOURCE_DIR}/libs/indidevice/indibase.cpp
+            ${indiclient_SOURCE_DIR}/libs/indidevice/indistandardproperty.cpp
+            ${indiclient_SOURCE_DIR}/libs/indidevice/parentdevice.cpp
+            ${indiclient_SOURCE_DIR}/libs/indidevice/watchdeviceproperty.cpp
+            ${indiclient_SOURCE_DIR}/libs/indidevice/property/indiproperties.cpp
+            ${indiclient_SOURCE_DIR}/libs/indidevice/property/indipropertybasic.cpp
+            ${indiclient_SOURCE_DIR}/libs/indidevice/property/indipropertyblob.cpp
+            ${indiclient_SOURCE_DIR}/libs/indidevice/property/indiproperty.cpp
+            ${indiclient_SOURCE_DIR}/libs/indidevice/property/indipropertylight.cpp
+            ${indiclient_SOURCE_DIR}/libs/indidevice/property/indipropertynumber.cpp
+            ${indiclient_SOURCE_DIR}/libs/indidevice/property/indipropertyswitch.cpp
+            ${indiclient_SOURCE_DIR}/libs/indidevice/property/indipropertytext.cpp
+            ${indiclient_SOURCE_DIR}/libs/indidevice/property/indipropertyview.cpp
+            ${indiclient_SOURCE_DIR}/libs/sockets/tcpsocket.cpp
+            ${indiclient_SOURCE_DIR}/libs/sockets/tcpsocket_unix.cpp
+            )
         target_include_directories(indiclient
             PRIVATE
             ${CMAKE_CURRENT_BINARY_DIR}/libindi
             PUBLIC
             ${CMAKE_CURRENT_BINARY_DIR}
             ${indiclient_SOURCE_DIR}
+            ${indiclient_SOURCE_DIR}/libs/sockets
+            ${indiclient_SOURCE_DIR}/libs/indiabstractclient
+            ${indiclient_SOURCE_DIR}/libs/indibase
+            ${indiclient_SOURCE_DIR}/libs/indicore
+            ${indiclient_SOURCE_DIR}/libs/indiclient
+            ${indiclient_SOURCE_DIR}/libs/indidevice
+            ${indiclient_SOURCE_DIR}/libs/indidevice/property
             ${indiclient_SOURCE_DIR}/libs)
         target_link_libraries(indiclient ${ZLIB_LIBRARIES})
     endif()
 ENDIF()
-

--- a/src/external/CMakeLists.txt
+++ b/src/external/CMakeLists.txt
@@ -93,6 +93,21 @@ IF(USE_PLUGIN_TELESCOPECONTROL)
         # Installed version has /usr/include/libindi, copy these headers to
         # such directory for a consistent #include
         file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/libindi)
+
+        # First, fix a missing include
+        file(READ
+            ${indiclient_SOURCE_DIR}/libs/indicore/indidevapi.h
+            INDIDEVAPI_H)
+        string(REGEX REPLACE "#include .lilxml.h."
+            "#include \"lilxml.h\"\n#include <stdarg.h>"
+            INDIDEVAPI_H "${INDIDEVAPI_H}")
+        file(WRITE
+            ${indiclient_SOURCE_DIR}/libs/indicore/indidevapi.h.new
+	        "${INDIDEVAPI_H}")
+        configure_file(${indiclient_SOURCE_DIR}/libs/indicore/indidevapi.h.new
+            ${indiclient_SOURCE_DIR}/libs/indicore/indidevapi.h COPYONLY)
+
+        # Now copy the headers
         file(GLOB INDI_HEADERS "${indiclient_SOURCE_DIR}/libs/*/*.h")
         file(COPY ${INDI_HEADERS}
             DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/libindi)
@@ -150,8 +165,8 @@ IF(USE_PLUGIN_TELESCOPECONTROL)
         configure_file(${indiclient_SOURCE_DIR}/config.h.cmake
             ${CMAKE_CURRENT_BINARY_DIR}/libindi/config.h )
         configure_file(${indiclient_SOURCE_DIR}/libs/indicore/indiapi.h.in
-		    ${indiclient_SOURCE_DIR}/libs/indicore/indiapi.h)
-		list(APPEND INDILIB_SOURCES
+            ${indiclient_SOURCE_DIR}/libs/indiapi.h)
+        list(APPEND INDILIB_SOURCES
             ${indiclient_SOURCE_DIR}/libs/indicore/lilxml.cpp
             ${indiclient_SOURCE_DIR}/libs/indicore/base64.c
             ${indiclient_SOURCE_DIR}/libs/indicore/indidevapi.c
@@ -187,6 +202,8 @@ IF(USE_PLUGIN_TELESCOPECONTROL)
         target_include_directories(indiclient
             PRIVATE
             ${CMAKE_CURRENT_BINARY_DIR}/libindi
+            ${indiclient_SOURCE_DIR}/libindi
+            ${indiclient_SOURCE_DIR}/libs
             PUBLIC
             ${CMAKE_CURRENT_BINARY_DIR}
             ${indiclient_SOURCE_DIR}

--- a/src/external/CMakeLists.txt
+++ b/src/external/CMakeLists.txt
@@ -151,7 +151,7 @@ IF(USE_PLUGIN_TELESCOPECONTROL)
             ${CMAKE_CURRENT_BINARY_DIR}/libindi/config.h )
         configure_file(${indiclient_SOURCE_DIR}/libs/indicore/indiapi.h.in
 		    ${indiclient_SOURCE_DIR}/libs/indicore/indiapi.h)
-        add_library(indiclient STATIC
+		list(APPEND INDILIB_SOURCES
             ${indiclient_SOURCE_DIR}/libs/indicore/lilxml.cpp
             ${indiclient_SOURCE_DIR}/libs/indicore/base64.c
             ${indiclient_SOURCE_DIR}/libs/indicore/indidevapi.c
@@ -175,8 +175,15 @@ IF(USE_PLUGIN_TELESCOPECONTROL)
             ${indiclient_SOURCE_DIR}/libs/indidevice/property/indipropertytext.cpp
             ${indiclient_SOURCE_DIR}/libs/indidevice/property/indipropertyview.cpp
             ${indiclient_SOURCE_DIR}/libs/sockets/tcpsocket.cpp
-            ${indiclient_SOURCE_DIR}/libs/sockets/tcpsocket_unix.cpp
             )
+        if(WIN32)
+            list(APPEND INDILIB_SOURCES ${indiclient_SOURCE_DIR}/libs/sockets/tcpsocket_win.cpp)
+        else()
+            list(APPEND INDILIB_SOURCES ${indiclient_SOURCE_DIR}/libs/sockets/tcpsocket_unix.cpp)
+        endif()
+
+        add_library(indiclient STATIC ${INDILIB_SOURCES})
+
         target_include_directories(indiclient
             PRIVATE
             ${CMAKE_CURRENT_BINARY_DIR}/libindi


### PR DESCRIPTION
### Description
Update to INDI 1.9.9 (current version) when building from source which handles remote server shut down a lot better.

TelescopeClientINDI itself doesn't require any change to link against 
INDI 1.9.9 either using `libindi-dev 1.9.9` from the INDI PPA, or compiling it as part of the stellarium build.

Fixes #2864 

### Screenshots (if appropriate):
Here's the log output of me connecting to my stellarmate, and then shutting down INDI remotely... with Stellarium not crashing!

```
...
Loaded plugin "TelescopeControl"
[TelescopeControl] Only embedded telescope servers are available.
[TelescopeControl] Adding device model: "Meade AutoStar compatible" "Any telescope or telescope mount compatible with Meade's AutoStar controller." "TelescopeServerLx200" 500000
[TelescopeControl] Adding device model: "Meade LX200 (compatible)" "Any telescope or telescope mount compatible with Meade LX200." "TelescopeServerLx200" 500000
[TelescopeControl] Adding device model: "Meade ETX70 (#494 Autostar, #506 CCS)" "Meade's ETX70 with the #494 Autostar controller and the #506 Connector Cable Set." "TelescopeServerLx200" 1500000
[TelescopeControl] Adding device model: "Losmandy G-11" "Losmandy's G-11 telescope mount." "TelescopeServerLx200" 500000
[TelescopeControl] Adding device model: "Wildcard Innovations Argo Navis (Meade mode)" "Wildcard Innovations' Argo Navis DTC in Meade LX200 emulation mode." "TelescopeServerLx200" 500000
[TelescopeControl] Adding device model: "Celestron NexStar (compatible)" "Any telescope or telescope mount compatible with Celestron NexStar." "TelescopeServerNexStar" 500000
[TelescopeControl] Adding device model: "Sky-Watcher SynScan (version 3 or later)" "Any Sky-Watcher mount that uses version 3 or later of the SynScan hand controller." "TelescopeServerNexStar" 500000
[TelescopeControl] Adding device model: "Sky-Watcher SynScan AZ GOTO" "The Sky-Watcher SynScan AZ GOTO mount used in a number of telescope models." "TelescopeServerNexStar" 500000
connectionType: TelescopeControl::ConnectionINDI  initString: "stellarmate:INDI:J2000:stellarmate:7624:EQMod Mount"
Creating telescope "stellarmate:INDI:J2000:stellarmate:7624:EQMod Mount" ; name/type/equinox/params: "stellarmate" "INDI" J2000 "stellarmate:7624:EQMod Mount"
TelescopeClientINDI::TelescopeClientINDI
INDI::BaseClient::connectServer: creating new connection...
[TelescopeControl] Loaded successfully 2 telescopes.
INDIConnection::newDevice| New Device...  "EQMod Mount"
INDIConnection::newProperty|  "CONNECTION"
INDIConnection::newProperty|  "DRIVER_INFO"
INDIConnection::newProperty|  "POLLING_PERIOD"
INDIConnection::newProperty|  "ALIGNMENT_POINT_MANDATORY_NUMBERS"
INDIConnection::newProperty|  "ALIGNMENT_POINT_OPTIONAL_BINARY_BLOB"
INDIConnection::newProperty|  "ALIGNMENT_POINTSET_SIZE"
INDIConnection::newProperty|  "ALIGNMENT_POINTSET_CURRENT_ENTRY"
INDIConnection::newProperty|  "ALIGNMENT_POINTSET_ACTION"
INDIConnection::newProperty|  "ALIGNMENT_POINTSET_COMMIT"
INDIConnection::newProperty|  "ALIGNMENT_SUBSYSTEM_MATH_PLUGINS"
INDIConnection::newProperty|  "ALIGNMENT_SUBSYSTEM_MATH_PLUGIN_INITIALISE"
INDIConnection::newProperty|  "ALIGNMENT_SUBSYSTEM_ACTIVE"
INDIConnection::newProperty|  "DEBUG"
INDIConnection::newProperty|  "SIMULATION"
INDIConnection::newProperty|  "CONFIG_PROCESS"
INDIConnection::newProperty|  "DEBUG_LEVEL"
INDIConnection::newProperty|  "LOGGING_LEVEL"
INDIConnection::newProperty|  "LOG_OUTPUT"
INDIConnection::newProperty|  "CONNECTION_MODE"
INDIConnection::newProperty|  "SYSTEM_PORTS"
INDIConnection::newProperty|  "DEVICE_PORT"
INDIConnection::newProperty|  "DEVICE_BAUD_RATE"
INDIConnection::newProperty|  "DEVICE_AUTO_SEARCH"
INDIConnection::newProperty|  "DEVICE_PORT_SCAN"
INDIConnection::newProperty|  "ACTIVE_DEVICES"
INDIConnection::newProperty|  "DOME_POLICY"
INDIConnection::newProperty|  "TELESCOPE_INFO"
INDIConnection::newProperty|  "SCOPE_CONFIG_NAME"
INDIConnection::newProperty|  "ON_COORD_SET"
INDIConnection::newProperty|  "EQUATORIAL_EOD_COORD"
INDIConnection::newProperty|  "TELESCOPE_ABORT_MOTION"
INDIConnection::newProperty|  "TELESCOPE_TRACK_MODE"
INDIConnection::newProperty|  "TELESCOPE_TRACK_STATE"
INDIConnection::newProperty|  "TELESCOPE_TRACK_RATE"
INDIConnection::newProperty|  "TELESCOPE_MOTION_NS"
INDIConnection::newProperty|  "TELESCOPE_MOTION_WE"
INDIConnection::newProperty|  "TELESCOPE_REVERSE_MOTION"
INDIConnection::newProperty|  "TELESCOPE_SLEW_RATE"
INDIConnection::newProperty|  "TARGET_EOD_COORD"
INDIConnection::newProperty|  "TIME_UTC"
INDIConnection::newProperty|  "GEOGRAPHIC_COORD"
INDIConnection::newProperty|  "TELESCOPE_PARK"
INDIConnection::newProperty|  "TELESCOPE_PARK_POSITION"
INDIConnection::newProperty|  "TELESCOPE_PARK_OPTION"
INDIConnection::newProperty|  "TELESCOPE_PIER_SIDE"
INDIConnection::newProperty|  "APPLY_SCOPE_CONFIG"
INDIConnection::newProperty|  "USEJOYSTICK"
INDIConnection::newProperty|  "SNOOP_JOYSTICK"
INDIConnection::newProperty|  "TELESCOPE_TIMED_GUIDE_NS"
INDIConnection::newProperty|  "TELESCOPE_TIMED_GUIDE_WE"
INDIConnection::newProperty|  "ALIGN_METHOD"
INDIConnection::newProperty|  "SLEWSPEEDS"
INDIConnection::newProperty|  "GUIDE_RATE"
INDIConnection::newProperty|  "PULSE_LIMITS"
INDIConnection::newProperty|  "MOUNTINFORMATION"
INDIConnection::newProperty|  "STEPPERS"
INDIConnection::newProperty|  "CURRENTSTEPPERS"
INDIConnection::newProperty|  "PERIODS"
INDIConnection::newProperty|  "JULIAN"
INDIConnection::newProperty|  "TIME_LST"
INDIConnection::newProperty|  "RASTATUS"
INDIConnection::newProperty|  "DESTATUS"
INDIConnection::newProperty|  "HEMISPHERE"
INDIConnection::newProperty|  "HORIZONTAL_COORD"
INDIConnection::newProperty|  "REVERSEDEC"
INDIConnection::newProperty|  "TARGETPIERSIDE"
INDIConnection::newProperty|  "STANDARDSYNC"
INDIConnection::newProperty|  "STANDARDSYNCPOINT"
INDIConnection::newProperty|  "SYNCPOLARALIGN"
INDIConnection::newProperty|  "SYNCMANAGE"
INDIConnection::newProperty|  "BACKLASH"
INDIConnection::newProperty|  "USEBACKLASH"
INDIConnection::newProperty|  "TELESCOPE_TRACK_DEFAULT"
INDIConnection::newProperty|  "ST4_GUIDE_RATE_NS"
INDIConnection::newProperty|  "ST4_GUIDE_RATE_WE"
INDIConnection::newProperty|  "ALIGNSYNCMODE"
INDIConnection::newProperty|  "AUXENCODER"
INDIConnection::newProperty|  "AUXENCODERVALUES"
INDIConnection::newProperty|  "SNAPPORT1"
INDIConnection::newProperty|  "ALIGNDATAFILE"
INDIConnection::newProperty|  "ALIGNDATA"
INDIConnection::newProperty|  "ALIGNPOINT"
INDIConnection::newProperty|  "ALIGNLIST"
INDIConnection::newProperty|  "ALIGNTELESCOPECOORDS"
INDIConnection::newProperty|  "ALIGNCOUNT"
INDIConnection::newProperty|  "ALIGNMODE"
INDIConnection::newProperty|  "HORIZONLIMITSDATAFILE"
INDIConnection::newProperty|  "HORIZONLIMITSDATAFITS"
INDIConnection::newProperty|  "HORIZONLIMITSPOINT"
INDIConnection::newProperty|  "HORIZONLIMITSTRAVERSE"
INDIConnection::newProperty|  "HORIZONLIMITSMANAGE"
INDIConnection::newProperty|  "HORIZONLIMITSFILEOPERATION"
INDIConnection::newProperty|  "HORIZONLIMITSONLIMIT"
INDIConnection::newProperty|  "HORIZONLIMITSLIMITGOTO"
2022-12-04T20:23:58: [DEBUG] SNOOP: FILTER_SLOT update...
2022-12-04T20:23:58: [DEBUG] SNOOP: FILTER_SLOT is 1
2022-12-04T20:23:58: [DEBUG] SNOOP: FILTER_SLOT update...
2022-12-04T20:23:58: [DEBUG] SNOOP: FILTER_SLOT is 1
2022-12-04T20:23:58: [DEBUG] SNOOP: FILTER_NAME update...
2022-12-04T20:23:58: [DEBUG] SNOOP: FILTER_NAME -> UVIR, LPro, LXtreme, H_Alpha, CLS, UHC, ZWO_DNB, Baader_Neodymium, , , , , 
2022-12-04T20:23:58: [DEBUG] SNOOP: FILTER_NAME update...
2022-12-04T20:23:58: [DEBUG] SNOOP: FILTER_NAME -> UVIR, LPro, LXtreme, H_Alpha, CLS, UHC, ZWO_DNB, Baader_Neodymium, , , , , 
libpng warning: iCCP: known incorrect sRGB profile

/* shut down INDI here */

Dispatch command error(-1): 
<delProperty device="Manual Filter" name="FILTER_SLOT" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="Manual Filter" name="FILTER_NAME" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="Manual Filter" name="USEJOYSTICK" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="Manual Filter" name="SNOOP_JOYSTICK" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="Manual Filter" name="SYNC_FILTER" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="Manual Filter" name="CONFIRM_FILTER_SET" timestamp="2022-12-04T20:24:11"/>
2022-12-04T20:24:11: [DEBUG] SNOOP: FILTER_SLOT update...
2022-12-04T20:24:11: [DEBUG] SNOOP: FILTER_SLOT is -1
2022-12-04T20:24:11: [DEBUG] SNOOP: FILTER_SLOT update...
2022-12-04T20:24:11: [DEBUG] SNOOP: FILTER_SLOT is -1
2022-12-04T20:24:11: [DEBUG] SNOOP: FILTER_NAME update...
2022-12-04T20:24:11: [DEBUG] SNOOP: FILTER_NAME -> 
2022-12-04T20:24:11: [DEBUG] SNOOP: FILTER_NAME update...
2022-12-04T20:24:11: [DEBUG] SNOOP: FILTER_NAME -> 
2022-12-04T20:24:11: [INFO] GPS disconnected successfully.
Dispatch command error(-1): 
<delProperty device="GPSD" name="GEOGRAPHIC_COORD" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="GPSD" name="TIME_UTC" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="GPSD" name="GPS_REFRESH" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="GPSD" name="GPS_REFRESH_PERIOD" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="GPSD" name="GPS_STATUS" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="GPSD" name="POLARIS" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="GPSD" name="GPS_TIME_SOURCE" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="GPSD" name="SIM_GEOGRAPHIC_COORD" timestamp="2022-12-04T20:24:11"/>
2022-12-04T20:24:11: [INFO] Saving device configuration...
2022-12-04T20:24:11: [INFO] Device configuration saved.
2022-12-04T20:24:11: [DEBUG] Configuration successfully saved.
2022-12-04T20:24:11: [DEBUG] Closing ZWO CCD ASI533MC Pro...
2022-12-04T20:24:11: [INFO] Camera is offline.
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI533MC Pro" name="CCD_FRAME" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI533MC Pro" name="CCD_FRAME_RESET" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI533MC Pro" name="CCD_INFO" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI533MC Pro" name="CCD_CAPTURE_FORMAT" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI533MC Pro" name="CCD_TRANSFER_FORMAT" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI533MC Pro" name="CCD_BINNING" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI533MC Pro" name="CCD_EXPOSURE" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI533MC Pro" name="CCD_ABORT_EXPOSURE" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI533MC Pro" name="CCD1" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI533MC Pro" name="CCD_COMPRESSION" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI533MC Pro" name="FITS_HEADER" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI533MC Pro" name="CCD_TEMPERATURE" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI533MC Pro" name="CCD_TEMP_RAMP" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI533MC Pro" name="CCD_FRAME_TYPE" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI533MC Pro" name="CCD_CFA" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI533MC Pro" name="SCOPE_INFO" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI533MC Pro" name="CCD_ROTATION" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI533MC Pro" name="WCS_CONTROL" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI533MC Pro" name="UPLOAD_MODE" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI533MC Pro" name="UPLOAD_SETTINGS" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI533MC Pro" name="CCD_FAST_TOGGLE" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI533MC Pro" name="CCD_FAST_COUNT" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI533MC Pro" name="CCD_VIDEO_STREAM" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI533MC Pro" name="STREAM_DELAY" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI533MC Pro" name="STREAMING_EXPOSURE" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI533MC Pro" name="FPS" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI533MC Pro" name="RECORD_FILE" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI533MC Pro" name="RECORD_STREAM" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI533MC Pro" name="RECORD_OPTIONS" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI533MC Pro" name="CCD_STREAM_FRAME" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI533MC Pro" name="CCD_STREAM_ENCODER" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI533MC Pro" name="CCD_STREAM_RECORDER" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI533MC Pro" name="LIMITS" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI533MC Pro" name="CCD_COOLER_POWER" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI533MC Pro" name="CCD_COOLER" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI533MC Pro" name="CCD_CONTROLS" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI533MC Pro" name="CCD_CONTROLS_MODE" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI533MC Pro" name="FLIP" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI533MC Pro" name="CCD_VIDEO_FORMAT" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI533MC Pro" name="BLINK" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI533MC Pro" name="SDK" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI533MC Pro" name="Serial Number" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI533MC Pro" name="NICKNAME" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI533MC Pro" name="ADC_DEPTH" timestamp="2022-12-04T20:24:11"/>
2022-12-04T20:24:11: [INFO] Saving device configuration...
2022-12-04T20:24:11: [INFO] Device configuration saved.
2022-12-04T20:24:11: [DEBUG] Configuration successfully saved.
2022-12-04T20:24:11: [DEBUG] Closing ZWO CCD ASI290MM Mini...
2022-12-04T20:24:11: [INFO] Camera is offline.
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI290MM Mini" name="CCD_FRAME" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI290MM Mini" name="CCD_FRAME_RESET" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI290MM Mini" name="CCD_INFO" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI290MM Mini" name="CCD_CAPTURE_FORMAT" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI290MM Mini" name="CCD_TRANSFER_FORMAT" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI290MM Mini" name="CCD_BINNING" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI290MM Mini" name="CCD_EXPOSURE" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI290MM Mini" name="CCD_ABORT_EXPOSURE" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI290MM Mini" name="CCD1" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI290MM Mini" name="CCD_COMPRESSION" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI290MM Mini" name="FITS_HEADER" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI290MM Mini" name="TELESCOPE_TIMED_GUIDE_NS" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI290MM Mini" name="TELESCOPE_TIMED_GUIDE_WE" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI290MM Mini" name="CCD_FRAME_TYPE" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI290MM Mini" name="SCOPE_INFO" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI290MM Mini" name="WCS_CONTROL" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI290MM Mini" name="UPLOAD_MODE" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI290MM Mini" name="UPLOAD_SETTINGS" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI290MM Mini" name="CCD_FAST_TOGGLE" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI290MM Mini" name="CCD_FAST_COUNT" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI290MM Mini" name="CCD_VIDEO_STREAM" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI290MM Mini" name="STREAM_DELAY" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI290MM Mini" name="STREAMING_EXPOSURE" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI290MM Mini" name="FPS" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI290MM Mini" name="RECORD_FILE" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI290MM Mini" name="RECORD_STREAM" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI290MM Mini" name="RECORD_OPTIONS" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI290MM Mini" name="CCD_STREAM_FRAME" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI290MM Mini" name="CCD_STREAM_ENCODER" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI290MM Mini" name="CCD_STREAM_RECORDER" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI290MM Mini" name="LIMITS" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI290MM Mini" name="CCD_TEMPERATURE" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI290MM Mini" name="CCD_CONTROLS" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI290MM Mini" name="CCD_CONTROLS_MODE" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI290MM Mini" name="FLIP" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI290MM Mini" name="CCD_VIDEO_FORMAT" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI290MM Mini" name="BLINK" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI290MM Mini" name="SDK" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI290MM Mini" name="Serial Number" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI290MM Mini" name="NICKNAME" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI290MM Mini" name="ADC_DEPTH" timestamp="2022-12-04T20:24:11"/>
Dispatch command error(-1): 
<delProperty device="ZWO CCD ASI290MM Mini"/>
Unloaded plugin "TelescopeControl"
Unloaded plugin "Satellites"
Unloaded plugin "PointerCoordinates"
Unloaded plugin "Oculars"
Unloaded plugin "NavStars"
Downloaded 0 files (0 kbytes) in a session of 62.526 sec (average of 0 kB/s + 0 files from cache (0 kB)).
LandscapeMgr: Clearing cache of 0 landscapes totalling about  0 MB.
StelGLWidget destroyed
/* shut down Stellarium here */
```

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system: Ubuntu 22.04LTS
* Graphics Card: Intel Corporation TigerLake-LP GT2 [Iris Xe Graphics] , Mesa Intel(R) Xe Graphics (TGL GT2) 4.6 (Core Profile) Mesa 22.2.0

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
