### PR TITLE
Use config settings screen_* in physical (unscaled) pixels

### DIFF
--- a/src/gui/ConfigurationDialog.cpp
+++ b/src/gui/ConfigurationDialog.cpp
@@ -1215,10 +1215,10 @@ void ConfigurationDialog::saveAllSettings()
 	{
 		QRect screenGeom = QGuiApplication::screens().at(screenNum)->geometry();
 
-		conf->setValue("video/screen_w", mainWindow.size().width());
-		conf->setValue("video/screen_h", mainWindow.size().height());
-		conf->setValue("video/screen_x", mainWindow.x() - screenGeom.x());
-		conf->setValue("video/screen_y", mainWindow.y() - screenGeom.y());
+		conf->setValue("video/screen_w", int(std::lround(mainWindow.size().width() * mainWindow.devicePixelRatio())));
+		conf->setValue("video/screen_h", int(std::lround(mainWindow.size().height() * mainWindow.devicePixelRatio())));
+		conf->setValue("video/screen_x", int(std::lround((mainWindow.x() - screenGeom.x()) * mainWindow.devicePixelRatio())));
+		conf->setValue("video/screen_y", int(std::lround((mainWindow.y() - screenGeom.y()) * mainWindow.devicePixelRatio())));
 	}
 
 	// clear the restore defaults flag if it is set.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -397,17 +397,22 @@ int main(int argc, char **argv)
 		qWarning() << "WARNING: screen" << screen << "not found";
 		screen = 0;
 	}
-	const QRect screenGeom = qApp->screens().at(screen)->geometry();
+	const auto qscreen = qApp->screens().at(screen);
+	const QRect screenGeom = qscreen->geometry();
+	const auto pixelRatio = qscreen->devicePixelRatio();
 
-	const auto size = QSize(confSettings->value("video/screen_w", screenGeom.width()).toInt(),
-							confSettings->value("video/screen_h", screenGeom.height()).toInt());
+	const auto virtSize = QSize(confSettings->value("video/screen_w", screenGeom.width()).toInt(),
+								confSettings->value("video/screen_h", screenGeom.height()).toInt());
+	const auto size = QSize(std::lround(virtSize.width()/pixelRatio),
+							std::lround(virtSize.height()/pixelRatio));
 	mainWin.resize(size);
 
 	const bool fullscreen = confSettings->value("video/fullscreen", true).toBool();
 	if (fullscreen)
 	{
 		// The "+1" below is to work around Linux/Gnome problem with mouse focus.
-		mainWin.move(screenGeom.x()+1, screenGeom.y()+1);
+		mainWin.move((screenGeom.x()+1)/pixelRatio,
+					 (screenGeom.y()+1)/pixelRatio);
 		// The fullscreen window appears on screen where is the majority of
 		// the normal window. Therefore we crop the normal window to the
 		// screen area to ensure that the majority is not on another screen.
@@ -418,7 +423,8 @@ int main(int argc, char **argv)
 	{
 		const int x = confSettings->value("video/screen_x", 0).toInt();
 		const int y = confSettings->value("video/screen_y", 0).toInt();
-		mainWin.move(x + screenGeom.x(), y + screenGeom.y());
+		mainWin.move((x + screenGeom.x())/pixelRatio,
+					 (y + screenGeom.y())/pixelRatio);
 	}
 
 	mainWin.show();


### PR DESCRIPTION
### Description
This makes the config settings `screen_{w,h,x,y}` work as defined in units of real pixels—the only sensible user-visible units for any screen. Previously, due to the Qt approach to GUI scaling, these settings were stored and read in units of virtual pixels.

I hope this change will relieve the debates about PR #3071.

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system: Ubuntu 20.04
* Graphics Card: Intel UHD Graphics 620

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
