### PR TITLE
Make it possible to restrict texture size of GUI panel button pixmaps

### DIFF
--- a/plugins/Oculars/src/gui/OcularsGuiPanel.cpp
+++ b/plugins/Oculars/src/gui/OcularsGuiPanel.cpp
@@ -173,13 +173,13 @@ OcularsGuiPanel::OcularsGuiPanel(Oculars* plugin,
 	int scale=static_cast<int>(lineHeight*scv*0.01f);
 	// TODO: change this load-once to interactively editable value of scaling coefficient
 	QPixmap pa(":/graphicGui/btTimeRewind-on.png");
-	QPixmap prevArrow = pa.scaledToHeight(scale * StelButton::getPixmapsDevicePixelRatio(), Qt::SmoothTransformation);
+	QPixmap prevArrow = pa.scaledToHeight(scale * StelButton::getInputPixmapsDevicePixelRatio(), Qt::SmoothTransformation);
 	QPixmap paOff(":/graphicGui/btTimeRewind-off.png");
-	QPixmap prevArrowOff = paOff.scaledToHeight(scale * StelButton::getPixmapsDevicePixelRatio(), Qt::SmoothTransformation);
+	QPixmap prevArrowOff = paOff.scaledToHeight(scale * StelButton::getInputPixmapsDevicePixelRatio(), Qt::SmoothTransformation);
 	QPixmap na(":/graphicGui/btTimeForward-on.png");
-	QPixmap nextArrow = na.scaledToHeight(scale * StelButton::getPixmapsDevicePixelRatio(), Qt::SmoothTransformation);
+	QPixmap nextArrow = na.scaledToHeight(scale * StelButton::getInputPixmapsDevicePixelRatio(), Qt::SmoothTransformation);
 	QPixmap naOff(":/graphicGui/btTimeForward-off.png");
-	QPixmap nextArrowOff = naOff.scaledToHeight(scale * StelButton::getPixmapsDevicePixelRatio(), Qt::SmoothTransformation);
+	QPixmap nextArrowOff = naOff.scaledToHeight(scale * StelButton::getInputPixmapsDevicePixelRatio(), Qt::SmoothTransformation);
 
 	StelActionMgr* actionMgr = StelApp::getInstance().getStelActionManager();
 	QString ocularsGroup = N_("Oculars"); // Possible group name: Oculars on-screen control panel
@@ -1258,13 +1258,13 @@ QPixmap OcularsGuiPanel::createPixmapFromText(const QString& text,
 		return QPixmap();
 	}
 
-	width  *= StelButton::getPixmapsDevicePixelRatio();
-	height *= StelButton::getPixmapsDevicePixelRatio();
+	width  *= StelButton::getInputPixmapsDevicePixelRatio();
+	height *= StelButton::getInputPixmapsDevicePixelRatio();
 
 	QPixmap pixmap(width, height);
 	pixmap.fill(backgroundColor);
 	auto scaledFont(font);
-	scaledFont.setPixelSize(font.pixelSize() * StelButton::getPixmapsDevicePixelRatio());
+	scaledFont.setPixelSize(font.pixelSize() * StelButton::getInputPixmapsDevicePixelRatio());
 
 	if (text.isEmpty())
 	{

--- a/src/gui/StelGuiItems.cpp
+++ b/src/gui/StelGuiItems.cpp
@@ -88,10 +88,24 @@ void StelButton::initCtor(const QPixmap& apixOn,
 	pixHover = apixHover;
 	pixNoChange = apixNoChange;
 
-	pixOn.setDevicePixelRatio(GUI_PIXMAPS_SCALE);
-	pixOff.setDevicePixelRatio(GUI_PIXMAPS_SCALE);
-	pixHover.setDevicePixelRatio(GUI_PIXMAPS_SCALE);
-	pixNoChange.setDevicePixelRatio(GUI_PIXMAPS_SCALE);
+	if(!pixmapsScale)
+	{
+		pixmapsScale = StelApp::getInstance().getSettings()->value("gui/pixmaps_scale", GUI_INPUT_PIXMAPS_SCALE).toDouble();
+	}
+	if(pixmapsScale != GUI_INPUT_PIXMAPS_SCALE)
+	{
+		const auto scale = pixmapsScale/GUI_INPUT_PIXMAPS_SCALE;
+		pixOn = pixOn.scaled(pixOn.size()*scale, Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
+		pixOff = pixOff.scaled(pixOff.size()*scale, Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
+		if(!pixHover.isNull())
+			pixHover = pixHover.scaled(pixHover.size()*scale, Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
+		if(!pixNoChange.isNull())
+			pixNoChange = pixNoChange.scaled(pixNoChange.size()*scale, Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
+	}
+	pixOn.setDevicePixelRatio(pixmapsScale);
+	pixOff.setDevicePixelRatio(pixmapsScale);
+	pixHover.setDevicePixelRatio(pixmapsScale);
+	pixNoChange.setDevicePixelRatio(pixmapsScale);
 
 	noBckground = noBackground;
 	isTristate_ = isTristate;
@@ -273,7 +287,7 @@ void StelButton::updateIcon()
 	if (opacity < 0.)
 		opacity = 0;
 	QPixmap pix(pixOn.size());
-	pix.setDevicePixelRatio(GUI_PIXMAPS_SCALE);
+	pix.setDevicePixelRatio(pixmapsScale);
 	pix.fill(QColor(0,0,0,0));
 	QPainter painter(&pix);
 	painter.setOpacity(opacity);
@@ -335,7 +349,7 @@ void StelButton::paint(QPainter* painter, const QStyleOptionGraphicsItem*, QWidg
 	const double ratio = painter->device()->devicePixelRatioF();
 	if(scaledCurrentPixmap.isNull() || ratio != scaledCurrentPixmap.devicePixelRatioF())
 	{
-		const auto scale = ratio / GUI_PIXMAPS_SCALE;
+		const auto scale = ratio / pixmapsScale;
 		scaledCurrentPixmap = pixmap().scaled(pixOn.size()*scale, Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
 		scaledCurrentPixmap.setDevicePixelRatio(ratio);
 	}

--- a/src/gui/StelGuiItems.hpp
+++ b/src/gui/StelGuiItems.hpp
@@ -116,8 +116,8 @@ public:
 
 	//! Get the width of the button image.
 	//! The width is based on pixOn.
-	int getButtonPixmapWidth() const {return pixOn.width() / GUI_PIXMAPS_SCALE;}
-	int getButtonPixmapHeight() const {return pixOn.height() / GUI_PIXMAPS_SCALE;}
+	int getButtonPixmapWidth() const {return pixOn.width() / pixmapsScale;}
+	int getButtonPixmapHeight() const {return pixOn.height() / pixmapsScale;}
 
 	//! Set the button opacity
 	void setOpacity(double v) {opacity=v; updateIcon();}
@@ -136,7 +136,7 @@ public:
 
 	QRectF boundingRect() const override;
 
-	static double getPixmapsDevicePixelRatio() { return GUI_PIXMAPS_SCALE; }
+	static double getInputPixmapsDevicePixelRatio() { return GUI_INPUT_PIXMAPS_SCALE; }
 
 signals:
 	//! Triggered when the button state changes
@@ -191,8 +191,11 @@ private:
 	double opacity;
 	double hoverOpacity;
 	bool triggerOnRelease = false;
-	// All pixmaps are supposed to be 500% scaled compared to their appearance on the screen when high-DPI scale factor is 100%
-	static constexpr double GUI_PIXMAPS_SCALE = 5;
+	// All input pixmaps are supposed to be 500% scaled compared to their
+	// appearance on the screen when high-DPI scale factor is 100%
+	static constexpr double GUI_INPUT_PIXMAPS_SCALE = 5;
+	// This is the actual scale to which the input pixmaps will be resized after loading
+	inline static double pixmapsScale = 0;
 };
 
 // The button bar on the left containing windows toggle buttons


### PR DESCRIPTION
A few times @gzotti complained that the new high-resolution pixmaps used for GUI panel buttons make performance worse on low-spec systems like Raspberry or something like that. This patch introduces a config file setting, `gui/pixmaps_scale`, which can vary from 1 to 5, to reduce the pixmaps loaded from resources to corresponding scale factor.

E.g., on a machine with a low-DPI monitor, where scale factor higher than 100% is not supposed to be useful, we can set this setting to `1`, and avoid using excessive VRAM for 500%-scale textures. Or, if the scaling factor of the monitor is higher than 100% but much lower than 500%, we can set that exact scaling factor as the maximum scale of the pixmaps, thus reducing VRAM use.

I'm not sure if this 500% increase of texture size really influences performance, but, since @gzotti complained more than once, I propose this patch, which might help.