### PR TITLE
Fix screenshot sizes

### DIFF
--- a/src/StelMainView.cpp
+++ b/src/StelMainView.cpp
@@ -1631,7 +1631,7 @@ void StelMainView::doScreenshot(void)
 	// HiDPI screens interfere, and the viewing angle has to be maintained.
 	// First, image size:
 	glWidget->makeCurrent();
-	float pixelRatio = static_cast<float>(QOpenGLContext::currentContext()->screen()->devicePixelRatio());
+	float pixelRatio = 1.f; // static_cast<float>(QOpenGLContext::currentContext()->screen()->devicePixelRatio());
 	int imgWidth =static_cast<int>(stelScene->width());
 	int imgHeight=static_cast<int>(stelScene->height());
 	bool nightModeWasEnabled=nightModeEffect->isEnabled();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Please include a summary of the change and which issue is fixed. -->
<!--- Please also include relevant motivation and context. -->
<!--- List any dependencies that are required for this change. -->

This is an attempt to fix a scaling issue where scaling was never expected: screenshots.

- A regular screenshot of the full-size screen shall have as many pixels as the screen, or less if screen scaling is set in the OS. In this case the image will have less pixels.
- A screenshot of a window smaller than screen size is expected to have just as many pixels as the window. 
- A screenshot with custom size has just that: a user-configured pixel count. Whatever screen scaling is set in the OS should not matter. 
- There are technical limits to screenshot sizes. Setting hardware maximum and then multiply by a scale factor is an obvious bug. 

Please explain why fiddling with a scaling factor here was important in the first place. 

For a first test, I have trivially set the pixelScale for screenshots to 1. Of course, remove code before merge. 

Fixes #2926 (issue)

### Screenshots (if appropriate):

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system: Windows 11
* Graphics Card: (Geforce)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
