### PR TITLE
Make sure that textures being loaded don't exceed OpenGL size limits

### DIFF
--- a/src/StelMainView.cpp
+++ b/src/StelMainView.cpp
@@ -872,12 +872,13 @@ void StelMainView::init()
 	glInfo.isGLES = format.renderableType()==QSurfaceFormat::OpenGLES;
 	qDebug().nospace() << "Luminance textures are " << (glInfo.supportsLuminanceTextures ? "" : "not ") << "supported";
 	glInfo.isCoreProfile = format.profile() == QSurfaceFormat::CoreProfile;
+
+	auto& gl = *QOpenGLContext::currentContext()->functions();
 	if(format.majorVersion() * 1000 + format.minorVersion() >= 4006 ||
 	   glInfo.mainContext->hasExtension("GL_EXT_texture_filter_anisotropic") ||
 	   glInfo.mainContext->hasExtension("GL_ARB_texture_filter_anisotropic"))
 	{
 		StelOpenGL::clearGLErrors();
-		auto& gl = *QOpenGLContext::currentContext()->functions();
 		gl.glGetIntegerv(GL_MAX_TEXTURE_MAX_ANISOTROPY, &glInfo.maxAnisotropy);
 		const auto error = gl.glGetError();
 		if(error != GL_NO_ERROR)
@@ -906,6 +907,8 @@ void StelMainView::init()
 			addr = glInfo.mainContext->getProcAddress("glMinSampleShadingARB");
 		glInfo.glMinSampleShading = reinterpret_cast<PFNGLMINSAMPLESHADINGPROC>(addr);
 	}
+	gl.glGetIntegerv(GL_MAX_TEXTURE_SIZE, &glInfo.maxTextureSize);
+	qDebug() << "Maximum 2D texture size:" << glInfo.maxTextureSize;
 
 	gui = new StelGui();
 

--- a/src/StelMainView.hpp
+++ b/src/StelMainView.hpp
@@ -74,6 +74,7 @@ public:
 		QOpenGLFunctions* functions;
 		PFNGLMINSAMPLESHADINGPROC glMinSampleShading = nullptr;
 		GLint maxAnisotropy = 0;
+		GLint maxTextureSize = 2048;
 		bool supportsLuminanceTextures = false;
 		bool isCoreProfile = false;
 		bool isGLES = false;

--- a/src/core/StelTexture.hpp
+++ b/src/core/StelTexture.hpp
@@ -141,7 +141,7 @@ private:
 	void wrapGLTexture(GLuint texId);
 
 	//! Convert a QImage into opengl compatible format.
-	static QByteArray convertToGLFormat(const QImage& image, GLint& format, GLint& type);
+	static QByteArray convertToGLFormat(QImage image, GLint& format, GLint& type, int& width, int& height);
 
 	//! This method should be called if the texture loading failed for any reasons
 	//! @param errorMessage the human friendly error message


### PR DESCRIPTION
This commit should fix the problem of untextured Moon on Raspberry Pi or other devices with small maximum texture size. I did check that it works by simulating a 2048px maximum, but didn't check on actual Raspberry Pi, which @gzotti said suffers from this problem.

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system: Ubuntu 20.04
* Graphics Card: Intel UHD Graphics 620

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
