### PR TITLE
Specify tab size explicitly in coding style document

### DIFF
--- a/doc/codingConventions.doxygen
+++ b/doc/codingConventions.doxygen
@@ -59,8 +59,7 @@ Settings for <a href="http://doc.qt.io/qtcreator/index.html">QtCreator</a> IDE y
 #define MIN_WIDTH 3
 static const QString VERSION = "0.10.1";
  @endcode
- - Indentation should be done with tabs, not spaces. This allows developers
- to use their favorite indent size without changing the code. 
+ - Indentation should be done with tabs, not spaces. Tab size is 8 characters.
  - When wrapping lines from long function calls, where the wrapped line does not start at the same level of indentation as the start of the function call, tab up to the start of the function call, and then use spaces to the opening parenthesis.
  @verbatim
  [--tab-][--tab-][--tab-]someFunction(param, ...


### PR DESCRIPTION
Due to a recent confusion in #3283, I found the need to explicitly specify tab size in the coding style. The statement that using tabs lets developers choose their favorite tab size is wrong whenever we find the need to align lines of code. So this patch alters the document.

Alternatively, while the alignment in the current code base is messed up (due to me in particular, since I never expected 8-char tabs to be used here), we might choose to set e.g. 4 chars per tab if everyone agrees.