### PR TITLE
Switch old-style landscape to fragment-shader-based direction computation

### DIFF
--- a/src/core/modules/Landscape.hpp
+++ b/src/core/modules/Landscape.hpp
@@ -304,10 +304,10 @@ protected:
 	} landscapeTexCoord;
 
 private:
-	void drawFog(StelCore* core, StelPainter&) const;
+	void drawFog(StelCore* core, int firstFreeTexSampler) const;
 	// drawLight==true for illumination layer, it then selects only the self-illuminating panels.
-	void drawDecor(StelCore* core, StelPainter&, const bool drawLight=false) const;
-	void drawGround(StelCore* core, StelPainter&) const;
+	void drawDecor(StelCore* core, int firstFreeTexSampler, bool drawLight = false) const;
+	void drawGround(StelCore* core, int firstFreeTexSampler) const;
 	QVector<Vec3d> groundVertexArr;
 	QVector<Vec2f> groundTexCoordArr;
 	StelTextureSP* sideTexs;
@@ -335,6 +335,24 @@ private:
 	};
 
 	QList<LOSSide> precomputedSides;
+
+	struct
+	{
+		int mapTex;
+		int vshift;
+		int tanMode;
+		int calibrated;
+		int brightness;
+		int rgbMaxValue;
+		int sideToRender;
+		int numberOfSides;
+		int sideTexCoords;
+		int ditherPattern;
+		int decorAngleShift;
+		int sideAngularHeight;
+		int fogCylinderHeight;
+		int projectionMatrixInverse;
+	} shaderVars;
 };
 
 /////////////////////////////////////////////////////////


### PR DESCRIPTION
This is the hardest kind of landscape to switch to fragment-shader-based computation of direction. First of all, because it has lots of parameters, which have to be tested to make sure they weren't broken.

But the most problematic part is performance: the default Guereins landscape has (8 sides)×2 + ground + fog, which means that we have to run the fragment shader 18 times, and this really hard to make fast. In particular, with the default Guereins landscape the original Stellarium before this PR runs at 34 FPS on my machine, while with fragment-shader-based computations it runs at 22 FPS. I pushed a second, experimental, commit that stitches all 8 sides of this landscape into one, so that we have only 4 fragment shader invocations, and this results in 29 FPS, which is faster but still not as fast as before this PR.

I didn't modify the other landscapes, I need your feedback about the current state (with and without the modification of Guereins): whether the performance is acceptable, any bugs you find with custom landscapes, etc.

### Screenshots

#### Original

![stellarium-013](https://user-images.githubusercontent.com/6376882/210410928-9ce041f1-19ef-48d2-ae13-d91315574ace.png)

#### After this PR

![stellarium-014](https://user-images.githubusercontent.com/6376882/210410945-53bf244c-9850-426d-8c79-ec22b821eb68.png)

#### Original

![stellarium-001](https://user-images.githubusercontent.com/6376882/210411901-f81a9764-3d61-4c83-98c9-a538cccb98c7.png)

#### After this PR

![stellarium-002](https://user-images.githubusercontent.com/6376882/210411938-cbd1323b-f62e-44c2-90a8-7756d42452bb.png)
