### PR TITLE
Satellites: Allow Satellite Number to be zero

### DIFF
--- a/plugins/Satellites/src/Satellites.cpp
+++ b/plugins/Satellites/src/Satellites.cpp
@@ -2685,7 +2685,7 @@ QString Satellites::getSatIdFromLine2(const QString& line)
 	if (!id.isEmpty())
 	{
 		// Strip any leading zeros as they should be unique ints as strings.
-		static const QRegularExpression re("^[0]*");
+		static const QRegularExpression re("^[0]*\\B");
 		id.remove(re);
 	}
 	return id;

--- a/plugins/Satellites/src/test/testSatellites.cpp
+++ b/plugins/Satellites/src/test/testSatellites.cpp
@@ -46,4 +46,14 @@ void TestSatellites::testNoSatDuplication()
     QVERIFY(dutA == dutB);
 }
 
-
+void TestSatellites::testSatZero()
+{
+    QString LineA = "2 00000 101.7770 337.7317 0012122 318.4445 104.4962 12.53641440 65623";
+    QString LineB = "2     0 101.7765 338.2965 0012116 317.3609 153.9519 12.53641545 65932";
+    QString dutA = Satellites::getSatIdFromLine2(LineA);
+    QString dutB = Satellites::getSatIdFromLine2(LineB);
+    QVERIFY(!dutA.isEmpty());
+    QVERIFY(!dutB.isEmpty());
+    QVERIFY("0" == dutA);
+    QVERIFY("0" == dutB);
+}

--- a/plugins/Satellites/src/test/testSatellites.hpp
+++ b/plugins/Satellites/src/test/testSatellites.hpp
@@ -30,6 +30,7 @@ private slots:
     void testCelestrackFormattedLine2();
     void testSpaceTrackFormattedLine2();
     void testNoSatDuplication();
+    void testSatZero();
 };
 
 #endif // TESTSATELLITES_HPP


### PR DESCRIPTION
### Description
6a7afb8f9e43236b746b22fcd19adf19ce80e07f added stripping of leading zeros, but a temporary/manually created Orbital Element may have a Satellite Number of zero, and that should be allowed.

I considered replacing the regular expression with `QString::toInt()` and `QString::number()`, but that's a larger change and doesn't allow non-numeric values. Adding the "not at a word boundary" assertion at the end is much simpler.

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### How Has This Been Tested?
I've added a unit test to test that `00000` and `    0` both parse and return `0`.

**Test Configuration**:
* Operating system: Debian Linux
* Graphics Card: Intel(R) UHD Graphics 620

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
