### PR TITLE
Fix observing list import/export 

### DIFF
--- a/guide/ch_tour.tex
+++ b/guide/ch_tour.tex
@@ -298,9 +298,7 @@ also section~\ref{sec:gui:configuration:tools} for more screenshot options.
 \section{Observing Lists (Bookmarks)}
 \label{sec:tour:bookmarks}
 
-You can store your favourite objects or views in observing lists. This
-feature extends the earlier bookmarks feature.
-
+You can store your favourite objects or views in observing lists. 
 Press \key{Alt+B} or \guibutton[0.75]{2.5}{bt_bookmarks.png} to call
 up the dialog.  A bookmarks file from previous versions will be
 imported and converted to the new format. You can however create an
@@ -319,14 +317,17 @@ a particular location. Likewise, the displayed landscape may be nice
 to restore. Additionally, the field of view may be relevant. To store
 these data and later retrieve them, use the respective checkboxes.
 
-You can also export the current list with the according
-button, or import such an exported list on another system. Lists are identified with an 
+You can also export the current list or all lists with the according
+button, or import such an exported list on another system. 
+To export the current list, keep the default \texttt{.sol} file type in the filename dialog.
+To export all your lists, use the \texttt{.ol} file type in the filename dialog.
+Lists are identified with an 
 Universally Unique Identifier (UUID) which we call OLUD (Observing List Unique Identifier). 
 On importing a list, existing lists with the same OLUD may be replaced after a warning. 
 During editing, storing a list with an existing name is prevented. 
 The list import may however import a list with an existing name as long as the OLUD is different. 
-To transfer all your lists to another system, copy, rename and import 
-(or just copy, to replace the existing) the full file \file{observingLists.json} 
+To transfer all your lists to another system, export them as \texttt{.ol} file, or
+copy, rename and import (or just copy, to replace the existing) the full file \file{observingLists.json} 
 from the \file{data/} subdirectory of your user directory (see section~\ref{sec:Directories}).
 
 

--- a/src/gui/ObsListDialog.cpp
+++ b/src/gui/ObsListDialog.cpp
@@ -926,8 +926,9 @@ void ObsListDialog::exportListButtonPressed()
 		{KEY_VERSION, FILE_VERSION}};
 
 	QVariantMap currentListMap={{selectedOlud, observingLists.value(selectedOlud).toMap()}};
-	QVariantMap oneListMap={{KEY_OBSERVING_LISTS, currentListMap}};
-	exportJsonMap.insert(KEY_OBSERVING_LISTS, oneListMap);
+	//QVariantMap oneListMap={{KEY_OBSERVING_LISTS, currentListMap}};
+	//exportJsonMap.insert(KEY_OBSERVING_LISTS, oneListMap);
+	exportJsonMap.insert(KEY_OBSERVING_LISTS, currentListMap);
 
 	jsonFile.resize(0);
 	StelJsonParser::write(exportJsonMap, &jsonFile);
@@ -979,9 +980,10 @@ void ObsListDialog::importListButtonPressed()
 							bool overwrite=true;
 							if (observingLists.contains(it.key()))
 							{
-								QVariantMap importedMap=it.value().toMap();
+								QVariantMap importedMap=it.value().toMap(); // This is a map of {{UUID, QMap},...}
 								QString importedName=importedMap.value(KEY_NAME).toString();
 								QString importedDate=importedMap.value(KEY_CREATION_DATE).toString();
+								qDebug() << "Imported Map named:" << importedName << "date" << importedDate << ":" << importedMap;
 								QVariantMap existingMap=observingLists.value(it.key()).toMap();
 								QString existingName=existingMap.value(KEY_NAME).toString();
 								QString existingDate=existingMap.value(KEY_CREATION_DATE).toString();

--- a/src/gui/ObsListDialog.cpp
+++ b/src/gui/ObsListDialog.cpp
@@ -141,16 +141,8 @@ void ObsListDialog::createDialogContent()
 	ui->treeView->setModel(itemModel);
 	ui->treeView->header()->setSectionsMovable(false);
 	ui->treeView->hideColumn(ColumnUUID);
-	ui->treeView->header()->setSectionResizeMode(ColumnDesignation,   QHeaderView::ResizeToContents);
-	ui->treeView->header()->setSectionResizeMode(ColumnNameI18n,      QHeaderView::ResizeToContents);
-	ui->treeView->header()->setSectionResizeMode(ColumnType,          QHeaderView::ResizeToContents);
-	ui->treeView->header()->setSectionResizeMode(ColumnRa,            QHeaderView::ResizeToContents);
-	ui->treeView->header()->setSectionResizeMode(ColumnDec,           QHeaderView::ResizeToContents);
-	ui->treeView->header()->setSectionResizeMode(ColumnMagnitude,     QHeaderView::ResizeToContents);
-	ui->treeView->header()->setSectionResizeMode(ColumnConstellation, QHeaderView::ResizeToContents);
-	ui->treeView->header()->setSectionResizeMode(ColumnDate,          QHeaderView::ResizeToContents);
-	ui->treeView->header()->setSectionResizeMode(ColumnLocation,      QHeaderView::ResizeToContents);
-	ui->treeView->header()->setSectionResizeMode(ColumnLandscapeID,   QHeaderView::ResizeToContents);
+	for (int c=ColumnDesignation; c<=ColumnLandscapeID; c++)
+		ui->treeView->header()->setSectionResizeMode(c, QHeaderView::ResizeToContents);
 	ui->treeView->header()->setStretchLastSection(true);
 	//Enable the sort for columns
 	ui->treeView->setSortingEnabled(true);
@@ -177,14 +169,15 @@ void ObsListDialog::createDialogContent()
 		observingLists = QMap<QString, QVariant>();
 		// Create one default empty list
 		// Creation date
-		const double JD = core->getJD();
+		const double JD = StelUtils::getJDFromSystem();
 		const QString listCreationDate = StelUtils::julianDayToISO8601String(JD + core->getUTCOffset(JD) / 24.).replace("T", " ");
 		QVariantMap emptyList = {
 			// Name, description, current date for the list, current sorting
 			{KEY_NAME,          qc_("new list", "default name for observing list if none is available")},
 			{KEY_DESCRIPTION,   QString()},
 			{KEY_SORTING,       QString()},
-			{KEY_CREATION_DATE, listCreationDate }};
+			{KEY_CREATION_DATE, listCreationDate },
+			{KEY_LAST_EDIT,     listCreationDate }};
 
 		observingLists.insert(olud, emptyList);
 		jsonMap.insert(KEY_OBSERVING_LISTS, observingLists);
@@ -432,6 +425,7 @@ void ObsListDialog::loadSelectedList()
 	ui->listNameLineEdit->setText(currentListName);
 	ui->descriptionLineEdit->setText(observingListMap.value(KEY_DESCRIPTION).toString());
 	ui->creationDateLineEdit->setText(observingListMap.value(KEY_CREATION_DATE).toString());
+	ui->lastEditLineEdit->setText(observingListMap.value(KEY_LAST_EDIT, observingListMap.value(KEY_CREATION_DATE)).toString());
 
 	if (observingListMap.value(KEY_OBJECTS).canConvert<QVariantList>())
 	{
@@ -662,7 +656,7 @@ QHash<QString, ObsListDialog::observingListItem> ObsListDialog::loadBookmarksFil
 /*
  * Save the bookmarks into observingLists QVariantMap
 */
-void ObsListDialog::saveBookmarksHashInObservingLists(const QHash<QString, observingListItem> &bookmarksHash)
+QString ObsListDialog::saveBookmarksHashInObservingLists(const QHash<QString, observingListItem> &bookmarksHash)
 {
 	// Creation date
 	double JD = StelUtils::getJDFromSystem(); // Mark with current system time
@@ -672,6 +666,7 @@ void ObsListDialog::saveBookmarksHashInObservingLists(const QHash<QString, obser
 		{KEY_NAME,          BOOKMARKS_LIST_NAME},
 		{KEY_DESCRIPTION,   BOOKMARKS_LIST_DESCRIPTION},
 		{KEY_CREATION_DATE, listCreationDate},
+		{KEY_LAST_EDIT,     listCreationDate},
 		{KEY_SORTING,       SORTING_BY_NAME}};
 
 	// Add actual list of (former) bookmark entries
@@ -689,6 +684,7 @@ void ObsListDialog::saveBookmarksHashInObservingLists(const QHash<QString, obser
 	QString bookmarkListOlud= (keys.empty() ? QUuid::createUuid().toString() : keys.at(0));
 
 	observingLists.insert(bookmarkListOlud, bookmarksObsList);
+	return bookmarkListOlud;
 }
 
 /*
@@ -907,9 +903,9 @@ void ObsListDialog::editListButtonPressed()
  */
 void ObsListDialog::exportListButtonPressed()
 {
-	static const QString filter = "JSON (*.json)";
+	static const QString filter = "Stellarium Observing List (*.sol)";
 	QString exportListJsonPath = QFileDialog::getSaveFileName(nullptr, q_("Export observing list as..."),
-							     QDir::homePath() + "/" + JSON_FILE_BASENAME + "_" + currentListName + ".json", filter);
+							     QDir::homePath() + "/" + JSON_FILE_BASENAME + "_" + currentListName + ".sol", filter);
 	QFile jsonFile(exportListJsonPath);
 	if (!jsonFile.open(QIODevice::ReadWrite | QIODevice::Text))
 	{
@@ -941,7 +937,7 @@ void ObsListDialog::exportListButtonPressed()
  */
 void ObsListDialog::importListButtonPressed()
 {
-	static const QString filter = "JSON (*.json)";
+	static const QString filter = "Stellarium Observing List (*.sol)";
 	QString fileToImportJsonPath = QFileDialog::getOpenFileName(nullptr, q_("Import observing list"),
 								    QDir::homePath(),
 								    filter);
@@ -983,15 +979,20 @@ void ObsListDialog::importListButtonPressed()
 								QVariantMap importedMap=it.value().toMap(); // This is a map of {{UUID, QMap},...}
 								QString importedName=importedMap.value(KEY_NAME).toString();
 								QString importedDate=importedMap.value(KEY_CREATION_DATE).toString();
-								qDebug() << "Imported Map named:" << importedName << "date" << importedDate << ":" << importedMap;
+								QString importedLastEditDate=importedMap.value(KEY_LAST_EDIT, importedMap.value(KEY_CREATION_DATE)).toString();
+								qDebug() << "Imported Map named:" << importedName << "created" << importedDate << "changed" << importedLastEditDate << ":" << importedMap;
 								QVariantMap existingMap=observingLists.value(it.key()).toMap();
 								QString existingName=existingMap.value(KEY_NAME).toString();
 								QString existingDate=existingMap.value(KEY_CREATION_DATE).toString();
-								QString message=QString(q_("A list named '%1' and dated %2 would overwrite your existing list '%3', dated %4. Accept?")).arg(importedName, importedDate, existingName, existingDate);
+								QString existingLastEdit=existingMap.value(KEY_LAST_EDIT, existingMap.value(KEY_CREATION_DATE)).toString();
+								QString message=QString(q_("A list named '%1', created %2 and last modified %3 would overwrite your existing list '%4', dated %5/%6. Accept?")).arg(importedName, importedDate, importedLastEditDate, existingName, existingDate, existingLastEdit);
 								overwrite=askConfirmation(message);
 							}
 							if (overwrite)
+							{
 								observingLists.insert(it.key(), it.value());
+								selectedOlud=it.key();
+							}
 						}
 					}
 				}
@@ -1010,7 +1011,7 @@ void ObsListDialog::importListButtonPressed()
 				{
 					QHash<QString, ObsListDialog::observingListItem> bookmarksHash=loadBookmarksFile(jsonFile);
 					// Put them to the main list. Note that this may create another list named "bookmarks list", however, with a different OLUD than the existing.
-					saveBookmarksHashInObservingLists(bookmarksHash);
+					selectedOlud=saveBookmarksHashInObservingLists(bookmarksHash);
 				}
 			}
 			else
@@ -1034,6 +1035,10 @@ void ObsListDialog::importListButtonPressed()
 			jsonFile.flush();
 			jsonFile.close();
 			tainted=false;
+
+			// Now we have stored to file, but the program is not aware of the new lists!
+			loadListNames(); // also populate Combobox and make sure at least some defaultOlud exists.
+			loadSelectedList();
 		} catch (std::runtime_error &e) {
 			qWarning() << "[ObservingList Creation/Edition] File format is wrong! Error: " << e.what();
 			messageBox(q_("Error"), q_("File format is wrong!"));
@@ -1096,7 +1101,7 @@ void ObsListDialog::addObjectButtonPressed()
 
 	if (!selectedObject.isEmpty())
 	{
-// TBD: this test should prevent adding duplicate entries, but fails. Maybe for V23.2!
+// TBD: this test should prevent adding duplicate entries, but fails. Maybe for V23.4!
 //		// No duplicate item in the same list
 //		bool is_already_in_list = false;
 //		QHash<QString, observingListItem>::iterator i;
@@ -1303,6 +1308,8 @@ void ObsListDialog::switchEditMode(bool enableEditMode, bool newList)
 
 		ui->creationDateLabel->setVisible(!isEditMode);         // Creation date:
 		ui->creationDateLineEdit->setVisible(!isEditMode);      //
+		ui->lastEditLabel->setVisible(!isEditMode);             // Last edit date:
+		ui->lastEditLineEdit->setVisible(!isEditMode);          //
 
 		// line with optional store items
 		ui->alsoStoreLabel->setVisible(isEditMode);            // Also store
@@ -1376,19 +1383,21 @@ void ObsListDialog::setFlagUseFov(bool b)
 
 /*
  * Prepare the currently displayed/edited list for storage
- * Returns QVariantList with keys={creation date, description, name, objects, sorting}
+ * Returns QVariantList with keys={creation date, last edit, description, name, objects, sorting}
  */
 QVariantMap ObsListDialog::prepareCurrentList(QHash<QString, observingListItem> &itemHash)
 {
-	// Creation date
-	const double JD = core->getJD();
-	const QString listCreationDate = StelUtils::julianDayToISO8601String(JD + core->getUTCOffset(JD) / 24.).replace("T", " ");
+	// Edit date
+	const double JD = StelUtils::getJDFromSystem();
+	const QString lastEditDate = StelUtils::julianDayToISO8601String(JD + core->getUTCOffset(JD) / 24.).replace("T", " ");
 	QVariantMap currentList = {
 		// Name, description, current date for the list, current sorting
 		{KEY_NAME,          currentListName},
 		{KEY_DESCRIPTION,   ui->descriptionLineEdit->text()},
 		{KEY_SORTING,       sorting},
-		{KEY_CREATION_DATE, listCreationDate }};
+		{KEY_CREATION_DATE, ui->creationDateLineEdit->text()},
+		{KEY_LAST_EDIT,     lastEditDate }
+	};
 
 	// List of objects
 	QVariantList listOfObjects;
@@ -1467,6 +1476,7 @@ const QString ObsListDialog::SHORT_NAME_VALUE           = QStringLiteral("Observ
 const QString ObsListDialog::KEY_DEFAULT_LIST_OLUD = QStringLiteral("defaultListOlud");
 const QString ObsListDialog::KEY_OBSERVING_LISTS   = QStringLiteral("observingLists");
 const QString ObsListDialog::KEY_CREATION_DATE     = QStringLiteral("creation date");
+const QString ObsListDialog::KEY_LAST_EDIT         = QStringLiteral("last edit");
 const QString ObsListDialog::KEY_BOOKMARKS         = QStringLiteral("bookmarks");
 const QString ObsListDialog::KEY_NAME              = QStringLiteral("name");
 const QString ObsListDialog::KEY_NAME_I18N         = QStringLiteral("nameI18n");

--- a/src/gui/ObsListDialog.hpp
+++ b/src/gui/ObsListDialog.hpp
@@ -50,6 +50,7 @@
 //! "observingLists": {
 //!     "{84744f7b-c353-45b0-8394-69af2a1e0917}": { // List OLUD. This is a unique ID
 //! 	"creation date": "2022-09-29 20:05:07",
+//!	"last edit": "2022-11-29 22:15:38",
 //! 	"description": "Bookmarks of previous Stellarium version.",
 //! 	"name": "bookmarks list",
 //! 	"objects": [                                // List is stored alphabetized, but given here in contextualized order for clarity.
@@ -75,6 +76,7 @@
 //!     },                                            // end of list 84744f7b-...
 //!     "{bd40274c-a321-40c1-a6f3-bc8f11026326}": {   // List OLUD of next list.
 //! 	"creation date": "2022-12-21 11:12:39",
+//!	"last edit": "2023-07-29 22:23:38",
 //! 	"description": "test of unification",
 //! 	"name": "mine_edited",
 //! 	"objects": [
@@ -292,7 +294,8 @@ private:
 	QVariantMap prepareCurrentList(QHash<QString, observingListItem> &itemHash);
 
 	//! Put the bookmarks in bookmarksHash into observingLists under the listname "bookmarks list". Does not write JSON!
-	void saveBookmarksHashInObservingLists(const QHash<QString, observingListItem> &bookmarksHash);
+	//! @return OLUD of the imported bookmarks list.
+	QString saveBookmarksHashInObservingLists(const QHash<QString, observingListItem> &bookmarksHash);
 
 	//! Sort the obsListTreeView by the column name given in parameter
 	void sortObsListTreeViewByColumnName(const QString &columnName);
@@ -380,6 +383,7 @@ private:
 	static const QString KEY_DEFAULT_LIST_OLUD;
 	static const QString KEY_OBSERVING_LISTS;
 	static const QString KEY_CREATION_DATE;
+	static const QString KEY_LAST_EDIT;
 	static const QString KEY_BOOKMARKS;
 	static const QString KEY_NAME;
 	static const QString KEY_NAME_I18N;

--- a/src/gui/ObsListDialog.hpp
+++ b/src/gui/ObsListDialog.hpp
@@ -113,7 +113,7 @@
 //! Fix a confusion introduced in the 1.* series:
 //! The ObsList has entries
 //! - "designation": The catalog number (DSO), HIP number (star), or canonical name (planet).
-//! - "nameI18n": translated name for display. Actually this is bad in case of list exchange.
+//! - "nameI18n": translated name for display. Actually this is bad design in case of list exchange.
 //! - "type": As given by ObjectP->getType() or getObjectType()? This was inconsistent.
 //! FIXES:
 //! - "designation" used in combination with type as real unique object ID. For DSO, getDSODesignationWIC() must be used.

--- a/src/gui/obsListDialog.ui
+++ b/src/gui/obsListDialog.ui
@@ -259,6 +259,16 @@
         <item>
          <widget class="QLineEdit" name="creationDateLineEdit"/>
         </item>
+        <item>
+         <widget class="QLabel" name="lastEditLabel">
+          <property name="text">
+           <string>Last edit:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="lastEditLineEdit"/>
+        </item>
        </layout>
       </item>
       <item row="3" column="0">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fix a few quirks and a real bug in ObsList import and export.

### Description
<!--- Please include a summary of the change and which issue is fixed. -->
<!--- Please also include relevant motivation and context. -->
<!--- List any dependencies that are required for this change. -->

List export exports a single list. 
On import, the name of the list is checked. 

List date is date of creation, not of last edit. Maybe we should change that?

The oh-so-important OLUD is actually not tested. If a list is created, an OLUD is given. Exporting to file, editing the "live" list, storing and importing the previously exported would (I think) just overwrite the existing list with same OLUD.  Is this not what should have been avoided? What is the scenario?


Fixes 
- [x] #3206 (issue)
- [x] after loading a list, show it immediately and fill its name in the name combo
- [x] On export, let users export single lists (ending: `.sol`) or the whole list of lists `.ol`
- [x] Change timestamp from list creation date to date of last edit.
- [x] On import, make sure to test existing lists not by name and last date, but by OLUD (or all 3?)
- [ ] (other observations)

### Screenshots (if appropriate):

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] This change requires a documentation update

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system: Win11
* Graphics Card: irrelevant

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (header file)
- [x] I have updated the respective chapter in the Stellarium User Guide
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
