### PR TITLE
Render ShowMySky atmosphere calculating view direction per fragment

### DIFF
--- a/src/core/modules/AtmosphereShowMySky.cpp
+++ b/src/core/modules/AtmosphereShowMySky.cpp
@@ -96,7 +96,7 @@ struct SkySettings : ShowMySky::Settings, QObject
 	bool useEclipseShader_ = false;
 
 	// These variables are not used by AtmosphereRenderer, but it's convenient to keep them here
-	QMatrix4x4 projectionMatrix_;
+	QMatrix4x4 projectionMatrixInverse_;
 
 private:
 	static constexpr const char* zeroOrderScatteringPropName() { return "LandscapeMgr.flagAtmosphereZeroOrderScattering"; }
@@ -175,7 +175,7 @@ double sunVisibilityDueToMoon(const double sunAngularRadius, const double moonAn
 	return visibleSolidAngleOfSun(sunAngularRadius, moonAngularRadius, angleBetweenSunAndMoon)/(M_PI*sqr(sunAngularRadius));
 }
 
-constexpr GLuint SKY_VERTEX_ATTRIB_INDEX=0, VIEW_RAY_ATTRIB_INDEX=1;
+constexpr GLuint SKY_VERTEX_ATTRIB_INDEX=0;
 }
 
 void AtmosphereShowMySky::initProperties()
@@ -209,6 +209,42 @@ void AtmosphereShowMySky::initProperties()
 	updateEclipseSimQuality(prop->getValue());
 
 	propertiesInited_ = true;
+}
+
+std::pair<QByteArray,QByteArray> AtmosphereShowMySky::getViewDirShaderSources(const StelProjector& projector) const
+{
+	static constexpr char viewDirVertShaderSrc[]=R"(
+#version 330
+in vec3 vertex;
+out vec3 ndcPos;
+void main()
+{
+	gl_Position = vec4(vertex, 1.);
+	ndcPos = vertex;
+}
+)";
+	const auto viewDirFragShaderSrc =
+		"#version 330\n" +
+		projector.getUnProjectShader() +
+		R"(
+in vec3 ndcPos;
+uniform mat4 projectionMatrixInverse;
+uniform bool isZenithProbe;
+vec3 calcViewDir()
+{
+	if(isZenithProbe) return vec3(0,0,1);
+
+	const float PI = 3.14159265;
+	vec4 winPos = projectionMatrixInverse * vec4(ndcPos, 1);
+	bool ok = false;
+	vec3 modelPos = unProject(winPos.x, winPos.y, ok).xyz;
+
+//	if(!ok) return vec3(0);
+
+	return normalize(modelPos);
+}
+)";
+	return {viewDirVertShaderSrc, viewDirFragShaderSrc};
 }
 
 void AtmosphereShowMySky::loadShaders()
@@ -285,34 +321,11 @@ void main()
 		if(!StelPainter::linkProg(luminanceToScreenProgram_.get(), "atmosphere luminance-to-screen"))
 			throw InitFailure("Shader program linking failed");
 	}
-	{
-		static constexpr char viewDirVertShaderSrc[]=R"(
-#version 330
-uniform mat4 projectionMatrix;
-
-in vec2 skyVertex;
-in vec4 viewRay;
-
-out vec3 viewDirUnnormalized;
-
-void main()
-{
-	viewDirUnnormalized = viewRay.xyz;
-	gl_Position = projectionMatrix*vec4(skyVertex, 0., 1.);
-}
-)";
-		static constexpr char viewDirFragShaderSrc[]=R"(
-#version 330
-in vec3 viewDirUnnormalized;
-vec3 calcViewDir()
-{
-	return normalize(viewDirUnnormalized);
-}
-)";
-		renderer_->initDataLoading(viewDirVertShaderSrc, viewDirFragShaderSrc,
-								   {std::pair<std::string,GLuint>{"viewRay", VIEW_RAY_ATTRIB_INDEX},
-								    std::pair<std::string,GLuint>{"skyVertex", SKY_VERTEX_ATTRIB_INDEX}});
-	}
+	const auto& core = StelApp::getInstance().getCore();
+	const auto projector = core->getProjection(StelCore::FrameAltAz, StelCore::RefractionOff);
+	const auto shaderSources = getViewDirShaderSources(*projector);
+	renderer_->initDataLoading(shaderSources.first, shaderSources.second,
+							   {std::pair<std::string,GLuint>{"vertex", SKY_VERTEX_ATTRIB_INDEX}});
 }
 
 void AtmosphereShowMySky::resizeRenderTarget(int width, int height)
@@ -351,21 +364,14 @@ void AtmosphereShowMySky::setupBuffers()
 		 1, -1,
 		-1,  1,
 		 1,  1,
-		// view ray for zenith probe (all to zenith)
-		0, 0, 1, 1,
-		0, 0, 1, 1,
-		0, 0, 1, 1,
-		0, 0, 1, 1,
 	};
-	constexpr int FS_QUAD_COORDS_PER_VERTEX = 2, VIEW_RAY_COORDS_PER_VERTEX = 4;
-	constexpr int NUM_FS_QUAD_VERTICES = 4;
+	constexpr int FS_QUAD_COORDS_PER_VERTEX = 2;
 	constexpr auto FS_QUAD_OFFSET_IN_VBO = 0;
-	constexpr auto VIEW_RAYS_OFFSET_IN_VBO = NUM_FS_QUAD_VERTICES * FS_QUAD_COORDS_PER_VERTEX * sizeof vertices[0];
 	GL(gl.glBufferData(GL_ARRAY_BUFFER, sizeof vertices, vertices, GL_STATIC_DRAW));
 
 	{
-		GL(gl.glGenVertexArrays(1, &luminanceToScreenVAO_));
-		GL(gl.glBindVertexArray(luminanceToScreenVAO_));
+		GL(gl.glGenVertexArrays(1, &mainVAO_));
+		GL(gl.glBindVertexArray(mainVAO_));
 		GL(gl.glVertexAttribPointer(0, FS_QUAD_COORDS_PER_VERTEX, GL_FLOAT, false, 0,
 									reinterpret_cast<const void*>(FS_QUAD_OFFSET_IN_VBO)));
 		GL(gl.glEnableVertexAttribArray(SKY_VERTEX_ATTRIB_INDEX));
@@ -376,21 +382,6 @@ void AtmosphereShowMySky::setupBuffers()
 		GL(gl.glVertexAttribPointer(SKY_VERTEX_ATTRIB_INDEX, FS_QUAD_COORDS_PER_VERTEX, GL_FLOAT, false, 0,
 									reinterpret_cast<const void*>(FS_QUAD_OFFSET_IN_VBO)));
 		GL(gl.glEnableVertexAttribArray(SKY_VERTEX_ATTRIB_INDEX));
-		GL(gl.glVertexAttribPointer(VIEW_RAY_ATTRIB_INDEX, VIEW_RAY_COORDS_PER_VERTEX, GL_FLOAT, false, 0,
-									reinterpret_cast<const void*>(VIEW_RAYS_OFFSET_IN_VBO)));
-		GL(gl.glEnableVertexAttribArray(VIEW_RAY_ATTRIB_INDEX));
-	}
-	{
-		GL(gl.glGenVertexArrays(1, &renderVAO_));
-		GL(gl.glBindVertexArray(renderVAO_));
-		indexBuffer.bind();
-		posGridBuffer.bind();
-		constexpr int POS_GRID_BUFFER_COORDS_PER_VERTEX = 2;
-		GL(gl.glVertexAttribPointer(SKY_VERTEX_ATTRIB_INDEX, POS_GRID_BUFFER_COORDS_PER_VERTEX, GL_FLOAT, false, 0, 0));
-		GL(gl.glEnableVertexAttribArray(SKY_VERTEX_ATTRIB_INDEX));
-		viewRayGridBuffer.bind();
-		GL(gl.glVertexAttribPointer(VIEW_RAY_ATTRIB_INDEX, VIEW_RAY_COORDS_PER_VERTEX, GL_FLOAT, false, 0, 0));
-		GL(gl.glEnableVertexAttribArray(VIEW_RAY_ATTRIB_INDEX));
 	}
 
 	GL(gl.glBindVertexArray(0));
@@ -421,29 +412,25 @@ AtmosphereShowMySky::AtmosphereShowMySky()
 	: showMySkyLib("ShowMySky")
 #endif
 	, viewport(0,0,0,0)
-	, gridMaxY(44)
-	, gridMaxX(44)
-	, reducedResolution(1)
-	, flagDynamicResolution(false)
-	, posGridBuffer(QOpenGLBuffer::VertexBuffer)
-	, indexBuffer(QOpenGLBuffer::IndexBuffer)
-	, viewRayGridBuffer(QOpenGLBuffer::VertexBuffer)
 	, luminanceToScreenProgram_(new QOpenGLShaderProgram())
 {
 	StelOpenGL::checkGLErrors(__FILE__,__LINE__);
-	indexBuffer.setUsagePattern(QOpenGLBuffer::StaticDraw);
-	indexBuffer.create();
-	viewRayGridBuffer.setUsagePattern(QOpenGLBuffer::DynamicDraw);
-	viewRayGridBuffer.create();
-	posGridBuffer.setUsagePattern(QOpenGLBuffer::StaticDraw);
-	posGridBuffer.create();
 
 	setFadeDuration(1.5);
+
+	const auto& conf=*StelApp::getInstance().getSettings();
+	reducedResolution = conf.value("landscape/atmosphere_resolution_reduction", 1).toInt();
+	flagDynamicResolution = conf.value("landscape/flag_atmosphere_dynamic_resolution", false).toBool();
+	if (!flagDynamicResolution)
+	{
+		atmoRes = reducedResolution;
+		if (reducedResolution>1)
+			qDebug() << "Atmosphere runs with statically reduced resolution:" << reducedResolution;
+	}
 
 	resolveFunctions();
 	try
 	{
-		const auto& conf=*StelApp::getInstance().getSettings();
 		const auto defaultPath = QDir::homePath() + "/cms";
 		const auto pathToData = conf.value("landscape/atmosphere_model_path", defaultPath).toString();
 		const auto gl = glfuncs();
@@ -455,21 +442,19 @@ AtmosphereShowMySky::AtmosphereShowMySky()
 		renderSurfaceFunc_=[this](QOpenGLShaderProgram& prog)
 		{
 			const auto& settings = *static_cast<SkySettings*>(skySettings_.get());
-			prog.setUniformValue("projectionMatrix", settings.projectionMatrix_);
+			prog.setUniformValue("projectionMatrixInverse", settings.projectionMatrixInverse_);
+			prog.setUniformValue("isZenithProbe", false);
+			const auto& core = StelApp::getInstance().getCore();
+			const auto projector = core->getProjection(StelCore::FrameAltAz, StelCore::RefractionOff);
+			projector->setUnProjectUniforms(prog);
 
 			auto& gl = *glfuncs();
 
-			GL(gl.glBindVertexArray(renderVAO_));
-
-			std::size_t shift=0;
-			for (int y=0;y<gridMaxY;++y)
-			{
-				GL(gl.glDrawElements(GL_TRIANGLE_STRIP, (gridMaxX+1)*2,
-						     GL_UNSIGNED_SHORT,	reinterpret_cast<void*>(shift)));
-				shift += (gridMaxX+1)*2*2;
-			}
-
+			GL(gl.glViewport(viewport[0], viewport[1], viewport[2]/atmoRes, viewport[3]/atmoRes));
+			GL(gl.glBindVertexArray(mainVAO_));
+			GL(gl.glDrawArrays(GL_TRIANGLE_STRIP, 0, 4));
 			GL(gl.glBindVertexArray(0));
+			GL(gl.glViewport(viewport[0], viewport[1], viewport[2], viewport[3]));
 		};
 		renderer_.reset(ShowMySky_AtmosphereRenderer_create(gl, &pathToData, skySettings_.get(), &renderSurfaceFunc_));
 		loadShaders();
@@ -505,64 +490,9 @@ AtmosphereShowMySky::~AtmosphereShowMySky()
 	{
 		auto& gl = *glfuncs();
 		GL(gl.glDeleteBuffers(1, &vbo_));
-		GL(gl.glDeleteVertexArrays(1, &luminanceToScreenVAO_));
+		GL(gl.glDeleteVertexArrays(1, &mainVAO_));
 		GL(gl.glDeleteVertexArrays(1, &zenithProbeVAO_));
 	}
-}
-
-void AtmosphereShowMySky::regenerateGrid()
-{
-	QSettings* conf = StelApp::getInstance().getSettings();
-	flagDynamicResolution = conf->value("landscape/flag_atmosphere_dynamic_resolution", false).toBool();
-	reducedResolution = conf->value("landscape/atmosphere_resolution_reduction", 1).toInt();
-	if (!flagDynamicResolution)
-	{
-		atmoRes = reducedResolution;
-		if (reducedResolution>1)
-			qDebug() << "Atmosphere runs with statically reduced resolution:" << reducedResolution;
-	}
-	const float width=viewport[2]/atmoRes, height=viewport[3]/atmoRes;
-	gridMaxY = conf->value("landscape/atmosphereybin", 44).toInt();
-	gridMaxX = std::floor(0.5+gridMaxY*(0.5*std::sqrt(3.0))*width/height);
-	const auto gridSize=(1+gridMaxX)*(1+gridMaxY);
-	posGrid.resize(gridSize);
-	viewRayGrid.resize(gridSize);
-	const auto stepX = width / (gridMaxX-0.5);
-	const auto stepY = height / gridMaxY;
-	const float viewportLeft = viewport[0];
-	const float viewportBottom = viewport[1];
-	for(int y=0; y<=gridMaxY; ++y)
-	{
-		for(int x=0; x<=gridMaxX; ++x)
-		{
-			Vec2f& v=posGrid[y*(1+gridMaxX)+x];
-			v[0] = viewportLeft + (x == 0 ? 0 : x == gridMaxX ? width : (x-0.5*(y&1))*stepX);
-			v[1] = viewportBottom+y*stepY;
-		}
-	}
-	posGridBuffer.bind();
-	posGridBuffer.allocate(&posGrid[0], posGrid.size()*sizeof posGrid[0]);
-	posGridBuffer.release();
-
-	// Generate the indices used to draw the quads
-	QVector<GLushort> indices((gridMaxX+1)*gridMaxY*2);
-	for(int y=0, i=0; y<gridMaxY; ++y)
-	{
-		auto g0 = y*(1+gridMaxX);
-		auto g1 = (y+1)*(1+gridMaxX);
-		for(int x=0; x<=gridMaxX; ++x)
-		{
-			indices[i++]=g0++;
-			indices[i++]=g1++;
-		}
-	}
-	indexBuffer.bind();
-	indexBuffer.allocate(&indices[0], (gridMaxX+1)*gridMaxY*2*2);
-	indexBuffer.release();
-
-	viewRayGridBuffer.bind();
-	viewRayGridBuffer.allocate(&viewRayGrid[0], (1+gridMaxX)*(1+gridMaxY)*4*4);
-	viewRayGridBuffer.release();
 }
 
 void AtmosphereShowMySky::probeZenithLuminances(const float altitude)
@@ -580,7 +510,11 @@ void AtmosphereShowMySky::probeZenithLuminances(const float altitude)
 	renderer_->setDrawSurfaceCallback([this](QOpenGLShaderProgram& prog)
 	{
 		const auto& settings = *static_cast<SkySettings*>(skySettings_.get());
-		prog.setUniformValue("projectionMatrix", settings.projectionMatrix_);
+		prog.setUniformValue("projectionMatrixInverse", settings.projectionMatrixInverse_);
+		prog.setUniformValue("isZenithProbe", true);
+		const auto& core = StelApp::getInstance().getCore();
+		const auto projector = core->getProjection(StelCore::FrameAltAz, StelCore::RefractionOff);
+		projector->setUnProjectUniforms(prog);
 
 		auto& gl = *glfuncs();
 		GL(gl.glBindVertexArray(zenithProbeVAO_));
@@ -611,7 +545,7 @@ void AtmosphereShowMySky::drawAtmosphere(Mat4f const& projectionMatrix, const fl
 	StelOpenGL::checkGLErrors(__FILE__,__LINE__);
 	Q_UNUSED(airglowRelativeBrightness)
 	auto& settings = *static_cast<SkySettings*>(skySettings_.get());
-	settings.projectionMatrix_ = projectionMatrix.toQMatrix();
+	settings.projectionMatrixInverse_ = projectionMatrix.toQMatrix().inverted();
 	settings.altitude_=altitude;
 	settings.sunAzimuth_=sunAzimuth;
 	settings.sunZenithAngle_=sunZenithAngle;
@@ -733,7 +667,6 @@ bool AtmosphereShowMySky::dynamicResolution(StelProjectorP prj, Vec3d &currPos, 
 	atmoRes=timeout?1:reducedResolution;
 	if (prevRes!=atmoRes)
 	{
-		regenerateGrid();
 		resizeRenderTarget(width, height);
 		bool verbose=qApp->property("verbose").toBool();
 		if (verbose)
@@ -762,16 +695,18 @@ void AtmosphereShowMySky::computeColor(StelCore* core, const double JD, const Pl
 		Q_UNUSED(extinctionCoefficient)
 		initProperties();
 
-		// The majority of calculations is done in fragment shader, but we still need a nontrivial
-		// grid to pass view rays, corresponding to the chosen projection, to the shader. Of course,
-		// best quality results would be if we did projection inside the shader, but that'd require
-		// having two implementations for each projection type: one for CPU and one for GPU.
 		const auto prj = core->getProjection(StelCore::FrameAltAz, StelCore::RefractionOff);
-		if (viewport != prj->getViewport())
+
+		if(!prevProjector_ || !prj->isSameProjection(*prevProjector_))
 		{
-			viewport = prj->getViewport();
-			regenerateGrid();
+			const auto shaderSources = getViewDirShaderSources(*prj);
+			renderer_->setViewDirShaders(shaderSources.first, shaderSources.second,
+										 {std::pair<std::string,GLuint>{"vertex", SKY_VERTEX_ATTRIB_INDEX}});
+			prevProjector_ = prj;
 		}
+
+		if (viewport != prj->getViewport())
+			viewport = prj->getViewport();
 		const auto width=viewport[2], height=viewport[3];
 		if(width!=prevWidth_ || height!=prevHeight_)
 		{
@@ -834,22 +769,6 @@ void AtmosphereShowMySky::computeColor(StelCore* core, const double JD, const Pl
 			averageLuminance = 0.001f;
 			return;
 		}
-
-		// FIXME: ignoring the "additional luminance" like star background etc.; see AtmospherePreetham for all potentially needed terms
-		const auto numViewRayGridPoints=(1+gridMaxX)*(1+gridMaxY);
-		const auto resX=(double)width/(width/atmoRes);
-		const auto resY=(double)height/(height/atmoRes);
-		for (int i=0; i<numViewRayGridPoints; ++i)
-		{
-			Vec3d point(1, 0, 0);
-			prj->unProject(posGrid[i][0]*resX,posGrid[i][1]*resY,point);
-
-			viewRayGrid[i].set(point[0], point[1], point[2], 0);
-		}
-
-		viewRayGridBuffer.bind();
-		viewRayGridBuffer.write(0, &viewRayGrid[0], viewRayGrid.size()*sizeof viewRayGrid[0]);
-		viewRayGridBuffer.release();
 
 		const auto sunAzimuth = std::atan2(sunDir[1], sunDir[0]);
 		const auto sunZenithAngle = std::acos(sunDir[2]);
@@ -926,7 +845,7 @@ void AtmosphereShowMySky::draw(StelCore* core)
 		GL(ditherPatternTex_->bind(ditherTexSampler));
 	GL(luminanceToScreenProgram_->setUniformValue(shaderAttribLocations.ditherPattern, ditherTexSampler));
 
-	GL(gl.glBindVertexArray(luminanceToScreenVAO_));
+	GL(gl.glBindVertexArray(mainVAO_));
 	GL(gl.glDrawArrays(GL_TRIANGLE_STRIP, 0, 4));
 	GL(gl.glBindVertexArray(0));
 

--- a/src/core/modules/AtmosphereShowMySky.hpp
+++ b/src/core/modules/AtmosphereShowMySky.hpp
@@ -94,11 +94,6 @@ private:
 	 *	Especially at full resolution, frames will be skipped depending on the speed of movement.
 	 */
 	bool flagDynamicResolution;
-	QVector<Vec2f> posGrid;
-	QOpenGLBuffer posGridBuffer;
-	QOpenGLBuffer indexBuffer;
-	QVector<Vec4f> viewRayGrid;
-	QOpenGLBuffer viewRayGridBuffer;
 
 	std::unique_ptr<QOpenGLShaderProgram> luminanceToScreenProgram_;
 	decltype(::ShowMySky_AtmosphereRenderer_create)* ShowMySky_AtmosphereRenderer_create=nullptr;
@@ -116,12 +111,13 @@ private:
 	} shaderAttribLocations;
 
 	StelTextureSP ditherPatternTex_;
+	StelProjectorP prevProjector_;
 	std::unique_ptr<TextureAverageComputer> textureAverager_;
 
 	float prevFad=0, prevFov=0;
 	Vec3d prevPos=Vec3d(0,0,0), prevSun=Vec3d(0,0,0);
 	int prevWidth_=0, prevHeight_=0, dynResTimer=0, prevRes=0, atmoRes=1;
-	GLuint renderVAO_=0, luminanceToScreenVAO_=0, zenithProbeVAO_=0, vbo_=0;
+	GLuint mainVAO_=0, zenithProbeVAO_=0, vbo_=0;
 	std::unique_ptr<ShowMySky::AtmosphereRenderer> renderer_;
 	std::unique_ptr<ShowMySky::Settings> skySettings_;
 	std::function<void(QOpenGLShaderProgram&)> renderSurfaceFunc_;
@@ -153,6 +149,7 @@ private:
 	                    float brightness, float lightPollutionGroundLuminance, float airglowRelativeBrightness,
 	                    bool drawAsEclipse, bool clearTarget);
 	bool dynamicResolution(StelProjectorP prj, Vec3d &sunPos, int width, int height);
+	std::pair<QByteArray,QByteArray> getViewDirShaderSources(const StelProjector& projector) const;
 	void probeZenithLuminances(float altitude);
 #endif // ENABLE_SHOWMYSKY
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

This PR makes atmosphere look better in the parts of the screen where view direction changes rapidly.

One problem that we have here is that switching between projections takes about 3 seconds to recompile all the ShowMySky shaders. After the particular projection has been switched to, usually the shaders are cached by the GPU driver (at least by NVIDIA and Mesa), so this has a limited impact. But I'm not sure if the initial delay is OK to have.

An alternative solution is to render the view directions to a separate texture and use it as an additional input for the renderer. This gets rid of the switching delay, but reduces performance for all other times (by about 9% of frame rate on my machine).

### Screenshots

#### Old

![Screenshot_2023-02-27_00-01-40](https://user-images.githubusercontent.com/6376882/221434131-8b158048-c065-4d5f-b87e-bfc5e56060d5.png)

#### New

![Screenshot_2023-02-27_00-02-12](https://user-images.githubusercontent.com/6376882/221434143-0707e964-c960-49e3-8e9e-e0b9f24e197a.png)


### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### How Has This Been Tested?
**Test Configuration**:
* Operating system: Ubuntu 20.04
* Graphics Card: Intel UHD Graphics 620

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
