### PR TITLE
Fix compilation on Qt configured for OpenGL ES2

### DIFF
--- a/plugins/Scenery3d/src/Frustum.cpp
+++ b/plugins/Scenery3d/src/Frustum.cpp
@@ -170,7 +170,7 @@ void Frustum::drawFrustum() const
 {
 // Minimum to avoid trouble when building on pure OpenGL ES systems
 // Not sure about ANGLE!
-#if !defined(QT_OPENGL_ES_2)
+#if !QT_CONFIG(opengles2)
 
 	Vec3f ntl = drawCorners[NTL];
 	Vec3f ntr = drawCorners[NTR];

--- a/plugins/Scenery3d/src/GLFuncs.hpp
+++ b/plugins/Scenery3d/src/GLFuncs.hpp
@@ -24,7 +24,7 @@
 #include <QOpenGLContext>
 #include <QOpenGLFunctions_1_0>
 
-#ifndef QT_OPENGL_ES_2
+#if !QT_CONFIG(opengles2)
 //! Defines some OpenGL functions not resolved through StelOpenGL (which only contains base OpenGL ES2 functions)
 //! Using the QOpenGLFunctions_*_* directly would solve this better, but it conflicts with the
 //! current StelOpenGL header dramatically.

--- a/plugins/Scenery3d/src/Polyhedron.cpp
+++ b/plugins/Scenery3d/src/Polyhedron.cpp
@@ -254,7 +254,7 @@ const QVector<Vec3f> &Polyhedron::getVerts() const
 
 void Polyhedron::render() const
 {
-#if !defined(QT_OPENGL_ES_2)
+#if !QT_CONFIG(opengles2)
 
 	//render each polygon
 	glExtFuncs->glColor3f(0.4f,0.4f,0.4f);

--- a/plugins/Scenery3d/src/S3DRenderer.cpp
+++ b/plugins/Scenery3d/src/S3DRenderer.cpp
@@ -52,7 +52,7 @@ Q_LOGGING_CATEGORY(s3drenderer, "stel.plugin.scenery3d.renderer")
 static const float LUNAR_BRIGHTNESS_FACTOR=0.2f;
 static const float VENUS_BRIGHTNESS_FACTOR=0.005f;
 
-#ifndef QT_OPENGL_ES_2
+#if !QT_CONFIG(opengles2)
 //this is the place where this is initialized
 GLExtFuncs* glExtFuncs;
 #endif
@@ -120,7 +120,7 @@ S3DRenderer::~S3DRenderer()
 	deleteShadowmapping();
 	deleteCubemapping();
 
-#ifndef QT_OPENGL_ES_2
+#if !QT_CONFIG(opengles2)
 	//delete extension functions
 	delete glExtFuncs;
 #endif
@@ -1403,7 +1403,7 @@ void S3DRenderer::drawCoordinatesText()
 void S3DRenderer::drawDebug()
 {
 	//frustum/box debug rendering only on desktop GL
-#ifndef QT_OPENGL_ES_2
+#if !QT_CONFIG(opengles2)
 	if(!shaderParameters.openglES)
 	{
 		QOpenGLShaderProgram* debugShader = shaderManager.getDebugShader();
@@ -1654,7 +1654,7 @@ void S3DRenderer::init()
 	QOpenGLContext* ctx = QOpenGLContext::currentContext();
 	Q_ASSERT(ctx);
 
-#ifndef QT_OPENGL_ES_2
+#if !QT_CONFIG(opengles2)
 	//initialize additional functions needed and not provided through StelOpenGL
 	glExtFuncs = new GLExtFuncs();
 	glExtFuncs->init(ctx);
@@ -1787,7 +1787,7 @@ bool S3DRenderer::initCubemapping()
 	}
 
 
-#ifndef QT_OPENGL_ES_2
+#if !QT_CONFIG(opengles2)
 	//if we are on an ES context, it may not be possible to specify texture bitdepth
 	bool isEs = QOpenGLContext::currentContext()->isOpenGLES();
 	GLint colorFormat = isEs ? GL_RGBA : GL_RGBA8;
@@ -1916,7 +1916,7 @@ bool S3DRenderer::initCubemapping()
 
 		GET_GLERROR()
 
-#ifndef QT_OPENGL_ES_2
+#if !QT_CONFIG(opengles2)
 		//attach cube tex + cube depth
 		//note that this function will be a NULL pointer if GS is not supported, so it is important to check support before using
 		glExtFuncs->glFramebufferTexture(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,cubeMapCubeTex,0);
@@ -2219,7 +2219,7 @@ bool S3DRenderer::initShadowmapping()
 			//Bind the depth map and setup parameters
 			glBindTexture(GL_TEXTURE_2D, shadowMapsArray.at(i));
 
-#ifndef QT_OPENGL_ES_2
+#if !QT_CONFIG(opengles2)
 			bool isEs = QOpenGLContext::currentContext()->isOpenGLES();
 			GLenum depthPcss = isEs ? GL_DEPTH_COMPONENT : GL_DEPTH_COMPONENT32F;
 			GLenum depthNormal = isEs ? GL_DEPTH_COMPONENT : GL_DEPTH_COMPONENT16;
@@ -2238,7 +2238,7 @@ bool S3DRenderer::initShadowmapping()
 			//NOTE: can't use depth compare mode on ES2
 			if(!pcssEnabled)
 			{
-#ifndef QT_OPENGL_ES_2
+#if !QT_CONFIG(opengles2)
 				if(!isEs)
 				{
 					glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_COMPARE_MODE, GL_COMPARE_R_TO_TEXTURE);
@@ -2254,7 +2254,7 @@ bool S3DRenderer::initShadowmapping()
 					|| shaderParameters.shadowFilterQuality == S3DEnum::SFQ_HIGH_HARDWARE) ? GL_LINEAR : GL_NEAREST;
 			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, filter);
 			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, filter);
-#ifndef QT_OPENGL_ES_2
+#if !QT_CONFIG(opengles2)
 			if(!isEs)
 			{
 				glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_BASE_LEVEL,0);
@@ -2273,7 +2273,7 @@ bool S3DRenderer::initShadowmapping()
 			//but the respective functions are not available on GLES2?
 			//On ANGLE, it seems to work without this settings (framebuffer is complete, etc.)
 			//but I don't know if it will work on other ES platforms?
-#ifndef QT_OPENGL_ES_2
+#if !QT_CONFIG(opengles2)
 			if(!isEs)
 			{
 				glExtFuncs->glDrawBuffer(GL_NONE); // essential for depth-only FBOs!!!

--- a/plugins/Scenery3d/src/SPolygon.cpp
+++ b/plugins/Scenery3d/src/SPolygon.cpp
@@ -118,7 +118,7 @@ void SPolygon::addUniqueVert(const Vec3f &v)
 
 void SPolygon::render()
 {
-#if !defined(QT_OPENGL_ES_2)
+#if !QT_CONFIG(opengles2)
 	//render each polygon
 	glExtFuncs->glColor3f(0.4f,0.4f,0.4f);
 

--- a/src/core/StelOpenGL.hpp
+++ b/src/core/StelOpenGL.hpp
@@ -60,7 +60,7 @@ namespace StelOpenGL
 
 // This is still needed for the ARM platform (armhf)
 
-#if defined(QT_OPENGL_ES_2)
+#if QT_CONFIG(opengles2)
 #ifndef GL_DOUBLE
 #define GL_DOUBLE GL_FLOAT
 #endif

--- a/src/core/modules/Planet.cpp
+++ b/src/core/modules/Planet.cpp
@@ -3345,7 +3345,7 @@ bool Planet::initFBO()
 		GL(gl->glActiveTexture(GL_TEXTURE1));
 		GL(gl->glBindTexture(GL_TEXTURE_2D, shadowTex));
 
-#ifndef QT_OPENGL_ES_2
+#if !QT_CONFIG(opengles2)
 		if(!isGLESv2)
 		{
 			GL(gl->glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_BASE_LEVEL, 0));
@@ -3376,7 +3376,7 @@ bool Planet::initFBO()
 		//see GL_EXT_framebuffer_object and GL_ARB_framebuffer_object
 		//on ES 2, this seems to be allowed (there are no glDrawBuffers/glReadBuffer functions there), see GLES spec section 4.4.4
 		//probably same on ES 3: though it has glDrawBuffers/glReadBuffer but no mention of it in section 4.4.4 and no FRAMEBUFFER_INCOMPLETE_DRAW_BUFFER is defined
-#ifndef QT_OPENGL_ES_2
+#if !QT_CONFIG(opengles2)
 		if(!ctx->isOpenGLES())
 		{
 #if (QT_VERSION>=QT_VERSION_CHECK(6,0,0))


### PR DESCRIPTION
Due to [QTBUG-83467](https://bugreports.qt.io/browse/QTBUG-83467) the `QT_OPENGL_ES_2` define is no longer present since Qt 6.0. Instead, one should use `QT_CONFIG(opengles2)`. This patch does this.

Fixes #2753

I have checked this on Qt 6 in desktop OpenGL and OpenGL ES 2 modes, and on Qt 5 desktop GL.