### PR TITLE
Fix default distance of "observer" to the parent

### DIFF
--- a/data/ssystem_major.ini
+++ b/data/ssystem_major.ini
@@ -1956,7 +1956,7 @@ orbit_Period=100000000000
 ; 1AU to make earth orbit less distorted
 orbit_SemiMajorAxis=149600000
 parent=Earth
-rot_obliquity=90
+rot_obliquity=0
 type=observer
 
 [mars_observer]
@@ -1971,7 +1971,7 @@ orbit_Period = 70000000000
 ; set to 1.5AU: Average light time as seen from earth.
 orbit_SemiMajorAxis = 224400000
 parent = Mars
-rot_obliquity =90
+rot_obliquity=0
 type = observer
 
 [jupiter_observer]
@@ -1986,7 +1986,7 @@ orbit_Period = 70000000000
 ; set to 5.2AU: Average light time as seen from earth.
 orbit_SemiMajorAxis = 777920000
 parent = Jupiter
-rot_obliquity =90
+rot_obliquity=0
 type = observer
 
 [saturn_observer]
@@ -2001,7 +2001,7 @@ orbit_Period = 70000000000
 ; set to 9.6AU: Average light time as seen from earth.
 orbit_SemiMajorAxis = 1436160000
 parent = Saturn
-rot_obliquity =90
+rot_obliquity=0
 type = observer
 
 [uranus_observer]
@@ -2016,7 +2016,7 @@ orbit_Period = 70000000000
 ; set to 19.2AU: Average light time as seen from earth.
 orbit_SemiMajorAxis = 2872320000
 parent = Uranus
-rot_obliquity =90
+rot_obliquity=0
 type = observer
 
 [neptune_observer]
@@ -2031,7 +2031,7 @@ orbit_Period = 70000000000
 ; set to 19.2AU: Average light time as seen from earth.
 orbit_SemiMajorAxis = 4498472000
 parent = Neptune
-rot_obliquity =90
+rot_obliquity=0
 type = observer
 
 [solar_system_observer]
@@ -2049,5 +2049,5 @@ orbit_Period=70000000000
 ;orbit_SemiMajorAxis=70 000 000 000
 ; place distance around Neptune distance...
 orbit_SemiMajorAxis=30
-rot_obliquity=90
+rot_obliquity=0
 type=observer

--- a/src/core/modules/SolarSystem.cpp
+++ b/src/core/modules/SolarSystem.cpp
@@ -760,11 +760,19 @@ bool SolarSystem::loadPlanets(const QString& filePath)
 
 #ifdef USE_GIMBAL_ORBIT
 		// undefine the flag in Orbit.h to disable and use the old, static observer solution (on an infinitely slow KeplerOrbit)
-		// Note that for now we ignore any orbit-related config values from the ini file.
+		// Note that for now we ignore any orbit-related config values except orbit_SemiMajorAxis from the ini file.
 		if (type=="observer")
 		{
+			double unit = 1; // AU
+			double defaultSemiMajorAxis = 1;
+			if (strParent!="Sun")
+			{
+				unit /= AU;  // Planet moons have distances given in km in the .ini file! But all further computation done in AU.
+				defaultSemiMajorAxis *= AU;
+			}
+			semi_major_axis = pd.value(secname+"/orbit_SemiMajorAxis", defaultSemiMajorAxis).toDouble() * unit;
 			// Create a pseudo orbit that allows interaction with keyboard
-			GimbalOrbit *orb = new GimbalOrbit(1, 0., 90.);    // [1 AU over north pole]
+			GimbalOrbit *orb = new GimbalOrbit(semi_major_axis, 0., 90.); // [Over north pole]
 			orbits.push_back(orb);
 
 			orbitPtr = orb;


### PR DESCRIPTION
The default distance of an "observer" location to its parent is fixed at 1 AU. This means that the properties in `ssystem_major.ini` are ignored. This patch fixes this behavior.

Note that I noticed that the units are specified in a non-intuitive way: the Sun-parented objects have semimajor axis in AU while others are specified in km. Please check that this interpretation is correct, because the User Guide isn't clear.

Fixes #2911