### PR TITLE
Use generic-icon in mime file

### DIFF
--- a/data/stellarium.xml
+++ b/data/stellarium.xml
@@ -4,6 +4,6 @@
      <sub-class-of type="text/plain"/>
      <comment>Stellarium Script</comment>
      <glob pattern="*.ssc"/>
-     <icon name="stellarium"/>
+     <generic-icon name="stellarium"/>
    </mime-type>
 </mime-info>


### PR DESCRIPTION
### Description
Since icons were standardized in shared-mime-info spec version 0.16, only generic-icon is recognized in the system database, where this file is installed by distribution packages.  This fixes the use of the mime-type icon on recent GNOME versions.

### Screenshots (if appropriate):

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### How Has This Been Tested?
By modifying the mime file locally, downloading a script, and opening the containing directory in my file manager.

**Test Configuration**:
* Operating system: Fedora 37
* Graphics Card: N/A

## Checklist:
- [ ] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
