### PR TITLE
Disable "dangerous" scripting calls unless --unsafe is passed

### DIFF
--- a/cmake/stellarium.pod.cmake
+++ b/cmake/stellarium.pod.cmake
@@ -94,6 +94,10 @@ latitudes should be prefixed with C<->.
 
 Print a list of landscape names and exit.
 
+=item B<--unsafe>
+
+Allow unsafe script execution.
+
 =item B<--landscape> I<name>
 
 Start Stellarium using landscape I<name>.

--- a/guide/app_config_ini.tex
+++ b/guide/app_config_ini.tex
@@ -736,10 +736,8 @@ password   & string & Password for proxy. E.g. \emph{xxxxx}\\\bottomrule
 \begin{tabularx}{\textwidth}{l|l|l|X}\toprule
 \emph{ID}                  & \emph{Type} & \emph{Default} & \emph{Description}\\\midrule
 startup\_script                            & string & startup.ssc & name of script executed on program start\\
-flag\_script\_allow\_absolute\_path        & bool   & false       & set true to allow running scripts from absolute pathnames.
-                                                                    This may pose a security risk if you run arbitrary scripts.\\
-flag\_allow\_screenshots\_dir              & bool   & false       & Allow scripts to set a target directory.\\
-flag\_allow\_write\_absolute\_path         & bool   & false       & set true to let scripts store output files to absolute pathnames.
+flag\_allow\_screenshot\_dir               & bool   & false       & Allow scripts to set a target directory.\\
+flag\_script\_allow\_write\_absolute\_path & bool   & false       & set true to let scripts store files to absolute pathnames.
                                                                     This may pose a security risk if you run scripts from other authors
                                                                     without checking what they are doing.\\\bottomrule 
 %% These are unused as on 0.15pre.

--- a/guide/ch_advanced_use.tex
+++ b/guide/ch_advanced_use.tex
@@ -489,6 +489,7 @@ For example, using the option \texttt{-c\ my\_config.ini} would resolve to the f
 -\/-sky-date         & date       & The initial date in \texttt{yyyymmdd} format. \\
 -\/-sky-time         & time       & The initial time in \texttt{hh:mm:ss} format. \\\midrule
 -\/-startup-script   & script name & The name of a script to run after the program has started. [\file{startup.ssc}] \\\midrule
+-\/-unsafe           & path        & Allow unsafe script execution \\\midrule
 -\/-fov              & angle (degrees) & The initial vertical field of view in degrees. \\\midrule
 -\/-scale-gui        & scale factor & Scaling the GUI according to scale factor\\
 -\/-gui-css style    & name       & Use \file{name.css} to define GUI style\\\midrule

--- a/src/CLIProcessor.cpp
+++ b/src/CLIProcessor.cpp
@@ -130,6 +130,7 @@ void CLIProcessor::parseCLIArgsPreConfig(const QStringList& argList)
 		          << "--restore-defaults      : Delete existing config.ini and use defaults\n"
 		          << "--multires-image        : With filename / URL argument, specify a\n"
 			  << "                          multi-resolution image to load\n"
+			  << "--unsafe                : Allow unsafe script execution\n"
 #ifdef Q_OS_WIN
 			  << "--angle-mode (or -a)    : Use ANGLE as OpenGL ES2 rendering engine (autodetect driver)\n"
 			  << "--angle-d3d9 (or -9)    : Force use Direct3D 9 for ANGLE OpenGL ES2 rendering engine\n"
@@ -176,7 +177,7 @@ void CLIProcessor::parseCLIArgsPostConfig(const QStringList& argList, QSettings*
 {	
 	// Over-ride config file options with command line options
 	// We should catch exceptions from argsGetOptionWithArg...
-	int fullScreen, altitude;
+	int fullScreen, altitude, allowUnsafe;
 	float fov;
 	QString landscapeId, homePlanet, longitude, latitude, skyDate, skyTime;
 	QString projectionType, screenshotDir, multiresImage, startupScript, customCSS;
@@ -195,6 +196,7 @@ void CLIProcessor::parseCLIArgsPostConfig(const QStringList& argList, QSettings*
 		latitude = argsGetOptionWithArg(argList, "", "--latitude", "").toString();
 		skyDate = argsGetOptionWithArg(argList, "", "--sky-date", "").toString();
 		skyTime = argsGetOptionWithArg(argList, "", "--sky-time", "").toString();
+		allowUnsafe = argsGetOption(argList, "", "--unsafe");
 		fov = argsGetOptionWithArg(argList, "", "--fov", -1.f).toFloat();
 		projectionType = argsGetOptionWithArg(argList, "", "--projection-type", "").toString();
 		screenshotDir = argsGetOptionWithArg(argList, "", "--screenshot-dir", "").toString();
@@ -213,6 +215,8 @@ void CLIProcessor::parseCLIArgsPostConfig(const QStringList& argList, QSettings*
 		qCritical() << "ERROR while checking command line options: " << e.what();
 		exit(0);
 	}
+
+	qApp->setProperty("allow_unsafe", allowUnsafe);
 
 	// Will be -1 if option is not found, in which case we don't change anything.
 	if (fullScreen==1)

--- a/src/scripting/StelMainScriptAPI.cpp
+++ b/src/scripting/StelMainScriptAPI.cpp
@@ -342,8 +342,10 @@ QStringList StelMainScriptAPI::getAllTimezoneNames()
 
 void StelMainScriptAPI::screenshot(const QString& prefix, bool invert, const QString& dir, const bool overwrite, const QString &format)
 {
+	const bool allowUnsafe = qApp->property("allow_unsafe").toBool();
+
 	QString realDir("");
-	if ((!dir.isEmpty()) && (!StelApp::getInstance().getScriptMgr().getFlagAllowExternalScreenshotDir()))
+	if (!allowUnsafe && (!dir.isEmpty()) && (!StelApp::getInstance().getScriptMgr().getFlagAllowExternalScreenshotDir()))
 	{
 		qWarning() << "SCRIPT CONFIGURATION ISSUE: the script wants to store a screenshot" << prefix << "." << format << "to an external directory " << dir;
 		qWarning() << "  To enable this, check the settings in the script console";
@@ -354,7 +356,7 @@ void StelMainScriptAPI::screenshot(const QString& prefix, bool invert, const QSt
 
 
 	const bool oldInvertSetting = StelMainView::getInstance().getFlagInvertScreenShotColors();
-	const QString oldFormat=StelMainView::getInstance().getScreenshotFormat();
+	QString oldFormat=StelMainView::getInstance().getScreenshotFormat();
 	if ((format.length()>0) && (format.length()<=4))
 		StelMainView::getInstance().setScreenshotFormat(format);
 	// Check requested against set image format.

--- a/src/scripting/StelScriptOutput.cpp
+++ b/src/scripting/StelScriptOutput.cpp
@@ -60,7 +60,10 @@ void StelScriptOutput::saveOutputAs(const QString &name)
 	const QDir dir=outputInfo.dir(); // will hold complete dirname
 	const QFileInfo newFileNameInfo(name);
 
-	const bool okToSaveToAbsolutePath=StelApp::getInstance().getSettings()->value("scripts/flag_allow_write_absolute_path", false).toBool();
+	const bool allowUnsafe = qApp->property("allow_unsafe").toBool();
+
+	const bool okToSaveToAbsolutePath=StelApp::getInstance().getSettings()->value("scripts/flag_allow_write_absolute_path", false).toBool()
+		|| allowUnsafe;
 
 	if (name.contains("config.ini"))
 	{
@@ -71,8 +74,8 @@ void StelScriptOutput::saveOutputAs(const QString &name)
 	if (!okToSaveToAbsolutePath && ((newFileNameInfo.isAbsolute() || (name.contains(".."))))) // The last condition may include dangerous/malicious paths
 	{
 		qWarning() << "SCRIPTING CONFIGURATION ISSUE: You are trying to save to an absolute pathname or move up in directories.";
-		qWarning() << "  To enable this, check the settings in the script console";
-		qWarning() << "  or edit config.ini and set [scripts]/flag_allow_write_absolute_path=true";
+		qWarning() << "  To enable this, pass the --unsafe flag";
+		qWarning() << "  or edit config.ini and set [scripts]/flag_script_allow_write_absolute_path=true";
 		asFile.setFileName(dir.absolutePath() + "/" + newFileNameInfo.fileName());
 	}
 	else if (okToSaveToAbsolutePath && (newFileNameInfo.isAbsolute()))


### PR DESCRIPTION
### Description

Disable "dangerous" scripting API usage by default. It can be enable with --unsafe.

This mitigates CVE-2023-28371 from both file association (opening a .ssc file from a GUI) and commandline usage.

This could break some commandline usage. The --unsafe flag must be added.

### Screenshots (if appropriate):

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Tested by triggering some unsafe scripting API with and without the flag.

**Test Configuration**:
* Operating system: Debian testing
* Graphics Card: not relevant

## Checklist:

WIP

- [X] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (header file)
- [X] I have updated the respective chapter in the Stellarium User Guide
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
