### PR TITLE
add missing include

### DIFF
--- a/plugins/MeteorShowers/src/MeteorShowersMgr.hpp
+++ b/plugins/MeteorShowers/src/MeteorShowersMgr.hpp
@@ -20,6 +20,7 @@
 #ifndef METEORSHOWERSMGR_HPP
 #define METEORSHOWERSMGR_HPP
 
+#include <QDateTime>
 #include <QNetworkReply>
 #include <QNetworkAccessManager>
 


### PR DESCRIPTION
### Description
Fixes build error with qt5:

stellarium-1.2/plugins/MeteorShowers/src/MeteorShowersMgr.hpp:331:12:
 error: field 'm_lastUpdate' has incomplete type 'QDateTime'

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
