### PR TITLE
Fix: bottom bar fontsize adaptations

### DIFF
--- a/src/gui/SkyGui.cpp
+++ b/src/gui/SkyGui.cpp
@@ -251,6 +251,9 @@ void SkyGui::init(StelGui* astelGui)
 	updateBarsPos();
 	connect(&StelApp::getInstance(), SIGNAL(colorSchemeChanged(const QString&)), this, SLOT(setStelStyle(const QString&)));
 	connect(bottomBar, SIGNAL(sizeChanged()), this, SLOT(updateBarsPos()));
+	// The first draw of path may show overshooting date line if there are too few buttons in the bottom bar.
+	// Correct this by a redraw 1/2s after startup
+	QTimer::singleShot(500, this, [=](){buttonBarsPath->updatePath(bottomBar, leftBar);});
 }
 
 void SkyGui::resizeEvent(QGraphicsSceneResizeEvent* event)

--- a/src/gui/SkyGui.cpp
+++ b/src/gui/SkyGui.cpp
@@ -176,20 +176,20 @@ const QString InfoPanel::getSelectedText(void) const
 
 SkyGui::SkyGui(QGraphicsItem * parent)
 	: QGraphicsWidget(parent)
-	, lastButtonbarWidth(0)
+	, lastBottomBarWidth(0)
 	, btHorizAutoHide(Q_NULLPTR)
 	, btVertAutoHide(Q_NULLPTR)
 	, autoHidebts(Q_NULLPTR)
-	, autoHideHorizontalButtonBar(true)
-	, autoHideVerticalButtonBar(true)
+	, autoHideBottomBar(true)
+	, autoHideLeftBar(true)
 	, stelGui(Q_NULLPTR)
 {
 	setObjectName("StelSkyGui");
 
 	// Construct the Windows buttons bar
-	winBar = new LeftStelBar(this);
+	leftBar = new LeftStelBar(this);
 	// Construct the bottom buttons bar
-	buttonBar = new BottomStelBar(this,
+	bottomBar = new BottomStelBar(this,
 				      QPixmap(":/graphicGui/btbgLeft.png"),
 				      QPixmap(":/graphicGui/btbgRight.png"),
 				      QPixmap(":/graphicGui/btbgMiddle.png"),
@@ -202,7 +202,7 @@ SkyGui::SkyGui(QGraphicsItem * parent)
 	connect(&StelApp::getInstance(), SIGNAL(progressBarRemoved(const StelProgressController*)), progressBarMgr, SLOT(removeProgressBar(const StelProgressController*)));
 
 	// The path drawn around the button bars
-	buttonBarPath = new StelBarsPath(this);
+	buttonBarsPath = new StelBarsPath(this);
 
 	animLeftBarTimeLine = new QTimeLine(200, this);
 	animLeftBarTimeLine->setEasingCurve(QEasingCurve(QEasingCurve::InOutSine));
@@ -235,22 +235,22 @@ void SkyGui::init(StelGui* astelGui)
 	infoPanel->setPos(8,8);
 
 	// If auto hide is off, show the relevant toolbars
-	if (!autoHideHorizontalButtonBar)
+	if (!autoHideBottomBar)
 	{
 		animBottomBarTimeLine->setDirection(QTimeLine::Forward);
 		animBottomBarTimeLine->start();
 	}
 
-	if (!autoHideVerticalButtonBar)
+	if (!autoHideLeftBar)
 	{
 		animLeftBarTimeLine->setDirection(QTimeLine::Forward);
 		animLeftBarTimeLine->start();
 	}
 
-	buttonBarPath->setZValue(-0.1);
+	buttonBarsPath->setZValue(-0.1);
 	updateBarsPos();
 	connect(&StelApp::getInstance(), SIGNAL(colorSchemeChanged(const QString&)), this, SLOT(setStelStyle(const QString&)));
-	connect(buttonBar, SIGNAL(sizeChanged()), this, SLOT(updateBarsPos()));
+	connect(bottomBar, SIGNAL(sizeChanged()), this, SLOT(updateBarsPos()));
 }
 
 void SkyGui::resizeEvent(QGraphicsSceneResizeEvent* event)
@@ -263,31 +263,31 @@ void SkyGui::hoverMoveEvent(QGraphicsSceneHoverEvent* event)
 {
 	const int hh = getSkyGuiHeight();
 
-	double x = event->pos().x();
-	double y = event->pos().y();
-	double maxX = winBar->boundingRect().width()+2.*buttonBarPath->getRoundSize();
-	double maxY = hh-(winBar->boundingRect().height()+buttonBar->boundingRect().height()+2.*buttonBarPath->getRoundSize());
-	double minX = 0;
+	const double x = event->pos().x();
+	const double y = event->pos().y();
+	double maxX = leftBar->boundingRect().width()+2.*buttonBarsPath->getRoundSize();
+	double maxY = hh-(leftBar->boundingRect().height()+bottomBar->boundingRect().height()+2.*buttonBarsPath->getRoundSize());
+	const double minX = 0;
 
-	if (x<=maxX && y>=maxY && animLeftBarTimeLine->state()==QTimeLine::NotRunning && winBar->pos().x()<minX)
+	if (x<=maxX && y>=maxY && animLeftBarTimeLine->state()==QTimeLine::NotRunning && leftBar->pos().x()<minX)
 	{
 		animLeftBarTimeLine->setDirection(QTimeLine::Forward);
 		animLeftBarTimeLine->start();
 	}
-	if (autoHideVerticalButtonBar && (x>maxX+30 || y<maxY-30) && animLeftBarTimeLine->state()==QTimeLine::NotRunning && winBar->pos().x()>=minX)
+	if (autoHideLeftBar && (x>maxX+30 || y<maxY-30) && animLeftBarTimeLine->state()==QTimeLine::NotRunning && leftBar->pos().x()>=minX)
 	{
 		animLeftBarTimeLine->setDirection(QTimeLine::Backward);
 		animLeftBarTimeLine->start();
 	}
 
-	maxX = winBar->boundingRect().width()+buttonBar->boundingRect().width()+2.*buttonBarPath->getRoundSize();
-	maxY = hh-buttonBar->boundingRect().height()+2.*buttonBarPath->getRoundSize();
+	maxX = leftBar->boundingRect().width()+bottomBar->boundingRect().width()+2.*buttonBarsPath->getRoundSize();
+	maxY = hh-bottomBar->boundingRect().height()+2.*buttonBarsPath->getRoundSize();
 	if (x<=maxX && y>=maxY && animBottomBarTimeLine->state()==QTimeLine::NotRunning && animBottomBarTimeLine->currentValue()<1.)
 	{
 		animBottomBarTimeLine->setDirection(QTimeLine::Forward);
 		animBottomBarTimeLine->start();
 	}
-	if (autoHideHorizontalButtonBar && (x>maxX+30 || y<maxY-30) && animBottomBarTimeLine->state()==QTimeLine::NotRunning && animBottomBarTimeLine->currentValue()>=0.9999999)
+	if (autoHideBottomBar && (x>maxX+30 || y<maxY-30) && animBottomBarTimeLine->state()==QTimeLine::NotRunning && animBottomBarTimeLine->currentValue()>=0.9999999)
 	{
 		animBottomBarTimeLine->setDirection(QTimeLine::Backward);
 		animBottomBarTimeLine->start();
@@ -315,12 +315,12 @@ int SkyGui::getSkyGuiHeight() const
 
 qreal SkyGui::getBottomBarHeight() const
 {
-	return buttonBar->boundingRect().height();
+	return bottomBar->boundingRect().height();
 }
 
 qreal SkyGui::getLeftBarWidth() const
 {
-	return winBar->boundingRect().width();
+	return leftBar->boundingRect().width();
 }
 
 //! Update the position of the button bars in the main window
@@ -331,32 +331,32 @@ void SkyGui::updateBarsPos()
 	bool updatePath = false;
 
 	// Use a position cache to avoid useless redraw triggered by the position set if the bars don't move
-	double rangeX = winBar->boundingRectNoHelpLabel().width()+2.*buttonBarPath->getRoundSize()+1.;
-	const qreal newWinBarX = buttonBarPath->getRoundSize()-(1.-animLeftBarTimeLine->currentValue())*rangeX-0.5;
-	const qreal newWinBarY = hh-winBar->boundingRectNoHelpLabel().height()-buttonBar->boundingRectNoHelpLabel().height()-20;
-	if (!qFuzzyCompare(winBar->pos().x(), newWinBarX) || !qFuzzyCompare(winBar->pos().y(), newWinBarY))
+	double rangeX = leftBar->boundingRectNoHelpLabel().width()+2.*buttonBarsPath->getRoundSize()+1.;
+	const qreal newLeftBarX = buttonBarsPath->getRoundSize()-(1.-animLeftBarTimeLine->currentValue())*rangeX-0.5;
+	const qreal newLeftBarY = hh-leftBar->boundingRectNoHelpLabel().height()-bottomBar->boundingRectNoHelpLabel().height()-20;
+	if (!qFuzzyCompare(leftBar->pos().x(), newLeftBarX) || !qFuzzyCompare(leftBar->pos().y(), newLeftBarY))
 	{
-		winBar->setPos(qRound(newWinBarX), qRound(newWinBarY));
+		leftBar->setPos(qRound(newLeftBarX), qRound(newLeftBarY));
 		updatePath = true;
 	}
 
-	double rangeY = buttonBar->boundingRectNoHelpLabel().height()+0.5-7.-buttonBarPath->getRoundSize();
-	const qreal newButtonBarX = winBar->boundingRectNoHelpLabel().right()+buttonBarPath->getRoundSize();
-	const qreal newButtonBarY = hh-buttonBar->boundingRectNoHelpLabel().height()-buttonBarPath->getRoundSize()+0.5+(1.-animBottomBarTimeLine->currentValue())*rangeY;
-	if (!qFuzzyCompare(buttonBar->pos().x(), newButtonBarX) || !qFuzzyCompare(buttonBar->pos().y(), newButtonBarY))
+	double rangeY = bottomBar->boundingRectNoHelpLabel().height()+0.5-7.-buttonBarsPath->getRoundSize();
+	const qreal newBottomBarX = leftBar->boundingRectNoHelpLabel().right()+buttonBarsPath->getRoundSize();
+	const qreal newBottomBarY = hh-bottomBar->boundingRectNoHelpLabel().height()-buttonBarsPath->getRoundSize()+0.5+(1.-animBottomBarTimeLine->currentValue())*rangeY;
+	if (!qFuzzyCompare(bottomBar->pos().x(), newBottomBarX) || !qFuzzyCompare(bottomBar->pos().y(), newBottomBarY))
 	{
-		buttonBar->setPos(qRound(newButtonBarX), qRound(newButtonBarY));
+		bottomBar->setPos(qRound(newBottomBarX), qRound(newBottomBarY));
 		updatePath = true;
 	}
 
-	if (lastButtonbarWidth != static_cast<int>(buttonBar->boundingRectNoHelpLabel().width()))
+	if (lastBottomBarWidth != static_cast<int>(bottomBar->boundingRectNoHelpLabel().width()))
 	{
+		lastBottomBarWidth = static_cast<int>(bottomBar->boundingRectNoHelpLabel().width());
 		updatePath = true;
-		lastButtonbarWidth = static_cast<int>(buttonBar->boundingRectNoHelpLabel().width());
 	}
 
 	if (updatePath)
-		buttonBarPath->updatePath(buttonBar, winBar);
+		buttonBarsPath->updatePath(bottomBar, leftBar);
 
 	const qreal newProgressBarX = ww-progressBarMgr->boundingRect().width()-20;
 	const qreal newProgressBarY = hh-progressBarMgr->boundingRect().height()+7;	
@@ -375,10 +375,10 @@ void SkyGui::updateBarsPos()
 void SkyGui::setStelStyle(const QString& style)
 {
 	Q_UNUSED(style)
-	buttonBarPath->setPen(QColor::fromRgbF(0.7,0.7,0.7,0.5));
-	buttonBarPath->setBrush(QColor::fromRgbF(0.15, 0.16, 0.19, 0.2));
-	buttonBar->setColor(QColor::fromRgbF(0.9, 0.91, 0.95, 0.9));
-	winBar->setColor(QColor::fromRgbF(0.9, 0.91, 0.95, 0.9));
+	buttonBarsPath->setPen(QColor::fromRgbF(0.7,0.7,0.7,0.5));
+	buttonBarsPath->setBrush(QColor::fromRgbF(0.15, 0.16, 0.19, 0.2));
+	bottomBar->setColor(QColor::fromRgbF(0.9, 0.91, 0.95, 0.9));
+	leftBar->setColor(QColor::fromRgbF(0.9, 0.91, 0.95, 0.9));
 }
 
 // Add a new progress bar in the lower right corner of the screen.

--- a/src/gui/SkyGui.cpp
+++ b/src/gui/SkyGui.cpp
@@ -251,9 +251,6 @@ void SkyGui::init(StelGui* astelGui)
 	updateBarsPos();
 	connect(&StelApp::getInstance(), SIGNAL(colorSchemeChanged(const QString&)), this, SLOT(setStelStyle(const QString&)));
 	connect(bottomBar, SIGNAL(sizeChanged()), this, SLOT(updateBarsPos()));
-	// The first draw of path may show overshooting date line if there are too few buttons in the bottom bar.
-	// Correct this by a redraw 1/2s after startup
-	QTimer::singleShot(500, this, [=](){buttonBarsPath->updatePath(bottomBar, leftBar);});
 }
 
 void SkyGui::resizeEvent(QGraphicsSceneResizeEvent* event)

--- a/src/gui/SkyGui.cpp
+++ b/src/gui/SkyGui.cpp
@@ -34,7 +34,7 @@
 #include <QRegularExpression>
 
 InfoPanel::InfoPanel(QGraphicsItem* parent) : QGraphicsTextItem("", parent),
-	infoPixmap(Q_NULLPTR)
+	infoPixmap(nullptr)
 {
 	QSettings* conf = StelApp::getInstance().getSettings();
 	Q_ASSERT(conf);
@@ -70,7 +70,7 @@ InfoPanel::~InfoPanel()
 	if (infoPixmap)
 	{
 		delete infoPixmap;
-		infoPixmap=Q_NULLPTR;
+		infoPixmap=nullptr;
 	}
 }
 
@@ -177,12 +177,12 @@ const QString InfoPanel::getSelectedText(void) const
 SkyGui::SkyGui(QGraphicsItem * parent)
 	: QGraphicsWidget(parent)
 	, lastBottomBarWidth(0)
-	, btHorizAutoHide(Q_NULLPTR)
-	, btVertAutoHide(Q_NULLPTR)
-	, autoHidebts(Q_NULLPTR)
+	, btHorizAutoHide(nullptr)
+	, btVertAutoHide(nullptr)
+	, autoHidebts(nullptr)
 	, autoHideBottomBar(true)
 	, autoHideLeftBar(true)
-	, stelGui(Q_NULLPTR)
+	, stelGui(nullptr)
 {
 	setObjectName("StelSkyGui");
 

--- a/src/gui/SkyGui.cpp
+++ b/src/gui/SkyGui.cpp
@@ -326,12 +326,12 @@ qreal SkyGui::getLeftBarWidth() const
 //! Update the position of the button bars in the main window
 void SkyGui::updateBarsPos()
 {
-	const int ww = getSkyGuiWidth();
-	const int hh = getSkyGuiHeight();
+	const int ww = getSkyGuiWidth();  // actually: window width
+	const int hh = getSkyGuiHeight(); // actually: window height
 	bool updatePath = false;
 
 	// Use a position cache to avoid useless redraw triggered by the position set if the bars don't move
-	double rangeX = leftBar->boundingRectNoHelpLabel().width()+2.*buttonBarsPath->getRoundSize()+1.;
+	const double rangeX = leftBar->boundingRectNoHelpLabel().width()+2.*buttonBarsPath->getRoundSize()+1.;
 	const qreal newLeftBarX = buttonBarsPath->getRoundSize()-(1.-animLeftBarTimeLine->currentValue())*rangeX-0.5;
 	const qreal newLeftBarY = hh-leftBar->boundingRectNoHelpLabel().height()-bottomBar->boundingRectNoHelpLabel().height()-20;
 	if (!qFuzzyCompare(leftBar->pos().x(), newLeftBarX) || !qFuzzyCompare(leftBar->pos().y(), newLeftBarY))
@@ -340,12 +340,14 @@ void SkyGui::updateBarsPos()
 		updatePath = true;
 	}
 
-	double rangeY = bottomBar->boundingRectNoHelpLabel().height()+0.5-7.-buttonBarsPath->getRoundSize();
+	const double rangeY = bottomBar->getButtonsBoundingRect().height()+1.5+bottomBar->getGap();
 	const qreal newBottomBarX = leftBar->boundingRectNoHelpLabel().right()+buttonBarsPath->getRoundSize();
-	const qreal newBottomBarY = hh-bottomBar->boundingRectNoHelpLabel().height()-buttonBarsPath->getRoundSize()+0.5+(1.-animBottomBarTimeLine->currentValue())*rangeY;
+	const qreal newBottomBarY = hh-bottomBar->boundingRectNoHelpLabel().height()+bottomBar->getGap()-buttonBarsPath->getRoundSize()+0.5+(1.-animBottomBarTimeLine->currentValue())*rangeY;
+
 	if (!qFuzzyCompare(bottomBar->pos().x(), newBottomBarX) || !qFuzzyCompare(bottomBar->pos().y(), newBottomBarY))
 	{
-		bottomBar->setPos(qRound(newBottomBarX), qRound(newBottomBarY));
+		//bottomBar->setPos(qRound(newBottomBarX), qRound(newBottomBarY)); // GZ: why qRound???
+		bottomBar->setPos(newBottomBarX, newBottomBarY);
 		updatePath = true;
 	}
 
@@ -366,7 +368,7 @@ void SkyGui::updateBarsPos()
 	// Update position of the auto-hide buttons
 	autoHidebts->setPos(0, hh-autoHidebts->childrenBoundingRect().height()+1);
 	double opacity = qMax(animLeftBarTimeLine->currentValue(), animBottomBarTimeLine->currentValue());
-	autoHidebts->setOpacity(opacity < 0.01 ? 0.01 : opacity);	// Work around a qt bug
+	autoHidebts->setOpacity(qMax(0.01, opacity));	// Work around a qt bug
 
 	// Update the screen as soon as possible.
 	StelMainView::getInstance().thereWasAnEvent();
@@ -384,7 +386,7 @@ void SkyGui::setStelStyle(const QString& style)
 // Add a new progress bar in the lower right corner of the screen.
 void SkyGui::addProgressBar(StelProgressController* p)
 {
-	return progressBarMgr->addProgressBar(p);
+	progressBarMgr->addProgressBar(p);
 }
 
 void SkyGui::paint(QPainter*, const QStyleOptionGraphicsItem*, QWidget*)

--- a/src/gui/SkyGui.cpp
+++ b/src/gui/SkyGui.cpp
@@ -346,8 +346,7 @@ void SkyGui::updateBarsPos()
 
 	if (!qFuzzyCompare(bottomBar->pos().x(), newBottomBarX) || !qFuzzyCompare(bottomBar->pos().y(), newBottomBarY))
 	{
-		//bottomBar->setPos(qRound(newBottomBarX), qRound(newBottomBarY)); // GZ: why qRound???
-		bottomBar->setPos(newBottomBarX, newBottomBarY);
+		bottomBar->setPos(qRound(newBottomBarX), qRound(newBottomBarY));
 		updatePath = true;
 	}
 

--- a/src/gui/SkyGui.hpp
+++ b/src/gui/SkyGui.hpp
@@ -20,7 +20,6 @@
 #ifndef SKYGUI_HPP
 #define SKYGUI_HPP
 
-#include "StelStyle.hpp"
 #include "StelObject.hpp"
 
 #include <QDebug>
@@ -62,17 +61,20 @@ public:
 	SkyGui(QGraphicsItem * parent=Q_NULLPTR);
 	//! Add a new progress bar in the lower right corner of the screen.
 	//! When the progress bar is deleted with removeProgressBar() the layout is automatically rearranged.
-	//! @return a pointer to the progress bar
 	void addProgressBar(StelProgressController*);
 	
 	void init(class StelGui* stelGui);
 	
 	virtual void paint(QPainter*, const QStyleOptionGraphicsItem*, QWidget* = Q_NULLPTR) Q_DECL_OVERRIDE;
 
+	//! actually returns window width
 	int getSkyGuiWidth() const;
+	//! actually returns window height
 	int getSkyGuiHeight() const;
-	qreal getBottomBarHeight() const; //!< return height of bottom Bar when fully shown
-	qreal getLeftBarWidth() const;    //!< return width of left Bar when fully shown
+	//! return height of bottom Bar when fully shown
+	qreal getBottomBarHeight() const;
+	//! return width of left Bar when fully shown
+	qreal getLeftBarWidth() const;
 	
 protected:
 	virtual void resizeEvent(QGraphicsSceneResizeEvent* event) Q_DECL_OVERRIDE;

--- a/src/gui/SkyGui.hpp
+++ b/src/gui/SkyGui.hpp
@@ -39,7 +39,7 @@ class InfoPanel : public QGraphicsTextItem
 	public:
 		//! Reads "gui/selected_object_info", etc from the configuration file.
 		InfoPanel(QGraphicsItem* parent);
-		~InfoPanel() Q_DECL_OVERRIDE;
+		~InfoPanel() override;
 		void setInfoTextFilters(const StelObject::InfoStringGroup& aflags) {infoTextFilters=aflags;}
 		const StelObject::InfoStringGroup& getInfoTextFilters(void) const {return infoTextFilters;}
 		void setTextFromObjects(const QList<StelObjectP>&);
@@ -58,14 +58,14 @@ class SkyGui: public QGraphicsWidget
 public:
 	friend class StelGui;
 	
-	SkyGui(QGraphicsItem * parent=Q_NULLPTR);
+	SkyGui(QGraphicsItem * parent=nullptr);
 	//! Add a new progress bar in the lower right corner of the screen.
 	//! When the progress bar is deleted with removeProgressBar() the layout is automatically rearranged.
 	void addProgressBar(StelProgressController*);
 	
 	void init(class StelGui* stelGui);
 	
-	virtual void paint(QPainter*, const QStyleOptionGraphicsItem*, QWidget* = Q_NULLPTR) Q_DECL_OVERRIDE;
+	void paint(QPainter*, const QStyleOptionGraphicsItem*, QWidget* = nullptr) override;
 
 	//! actually returns window width
 	int getSkyGuiWidth() const;
@@ -77,9 +77,9 @@ public:
 	qreal getLeftBarWidth() const;
 	
 protected:
-	virtual void resizeEvent(QGraphicsSceneResizeEvent* event) Q_DECL_OVERRIDE;
-	virtual void hoverMoveEvent(QGraphicsSceneHoverEvent* event) Q_DECL_OVERRIDE;
-	virtual QVariant itemChange(GraphicsItemChange change, const QVariant & value) Q_DECL_OVERRIDE;
+	void resizeEvent(QGraphicsSceneResizeEvent* event) override;
+	void hoverMoveEvent(QGraphicsSceneHoverEvent* event) override;
+	QVariant itemChange(GraphicsItemChange change, const QVariant & value) override;
 
 private slots:
 	//! Load color scheme from the given ini file and section name

--- a/src/gui/SkyGui.hpp
+++ b/src/gui/SkyGui.hpp
@@ -39,7 +39,6 @@ class InfoPanel : public QGraphicsTextItem
 {
 	public:
 		//! Reads "gui/selected_object_info", etc from the configuration file.
-		//! @todo Bad idea to read from the configuration file in a constructor? --BM
 		InfoPanel(QGraphicsItem* parent);
 		~InfoPanel() Q_DECL_OVERRIDE;
 		void setInfoTextFilters(const StelObject::InfoStringGroup& aflags) {infoTextFilters=aflags;}
@@ -90,12 +89,12 @@ public slots:
 	void updateBarsPos();
 
 private:
-	class StelBarsPath* buttonBarPath;
+	class StelBarsPath* buttonBarsPath;
 	QTimeLine* animLeftBarTimeLine;
 	QTimeLine* animBottomBarTimeLine;
-	int lastButtonbarWidth;
-	class LeftStelBar* winBar;
-	BottomStelBar* buttonBar;
+	int lastBottomBarWidth;
+	class LeftStelBar* leftBar;
+	BottomStelBar* bottomBar;
 	class InfoPanel* infoPanel;
 	class StelProgressBarMgr* progressBarMgr;
 
@@ -105,8 +104,8 @@ private:
 
 	class CornerButtons* autoHidebts;
 
-	bool autoHideHorizontalButtonBar;
-	bool autoHideVerticalButtonBar;
+	bool autoHideBottomBar;
+	bool autoHideLeftBar;
 	
 	StelGui* stelGui;
 };

--- a/src/gui/StelGui.cpp
+++ b/src/gui/StelGui.cpp
@@ -316,43 +316,43 @@ void StelGui::init(QGraphicsWidget *atopLevelGraphicsWidget)
 	pxmapOn = QPixmap(":/graphicGui/btGotoSelectedObject-on.png");
 	pxmapOff = QPixmap(":/graphicGui/btGotoSelectedObject-off.png");
 	buttonGotoSelectedObject = new StelButton(nullptr, pxmapOn, pxmapOff, pxmapGlow32x32, "actionGoto_Selected_Object");
-	skyGui->buttonBar->addButton(buttonGotoSelectedObject, "060-othersGroup");
+	skyGui->bottomBar->addButton(buttonGotoSelectedObject, "060-othersGroup");
 
 	pxmapOn = QPixmap(":/graphicGui/btNightView-on.png");
 	pxmapOff = QPixmap(":/graphicGui/btNightView-off.png");
 	buttonNightmode = new StelButton(nullptr, pxmapOn, pxmapOff, pxmapGlow32x32, "actionShow_Night_Mode");
-	skyGui->buttonBar->addButton(buttonNightmode, "060-othersGroup");
+	skyGui->bottomBar->addButton(buttonNightmode, "060-othersGroup");
 
 	pxmapOn = QPixmap(":/graphicGui/btFullScreen-on.png");
 	pxmapOff = QPixmap(":/graphicGui/btFullScreen-off.png");
 	buttonFullscreen = new StelButton(nullptr, pxmapOn, pxmapOff, pxmapGlow32x32, "actionSet_Full_Screen_Global");
 	buttonFullscreen->setTriggerOnRelease(true);
-	skyGui->buttonBar->addButton(buttonFullscreen, "060-othersGroup");
+	skyGui->bottomBar->addButton(buttonFullscreen, "060-othersGroup");
 
 	pxmapOn = QPixmap(":/graphicGui/btTimeRewind-on.png");
 	pxmapOff = QPixmap(":/graphicGui/btTimeRewind-off.png");
 	buttonTimeRewind = new StelButton(nullptr, pxmapOn, pxmapOff, pxmapGlow32x32, "actionDecrease_Time_Speed");
-	skyGui->buttonBar->addButton(buttonTimeRewind, "070-timeGroup");
+	skyGui->bottomBar->addButton(buttonTimeRewind, "070-timeGroup");
 
 	pxmapOn = QPixmap(":/graphicGui/btTimeRealtime-on.png");
 	pxmapOff = QPixmap(":/graphicGui/btTimeRealtime-off.png");
 	pxmapDefault = QPixmap(":/graphicGui/btTimePause-on.png");
 	buttonTimeRealTimeSpeed = new StelButton(nullptr, pxmapOn, pxmapOff, pxmapDefault, pxmapGlow32x32, "actionSet_Real_Time_Speed");
-	skyGui->buttonBar->addButton(buttonTimeRealTimeSpeed, "070-timeGroup");
+	skyGui->bottomBar->addButton(buttonTimeRealTimeSpeed, "070-timeGroup");
 
 	pxmapOn = QPixmap(":/graphicGui/btTimeNow-on.png");
 	pxmapOff = QPixmap(":/graphicGui/btTimeNow-off.png");
 	buttonTimeCurrent = new StelButton(nullptr, pxmapOn, pxmapOff, pxmapGlow32x32, "actionReturn_To_Current_Time");
-	skyGui->buttonBar->addButton(buttonTimeCurrent, "070-timeGroup");
+	skyGui->bottomBar->addButton(buttonTimeCurrent, "070-timeGroup");
 
 	pxmapOn = QPixmap(":/graphicGui/btTimeForward-on.png");
 	pxmapOff = QPixmap(":/graphicGui/btTimeForward-off.png");
 	buttonTimeForward = new StelButton(nullptr, pxmapOn, pxmapOff, pxmapGlow32x32, "actionIncrease_Time_Speed");
-	skyGui->buttonBar->addButton(buttonTimeForward, "070-timeGroup");
+	skyGui->bottomBar->addButton(buttonTimeForward, "070-timeGroup");
 
 	pxmapOn = QPixmap(":/graphicGui/btQuit.png");	
 	buttonQuit = new StelButton(nullptr, pxmapOn, pxmapOn, pxmapGlow32x32, "actionQuit_Global");
-	skyGui->buttonBar->addButton(buttonQuit, "080-quitGroup");
+	skyGui->bottomBar->addButton(buttonQuit, "080-quitGroup");
 
 	// add the flip and other buttons if requested in the config
 	setFlagShowFlipButtons(conf->value("gui/flag_show_flip_buttons", false).toBool());
@@ -387,12 +387,12 @@ void StelGui::init(QGraphicsWidget *atopLevelGraphicsWidget)
 	setStelStyle(StelApp::getInstance().getCurrentStelStyle());
 
 	int margin = conf->value("gui/space_between_groups", 5).toInt();
-	skyGui->buttonBar->setGroupMargin("020-gridsGroup", margin, 0);
-	skyGui->buttonBar->setGroupMargin("030-landscapeGroup", margin, 0);
-	skyGui->buttonBar->setGroupMargin("040-nebulaeGroup", margin, 0);
-	skyGui->buttonBar->setGroupMargin("060-othersGroup", margin, margin);
-	skyGui->buttonBar->setGroupMargin("070-timeGroup", margin, 0);
-	skyGui->buttonBar->setGroupMargin("080-quitGroup", margin, 0);
+	skyGui->bottomBar->setGroupMargin("020-gridsGroup", margin, 0);
+	skyGui->bottomBar->setGroupMargin("030-landscapeGroup", margin, 0);
+	skyGui->bottomBar->setGroupMargin("040-nebulaeGroup", margin, 0);
+	skyGui->bottomBar->setGroupMargin("060-othersGroup", margin, margin);
+	skyGui->bottomBar->setGroupMargin("070-timeGroup", margin, 0);
+	skyGui->bottomBar->setGroupMargin("080-quitGroup", margin, 0);
 
 	skyGui->setGeometry(atopLevelGraphicsWidget->geometry());
 	skyGui->updateBarsPos();
@@ -422,7 +422,7 @@ void StelGui::addButtonOnBottomBar(QString buttonName, QString actionName, QStri
 	QPixmap pxmapOn = QPixmap(QString(":/graphicGui/%1-on.png").arg(buttonName));
 	QPixmap pxmapOff = QPixmap(QString(":/graphicGui/%1-off.png").arg(buttonName));
 	StelButton* b = new StelButton(nullptr, pxmapOn, pxmapOff, pxmapGlow, actionName);
-	skyGui->buttonBar->addButton(b, groupName);
+	skyGui->bottomBar->addButton(b, groupName);
 }
 
 void StelGui::addButtonOnLeftBar(QString buttonName, QString actionName)
@@ -431,7 +431,7 @@ void StelGui::addButtonOnLeftBar(QString buttonName, QString actionName)
 	QPixmap pxmapOn = QPixmap(QString(":/graphicGui/%1-on.png").arg(buttonName));
 	QPixmap pxmapOff = QPixmap(QString(":/graphicGui/%1-off.png").arg(buttonName));
 	StelButton* b = new StelButton(nullptr, pxmapOn, pxmapOff, pxmapGlow, actionName);
-	skyGui->winBar->addButton(b);
+	skyGui->leftBar->addButton(b);
 }
 
 void StelGui::quit()
@@ -1279,7 +1279,7 @@ bool StelGui::getVisible() const
 
 bool StelGui::isCurrentlyUsed() const
 {
-	return skyGui->buttonBar->isUnderMouse() || skyGui->winBar->isUnderMouse();
+	return skyGui->bottomBar->isUnderMouse() || skyGui->leftBar->isUnderMouse();
 }
 
 void StelGui::setInfoTextFilters(const StelObject::InfoStringGroup& aflags)
@@ -1294,12 +1294,12 @@ const StelObject::InfoStringGroup& StelGui::getInfoTextFilters() const
 
 BottomStelBar* StelGui::getButtonBar() const
 {
-	return skyGui->buttonBar;
+	return skyGui->bottomBar;
 }
 
 LeftStelBar* StelGui::getWindowsButtonBar() const
 {
-	return skyGui->winBar;
+	return skyGui->leftBar;
 }
 
 SkyGui* StelGui::getSkyGui() const
@@ -1309,28 +1309,28 @@ SkyGui* StelGui::getSkyGui() const
 
 bool StelGui::getAutoHideHorizontalButtonBar() const
 {
-	return skyGui->autoHideHorizontalButtonBar;
+	return skyGui->autoHideBottomBar;
 }
 
 void StelGui::setAutoHideHorizontalButtonBar(bool b)
 {
-	if (skyGui->autoHideHorizontalButtonBar!=b)
+	if (skyGui->autoHideBottomBar!=b)
 	{
-		skyGui->autoHideHorizontalButtonBar=b;
+		skyGui->autoHideBottomBar=b;
 		emit autoHideHorizontalButtonBarChanged(b);
 	}
 }
 
 bool StelGui::getAutoHideVerticalButtonBar() const
 {
-	return skyGui->autoHideVerticalButtonBar;
+	return skyGui->autoHideLeftBar;
 }
 
 void StelGui::setAutoHideVerticalButtonBar(bool b)
 {
-	if (skyGui->autoHideVerticalButtonBar!=b)
+	if (skyGui->autoHideLeftBar!=b)
 	{
-		skyGui->autoHideVerticalButtonBar=b;
+		skyGui->autoHideLeftBar=b;
 		emit autoHideVerticalButtonBarChanged(b);
 	}
 }

--- a/src/gui/StelGuiItems.cpp
+++ b/src/gui/StelGuiItems.cpp
@@ -384,6 +384,7 @@ LeftStelBar::~LeftStelBar()
 
 void LeftStelBar::addButton(StelButton* button)
 {
+	prepareGeometryChange();
 	double posY = 0;
 	if (QGraphicsItem::childItems().size()!=0)
 	{
@@ -392,7 +393,7 @@ void LeftStelBar::addButton(StelButton* button)
 	}
 	button->setParentItem(this);
 	button->setFocusOnSky(false);
-	button->prepareGeometryChange(); // could possibly be removed when qt 4.6 become stable
+	//button->prepareGeometryChange(); // could possibly be removed when qt 4.6 become stable
 	button->setPos(0., qRound(posY+10.5));
 
 	connect(button, SIGNAL(hoverChanged(bool)), this, SLOT(buttonHoverChanged(bool)));
@@ -557,6 +558,7 @@ BottomStelBar::BottomStelBar(QGraphicsItem* parent,
 //! connect from StelApp to resize fonts on the fly.
 void BottomStelBar::setFontSizeFromApp(int size)
 {
+	prepareGeometryChange();
 	QFont font=QGuiApplication::font();
 	// Font size was developed based on base font size 13, i.e. 12
 	font.setPixelSize(size-1);
@@ -628,6 +630,7 @@ BottomStelBar::~BottomStelBar()
 
 void BottomStelBar::addButton(StelButton* button, const QString& groupName, const QString& beforeActionName)
 {
+	prepareGeometryChange();
 	QList<StelButton*>& g = buttonGroups[groupName].elems;
 	bool done = false;
 	for (int i=0; i<g.size(); ++i)
@@ -1264,7 +1267,7 @@ QRectF CornerButtons::boundingRect() const
 	if (QGraphicsItem::childItems().size()==0)
 		return QRectF();
 	const QRectF& r = childrenBoundingRect();
-	return QRectF(0, 0, r.width()-1, r.height()-1);
+	return QRectF(0, 0, r.width(), r.height());
 }
 
 void CornerButtons::setOpacity(double opacity)

--- a/src/gui/StelGuiItems.cpp
+++ b/src/gui/StelGuiItems.cpp
@@ -135,7 +135,7 @@ void StelButton::initCtor(const QPixmap& apixOn,
 	StelGui* gui = dynamic_cast<StelGui*>(StelApp::getInstance().getGui());
 	connect(gui, SIGNAL(flagUseButtonsBackgroundChanged(bool)), this, SLOT(updateIcon()));
 
-	if (action!=Q_NULLPTR)
+	if (action!=nullptr)
 	{
 		if (action->isCheckable())
 		{
@@ -148,7 +148,7 @@ void StelButton::initCtor(const QPixmap& apixOn,
 			QObject::connect(this, SIGNAL(triggered()), action, SLOT(trigger()));
 		}
 	}
-	if (secondAction!=Q_NULLPTR)
+	if (secondAction!=nullptr)
 	{
 			QObject::connect(this, SIGNAL(triggeredRight()), secondAction, SLOT(trigger()));
 	}
@@ -180,7 +180,7 @@ StelButton::StelButton(QGraphicsItem* parent,
 	: QGraphicsPixmapItem(pixOff, parent)
 {
 	StelAction *action = StelApp::getInstance().getStelActionManager()->findAction(actionId);
-	initCtor(pixOn, pixOff, pixNoChange, pixHover, action, Q_NULLPTR, noBackground, isTristate);
+	initCtor(pixOn, pixOff, pixNoChange, pixHover, action, nullptr, noBackground, isTristate);
 }
 
 StelButton::StelButton(QGraphicsItem* parent,
@@ -193,7 +193,7 @@ StelButton::StelButton(QGraphicsItem* parent,
 	: QGraphicsPixmapItem(pixOff, parent)
 {
 	StelAction *action = StelApp::getInstance().getStelActionManager()->findAction(actionId);
-	StelAction *otherAction=Q_NULLPTR;
+	StelAction *otherAction=nullptr;
 	if (!otherActionId.isEmpty())
 		otherAction = StelApp::getInstance().getStelActionManager()->findAction(otherActionId);
 
@@ -260,7 +260,7 @@ void StelButton::mouseReleaseEvent(QGraphicsSceneMouseEvent* event)
 {
 	if (event->button()==Qt::LeftButton)
 	{
-		if (action!=Q_NULLPTR && !action->isCheckable())
+		if (action!=nullptr && !action->isCheckable())
 			setChecked(toggleChecked(checked));
 
 		if (flagChangeFocus) // true if button is on bottom bar
@@ -363,8 +363,8 @@ void StelButton::paint(QPainter* painter, const QStyleOptionGraphicsItem*, QWidg
 
 LeftStelBar::LeftStelBar(QGraphicsItem* parent)
 	: QGraphicsItem(parent)
-	, hideTimeLine(Q_NULLPTR)
-	, helpLabelPixmap(Q_NULLPTR)
+	, hideTimeLine(nullptr)
+	, helpLabelPixmap(nullptr)
 {
 	// Create the help label
 	helpLabel = new QGraphicsSimpleTextItem("", this);
@@ -379,7 +379,7 @@ LeftStelBar::LeftStelBar(QGraphicsItem* parent)
 
 LeftStelBar::~LeftStelBar()
 {
-	if (helpLabelPixmap) { delete helpLabelPixmap; helpLabelPixmap=Q_NULLPTR; }
+	if (helpLabelPixmap) { delete helpLabelPixmap; helpLabelPixmap=nullptr; }
 }
 
 void LeftStelBar::addButton(StelButton* button)
@@ -508,16 +508,16 @@ BottomStelBar::BottomStelBar(QGraphicsItem* parent,
                              const QPixmap& pixMiddle,
                              const QPixmap& pixSingle) :
 	QGraphicsItem(parent),
-	locationPixmap(Q_NULLPTR),
-	datetimePixmap(Q_NULLPTR),
-	fovPixmap(Q_NULLPTR),
-	fpsPixmap(Q_NULLPTR),
+	locationPixmap(nullptr),
+	datetimePixmap(nullptr),
+	fovPixmap(nullptr),
+	fpsPixmap(nullptr),
 	gap(2),
 	pixBackgroundLeft(pixLeft),
 	pixBackgroundRight(pixRight),
 	pixBackgroundMiddle(pixMiddle),
 	pixBackgroundSingle(pixSingle),
-	helpLabelPixmap(Q_NULLPTR)
+	helpLabelPixmap(nullptr)
 {
 	// The text is dummy just for testing
 	datetime = new QGraphicsSimpleTextItem("2008-02-06  17:33", this);
@@ -612,18 +612,18 @@ BottomStelBar::~BottomStelBar()
 	{
 		for (auto* b : qAsConst(group.elems))
 		{
-			if (b->parentItem()==Q_NULLPTR)
+			if (b->parentItem()==nullptr)
 			{
 				delete b;
-				b=Q_NULLPTR;
+				b=nullptr;
 			}
 		}
 	}
-	if (datetimePixmap) { delete datetimePixmap; datetimePixmap=Q_NULLPTR; }
-	if (locationPixmap) { delete locationPixmap; locationPixmap=Q_NULLPTR; }
-	if (fovPixmap) { delete fovPixmap; fovPixmap=Q_NULLPTR; }
-	if (fpsPixmap) { delete fpsPixmap; fpsPixmap=Q_NULLPTR; }
-	if (helpLabelPixmap) { delete helpLabelPixmap; helpLabelPixmap=Q_NULLPTR; }
+	if (datetimePixmap) { delete datetimePixmap; datetimePixmap=nullptr; }
+	if (locationPixmap) { delete locationPixmap; locationPixmap=nullptr; }
+	if (fovPixmap) { delete fovPixmap; fovPixmap=nullptr; }
+	if (fpsPixmap) { delete fpsPixmap; fpsPixmap=nullptr; }
+	if (helpLabelPixmap) { delete helpLabelPixmap; helpLabelPixmap=nullptr; }
 }
 
 void BottomStelBar::addButton(StelButton* button, const QString& groupName, const QString& beforeActionName)
@@ -654,7 +654,7 @@ void BottomStelBar::addButton(StelButton* button, const QString& groupName, cons
 StelButton* BottomStelBar::hideButton(const QString& actionName)
 {
 	QString gName;
-	StelButton* bToRemove = Q_NULLPTR;
+	StelButton* bToRemove = nullptr;
 	for (auto iter = buttonGroups.begin(); iter != buttonGroups.end(); ++iter)
 	{
 		int i=0;
@@ -670,15 +670,15 @@ StelButton* BottomStelBar::hideButton(const QString& actionName)
 			++i;
 		}
 	}
-	if (bToRemove == Q_NULLPTR)
-		return Q_NULLPTR;
+	if (bToRemove == nullptr)
+		return nullptr;
 	if (buttonGroups[gName].elems.size() == 0)
 	{
 		buttonGroups.remove(gName);
 	}
 	// Cannot really delete because some part of the GUI depend on the presence of some buttons
 	// so just make invisible
-	bToRemove->setParentItem(Q_NULLPTR);
+	bToRemove->setParentItem(nullptr);
 	bToRemove->setVisible(false);
 	updateButtonsGroups();
 	emit sizeChanged();
@@ -767,14 +767,14 @@ void BottomStelBar::updateButtonsGroups()
 			{
 				if (buttons.size() == 1)
 				{
-					if (group.pixBackgroundSingle == Q_NULLPTR)
+					if (group.pixBackgroundSingle == nullptr)
 						b->setBackgroundPixmap(pixBackgroundSingle);
 					else
 						b->setBackgroundPixmap(*group.pixBackgroundSingle);
 				}
 				else
 				{
-					if (group.pixBackgroundLeft == Q_NULLPTR)
+					if (group.pixBackgroundLeft == nullptr)
 						b->setBackgroundPixmap(pixBackgroundLeft);
 					else
 						b->setBackgroundPixmap(*group.pixBackgroundLeft);
@@ -784,19 +784,19 @@ void BottomStelBar::updateButtonsGroups()
 			{
 				if (buttons.size() != 1)
 				{
-					if (group.pixBackgroundSingle == Q_NULLPTR)
+					if (group.pixBackgroundSingle == nullptr)
 						b->setBackgroundPixmap(pixBackgroundSingle);
 					else
 						b->setBackgroundPixmap(*group.pixBackgroundSingle);
 				}
-				if (group.pixBackgroundRight == Q_NULLPTR)
+				if (group.pixBackgroundRight == nullptr)
 					b->setBackgroundPixmap(pixBackgroundRight);
 				else
 					b->setBackgroundPixmap(*group.pixBackgroundRight);
 			}
 			else
 			{
-				if (group.pixBackgroundMiddle == Q_NULLPTR)
+				if (group.pixBackgroundMiddle == nullptr)
 					b->setBackgroundPixmap(pixBackgroundMiddle);
 				else
 					b->setBackgroundPixmap(*group.pixBackgroundMiddle);
@@ -1251,7 +1251,7 @@ void StelProgressBarMgr::addProgressBar(const StelProgressController* p)
 	pb->setMinimum(p->getMin());
 	pb->setMaximum(p->getMax());
 	pb->setFormat(p->getFormat());
-	if (gui!=Q_NULLPTR)
+	if (gui!=nullptr)
 		pb->setStyleSheet(gui->getStelStyle().qtStyleSheet);
 	QGraphicsProxyWidget* pbProxy = new QGraphicsProxyWidget();
 	pbProxy->setWidget(pb);
@@ -1310,7 +1310,7 @@ void CornerButtons::setOpacity(double opacity)
 	for (auto* child : QGraphicsItem::childItems())
 	{
 		StelButton* sb = qgraphicsitem_cast<StelButton*>(child);
-		Q_ASSERT(sb!=Q_NULLPTR);
+		Q_ASSERT(sb!=nullptr);
 		sb->setOpacity(opacity);
 	}
 }

--- a/src/gui/StelGuiItems.cpp
+++ b/src/gui/StelGuiItems.cpp
@@ -61,7 +61,6 @@ QPixmap getTextPixmap(const QString& str, QFont font)
 {
 	// Render the text str into a QPixmap.
 	QRect strRect = QFontMetrics(font).boundingRect(str);
-	//qDebug() << "getTextPixMap " << str << strRect;
 	int w = static_cast<int>(1.02f*static_cast<float>(strRect.width()))+1;
 	int h = strRect.height();
 
@@ -1093,7 +1092,6 @@ QRectF BottomStelBar::boundingRect() const
 	if (QGraphicsItem::childItems().size()==0)
 		return QRectF();
 	const QRectF& r = childrenBoundingRect(); // BBX of status text (Location/FoV/FPS/Time) and buttons
-	//return QRectF(0, 0, r.width()-1, r.height()-1); // Why return a smaller BR than children?
 	return QRectF(0, 0, r.width(), r.height());
 }
 

--- a/src/gui/StelGuiItems.cpp
+++ b/src/gui/StelGuiItems.cpp
@@ -1001,7 +1001,7 @@ void BottomStelBar::updateText(bool updatePos, bool updateTopocentric)
 	if (getFlagFovDms())
 		fovText=QString("%1 %2").arg(qc_("FOV", "abbreviation"), fovdms);
 	else
-		fovText=QString("%1 %2%3").arg(qc_("FOV", "abbreviation"), QString::number(core->getMovementMgr()->getCurrentFov(), 'f', 1), QChar(0x00B0));
+		fovText=QString("%1 %2%3").arg(qc_("FOV", "abbreviation"), QString::number(core->getMovementMgr()->getCurrentFov(), 'g', 3), QChar(0x00B0));
 
 	if (fov->text()!=fovText || (fovPixmap && fovPixmap->data(0).toBool()))
 	{

--- a/src/gui/StelGuiItems.cpp
+++ b/src/gui/StelGuiItems.cpp
@@ -1049,19 +1049,13 @@ void BottomStelBar::updateText(bool updatePos, bool updateTopocentric)
 	{
 		// The location string starts at left, dateTime ends at right. FoV and FPS come ahead of dateTime.
 		// In case the strings are wider than available button space, they are now pushed to the right.
-		QFontMetrics fpsMetrics(fps->font());
-		int fpsShift = fpsMetrics.boundingRect(fpsstr).width() + fpsMetrics.boundingRect("MMMM").width();
-
-		QFontMetrics fovMetrics(fov->font());
-		int fovShift = fpsShift + fovMetrics.boundingRect(fovstr).width() + fovMetrics.boundingRect("MMMM").width();
-		if (getFlagFovDms())
-			fovShift += fovMetrics.boundingRect("MM'SS\"").width();
-
-		QRectF rectCh = getButtonsBoundingRect();
-		QFontMetrics locationMetrics(location->font());
-		int locationWidth=locationMetrics.boundingRect(location->text() + "MMM").width();
+		QFontMetrics fontMetrics(location->font());
+		int fpsShift     = fontMetrics.boundingRect(fps->text()+"MMM").width();
+		int fovShift     = fontMetrics.boundingRect(fov->text()+"MMM").width() + fpsShift;
+		int locationWidth= fontMetrics.boundingRect(location->text() + "MMM").width();
 		location->setPos(0, 0);
 
+		QRectF rectCh = getButtonsBoundingRect();
 		int dateTimePos = static_cast<int>(rectCh.right()-datetime->boundingRect().width())-5;
 		if ((dateTimePos%2) == 1) dateTimePos--; // make even pixel
 

--- a/src/gui/StelGuiItems.cpp
+++ b/src/gui/StelGuiItems.cpp
@@ -1008,20 +1008,6 @@ void BottomStelBar::updateText(bool updatePos, bool updateTopocentric)
 		updatePos = true;
 		if (getFlagShowFov())
 		{
-			// DEBUG: SHOW DIFFERENT VALUES...
-//			SkyGui * skyGui= static_cast<StelGui *>(StelApp::getInstance().getGui())->getSkyGui();
-//			QFontMetrics locationMetrics(location->font());
-//			QRectF buttonBoundingRect=getButtonsBoundingRect();
-//			QString bbbr=QString("BBX: %1 ww: %2 hh: %3 h: %4,  %5 ch: %6x%7 bb: %8x%9").arg(QString::number(boundingRectNoHelpLabel().height(), 'f', 3),
-//										QString::number(skyGui->getSkyGuiWidth()),
-//										QString::number(skyGui->getSkyGuiHeight()),
-//										QString::number(locationMetrics.boundingRect("M").height()), // h: height
-//										QString::number(childItems().count()),                       // NN ch.
-//										QString::number(childrenBoundingRect().width()),
-//										QString::number(childrenBoundingRect().height()),
-//										QString::number(buttonBoundingRect.width()),
-//										QString::number(buttonBoundingRect.height()));
-//			fov->setText(bbbr);
 			fov->setText(fovText);
 			fov->setToolTip(QString("%1: %2").arg(q_("Field of view"), fovdms));
 			if (qApp->property("text_texture")==true) // CLI option -t given?
@@ -1090,26 +1076,6 @@ void BottomStelBar::updateText(bool updatePos, bool updateTopocentric)
 			fovPixmap->setPos(datetimePixmap->x()-fovShift, yPos);
 			fpsPixmap->setPos(datetimePixmap->x()-fpsShift, yPos);
 		}
-
-//		// TEST
-//		QRectF br=boundingRect();            // Same size as childrenBoundingRect, just at offset 0/0.
-//		QRectF chBR=childrenBoundingRect();  // Same as boundingRectNoHelpLabel unless helpItem is shown.
-//		QRectF bbnhl=boundingRectNoHelpLabel();
-//		QString brStr=QString("BR: %1x%2+%3+%4 CBR: %5x%6+%7+%8 BBNHL: %9x%10+%11+%12").arg(QString::number(br.width(), 'f', 2),
-//									      QString::number(br.height(), 'f', 2),
-//									      QString::number(br.left(), 'f', 2),
-//									      QString::number(br.top(), 'f', 2),
-//									      QString::number(chBR.width(), 'f', 2),
-//									      QString::number(chBR.height(), 'f', 2),
-//									      QString::number(chBR.left(), 'f', 2),
-//									      QString::number(chBR.top(), 'f', 2)
-//									      ).arg(
-//									      QString::number(bbnhl.width(), 'f', 2),
-//									      QString::number(bbnhl.height(), 'f', 2),
-//									      QString::number(bbnhl.left(), 'f', 2),
-//									      QString::number(bbnhl.top(), 'f', 2)
-//									      );
-//		datetime->setText(brStr);
 		emit sizeChanged();
 	}
 }

--- a/src/gui/StelGuiItems.cpp
+++ b/src/gui/StelGuiItems.cpp
@@ -1110,6 +1110,7 @@ void BottomStelBar::updateText(bool updatePos, bool updateTopocentric)
 //									      QString::number(bbnhl.top(), 'f', 2)
 //									      );
 //		datetime->setText(brStr);
+		emit sizeChanged();
 	}
 }
 

--- a/src/gui/StelGuiItems.cpp
+++ b/src/gui/StelGuiItems.cpp
@@ -1152,23 +1152,23 @@ StelBarsPath::StelBarsPath(QGraphicsItem* parent) : QGraphicsPathItem(parent), r
 	setPen(aPen);
 }
 
-void StelBarsPath::updatePath(BottomStelBar* bot, LeftStelBar* lef)
+void StelBarsPath::updatePath(BottomStelBar* bottom, LeftStelBar* left)
 {
-	QPainterPath newPath;
-	QPointF p = lef->pos() + QPointF(-0.5,0.5);
-	QRectF r = lef->boundingRectNoHelpLabel();
-	QPointF p2 = bot->pos() + QPointF(-0.5,0.5);
-	QRectF r2 = bot->boundingRectNoHelpLabel();
+	const QPointF l = left->pos() + QPointF(-0.5,0.5);   // pos() seems to be the top-left point.
+	const QRectF lB = left->boundingRectNoHelpLabel();
+	const QPointF b = bottom->pos() + QPointF(-0.5,0.5);
+	const QRectF bB = bottom->boundingRectNoHelpLabel();
 
-	newPath.moveTo(p.x()-roundSize, p.y()-roundSize);
-	newPath.lineTo(p.x()+r.width(),p.y()-roundSize);
-	newPath.arcTo(p.x()+r.width()-roundSize, p.y()-roundSize, 2.*roundSize, 2.*roundSize, 90, -90);
-	newPath.lineTo(p.x()+r.width()+roundSize, p2.y()-roundSize);
-	newPath.lineTo(p2.x()+r2.width(),p2.y()-roundSize);
-	newPath.arcTo(p2.x()+r2.width()-roundSize, p2.y()-roundSize, 2.*roundSize, 2.*roundSize, 90, -90);
-	newPath.lineTo(p2.x()+r2.width()+roundSize, p2.y()+r2.height()+roundSize);
-	newPath.lineTo(p.x()-roundSize, p2.y()+r2.height()+roundSize);
-	setPath(newPath);
+	QPainterPath path(QPointF(l.x()-roundSize, l.y()-roundSize));                                 // top left point
+	//path.lineTo(l.x()+lB.width()-roundSize,l.y()-roundSize);                                    // top edge. Not needed because the arc connects anyhow!
+	path.arcTo(l.x()+lB.width()-roundSize, l.y()-roundSize, 2.*roundSize, 2.*roundSize, 90, -90); // top-right curve of left bar
+	path.lineTo(l.x()+lB.width()+roundSize, b.y()-roundSize);                                     // vertical to inside sharp edge
+	//path.lineTo(b.x()+bB.width(),b.y()-roundSize);                                              // Top edge of bottom bar. Not needed because the arc connects anyhow!
+	path.arcTo(b.x()+bB.width()-roundSize, b.y()-roundSize, 2.*roundSize, 2.*roundSize, 90, -90); // top right curved edge of bottom bar (just connects.)
+	path.lineTo(b.x()+bB.width()+roundSize, b.y()+bB.height()+roundSize);
+	path.lineTo(l.x()-roundSize, b.y()+bB.height()+roundSize);                                    // bottom line (outside screen area!)
+	path.closeSubpath();                                                                          // vertical line up left outside screen
+	setPath(path);
 }
 
 void StelBarsPath::setBackgroundOpacity(double opacity)

--- a/src/gui/StelGuiItems.cpp
+++ b/src/gui/StelGuiItems.cpp
@@ -1067,7 +1067,7 @@ void BottomStelBar::updateText(bool updatePos, bool updateTopocentric)
 		// The location string starts at left, dateTime ends at right. FoV and FPS come ahead of dateTime.
 		// In case the strings are wider than available button space, they are now pushed to the right.
 		QFontMetrics fontMetrics(location->font());
-		int fpsShift     = qMax(fontMetrics.boundingRect(fps->text()+"MMM").width(), fontMetrics.boundingRect(qc_("FPS", "abbreviation")+"12.3 MMM").width());
+		int fpsShift     = qMax(fontMetrics.boundingRect(fps->text()+"MMM").width(), fontMetrics.boundingRect(qc_("FPS", "abbreviation")+"MM.M MMM").width());
 		int fovShift     = fontMetrics.boundingRect(fov->text()+"MMM").width() + fpsShift;
 		int locationWidth= fontMetrics.boundingRect(location->text() + "MMM").width();
 		location->setPos(0, 0);

--- a/src/gui/StelGuiItems.cpp
+++ b/src/gui/StelGuiItems.cpp
@@ -61,7 +61,7 @@ QPixmap getTextPixmap(const QString& str, QFont font)
 {
 	// Render the text str into a QPixmap.
 	QRect strRect = QFontMetrics(font).boundingRect(str);
-	qDebug() << "getTextPixMap " << str << strRect;
+	//qDebug() << "getTextPixMap " << str << strRect;
 	int w = static_cast<int>(1.02f*static_cast<float>(strRect.width()))+1;
 	int h = strRect.height();
 
@@ -1070,7 +1070,7 @@ void BottomStelBar::updateText(bool updatePos, bool updateTopocentric)
 		{
 			const qreal yPos = -fontMetrics.descent();
 			locationPixmap->setPos(0,yPos);
-			int dateTimePos = static_cast<int>(rectCh.right()-datetimePixmap->boundingRect().width())-5;
+			dateTimePos = static_cast<int>(rectCh.right()-datetimePixmap->boundingRect().width())-5;
 			if ((dateTimePos%2) == 1) dateTimePos--; // make even pixel
 			datetimePixmap->setPos(dateTimePos+rightPush, yPos);
 			fovPixmap->setPos(datetimePixmap->x()-fovShift, yPos);

--- a/src/gui/StelGuiItems.cpp
+++ b/src/gui/StelGuiItems.cpp
@@ -1030,29 +1030,36 @@ void BottomStelBar::updateText(bool updatePos, bool updateTopocentric)
 
 	if (updatePos)
 	{
+		// The location string starts at left, dateTime ends at right. FoV and FPS come ahead of dateTime.
+		// In case the strings are wider than available button space, they are now pushed to the right.
 		QFontMetrics fpsMetrics(fps->font());
-		int fpsShift = fpsMetrics.boundingRect(fpsstr).width() + 50;
+		int fpsShift = fpsMetrics.boundingRect(fpsstr).width() + fpsMetrics.boundingRect("MMMM").width();
 
 		QFontMetrics fovMetrics(fov->font());
-		int fovShift = fpsShift + fovMetrics.boundingRect(fovstr).width() + 80;
+		int fovShift = fpsShift + fovMetrics.boundingRect(fovstr).width() + fovMetrics.boundingRect("MMMM").width();
 		if (getFlagFovDms())
-			fovShift += 25;
+			fovShift += fovMetrics.boundingRect("MM'SS\"").width();
 
 		QRectF rectCh = getButtonsBoundingRect();
-		location->setPos(0, 0);		
-		int dtp = static_cast<int>(rectCh.right()-datetime->boundingRect().width())-5;
-		if ((dtp%2) == 1) dtp--; // make even pixel
-		datetime->setPos(dtp,0);
+		location->setPos(0, 0);
+		QFontMetrics locationMetrics(fov->font());
+		int locationWidth=locationMetrics.boundingRect(location->text()).width() + locationMetrics.boundingRect("MMM").width();
+
+		int dateTimePos = static_cast<int>(rectCh.right()-datetime->boundingRect().width())-5;
+		if ((dateTimePos%2) == 1) dateTimePos--; // make even pixel
+
+		const int rightPush=qMax(0, locationWidth-(dateTimePos-fovShift));
+		datetime->setPos(dateTimePos+rightPush,0);
 		fov->setPos(datetime->x()-fovShift, 0);
 		fps->setPos(datetime->x()-fpsShift, 0);
 		if (qApp->property("text_texture")==true) // CLI option -t given?
 		{
 			locationPixmap->setPos(0,0);
-			int dtp = static_cast<int>(rectCh.right()-datetimePixmap->boundingRect().width())-5;
-			if ((dtp%2) == 1) dtp--; // make even pixel
-			datetimePixmap->setPos(dtp,0);
-			fovPixmap->setPos(datetime->x()-fovShift, 0);
-			fpsPixmap->setPos(datetime->x()-fpsShift, 0);
+			int dateTimePos = static_cast<int>(rectCh.right()-datetimePixmap->boundingRect().width())-5;
+			if ((dateTimePos%2) == 1) dateTimePos--; // make even pixel
+			datetimePixmap->setPos(dateTimePos,0);
+			fovPixmap->setPos(datetimePixmap->x()-fovShift, 0);
+			fpsPixmap->setPos(datetimePixmap->x()-fpsShift, 0);
 		}
 	}
 }

--- a/src/gui/StelGuiItems.hpp
+++ b/src/gui/StelGuiItems.hpp
@@ -292,7 +292,8 @@ private slots:
 	void setFont(QFont font);
 
 private:
-	void updateText(bool forceUpdatePos=false);
+	// updateTopocentric: regardless of topocentric setting, reformat the string if true
+	void updateText(bool forceUpdatePos=false, bool updateTopocentric=false);
 	void updateButtonsGroups();
 	QRectF getButtonsBoundingRect() const;
 	// Elements which get displayed above the buttons:

--- a/src/gui/StelGuiItems.hpp
+++ b/src/gui/StelGuiItems.hpp
@@ -215,6 +215,11 @@ public:
 private slots:
 	//! Update the help label when a button is hovered
 	void buttonHoverChanged(bool b);
+
+	//! connect from StelApp to resize fonts on the fly.
+	void setFontSizeFromApp(int size);
+	//! connect from StelApp to set font on the fly.
+	void setFont(QFont font);
 private:
 	QTimeLine* hideTimeLine;
 	QGraphicsSimpleTextItem* helpLabel;

--- a/src/gui/StelGuiItems.hpp
+++ b/src/gui/StelGuiItems.hpp
@@ -346,12 +346,13 @@ private:
 	QGraphicsPixmapItem* helpLabelPixmap; // bad-graphics replacement.
 };
 
-// The path around the bottom left button bars
+//! @class StelBarsPath: The path around the bottom and left button bars
 class StelBarsPath : public QGraphicsPathItem
 {
 	public:
 		StelBarsPath(QGraphicsItem* parent);
-		void updatePath(BottomStelBar* bot, LeftStelBar* lef);
+		//! defines a line around the two button bars
+		void updatePath(BottomStelBar* bottom, LeftStelBar* left);
 		//! return radius of corner arc
 		double getRoundSize() const {return roundSize;}
 		void setBackgroundOpacity(double opacity);

--- a/src/gui/StelGuiItems.hpp
+++ b/src/gui/StelGuiItems.hpp
@@ -254,7 +254,7 @@ public:
 							const QPixmap& pixRight=QPixmap(), const QPixmap& pixMiddle=QPixmap(),
 							const QPixmap& pixSingle=QPixmap());
 
-	//! Set the color for all the sub elements
+	//! Set the brush color for all the sub elements (Seems not to do anything, in fact!)
 	void setColor(const QColor& c);
 
 	//! Set whether time must be displayed in the bottom bar
@@ -279,6 +279,10 @@ public:
 	void setFlagShowTz(bool b) { flagShowTZ=b; }
 	bool getFlagShowTz() const { return flagShowTZ; }
 
+	//! @return boundingRect of the buttons only
+	QRectF getButtonsBoundingRect() const;
+	//! @return height of vertical gap (pixels)
+	int getGap() const {return gap;}
 signals:
 	void sizeChanged();
 
@@ -295,7 +299,6 @@ private:
 	// updateTopocentric: regardless of topocentric setting, reformat the string if true
 	void updateText(bool forceUpdatePos=false, bool updateTopocentric=false);
 	void updateButtonsGroups();
-	QRectF getButtonsBoundingRect() const;
 	// Elements which get displayed above the buttons:
 	QGraphicsSimpleTextItem* location;
 	QGraphicsSimpleTextItem* datetime;
@@ -307,6 +310,7 @@ private:
 	QGraphicsPixmapItem* datetimePixmap;
 	QGraphicsPixmapItem* fovPixmap;
 	QGraphicsPixmapItem* fpsPixmap;
+	int gap; // a pixel distance between status line and buttons. May have fixed size or could depend on status element font size QFontMetrics::descent()
 
 
 

--- a/src/gui/StelGuiItems.hpp
+++ b/src/gui/StelGuiItems.hpp
@@ -206,8 +206,8 @@ class LeftStelBar : public QObject, public QGraphicsItem
 public:
 	LeftStelBar(QGraphicsItem* parent);
 	~LeftStelBar() override;
-	virtual void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = nullptr) override;
-	virtual QRectF boundingRect() const override;
+	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = nullptr) override;
+	QRectF boundingRect() const override;
 	void addButton(StelButton* button);
 	QRectF boundingRectNoHelpLabel() const;
 	//! Set the color for all the sub elements

--- a/src/gui/StelGuiItems.hpp
+++ b/src/gui/StelGuiItems.hpp
@@ -53,9 +53,9 @@ class CornerButtons : public QObject, public QGraphicsItem
 	Q_OBJECT
 	Q_INTERFACES(QGraphicsItem)
 public:
-	CornerButtons(QGraphicsItem* parent=Q_NULLPTR);
-	virtual void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = Q_NULLPTR) Q_DECL_OVERRIDE;
-	virtual QRectF boundingRect() const Q_DECL_OVERRIDE;
+	CornerButtons(QGraphicsItem* parent=nullptr);
+	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = nullptr) override;
+	QRectF boundingRect() const override;
 	void setOpacity(double opacity);
 private:
 	mutable double lastOpacity;
@@ -77,9 +77,9 @@ public:
 	//! @param noBackground define whether the button background image have to be used
 	StelButton(QGraphicsItem* parent, const QPixmap& pixOn, const QPixmap& pixOff,
 		   const QPixmap& pixHover=QPixmap(),
-		   class StelAction* action=Q_NULLPTR,
+		   class StelAction* action=nullptr,
 		   bool noBackground=false,
-		   StelAction *otherAction=Q_NULLPTR);
+		   StelAction *otherAction=nullptr);
 	
 	//! Constructor
 	//! @param parent the parent item
@@ -154,10 +154,10 @@ public slots:
 	void setChecked(bool b) { setChecked(static_cast<int>(b)); }
 
 protected:
-	virtual void hoverEnterEvent(QGraphicsSceneHoverEvent* event) Q_DECL_OVERRIDE;
-	virtual void hoverLeaveEvent(QGraphicsSceneHoverEvent* event) Q_DECL_OVERRIDE;
-	virtual void mousePressEvent(QGraphicsSceneMouseEvent* event) Q_DECL_OVERRIDE;
-	virtual void mouseReleaseEvent(QGraphicsSceneMouseEvent* event) Q_DECL_OVERRIDE;
+	void hoverEnterEvent(QGraphicsSceneHoverEvent* event) override;
+	void hoverLeaveEvent(QGraphicsSceneHoverEvent* event) override;
+	void mousePressEvent(QGraphicsSceneMouseEvent* event) override;
+	void mouseReleaseEvent(QGraphicsSceneMouseEvent* event) override;
 	void paint(QPainter*, const QStyleOptionGraphicsItem*, QWidget*) override;
 private slots:
 	void animValueChanged(qreal value);
@@ -205,9 +205,9 @@ class LeftStelBar : public QObject, public QGraphicsItem
 	Q_INTERFACES(QGraphicsItem)
 public:
 	LeftStelBar(QGraphicsItem* parent);
-	~LeftStelBar() Q_DECL_OVERRIDE;
-	virtual void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = Q_NULLPTR) Q_DECL_OVERRIDE;
-	virtual QRectF boundingRect() const Q_DECL_OVERRIDE;
+	~LeftStelBar() override;
+	virtual void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = nullptr) override;
+	virtual QRectF boundingRect() const override;
 	void addButton(StelButton* button);
 	QRectF boundingRectNoHelpLabel() const;
 	//! Set the color for all the sub elements
@@ -233,9 +233,9 @@ class BottomStelBar : public QObject, public QGraphicsItem
 	Q_INTERFACES(QGraphicsItem)
 public:
 	BottomStelBar(QGraphicsItem* parent, const QPixmap& pixLeft=QPixmap(), const QPixmap& pixRight=QPixmap(), const QPixmap& pixMiddle=QPixmap(), const QPixmap& pixSingle=QPixmap());
-	virtual ~BottomStelBar() Q_DECL_OVERRIDE;
-	virtual void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = Q_NULLPTR) Q_DECL_OVERRIDE;
-	virtual QRectF boundingRect() const Q_DECL_OVERRIDE;
+	~BottomStelBar() override;
+	void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = nullptr) override;
+	QRectF boundingRect() const override;
 	QRectF boundingRectNoHelpLabel() const;
 
 	//! Add a button in a group in the button bar. Group are displayed in alphabetic order.
@@ -317,8 +317,8 @@ private:
 	struct ButtonGroup
 	{
 		ButtonGroup() : leftMargin(0), rightMargin(0),
-						pixBackgroundLeft(Q_NULLPTR), pixBackgroundRight(Q_NULLPTR),
-						pixBackgroundMiddle(Q_NULLPTR), pixBackgroundSingle(Q_NULLPTR) {}
+						pixBackgroundLeft(nullptr), pixBackgroundRight(nullptr),
+						pixBackgroundMiddle(nullptr), pixBackgroundSingle(nullptr) {}
 		//! Elements of the group
 		QList<StelButton*> elems;
 		//! Left margin size in pixel

--- a/src/gui/configurationDialog.ui
+++ b/src/gui/configurationDialog.ui
@@ -1902,7 +1902,7 @@
                   <number>5</number>
                  </property>
                  <property name="maximum">
-                  <number>30</number>
+                  <number>50</number>
                  </property>
                  <property name="value">
                   <number>13</number>
@@ -1943,7 +1943,7 @@
                   <number>7</number>
                  </property>
                  <property name="maximum">
-                  <number>24</number>
+                  <number>50</number>
                  </property>
                  <property name="value">
                   <number>13</number>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This should fix a few issues which have become more apparent around the now default-visible font selection and font size switches. A preliminary fix was attempted in #3014.

GUI help text did not follow font and font size changes. 
A non-default font and font size may lead to a visible (1-pixel) peek of the sliding buttons. The bottom bar must be properly reconstructed whenever font/size change.

A few other little quirks as I find them.



### Description
<!--- Please include a summary of the change and which issue is fixed. -->
<!--- Please also include relevant motivation and context. -->
<!--- List any dependencies that are required for this change. -->

Fixes #3014 (issue)

### Screenshots (if appropriate):

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system: Windows 11
* Graphics Card: Geforce 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
