### PR TITLE
AstroCalc: Fix RTS

### DIFF
--- a/plugins/NavStars/src/gui/NavStarsWindow.cpp
+++ b/plugins/NavStars/src/gui/NavStarsWindow.cpp
@@ -128,13 +128,15 @@ void NavStarsWindow::populateToday()
 
 	// Moon
 	Vec4d moon = GETSTELMODULE(SolarSystem)->getMoon()->getRTSTime(core, 0.);
-	if (moon[3]==0.)
-	{
-		moonrise = StelUtils::hoursToHmsStr(StelUtils::getHoursFromJulianDay(moon[0]+utcShift), true);
-		moonset = StelUtils::hoursToHmsStr(StelUtils::getHoursFromJulianDay(moon[2]+utcShift), true);
-	}
+	if (moon[3]==30 || moon[3]<0 || moon[3]>50) // no moonrise on current date
+		moonrise = dash;
 	else
-		moonrise = moonset = dash;
+		moonrise = StelUtils::hoursToHmsStr(StelUtils::getHoursFromJulianDay(moon[0]+utcShift), true);
+
+	if (moon[3]==40 || moon[3]<0 || moon[3]>50) // no moonset on current date
+		moonset = dash;
+	else
+		moonset = StelUtils::hoursToHmsStr(StelUtils::getHoursFromJulianDay(moon[2]+utcShift), true);
 
 	// day
 	Vec4d day = sun->getRTSTime(core, 0.);

--- a/src/core/StelObject.cpp
+++ b/src/core/StelObject.cpp
@@ -1131,7 +1131,8 @@ QVariantMap StelObject::getInfoMap(const StelCore *core) const
 			map.insert("transit-dhr", hours);
 		}
 
-		if (rts[3]==30 || rts[3]<0 || rts[3]>50) // no rise
+		StelUtils::getDateFromJulianDay(rts[0]+utcShift, &year, &month, &day);
+		if (rts[3]==30 || rts[3]<0 || rts[3]>50 || day != currentdate) // no rise
 		{
 			map.insert("rise", "---");
 		}
@@ -1142,7 +1143,8 @@ QVariantMap StelObject::getInfoMap(const StelCore *core) const
 			map.insert("rise-dhr", hours);
 		}
 
-		if (rts[3]==40 || rts[3]<0 || rts[3]>50) // no set
+		StelUtils::getDateFromJulianDay(rts[2]+utcShift, &year, &month, &day);
+		if (rts[3]==40 || rts[3]<0 || rts[3]>50 || day != currentdate) // no set
 		{
 			map.insert("set", "---");
 		}

--- a/src/core/StelObject.cpp
+++ b/src/core/StelObject.cpp
@@ -172,6 +172,9 @@ Vec4d StelObject::getRTSTime(const StelCore *core, const double altitude) const
 	const double rotRate = obsPlanet->getSiderealDay();
 	const double currentJD=core->getJD();
 	const double currentJDE=core->getJDE();
+	const double utcShift = core->getUTCOffset(currentJD) / 24.;
+	int year, month, day, currentdate;
+	StelUtils::getDateFromJulianDay(currentJD+utcShift, &year, &month, &currentdate);
 
 	// And convert to equatorial coordinates of date. We can also use this day's current aberration, given the other uncertainties/omissions.
 	const Vec3d eq_2=getEquinoxEquatorialPos(core);
@@ -206,6 +209,14 @@ Vec4d StelObject::getRTSTime(const StelCore *core, const double altitude) const
 
 	double mr, ms, flag=0.;
 	double mt=-h2*(0.5*rotRate/M_PI);
+	StelUtils::getDateFromJulianDay(currentJD+mt+utcShift, &year, &month, &day);
+	if (day != currentdate)
+	{
+		if (mt<0.)
+			mt += rotRate;
+		else
+			mt -= rotRate;
+	}
 
 	// circumpolar: set rise and set times to lower culmination, i.e. 1/2 rotation from transit
 	if (fabs(cosH0)>1.)
@@ -1118,23 +1129,6 @@ QVariantMap StelObject::getInfoMap(const StelCore *core) const
 			map.insert("set", StelUtils::hoursToHmsStr(hours, true));
 			map.insert("set-dhr", hours);
 		}
-		/*
-		if (rts[3]==0.)
-		{
-			StelUtils::getTimeFromJulianDay(rts[0]+utcShift, &hr, &min, &sec);
-			hours=hr+static_cast<double>(min)/60. + static_cast<double>(sec)/3600.;
-			map.insert("rise", StelUtils::hoursToHmsStr(hours, true));
-			map.insert("rise-dhr", hours);
-			StelUtils::getTimeFromJulianDay(rts[2]+utcShift, &hr, &min, &sec);
-			hours=hr+static_cast<double>(min)/60. + static_cast<double>(sec)/3600.;
-			map.insert("set", StelUtils::hoursToHmsStr(hours, true));
-			map.insert("set-dhr", hours);
-		}
-		else {
-			map.insert("rise", "---");
-			map.insert("set", "---");
-		}
-		*/
 	}
 	return map;
 }

--- a/src/core/StelObject.cpp
+++ b/src/core/StelObject.cpp
@@ -209,6 +209,7 @@ Vec4d StelObject::getRTSTime(const StelCore *core, const double altitude) const
 
 	double mr, ms, flag=0.;
 	double mt=-h2*(0.5*rotRate/M_PI);
+	// Transit should occur on current date
 	StelUtils::getDateFromJulianDay(currentJD+mt+utcShift, &year, &month, &day);
 	if (day != currentdate)
 	{
@@ -232,6 +233,26 @@ Vec4d StelObject::getRTSTime(const StelCore *core, const double altitude) const
 
 		mr = mt - H0*rotRate/(2.*M_PI);
 		ms = mt + H0*rotRate/(2.*M_PI);
+	}
+
+	// Rise should occur on current date
+	StelUtils::getDateFromJulianDay(currentJD+mr+utcShift, &year, &month, &day);
+	if (day != currentdate)
+	{
+		if (mr<0.)
+			mr += rotRate;
+		else
+			mr -= rotRate;
+	}
+
+	// Set should occur on current date
+	StelUtils::getDateFromJulianDay(currentJD+ms+utcShift, &year, &month, &day);
+	if (day != currentdate)
+	{
+		if (ms<0.)
+			ms += rotRate;
+		else
+			ms -= rotRate;
 	}
 
 	//omgr->addToExtraInfoString(StelObject::DebugAid, QString("m<sub>t</sub>= %1<br/>").arg(QString::number(mt, 'f', 6)));
@@ -707,7 +728,8 @@ QString StelObject::getCommonInfoString(const StelCore *core, const InfoStringGr
 			res += "<table style='margin:0em 0em 0em -0.125em;border-spacing:0px;border:0px;'>";
 
 		// Rise
-		if (rts[3]==30 || rts[3]<0 || rts[3]>50) // no rise
+		StelUtils::getDateFromJulianDay(rts[0]+utcShift, &year, &month, &day);
+		if (rts[3]==30 || rts[3]<0 || rts[3]>50 || day != currentdate) // no rise
 		{
 			if (withTables)
 				res += QString("<tr><td>%1:</td><td style='text-align:right;'>%2</td></tr>").arg(sRise, dash);
@@ -744,7 +766,8 @@ QString StelObject::getCommonInfoString(const StelCore *core, const InfoStringGr
 		}
 
 		// Set
-		if (rts[3]==40 || rts[3]<0 || rts[3]>50) // no set
+		StelUtils::getDateFromJulianDay(rts[2]+utcShift, &year, &month, &day);
+		if (rts[3]==40 || rts[3]<0 || rts[3]>50 || day != currentdate) // no set
 		{
 			if (withTables)
 				res += QString("<tr><td>%1:</td><td style='text-align:right;'>%2</td></tr>").arg(sSet, dash);

--- a/src/core/modules/Planet.cpp
+++ b/src/core/modules/Planet.cpp
@@ -4912,15 +4912,13 @@ void Planet::setApparentMagnitudeAlgorithm(QString algorithm)
 // We don't compute positions for midnights, but only for two extra positions 1 JD before and after "now", to allow interpolation of positions.
 // Also, the estimate h0 for the Moon in the literature is based on geocentric computation.
 // NOTE: Limitation for efficiency: If this is a planet moon from another planet, we compute RTS for the parent planet instead!
-Vec4d Planet::getRTSTime(const StelCore *core, const double altitude) const
+Vec4d Planet::getClosestRTSTime(const StelCore *core, const double altitude) const
 {
 	const StelLocation loc=core->getCurrentLocation();
 	if (loc.name.contains("->")) // a spaceship
 		return Vec4d(0., 0., 0., -1000.);
 
-	// Keep time in sync (method from line 592) to fix slow down of time when the moon is selected
 	const double currentJD = core->getJDOfLastJDUpdate();
-	const qint64 millis = core->getMilliSecondsOfLastJDUpdate();
 	const double currentJDE = core->getJDE();
 	double mr, ms, mt, flag=0.;
 
@@ -5051,7 +5049,6 @@ Vec4d Planet::getRTSTime(const StelCore *core, const double altitude) const
 			ms += ms2;
 		}
 		core1->setJD(currentJD);
-		core1->setMilliSecondsOfLastJDUpdate(millis); // restore millis.
 		core1->update(0); // enforce update
 	}
 	else
@@ -5242,4 +5239,102 @@ Vec4d Planet::getRTSTime(const StelCore *core, const double altitude) const
 	//omgr->addToExtraInfoString(StelObject::DebugAid, QString("set     = %1<br/>").arg(StelUtils::julianDayToISO8601String(currentJD+ms)));
 
 	return Vec4d(currentJD+mr, currentJD+mt, currentJD+ms, flag);
+}
+
+Vec4d Planet::getRTSTime(const StelCore *core, const double altitude) const
+{
+	// Keep time in sync (method from line 592) to fix slow down of time when the moon is selected
+	const double currentJD = core->getJDOfLastJDUpdate();
+	const qint64 millis = core->getMilliSecondsOfLastJDUpdate();
+	const double utcShift = core->getUTCOffset(currentJD) / 24.;
+	StelCore* core1 = StelApp::getInstance().getCore();
+	Vec4d rts = getClosestRTSTime(core1,altitude);
+	int year, month, day, currentdate;
+	StelUtils::getDateFromJulianDay(currentJD+utcShift, &year, &month, &currentdate);
+	Vec4d rtsNew;
+
+	// Transit
+	StelUtils::getDateFromJulianDay(rts[1]+utcShift, &year, &month, &day);
+	if (day != currentdate)
+	{
+		if (rts[1]<currentJD) // found time before current date
+		{
+			core1->setJD(rts[1]+1.); // try again for current date
+			core1->update(0); // force update to get new coordinates
+			rtsNew = getClosestRTSTime(core1,altitude);
+			rts[1] = rtsNew[1];
+			rts[3] = rtsNew[3];
+		}
+		else if (rts[1]>currentJD) // found time after current date
+		{
+			core1->setJD(rts[1]-1.); // try again for current date
+			core1->update(0); // force update to get new coordinates
+			rtsNew = getClosestRTSTime(core1,altitude);
+			rts[1] = rtsNew[1];
+			rts[3] = rtsNew[3];
+		}
+	}
+
+	// Rise
+	StelUtils::getDateFromJulianDay(rts[0]+utcShift, &year, &month, &day);
+	if (day != currentdate)
+	{
+		if (rts[0]<currentJD) // found time before current date
+		{
+			core1->setJD(rts[0]+1.); // try again for current date
+			core1->update(0); // force update to get new coordinates
+			rtsNew = getClosestRTSTime(core1,altitude);
+			rts[0] = rtsNew[0];
+			rts[3] = rtsNew[3];
+		}
+		else if (rts[0]>currentJD) // found time after current date
+		{
+			core1->setJD(rts[0]-1.); // try again for current date
+			core1->update(0); // force update to get new coordinates
+			rtsNew = getClosestRTSTime(core1,altitude);
+			rts[0] = rtsNew[0];
+			rts[3] = rtsNew[3];
+		}
+	}
+
+	// Set
+	StelUtils::getDateFromJulianDay(rts[2]+utcShift, &year, &month, &day);
+	if (day != currentdate)
+	{
+		if (rts[2]<currentJD) // found time before current date
+		{
+			core1->setJD(rts[2]+1.); // try again for current date
+			core1->update(0); // force update to get new coordinates
+			rtsNew = getClosestRTSTime(core1,altitude);
+			rts[2] = rtsNew[2];
+			rts[3] = rtsNew[3];
+		}
+		else if (rts[2]>currentJD) // found time after current date
+		{
+			core1->setJD(rts[2]-1.); // try again for current date
+			core1->update(0); // force update to get new coordinates
+			rtsNew = getClosestRTSTime(core1,altitude);
+			rts[2] = rtsNew[2];
+			rts[3] = rtsNew[3];
+		}
+	}
+
+	double mr = rts[0];
+	double mt = rts[1];
+	double ms = rts[2];
+	int flag = rts[3];
+	if (flag==0)
+	{
+		StelUtils::getDateFromJulianDay(mt+utcShift, &year, &month, &day);
+		if (day != currentdate) flag = 20; // no transit
+		StelUtils::getDateFromJulianDay(mr+utcShift, &year, &month, &day);
+		if (day != currentdate) flag = 30; // no rise
+		StelUtils::getDateFromJulianDay(ms+utcShift, &year, &month, &day);
+		if (day != currentdate) flag = 40; // no set
+	}
+	core1->setJD(currentJD);
+	core1->setMilliSecondsOfLastJDUpdate(millis); // restore millis.
+	core1->update(0); // enforce update
+
+	return Vec4d(mr, mt, ms, flag);
 }

--- a/src/core/modules/Planet.cpp
+++ b/src/core/modules/Planet.cpp
@@ -4918,7 +4918,9 @@ Vec4d Planet::getClosestRTSTime(const StelCore *core, const double altitude) con
 	if (loc.name.contains("->")) // a spaceship
 		return Vec4d(0., 0., 0., -1000.);
 
+	// Keep time in sync (method from line 592) to fix slow down of time when the moon is selected
 	const double currentJD = core->getJDOfLastJDUpdate();
+	const qint64 millis = core->getMilliSecondsOfLastJDUpdate();
 	const double currentJDE = core->getJDE();
 	double mr, ms, mt, flag=0.;
 
@@ -5049,6 +5051,7 @@ Vec4d Planet::getClosestRTSTime(const StelCore *core, const double altitude) con
 			ms += ms2;
 		}
 		core1->setJD(currentJD);
+		core1->setMilliSecondsOfLastJDUpdate(millis); // restore millis.
 		core1->update(0); // enforce update
 	}
 	else

--- a/src/core/modules/Planet.hpp
+++ b/src/core/modules/Planet.hpp
@@ -612,6 +612,13 @@ public:
 	//!       * -1000. is used as "invalid" value. The result should then not be used.
 	//! @note This is based on Meeus, Astronomical Algorithms (2nd ed.), but deviates in details.
 	//! @note Limitation for efficiency: If this is a planet moon from another planet, we compute RTS for the parent planet instead!
+	virtual Vec4d getClosestRTSTime(const StelCore* core, const double altitude=0.) const;
+
+	//! Adaptation of getClosestRTSTime() to compute times of rise, transit and set for a solar system object for current location and date.
+	//! @note The fourth element flags particular conditions:
+	//!       *   +20 for objects with no transit time on current date.
+	//!       *   +30 for objects with no rise time on current date.
+	//!       *   +40 for objects with no set time on current date.
 	virtual Vec4d getRTSTime(const StelCore* core, const double altitude=0.) const Q_DECL_OVERRIDE;
 
 	void resetTextures();

--- a/src/core/modules/SpecificTimeMgr.cpp
+++ b/src/core/modules/SpecificTimeMgr.cpp
@@ -128,7 +128,16 @@ void SpecificTimeMgr::nextTransit()
 		core->update(0);
 		Vec4d rts = selected[0]->getRTSTime(core);
 		if (rts[3]>-1000.)
-			core->setJD(rts[1]);
+		{
+			if (rts[3]!=20)
+				core->setJD(rts[1]);
+			else { // no transit
+				core->addSolarDays(1.0);
+				core->update(0);
+				rts = selected[0]->getRTSTime(core);
+				core->setJD(rts[1]);
+			}
+		}
 	}
 }
 
@@ -141,7 +150,16 @@ void SpecificTimeMgr::nextRising()
 		core->update(0);
 		Vec4d rts = selected[0]->getRTSTime(core);
 		if (rts[3]>-1000.)
-			core->setJD(rts[0]);
+		{
+			if (rts[3]!=30)
+				core->setJD(rts[0]);
+			else { // no rise
+				core->addSolarDays(1.0);
+				core->update(0);
+				rts = selected[0]->getRTSTime(core);
+				core->setJD(rts[0]);
+			}
+		}
 	}
 }
 
@@ -154,7 +172,16 @@ void SpecificTimeMgr::nextSetting()
 		core->update(0);
 		Vec4d rts = selected[0]->getRTSTime(core);
 		if (rts[3]>-1000.)
-			core->setJD(rts[2]);
+		{
+			if (rts[3]!=40)
+				core->setJD(rts[2]);
+			else { // no set
+				core->addSolarDays(1.0);
+				core->update(0);
+				rts = selected[0]->getRTSTime(core);
+				core->setJD(rts[2]);
+			}
+		}
 	}
 }
 
@@ -167,7 +194,16 @@ void SpecificTimeMgr::previousTransit()
 		core->update(0);
 		Vec4d rts = selected[0]->getRTSTime(core);
 		if (rts[3]>-1000.)
-			core->setJD(rts[1]);
+		{
+			if (rts[3]!=20)
+				core->setJD(rts[1]);
+			else { // no transit
+				core->addSolarDays(-1.0);
+				core->update(0);
+				rts = selected[0]->getRTSTime(core);
+				core->setJD(rts[1]);
+			}
+		}
 	}
 }
 
@@ -180,7 +216,16 @@ void SpecificTimeMgr::previousRising()
 		core->update(0);
 		Vec4d rts = selected[0]->getRTSTime(core);
 		if (rts[3]>-1000.)
-			core->setJD(rts[0]);
+		{
+			if (rts[3]!=30)
+				core->setJD(rts[0]);
+			else { // no rise
+				core->addSolarDays(-1.0);
+				core->update(0);
+				rts = selected[0]->getRTSTime(core);
+				core->setJD(rts[0]);
+			}
+		}
 	}
 }
 
@@ -193,7 +238,16 @@ void SpecificTimeMgr::previousSetting()
 		core->update(0);
 		Vec4d rts = selected[0]->getRTSTime(core);
 		if (rts[3]>-1000.)
-			core->setJD(rts[2]);
+		{
+			if (rts[3]!=40)
+				core->setJD(rts[2]);
+			else { // no set
+				core->addSolarDays(-1.0);
+				core->update(0);
+				rts = selected[0]->getRTSTime(core);
+				core->setJD(rts[2]);
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
The problems are:
- Stellarium calculates RTS of the Moon by choosing the nearest instances. Sometimes, rise or transit or set time occurs on previous day or next day.
- There are time spikes in AstroCalc's RTS table which is a remaining issue in #1482 (near bottom of the page).

This PR will fix them by:
1. When select the Moon (or other objects). Info will show '(previous day)' or '(next day)' after the time to inform us that the calculated event doesn't happen on current day.
2. RTS table in AstroCalc will show the events that occur on the same date in the same row. This should make it easier to read/process in other applications.
3. Fixing above helps us eliminate time spikes issue.

![Moon-RTS](https://user-images.githubusercontent.com/41257965/215240857-a30eef97-3a80-4b44-987e-3dcb8f011243.png)

Fixes #2990 and remaining issue in #1482

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### How Has This Been Tested?

**Test Configuration**:
* Operating system: Manjaro 22.0.1
* Graphics Card: -

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
