### PR TITLE
Improve quality of rings rendering

### DIFF
--- a/data/shaders/planet.frag
+++ b/data/shaders/planet.frag
@@ -349,7 +349,24 @@ void main()
     //apply texture-colored rimlight
     //litColor.xyz = clamp( litColor.xyz + vec3(outgas), 0.0, 1.0);
 
-    lowp vec4 texColor = texture2D(tex, texc);
+    lowp vec4 texColor;
+#ifdef RINGS_SUPPORT
+    if(isRing)
+    {
+        float radius = length(texc);
+        float s = (radius - innerRadius) / (outerRadius - innerRadius);
+        vec2 texCoord = vec2(s, 0.5);
+        texColor = texture2D(tex, texCoord);
+        // Guard against poor quality mipmap filtering (e.g. Mesa with NPOT textures).
+        if(radius > outerRadius)
+            texColor = vec4(0);
+    }
+    else
+#endif
+    {
+        texColor = texture2D(tex, texc);
+    }
+
 #ifdef IS_MOON
     // Undo the extraneous gamma encoded in the texture.
     // FIXME: ideally, we want all the calculations to be done in linear scale,

--- a/src/core/modules/Planet.cpp
+++ b/src/core/modules/Planet.cpp
@@ -3754,13 +3754,12 @@ void sRing(Ring3DModel* model, const float rMin, const float rMax, unsigned shor
 	float r = rMin;
 	for (unsigned short int i=0; i<=stacks; ++i)
 	{
-		const float tex_r0 = (r-rMin)/(rMax-rMin);
 		unsigned short int j;
 		for (j=0,cos_sin_theta_p=cos_sin_theta; j<=slices; ++j,cos_sin_theta_p+=2)
 		{
 			x = r*cos_sin_theta_p[0];
 			y = r*cos_sin_theta_p[1];
-			model->texCoordArr << tex_r0 << 0.5f;
+			model->texCoordArr << x << y;
 			model->vertexArr << x << y << 0.f;
 		}
 		r+=dr;
@@ -4125,6 +4124,8 @@ void Planet::drawSphere(StelPainter* painter, float screenRd, bool drawOnlyRing)
 		GL(ringPlanetShaderProgram->setUniformValue(ringPlanetShaderVars.isRing, true));
 		GL(ringPlanetShaderProgram->setUniformValue(ringPlanetShaderVars.tex, 2));
 		GL(ringPlanetShaderProgram->setUniformValue(ringPlanetShaderVars.ringS, 1));
+		GL(ringPlanetShaderProgram->setUniformValue(ringPlanetShaderVars.outerRadius, rings->radiusMax));
+		GL(ringPlanetShaderProgram->setUniformValue(ringPlanetShaderVars.innerRadius, rings->radiusMin));
 		
 		QMatrix4x4 shadowCandidatesData;
 		const Vec4d position = rData.mTarget * rData.modelMatrix.getColumn(3);


### PR DESCRIPTION
### Description
Current code that renders planetary rings has some issues:

* ~Outermost layer has a gap, as noted in #2775, and it becomes obvious even on Saturn if we reduce number of "stacks" in the call to `sRing()` to 3 or 2;~
* Rings of Saturn are obviously polygonal when zoomed in to screen size (see left and right sides of the screenshot below);
* ~Additionally, ring shadow is not quite smooth: sort of aliased.~

This PR redoes the rings in the following way:

* ~Instead of making a polygonal model of the rings, the whole model becomes just a quad, and~ texture coordinates are computed in the fragment shader to yield an annulus ~instead of the square~.
* ~Mip mapping is enabled for ring texture.~
* ~Shadow is made behave correctly with mip mapping, finally becoming smooth.~

### Screenshots (if appropriate):

#### Old Saturn (viewed from Jupiter):

![stellarium-003](https://user-images.githubusercontent.com/6376882/207723482-e48464b5-ddcd-49b2-bd82-4084122bdf04.png)

#### New Saturn (viewed from Jupiter)

![stellarium-004](https://user-images.githubusercontent.com/6376882/207723541-d46e2cb9-9ef4-453a-9484-672c0200c764.png)

#### Old Uranus

![stellarium-001](https://user-images.githubusercontent.com/6376882/207724103-fb252496-4ec6-47d8-9186-4b7f54bff385.png)

#### New Uranus

![stellarium-002](https://user-images.githubusercontent.com/6376882/207724127-46152491-79a2-4c42-8781-dc28c50ba1a9.png)

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### How Has This Been Tested?

**Test Configuration**:
* Operating system: Ubuntu 20.04
* Graphics Card: Intel UHD Graphics 620

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules