### PR TITLE
Fix bottom bar position

### DIFF
--- a/src/gui/SkyGui.cpp
+++ b/src/gui/SkyGui.cpp
@@ -340,7 +340,7 @@ void SkyGui::updateBarsPos()
 		updatePath = true;
 	}
 
-	double rangeY = buttonBar->boundingRectNoHelpLabel().height()+0.5-7.-buttonBarPath->getRoundSize();
+	double rangeY = buttonBar->boundingRectNoHelpLabel().height()+0.5-6.-buttonBarPath->getRoundSize();
 	const qreal newButtonBarX = winBar->boundingRectNoHelpLabel().right()+buttonBarPath->getRoundSize();
 	const qreal newButtonBarY = hh-buttonBar->boundingRectNoHelpLabel().height()-buttonBarPath->getRoundSize()+0.5+(1.-animBottomBarTimeLine->currentValue())*rangeY;
 	if (!qFuzzyCompare(buttonBar->pos().x(), newButtonBarX) || !qFuzzyCompare(buttonBar->pos().y(), newButtonBarY))


### PR DESCRIPTION
Currently the buttons in the bottom bar are not fully hidden when the bar is retracted down. Instead, top pixel row is visible, which prevents ejection of the button bar if the mouse pointer is moved too fast to the bottom of the screen.

See the screenshot:

![Screenshot_2023-01-22_22-56-51](https://user-images.githubusercontent.com/6376882/213928351-c0399a4e-1951-4461-89c3-50ec4b02b04b.png)

This patch moves it 1 pixel lower to completely hide the buttons.

This is a trivial patch, but I'm not completely sure that the problem is the same on all platforms. I checked it on Ubuntu 20.04. If it's also present on Windows and macOS, feel free to merge. If it's not, but this patch doesn't make it look bad, then I guess we can merge it too.