### PR TITLE
Use a linear color space when rendering

### DIFF
--- a/data/shaders/planet.frag
+++ b/data/shaders/planet.frag
@@ -422,6 +422,7 @@ void main()
 		// FIXME: this should be calculated properly in linear space as
 		// extinction of sunlight, and with subsequent tone mapping.
 		// Current implementation is a legacy from older times.
+		// shadowColor is passed as a GL_RGBA texture, so the sample is sRGB-encoded
 		lowp vec4 color = vec4(linearToSRGB(finalColor.rgb), finalColor.a);
 		lowp float alpha = clamp(shadowColor.a, 0.0, 0.7); // clamp alpha to allow some maria detail
         finalColor = eclipsePush * (1.0-0.75*shadowColor.a) * mix(color, shadowColor, alpha);

--- a/data/shaders/planet.frag
+++ b/data/shaders/planet.frag
@@ -174,7 +174,7 @@ void main()
 	{
 		// We are drawing the Sun
 		vec4 texColor = texture2D(tex, texc);
-		texColor.rgb = srgbToLinear(texColor.rgb * sunInfo.rgb);
+		texColor.rgb = texColor.rgb * srgbToLinear(sunInfo.rgb);
 		// Reference: chapter 14.7 "Limb Darkening" in "Allen’s Astrophysical Quantities",
 		//            A.N.Cox (ed.), 4th edition, New York: Springer-Verlag, 2002.
 		//            DOI 10.1007/978-1-4612-1186-0
@@ -189,7 +189,7 @@ void main()
 		float cosTheta2 = cosTheta*cosTheta;
 		vec3 limbDarkeningCoef = a0 + a1*cosTheta + a2*cosTheta2;
 		vec3 color = texColor.rgb * limbDarkeningCoef;
-		FRAG_COLOR = vec4(linearToSRGB(color), texColor.a);
+		FRAG_COLOR = vec4(color, texColor.a);
 		return;
 	}
 #endif
@@ -398,8 +398,6 @@ void main()
         texColor = texture2D(tex, texc);
     }
 
-    texColor.rgb = srgbToLinear(texColor.rgb);
-
     mediump vec4 finalColor = texColor;
 	// apply (currently only Martian) pole caps. texc.t=0 at south pole, 1 at north pole. 
 	if (texc.t>poleLat.x-0.01+0.001*sin(texc.s*18.*M_PI)) {	// North pole near t=1
@@ -434,7 +432,5 @@ void main()
     //apply white rimlight
     finalColor.xyz = clamp( finalColor.xyz + vec3(outgas), 0.0, 1.0);
 
-    FRAG_COLOR = vec4(linearToSRGB(finalColor.rgb), finalColor.a);
-    //to debug texture issues, uncomment and reload shader
-    //FRAG_COLOR = texColor;
+    FRAG_COLOR = finalColor;
 }

--- a/data/shaders/xyYToRGB.glsl
+++ b/data/shaders/xyYToRGB.glsl
@@ -45,10 +45,10 @@ vec3 xyYToRGB(highp float x, highp float y, highp float Y)
 		if (flagUseTmGamma)
 		{
 			Y = pow(abs(Y*pi*1e-4), alphaWaOverAlphaDa*oneOverGamma)* term2TimesOneOverMaxdLpOneOverGamma;
-			return vec3(0.787077, 0.9898434, 1.9256125) * Y * brightnessScale;
+			return srgbToLinear(vec3(0.787077, 0.9898434, 1.9256125) * Y * brightnessScale);
 		}else{
 			Y = pow(abs(Y*pi*1e-4), alphaWaOverAlphaDa) * term2TimesOneOverMaxdL;
-			return pow(vec3(0.787077, 0.9898434, 1.9256125) * abs(Y * brightnessScale), vec3(oneOverGamma));
+			return vec3(0.787077, 0.9898434, 1.9256125) * abs(Y * brightnessScale);
 		}
 	}
 	else
@@ -93,9 +93,9 @@ vec3 xyYToRGB(highp float x, highp float y, highp float Y)
                                vec3(-0.3446944, +0.0415560, +1.0154096));
 		}
 	  	if (flagUseTmGamma){
-			return XYZ2RGB * XYZ * brightnessScale;
+			return srgbToLinear(abs(XYZ2RGB * XYZ * brightnessScale));
 		}else{
-			return pow(abs(XYZ2RGB * XYZ * brightnessScale), vec3(oneOverGamma));
+			return XYZ2RGB * XYZ * brightnessScale;
 		}
 	}
 }

--- a/src/StelMainView.cpp
+++ b/src/StelMainView.cpp
@@ -873,10 +873,7 @@ void StelMainView::init()
 	glInfo.vendor = QString(reinterpret_cast<const char*>(glInfo.functions->glGetString(GL_VENDOR)));
 	glInfo.renderer = QString(reinterpret_cast<const char*>(glInfo.functions->glGetString(GL_RENDERER)));
 	const auto format = glInfo.mainContext->format();
-	glInfo.supportsLuminanceTextures = format.profile() == QSurfaceFormat::CompatibilityProfile ||
-									   format.majorVersion() < 3;
 	glInfo.isGLES = format.renderableType()==QSurfaceFormat::OpenGLES;
-	qDebug().nospace() << "Luminance textures are " << (glInfo.supportsLuminanceTextures ? "" : "not ") << "supported";
 	glInfo.isCoreProfile = format.profile() == QSurfaceFormat::CoreProfile;
 
 	auto& gl = *QOpenGLContext::currentContext()->functions();

--- a/src/StelMainView.cpp
+++ b/src/StelMainView.cpp
@@ -913,6 +913,46 @@ void StelMainView::init()
 	gl.glGetIntegerv(GL_MAX_TEXTURE_SIZE, &glInfo.maxTextureSize);
 	qDebug() << "Maximum 2D texture size:" << glInfo.maxTextureSize;
 
+	// sRGB support in GLES is a mess
+	if(glInfo.isGLES)
+	{
+		if(format.majorVersion() >= 3 || glInfo.mainContext->hasExtension("GL_EXT_texture_sRGB"))
+		{
+			glInfo.srgbTextureFormatRGB = GL_RGB;
+			glInfo.srgbTextureFormatRGBA = GL_RGBA;
+			glInfo.srgbTextureInternalFormatRGB = GL_SRGB8;
+			glInfo.srgbTextureInternalFormatRGBA = GL_SRGB8_ALPHA8;
+			glInfo.supportsGenerateMipmapSRGB = false;
+		}
+		else if(glInfo.mainContext->hasExtension("GL_EXT_sRGB"))
+		{
+			glInfo.srgbTextureFormatRGB = GL_SRGB;
+			glInfo.srgbTextureFormatRGBA = GL_SRGB_ALPHA_EXT;
+			glInfo.srgbTextureInternalFormatRGB = GL_SRGB;
+			glInfo.srgbTextureInternalFormatRGBA = GL_SRGB_ALPHA_EXT;
+			glInfo.supportsGenerateMipmapSRGB = false;
+		}
+		else
+		{
+			qCritical() << "No support for sRGB textures found, expect rendering problems!";
+			// Let the user still have gamma-incorrect rendering if possible (though
+			// configurations without sRGB support would likely have other problems).
+			glInfo.srgbTextureFormatRGB = GL_RGB;
+			glInfo.srgbTextureFormatRGBA = GL_RGBA;
+			glInfo.srgbTextureInternalFormatRGB = GL_RGB;
+			glInfo.srgbTextureInternalFormatRGBA = GL_RGBA;
+			glInfo.supportsGenerateMipmapSRGB = true;
+		}
+	}
+	else
+	{
+		glInfo.srgbTextureFormatRGB = GL_RGB;
+		glInfo.srgbTextureFormatRGBA = GL_RGBA;
+		glInfo.srgbTextureInternalFormatRGB = GL_SRGB8;
+		glInfo.srgbTextureInternalFormatRGBA = GL_SRGB8_ALPHA8;
+		glInfo.supportsGenerateMipmapSRGB = true;
+	}
+
 	gui = new StelGui();
 
 	// Should be check of requirements disabled? -- NO! This is intentional here, and does no harm.

--- a/src/StelMainView.hpp
+++ b/src/StelMainView.hpp
@@ -77,6 +77,11 @@ public:
 		PFNGLMINSAMPLESHADINGPROC glMinSampleShading = nullptr;
 		GLint maxAnisotropy = 0;
 		GLint maxTextureSize = 2048;
+		GLenum srgbTextureFormatRGB = GL_RGB;
+		GLenum srgbTextureFormatRGBA = GL_RGBA;
+		GLenum srgbTextureInternalFormatRGB = GL_SRGB8;
+		GLenum srgbTextureInternalFormatRGBA = GL_SRGB8_ALPHA8;
+		bool supportsGenerateMipmapSRGB = true;
 		bool isCoreProfile = false;
 		bool isGLES = false;
 	};

--- a/src/StelMainView.hpp
+++ b/src/StelMainView.hpp
@@ -77,7 +77,6 @@ public:
 		PFNGLMINSAMPLESHADINGPROC glMinSampleShading = nullptr;
 		GLint maxAnisotropy = 0;
 		GLint maxTextureSize = 2048;
-		bool supportsLuminanceTextures = false;
 		bool isCoreProfile = false;
 		bool isGLES = false;
 	};

--- a/src/core/StelApp.hpp
+++ b/src/core/StelApp.hpp
@@ -20,12 +20,14 @@
 #ifndef STELAPP_HPP
 #define STELAPP_HPP
 
+#include <memory>
 #include <qguiapplication.h>
 #include <QString>
 #include <QObject>
 #if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
 #include <QRandomGenerator>
 #endif
+#include "StelTextureTypes.hpp"
 #include "StelModule.hpp"
 #include "VecMath.hpp"
 
@@ -39,6 +41,9 @@ class StelMainView;
 class StelSkyCultureMgr;
 class StelViewportEffect;
 class QOpenGLFramebufferObject;
+class QOpenGLVertexArrayObject;
+class QOpenGLShaderProgram;
+class QOpenGLBuffer;
 class QOpenGLFunctions;
 class QSettings;
 class QNetworkAccessManager;
@@ -372,6 +377,8 @@ private:
 	//! @param drawFbo the OpenGL fbo we need to render into.
 	void applyRenderBuffer(quint32 drawFbo=0);
 
+	void setupLinearToSRGBBlitter();
+
 	QString getVersion() const;
 
 	// The StelApp singleton
@@ -479,6 +486,18 @@ private:
 
 	// Framebuffer object used for viewport effects.
 	QOpenGLFramebufferObject* renderBuffer;
+	std::unique_ptr<QOpenGLBuffer> linearToSRGB_VBO;
+	std::unique_ptr<QOpenGLVertexArrayObject> linearToSRGB_VAO;
+	std::unique_ptr<QOpenGLShaderProgram> linearToSRGB_Program;
+	std::unique_ptr<QOpenGLFramebufferObject> linearLightTexFBO;
+	std::unique_ptr<QOpenGLFramebufferObject> linearLightMultisampledFBO;
+	StelTextureSP ditherPatternTex;
+	struct LinearToSRGBUniformLocations
+	{
+		int tex;
+		int ditherPattern;
+		int rgbMaxValue;
+	} linearToSRGBUniformLocations;
 	StelViewportEffect* viewportEffect;
 	QOpenGLFunctions* gl;
 	

--- a/src/core/StelPainter.cpp
+++ b/src/core/StelPainter.cpp
@@ -24,6 +24,7 @@
 #include "StelLocaleMgr.hpp"
 #include "StelProjector.hpp"
 #include "StelProjectorClasses.hpp"
+#include "StelSRGB.hpp"
 #include "StelUtils.hpp"
 #include "StelTextureMgr.hpp"
 #include "SaturationShader.hpp"
@@ -768,7 +769,7 @@ void StelPainter::drawText(float x, float y, const QString& str, float angleDeg,
 		QFont tmpFont = currentFont;
 		tmpFont.setPixelSize(currentFont.pixelSize()*static_cast<int>(static_cast<float>(prj->getDevicePixelsPerPixel())*StelApp::getInstance().getGlobalScalingRatio()));
 		painter.setFont(tmpFont);
-		painter.setPen(currentColor.toQColor());
+		painter.setPen(srgbToLinear(currentColor).toQColor());
 		
 		float scaleRatio = StelApp::getInstance().getGlobalScalingRatio();
 		xshift*=scaleRatio;
@@ -2496,7 +2497,7 @@ void StelPainter::drawFixedColorWideLinesAsQuads(const ArrayDesc& vertexArray, i
 	pr->setAttributeBuffer(basicShaderVars.vertex, vertexArray.type, 0, 4);
 	pr->enableAttributeArray(basicShaderVars.vertex);
 	pr->setUniformValue(basicShaderVars.projectionMatrix, QMatrix4x4{});
-	pr->setUniformValue(basicShaderVars.color, currentColor.toQVector());
+	pr->setUniformValue(basicShaderVars.color, srgbToLinear(currentColor).toQVector());
 
 #ifdef GL_MULTISAMPLE
 	const bool multisampleWasOn = multisamplingEnabled && glIsEnabled(GL_MULTISAMPLE);
@@ -2585,7 +2586,7 @@ void StelPainter::drawFromArray(DrawingMode mode, int count, int offset, bool do
 			pr->setAttributeBuffer(wideLineShaderVars.vertex, projectedVertexArray.type, 0, projectedVertexArray.size);
 			pr->enableAttributeArray(wideLineShaderVars.vertex);
 			pr->setUniformValue(wideLineShaderVars.projectionMatrix, qMat);
-			pr->setUniformValue(wideLineShaderVars.color, currentColor.toQVector());
+			pr->setUniformValue(wideLineShaderVars.color, srgbToLinear(currentColor).toQVector());
 			pr->setUniformValue(wideLineShaderVars.lineWidth, glState.lineWidth);
 			GLint viewport[4] = {};
 			glGetIntegerv(GL_VIEWPORT, viewport);
@@ -2596,7 +2597,7 @@ void StelPainter::drawFromArray(DrawingMode mode, int count, int offset, bool do
 			pr->setAttributeBuffer(basicShaderVars.vertex, projectedVertexArray.type, 0, projectedVertexArray.size);
 			pr->enableAttributeArray(basicShaderVars.vertex);
 			pr->setUniformValue(basicShaderVars.projectionMatrix, qMat);
-			pr->setUniformValue(basicShaderVars.color, currentColor.toQVector());
+			pr->setUniformValue(basicShaderVars.color, srgbToLinear(currentColor).toQVector());
 		}
 	}
 	else if (texCoordArray.enabled && !colorArray.enabled && !normalArray.enabled && !wideLineMode)
@@ -2616,7 +2617,7 @@ void StelPainter::drawFromArray(DrawingMode mode, int count, int offset, bool do
 		pr->setAttributeBuffer(texturesShaderVars.vertex, projectedVertexArray.type, 0, projectedVertexArray.size);
 		pr->enableAttributeArray(texturesShaderVars.vertex);
 		pr->setUniformValue(texturesShaderVars.projectionMatrix, qMat);
-		pr->setUniformValue(texturesShaderVars.texColor, currentColor.toQVector());
+		pr->setUniformValue(texturesShaderVars.texColor, srgbToLinear(currentColor).toQVector());
 		pr->setAttributeBuffer(texturesShaderVars.texCoord, texCoordArray.type, texCoordDataOffset, texCoordArray.size);
 		pr->enableAttributeArray(texturesShaderVars.texCoord);
 		//pr->setUniformValue(texturesShaderVars.texture, 0);    // use texture unit 0

--- a/src/core/StelPainter.hpp
+++ b/src/core/StelPainter.hpp
@@ -429,8 +429,6 @@ private:
 		int vertex;
 		int texColor;
 		int texture;
-		int ditherPattern;
-		int rgbMaxValue;
 	};
 	static TexturesShaderVars texturesShaderVars;
 	static QOpenGLShaderProgram* texturesColorShaderProgram;
@@ -440,8 +438,6 @@ private:
 		int vertex;
 		int color;
 		int texture;
-		int ditherPattern;
-		int rgbMaxValue;
 		int saturation;
 	};
 	static TexturesColorShaderVars texturesColorShaderVars;
@@ -465,8 +461,6 @@ private:
 		int vertex;
 	};
 	static ColorfulWideLineShaderVars colorfulWideLineShaderVars;
-
-	StelTextureSP ditherPatternTex;
 
 	static bool multisamplingEnabled;
 

--- a/src/core/StelSRGB.hpp
+++ b/src/core/StelSRGB.hpp
@@ -32,6 +32,15 @@ F srgbToLinear(const F c)
 }
 
 template<typename F>
+Vector4<F> srgbToLinear(const Vector4<F>& srgba)
+{
+	return {srgbToLinear(srgba[0]),
+			srgbToLinear(srgba[1]),
+			srgbToLinear(srgba[2]),
+			srgba[3]};
+}
+
+template<typename F>
 Vector3<F> srgbToLinear(const Vector3<F>& srgb)
 {
 	return {srgbToLinear(srgb[0]), srgbToLinear(srgb[1]), srgbToLinear(srgb[2])};

--- a/src/core/StelSRGB.hpp
+++ b/src/core/StelSRGB.hpp
@@ -25,14 +25,16 @@
 #include "VecMath.hpp"
 
 template<typename F>
+F srgbToLinear(const F c)
+{
+	return c > F(0.04045) ? std::pow((c+F(0.055))/F(1.055), F(2.4))
+						  : c / F(12.92);
+}
+
+template<typename F>
 Vector3<F> srgbToLinear(const Vector3<F>& srgb)
 {
-	const auto lin = [](const F c)
-	{
-		return c > F(0.04045) ? std::pow((c+F(0.055))/F(1.055), F(2.4))
-							  : c / F(12.92);
-	};
-	return {lin(srgb[0]), lin(srgb[1]), lin(srgb[2])};
+	return {srgbToLinear(srgb[0]), srgbToLinear(srgb[1]), srgbToLinear(srgb[2])};
 }
 
 inline QByteArray makeSRGBUtilsShader()

--- a/src/core/StelSRGB.hpp
+++ b/src/core/StelSRGB.hpp
@@ -20,7 +20,20 @@
 #ifndef INCLUDE_ONCE_E0C038F5_4B24_4B2C_9AFC_B1B8F0BC4BAF
 #define INCLUDE_ONCE_E0C038F5_4B24_4B2C_9AFC_B1B8F0BC4BAF
 
+#include <cmath>
 #include <QByteArray>
+#include "VecMath.hpp"
+
+template<typename F>
+Vector3<F> srgbToLinear(const Vector3<F>& srgb)
+{
+	const auto lin = [](const F c)
+	{
+		return c > F(0.04045) ? std::pow((c+F(0.055))/F(1.055), F(2.4))
+							  : c / F(12.92);
+	};
+	return {lin(srgb[0]), lin(srgb[1]), lin(srgb[2])};
+}
 
 inline QByteArray makeSRGBUtilsShader()
 {

--- a/src/core/StelSkyDrawer.cpp
+++ b/src/core/StelSkyDrawer.cpp
@@ -25,6 +25,7 @@
 #include "StelToneReproducer.hpp"
 #include "StelTextureMgr.hpp"
 #include "StelApp.hpp"
+#include "StelSRGB.hpp"
 #include "StelCore.hpp"
 #include "StelMovementMgr.hpp"
 #include "StelPainter.hpp"
@@ -496,14 +497,16 @@ bool StelSkyDrawer::drawPointSource(StelPainter* sPainter, const Vec3d& v, const
 
 		texBigHalo->bind();
 		sPainter->setBlending(true, GL_ONE, GL_ONE);
-		sPainter->setColor(color*cmag);
+		sPainter->setColor(srgbToLinear(color*cmag));
 		sPainter->drawSprite2dModeNoDeviceScale(win[0], win[1], rmag);
 	}
 
-	unsigned char starColor[3] = {0, 0, 0};
-	starColor[0] = static_cast<unsigned char>(std::min(static_cast<int>(color[0]*tw*255+0.5f), 255));
-	starColor[1] = static_cast<unsigned char>(std::min(static_cast<int>(color[1]*tw*255+0.5f), 255));
-	starColor[2] = static_cast<unsigned char>(std::min(static_cast<int>(color[2]*tw*255+0.5f), 255));
+	const auto starColorVec = srgbToLinear(color*tw+Vec3f(0.5/255))*255;
+	const uint8_t starColor[3] = {
+		static_cast<uint8_t>(std::min(starColorVec[0], 255.f)),
+		static_cast<uint8_t>(std::min(starColorVec[1], 255.f)),
+		static_cast<uint8_t>(std::min(starColorVec[2], 255.f)),
+	};
 	
 	// Store the drawing instructions in the vertex arrays
 	StarVertex* vx = &(vertexArray[nbPointSources*6]);

--- a/src/core/StelSkyImageTile.cpp
+++ b/src/core/StelSkyImageTile.cpp
@@ -212,7 +212,9 @@ void StelSkyImageTile::getTilesToDraw(QMultiMap<double, StelSkyImageTile*>& resu
 		{
 			// The tile has an associated texture, but it is not yet loaded: load it now
 			StelTextureMgr& texMgr=StelApp::getInstance().getTextureManager();
-			tex = texMgr.createTextureThread(absoluteImageURI, StelTexture::StelTextureParams(true, GL_LINEAR, GL_CLAMP_TO_EDGE, false, decimation));
+			const auto params = StelTexture::StelTextureParams(true, GL_LINEAR, GL_CLAMP_TO_EDGE, false,
+															   StelTexture::ColorSpace::LinearSRGB, decimation);
+			tex = texMgr.createTextureThread(absoluteImageURI, params);
 			if (!tex)
 			{
 				qWarning() << "WARNING : Can't create tile: " << absoluteImageURI;

--- a/src/core/StelSkyImageTile.cpp
+++ b/src/core/StelSkyImageTile.cpp
@@ -213,7 +213,7 @@ void StelSkyImageTile::getTilesToDraw(QMultiMap<double, StelSkyImageTile*>& resu
 			// The tile has an associated texture, but it is not yet loaded: load it now
 			StelTextureMgr& texMgr=StelApp::getInstance().getTextureManager();
 			const auto params = StelTexture::StelTextureParams(true, GL_LINEAR, GL_CLAMP_TO_EDGE, false,
-															   StelTexture::ColorSpace::LinearSRGB, decimation);
+															   StelTexture::ColorSpace::sRGB, decimation);
 			tex = texMgr.createTextureThread(absoluteImageURI, params);
 			if (!tex)
 			{

--- a/src/core/StelTexture.cpp
+++ b/src/core/StelTexture.cpp
@@ -300,21 +300,14 @@ QByteArray StelTexture::convertToGLFormat(QImage image, GLint& format, GLint& ty
 		image = image.scaled(width, height, Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
 	}
 
-	if (glInfo.supportsLuminanceTextures && image.isGrayscale())
-	{
-		format = image.hasAlphaChannel() ? GL_LUMINANCE_ALPHA : GL_LUMINANCE;
-	}
-	else if (image.hasAlphaChannel())
+	if (image.hasAlphaChannel())
 	{
 		format = GL_RGBA;
 	}
 	else
 		format = GL_RGB;
 	type = GL_UNSIGNED_BYTE;
-	int bpp = format == GL_LUMINANCE_ALPHA ? 2 :
-						  format == GL_LUMINANCE ? 1 :
-									    format == GL_RGBA ? 4 :
-												 3;
+	int bpp = format == format == GL_RGBA ? 4 : 3;
 
 	ret.reserve(width * height * bpp);
 	QImage tmp = image.convertToFormat(QImage::Format_ARGB32);
@@ -337,13 +330,6 @@ QByteArray StelTexture::convertToGLFormat(QImage image, GLint& format, GLint& ty
 					break;
 				case GL_RGB:
 					ret.append(ptr + 1, 3);
-					break;
-				case GL_LUMINANCE:
-					ret.append(ptr + 1, 1);
-					break;
-				case GL_LUMINANCE_ALPHA:
-					ret.append(ptr + 1, 1);
-					ret.append(ptr, 1);
 					break;
 				default:
 					Q_ASSERT(false);
@@ -396,11 +382,6 @@ bool StelTexture::glLoad(const GLData& data)
 		case GL_RGBA:
 			//RGBA pixels are always in 4 byte aligned rows
 			gl->glPixelStorei(GL_UNPACK_ALIGNMENT, 4);
-			alphaChannel = true;
-			break;
-		case GL_LUMINANCE_ALPHA:
-			//these ones are at least always in 2 byte aligned rows, but may also be 4 aligned
-			gl->glPixelStorei(GL_UNPACK_ALIGNMENT, 2);
 			alphaChannel = true;
 			break;
 		default:

--- a/src/core/StelTexture.hpp
+++ b/src/core/StelTexture.hpp
@@ -85,7 +85,7 @@ public:
 	//! Return the width and height of the texture in pixels
 	bool getDimensions(int &width, int &height);
 
-	//! Returns whether the texture has an alpha channel (GL_RGBA or GL_LUMINANCE_ALPHA format)
+	//! Returns whether the texture has an alpha channel (GL_RGBA format)
 	//! This only returns valid information after the texture is fully loaded.
 	bool hasAlphaChannel() const { return alphaChannel ; }
 

--- a/src/core/StelTexture.hpp
+++ b/src/core/StelTexture.hpp
@@ -41,15 +41,24 @@ class StelTexture: public QObject, public QEnableSharedFromThis<StelTexture>
 	Q_OBJECT
 
 public:
+	enum class ColorSpace
+	{
+		sRGB,
+		LinearSRGB,
+	};
 	//! Contains the parameters defining how a texture is created.
 	struct StelTextureParams
 	{
-		StelTextureParams(bool qgenerateMipmaps=false, GLint afiltering=GL_LINEAR, GLint awrapMode=GL_CLAMP_TO_EDGE, bool qfilterMipmaps=false, int decimateBy=1) :
+		StelTextureParams(bool qgenerateMipmaps=false, GLint afiltering=GL_LINEAR, GLint awrapMode=GL_CLAMP_TO_EDGE,
+						  bool qfilterMipmaps=false, ColorSpace colorSpace=ColorSpace::LinearSRGB, int decimateBy=1) :
 				generateMipmaps(qgenerateMipmaps),
 				filterMipmaps(qfilterMipmaps),
 				filtering(afiltering),
 				wrapMode(awrapMode),
-				decimation(decimateBy){;}
+				decimation(decimateBy),
+				colorSpace(colorSpace)
+		{
+		}
 		//! Define if mipmaps must be created.
 		bool generateMipmaps;
 		//! If true, mipmapped textures are filtered with GL_LINEAR_MIPMAP_LINEAR instead of GL_LINEAR_MIPMAP_NEAREST (i.e. enabling "trilinear" filtering)
@@ -61,6 +70,7 @@ public:
 		//! Allow a reduction of the size of the texture image (useful for very limited hardware)
 		//! The image size will be divided by this factor (e.g. 2, 3, 4, ...)
 		int decimation;
+		ColorSpace colorSpace;
 	};
 
 	//! Destructor

--- a/src/core/StelTexture.hpp
+++ b/src/core/StelTexture.hpp
@@ -50,7 +50,7 @@ public:
 	struct StelTextureParams
 	{
 		StelTextureParams(bool qgenerateMipmaps=false, GLint afiltering=GL_LINEAR, GLint awrapMode=GL_CLAMP_TO_EDGE,
-						  bool qfilterMipmaps=false, ColorSpace colorSpace=ColorSpace::LinearSRGB, int decimateBy=1) :
+						  bool qfilterMipmaps=false, ColorSpace colorSpace=ColorSpace::sRGB, int decimateBy=1) :
 				generateMipmaps(qgenerateMipmaps),
 				filterMipmaps(qfilterMipmaps),
 				filtering(afiltering),

--- a/src/core/modules/AtmospherePreetham.hpp
+++ b/src/core/modules/AtmospherePreetham.hpp
@@ -71,8 +71,6 @@ private:
 	//! Vertex shader used for xyYToRGB computation
 	class QOpenGLShaderProgram* atmoShaderProgram;
 	struct {
-		int ditherPattern;
-		int rgbMaxValue;
 		int alphaWaOverAlphaDa;
 		int oneOverGamma;
 		int term2TimesOneOverMaxdLpOneOverGamma; // original
@@ -87,8 +85,6 @@ private:
 		int skyColor;
 		int doSRGB;
 	} shaderAttribLocations;
-
-	StelTextureSP ditherPatternTex;
 
 	//! Binds actual VAO if it's supported, sets up the relevant state manually otherwise.
 	void bindVAO();

--- a/src/core/modules/AtmosphereShowMySky.hpp
+++ b/src/core/modules/AtmosphereShowMySky.hpp
@@ -100,8 +100,6 @@ private:
 
 	struct {
 		int doSRGB;
-		int rgbMaxValue;
-		int ditherPattern;
 		int oneOverGamma;
 		int brightnessScale;
 		int luminanceTexture;
@@ -111,7 +109,6 @@ private:
 		int flagUseTmGamma;                      // switch between their use, true to use the first expression.
 	} shaderAttribLocations;
 
-	StelTextureSP ditherPatternTex_;
 	StelProjectorP prevProjector_;
 	std::unique_ptr<TextureAverageComputer> textureAverager_;
 

--- a/src/core/modules/Landscape.cpp
+++ b/src/core/modules/Landscape.cpp
@@ -21,6 +21,7 @@
 
 #include "Landscape.hpp"
 #include "StelApp.hpp"
+#include "StelSRGB.hpp"
 #include "StelTextureMgr.hpp"
 #include "StelFileMgr.hpp"
 #include "StelLocation.hpp"
@@ -1063,7 +1064,9 @@ void LandscapeOldStyle::drawFog(StelCore*const core, const int firstFreeTexSampl
 	renderProgram->setUniformValue(shaderVars.vshift, vpos);
 
 	const float brightness = landFader.getInterstate()*fogFader.getInterstate()*(0.1f+0.1f*landscapeBrightness);
-	renderProgram->setUniformValue(shaderVars.brightness, brightness, brightness, brightness, landFader.getInterstate());
+	renderProgram->setUniformValue(shaderVars.brightness,
+								   srgbToLinear(brightness), srgbToLinear(brightness), srgbToLinear(brightness),
+								   landFader.getInterstate());
 	renderProgram->setUniformValue(shaderVars.projectionMatrixInverse, prj->getProjectionMatrix().toQMatrix().inverted());
 	prj->setUnProjectUniforms(*renderProgram);
 
@@ -1085,13 +1088,14 @@ void LandscapeOldStyle::drawDecor(StelCore*const core, const int firstFreeTexSam
 	if (drawLight)
 	{
 		const auto brightness = illumFader.getInterstate()*lightScapeBrightness;
-		renderProgram->setUniformValue(shaderVars.brightness, brightness, brightness, brightness,
+		renderProgram->setUniformValue(shaderVars.brightness,
+									   srgbToLinear(brightness), srgbToLinear(brightness), srgbToLinear(brightness),
 									   landFader.getInterstate());
 	}
 	else
 	{
 		renderProgram->setUniformValue(shaderVars.brightness,
-									   landscapeBrightness, landscapeBrightness, landscapeBrightness,
+									   srgbToLinear(landscapeBrightness), srgbToLinear(landscapeBrightness), srgbToLinear(landscapeBrightness),
 									   landFader.getInterstate());
 	}
 
@@ -1187,7 +1191,7 @@ void LandscapeOldStyle::drawGround(StelCore*const core, const int firstFreeTexSa
 	renderProgram->setUniformValue(shaderVars.vshift, vshift);
 	renderProgram->setUniformValue(shaderVars.projectionMatrixInverse, prj->getProjectionMatrix().toQMatrix().inverted());
 	renderProgram->setUniformValue(shaderVars.brightness,
-								   landscapeBrightness, landscapeBrightness, landscapeBrightness,
+								   srgbToLinear(landscapeBrightness), srgbToLinear(landscapeBrightness), srgbToLinear(landscapeBrightness),
 								   landFader.getInterstate());
 	prj->setUnProjectUniforms(*renderProgram);
 	gl.glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
@@ -1649,8 +1653,8 @@ void main(void)
 	{
 		renderProgram->bind();
 		renderProgram->setUniformValue(shaderVars.brightness,
-									   landscapeBrightness, landscapeBrightness,
-									   landscapeBrightness, landFader.getInterstate());
+									   srgbToLinear(landscapeBrightness), srgbToLinear(landscapeBrightness),
+									   srgbToLinear(landscapeBrightness), landFader.getInterstate());
 		const int mainTexSampler = 0;
 		mapTex->bind(mainTexSampler);
 		renderProgram->setUniformValue(shaderVars.mapTex, mainTexSampler);
@@ -1672,7 +1676,7 @@ void main(void)
 			gl.glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_COLOR);
 			const float brightness = landFader.getInterstate()*fogFader.getInterstate()*(0.1f+0.1f*landscapeBrightness);
 
-			renderProgram->setUniformValue(shaderVars.brightness, brightness, brightness, brightness,
+			renderProgram->setUniformValue(shaderVars.brightness, srgbToLinear(brightness), srgbToLinear(brightness), srgbToLinear(brightness),
 										   landFader.getInterstate());
 			mapTexFog->bind();
 			gl.glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
@@ -1682,7 +1686,7 @@ void main(void)
 		{
 			gl.glBlendFunc(GL_SRC_ALPHA, GL_ONE);
 			const float brightness = lightScapeBrightness*illumFader.getInterstate();
-			renderProgram->setUniformValue(shaderVars.brightness, brightness, brightness, brightness,
+			renderProgram->setUniformValue(shaderVars.brightness, srgbToLinear(brightness), srgbToLinear(brightness), srgbToLinear(brightness),
 										   landFader.getInterstate());
 			mapTexIllum->bind();
 			gl.glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
@@ -2001,14 +2005,14 @@ void main(void)
 	{
 		renderProgram->bind();
 		renderProgram->setUniformValue(shaderVars.bottomCapColor,
-									   landscapeBrightness*bottomCapColor[0],
-									   landscapeBrightness*bottomCapColor[1],
-									   landscapeBrightness*bottomCapColor[2],
+									   srgbToLinear(landscapeBrightness*bottomCapColor[0]),
+									   srgbToLinear(landscapeBrightness*bottomCapColor[1]),
+									   srgbToLinear(landscapeBrightness*bottomCapColor[2]),
 									   bottomCapColor[0] < 0 ? 0 : landFader.getInterstate());
 
 		renderProgram->setUniformValue(shaderVars.brightness,
-									   landscapeBrightness, landscapeBrightness,
-									   landscapeBrightness, landFader.getInterstate());
+									   srgbToLinear(landscapeBrightness), srgbToLinear(landscapeBrightness),
+									   srgbToLinear(landscapeBrightness), landFader.getInterstate());
 		const int mainTexSampler = 0;
 		mapTex->bind(mainTexSampler);
 		renderProgram->setUniformValue(shaderVars.mapTex, mainTexSampler);
@@ -2033,7 +2037,7 @@ void main(void)
 			const float brightness = landFader.getInterstate()*fogFader.getInterstate()*(0.1f+0.1f*landscapeBrightness);
 
 			renderProgram->setUniformValue(shaderVars.bottomCapColor, 0.f, 0.f, 0.f, 0.f);
-			renderProgram->setUniformValue(shaderVars.brightness, brightness, brightness, brightness,
+			renderProgram->setUniformValue(shaderVars.brightness, srgbToLinear(brightness), srgbToLinear(brightness), srgbToLinear(brightness),
 										   landFader.getInterstate());
 			mapTexFog->bind();
 			renderProgram->setUniformValue(shaderVars.mapTexTop, fogTexTop);
@@ -2047,7 +2051,7 @@ void main(void)
 			gl.glBlendFunc(GL_SRC_ALPHA, GL_ONE);
 			const float brightness = lightScapeBrightness*illumFader.getInterstate();
 			renderProgram->setUniformValue(shaderVars.bottomCapColor, 0.f, 0.f, 0.f, 0.f);
-			renderProgram->setUniformValue(shaderVars.brightness, brightness, brightness, brightness,
+			renderProgram->setUniformValue(shaderVars.brightness, srgbToLinear(brightness), srgbToLinear(brightness), srgbToLinear(brightness),
 										   landFader.getInterstate());
 			mapTexIllum->bind();
 			renderProgram->setUniformValue(shaderVars.mapTexTop, illumTexTop);

--- a/src/core/modules/Landscape.hpp
+++ b/src/core/modules/Landscape.hpp
@@ -229,7 +229,6 @@ protected:
 	std::unique_ptr<QOpenGLVertexArrayObject> vao;
 	std::unique_ptr<QOpenGLBuffer> vbo;
 	StelProjectorP prevProjector;
-	StelTextureSP ditherPatternTex;
 	std::unique_ptr<QOpenGLShaderProgram> renderProgram;
 
 	double radius;
@@ -360,9 +359,7 @@ private:
 		int tanMode;
 		int calibrated;
 		int brightness;
-		int rgbMaxValue;
 		int whatToRender;
-		int ditherPattern;
 		int decorAngleShift;
 		int firstSideInBatch;
 		int sidePresenceMask;
@@ -437,8 +434,6 @@ private:
 		int texFov;
 		int mapTex;
 		int brightness;
-		int rgbMaxValue;
-		int ditherPattern;
 		int projectionMatrixInverse;
 	} shaderVars;
 };
@@ -503,9 +498,7 @@ private:
 		int mapTex;
 		int mapTexTop;
 		int brightness;
-		int rgbMaxValue;
 		int mapTexBottom;
-		int ditherPattern;
 		int bottomCapColor;
 		int projectionMatrixInverse;
 	} shaderVars;

--- a/src/core/modules/MilkyWay.cpp
+++ b/src/core/modules/MilkyWay.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "MilkyWay.hpp"
+#include "StelSRGB.hpp"
 #include "StelFader.hpp"
 #include "StelTexture.hpp"
 #include "StelUtils.hpp"
@@ -337,7 +338,7 @@ void main(void)
 	renderProgram->setUniformValue(shaderVars.mainTex, mainTexSampler);
 
 	renderProgram->setUniformValue(shaderVars.projectionMatrixInverse, projector->getProjectionMatrix().toQMatrix().inverted());
-	renderProgram->setUniformValue(shaderVars.brightness, c.toQVector());
+	renderProgram->setUniformValue(shaderVars.brightness, srgbToLinear(c).toQVector());
 	renderProgram->setUniformValue(shaderVars.saturation, GLfloat(saturation));
 
 	core->setAberrationUniforms(*renderProgram);

--- a/src/core/modules/MilkyWay.hpp
+++ b/src/core/modules/MilkyWay.hpp
@@ -124,8 +124,6 @@ private:
 		int mainTex;
 		int brightness;
 		int saturation;
-		int rgbMaxValue;
-		int ditherPattern;
 		int bortleIntensity;
 		int extinctionEnabled;
 		int projectionMatrixInverse;
@@ -133,7 +131,6 @@ private:
 
 	std::unique_ptr<QOpenGLVertexArrayObject> vao;
 	std::unique_ptr<QOpenGLBuffer> vbo;
-	StelTextureSP ditherPatternTex;
 	StelProjectorP prevProjector;
 	std::unique_ptr<QOpenGLShaderProgram> renderProgram;
 };

--- a/src/core/modules/Planet.cpp
+++ b/src/core/modules/Planet.cpp
@@ -311,7 +311,8 @@ Planet::Planet(const QString& englishName,
 		QString normalMapFile = StelFileMgr::findFile("textures/"+normalMapName, StelFileMgr::File);
 		if (!normalMapFile.isEmpty())
 		{
-			normalMap = texMan.createTextureThread(normalMapFile, StelTexture::StelTextureParams(true, GL_LINEAR, GL_REPEAT), false);
+			const StelTexture::StelTextureParams params(true, GL_LINEAR, GL_REPEAT, false, StelTexture::ColorSpace::LinearSRGB);
+			normalMap = texMan.createTextureThread(normalMapFile, params, false);
 			normalMapFileOrig = normalMapFile;
 		}
 	}
@@ -321,7 +322,8 @@ Planet::Planet(const QString& englishName,
 		QString horizonMapFile = StelFileMgr::findFile("textures/"+horizonMapName, StelFileMgr::File);
 		if (!horizonMapFile.isEmpty())
 		{
-			horizonMap = texMan.createTextureThread(horizonMapFile, StelTexture::StelTextureParams(true, GL_LINEAR, GL_REPEAT), false);
+			const StelTexture::StelTextureParams params(true, GL_LINEAR, GL_REPEAT, false, StelTexture::ColorSpace::LinearSRGB);
+			horizonMap = texMan.createTextureThread(horizonMapFile, params, false);
 			horizonMapFileOrig = horizonMapFile;
 		}
 	}

--- a/src/core/modules/SolarSystem.cpp
+++ b/src/core/modules/SolarSystem.cpp
@@ -1244,7 +1244,13 @@ bool SolarSystem::loadPlanets(const QString& filePath)
 
 	// special case: load earth shadow texture
 	if (!Planet::texEarthShadow)
-		Planet::texEarthShadow = StelApp::getInstance().getTextureManager().createTexture(StelFileMgr::getInstallationDir()+"/textures/earth-shadow.png");
+	{
+		auto& texMan = StelApp::getInstance().getTextureManager();
+		const auto path = StelFileMgr::getInstallationDir()+"/textures/earth-shadow.png";
+		const StelTexture::StelTextureParams params(false, GL_LINEAR, GL_CLAMP_TO_EDGE, false,
+													StelTexture::ColorSpace::LinearSRGB);
+		Planet::texEarthShadow = texMan.createTexture(path, params);
+	}
 
 	// Also comets just have static textures.
 	if (!Comet::comaTexture)

--- a/src/core/modules/ZodiacalLight.cpp
+++ b/src/core/modules/ZodiacalLight.cpp
@@ -21,6 +21,7 @@
 #include "ZodiacalLight.hpp"
 #include "SolarSystem.hpp"
 #include "StelFader.hpp"
+#include "StelSRGB.hpp"
 // For debugging draw() only:
 //#include "StelObjectMgr.hpp"
 #include "StelTexture.hpp"
@@ -385,7 +386,7 @@ void main(void)
 	renderProgram->setUniformValue(shaderVars.mainTex, mainTexSampler);
 
 	renderProgram->setUniformValue(shaderVars.projectionMatrixInverse, projector->getProjectionMatrix().toQMatrix().inverted());
-	renderProgram->setUniformValue(shaderVars.brightness, c.toQVector());
+	renderProgram->setUniformValue(shaderVars.brightness, srgbToLinear(c).toQVector());
 	renderProgram->setUniformValue(shaderVars.lambdaSun, GLfloat(lambdaSun));
 
 	projector->setUnProjectUniforms(*renderProgram);

--- a/src/core/modules/ZodiacalLight.cpp
+++ b/src/core/modules/ZodiacalLight.cpp
@@ -109,8 +109,6 @@ void ZodiacalLight::init()
 	setupCurrentVAO();
 	releaseVAO();
 
-	ditherPatternTex = StelApp::getInstance().getTextureManager().getDitheringTexture(0);
-
 	QString displayGroup = N_("Display Options");
 	addAction("actionShow_ZodiacalLight", displayGroup, N_("Zodiacal Light"), "flagZodiacalLightDisplayed", "Ctrl+Shift+Z");
 
@@ -264,7 +262,6 @@ void main()
 			StelOpenGL::globalShaderPrefix(StelOpenGL::FRAGMENT_SHADER) +
 			projector->getUnProjectShader() +
 			extinction.getForwardTransformShader() +
-			makeDitheringShader()+
 			R"(
 VARYING highp vec3 ndcPos;
 uniform sampler2D mainTex;
@@ -303,7 +300,7 @@ void main(void)
 	}
 
     vec4 color = texture2D(mainTex, texc)*vec4(brightness,1)*extinctionFactor;
-	FRAG_COLOR = dither(color);
+	FRAG_COLOR = color;
 }
 )";
 		ok = renderProgram->addShaderFromSourceCode(QOpenGLShader::Fragment, frag);
@@ -321,8 +318,6 @@ void main(void)
 		shaderVars.mainTex          = renderProgram->uniformLocation("mainTex");
 		shaderVars.lambdaSun        = renderProgram->uniformLocation("lambdaSun");
 		shaderVars.brightness       = renderProgram->uniformLocation("brightness");
-		shaderVars.rgbMaxValue      = renderProgram->uniformLocation("rgbMaxValue");
-		shaderVars.ditherPattern    = renderProgram->uniformLocation("ditherPattern");
 		shaderVars.bortleIntensity  = renderProgram->uniformLocation("bortleIntensity");
 		shaderVars.extinctionEnabled= renderProgram->uniformLocation("extinctionEnabled");
 		shaderVars.projectionMatrixInverse = renderProgram->uniformLocation("projectionMatrixInverse");
@@ -389,14 +384,9 @@ void main(void)
 	mainTex->bind(mainTexSampler);
 	renderProgram->setUniformValue(shaderVars.mainTex, mainTexSampler);
 
-	const int ditherTexSampler = 1;
-	ditherPatternTex->bind(ditherTexSampler);
-	renderProgram->setUniformValue(shaderVars.ditherPattern, ditherTexSampler);
-
 	renderProgram->setUniformValue(shaderVars.projectionMatrixInverse, projector->getProjectionMatrix().toQMatrix().inverted());
 	renderProgram->setUniformValue(shaderVars.brightness, c.toQVector());
 	renderProgram->setUniformValue(shaderVars.lambdaSun, GLfloat(lambdaSun));
-	renderProgram->setUniformValue(shaderVars.rgbMaxValue, calcRGBMaxValue(core->getDitheringMode()).toQVector());
 
 	projector->setUnProjectUniforms(*renderProgram);
 	extinction.setForwardTransformUniforms(*renderProgram);

--- a/src/core/modules/ZodiacalLight.hpp
+++ b/src/core/modules/ZodiacalLight.hpp
@@ -149,15 +149,12 @@ private:
 		int mainTex;
 		int lambdaSun;
 		int brightness;
-		int rgbMaxValue;
-		int ditherPattern;
 		int bortleIntensity;
 		int extinctionEnabled;
 		int projectionMatrixInverse;
 	} shaderVars;
 	std::unique_ptr<QOpenGLVertexArrayObject> vao;
 	std::unique_ptr<QOpenGLBuffer> vbo;
-	StelTextureSP ditherPatternTex;
 	StelProjectorP prevProjector;
 	std::unique_ptr<QOpenGLShaderProgram> renderProgram;
 };


### PR DESCRIPTION
Historically, Stellarium did all the rendering in nonlinear sRGB color space. This means that all the operations like brightening and blending were done not quite correctly, sometimes leading to serious overshooting of colors, like in bug #3067.

This PR is an attempt to switch the rendering to linear-sRGB color space, i.e. the color space where the primaries and the white point are set to sRGB, but the nonlinear transfer function AKA gamma has not been applied. To achieve this, the following steps are done:

1. Have a separate high-color-depth FBO for linear-color scene rendering
2. When the linear-color scene is ready, blit this FBO to the target framebuffer, applying the sRGB transfer function and dithering
3. To avoid the need for explicit conversion of texture data from sRGB to linear-sRGB inside the shaders, the internal format of the textures is set to `GL_SRGB8` or `GL_SRGB8_ALPHA8`, which makes the hardware perform the conversion when sampling (and additionally, do minification filtering in linear colors).

There's a **problem** though: in my tests on Intel UHD Graphics 620 with Mesa 21.2.6 in OpenGL ES 2 mode the `GL_SRGB8*` formats appeared to be not color renderable, which precludes the use of `glGenerateMipmap()` for them. This in particular makes anisotropic filtering impossible even if we generate the mipmaps manually. The particular objects affected are the Moon, Jupiter, bottom of the old-style landscape (dunno why the sides are not): they become black in the current state of this branch.

The question is whether it's actually a problem in real-life OpenGL ES use cases. Does this problem happen on Windows/ANGLE? What about the small Linux systems where OpenGL ES is the only 3D API? I don't have any hardware to test this, so please try on yours.