### PR TITLE
AstroCalc: show current location of object

### DIFF
--- a/src/core/modules/SolarSystem.cpp
+++ b/src/core/modules/SolarSystem.cpp
@@ -94,6 +94,7 @@ SolarSystem::SolarSystem() : StelObjectModule()
 	, ephemerisHorizontalCoordinates(false)
 	, ephemerisLineDisplayed(false)
 	, ephemerisAlwaysOn(false)
+	, ephemerisNow(false)
 	, ephemerisLineThickness(1)
 	, ephemerisSkipDataDisplayed(false)
 	, ephemerisSkipMarkersDisplayed(false)
@@ -140,6 +141,7 @@ SolarSystem::~SolarSystem()
 
 	texEphemerisMarker.clear();
 	texEphemerisCometMarker.clear();
+	texEphemerisNowMarker.clear();
 	texPointer.clear();
 
 	delete allTrails;
@@ -252,6 +254,7 @@ void SolarSystem::init()
 	// Ephemeris stuff
 	setFlagEphemerisMarkers(conf->value("astrocalc/flag_ephemeris_markers", true).toBool());
 	setFlagEphemerisAlwaysOn(conf->value("astrocalc/flag_ephemeris_alwayson", true).toBool());
+	setFlagEphemerisNow(conf->value("astrocalc/flag_ephemeris_now", false).toBool());
 	setFlagEphemerisDates(conf->value("astrocalc/flag_ephemeris_dates", false).toBool());
 	setFlagEphemerisMagnitudes(conf->value("astrocalc/flag_ephemeris_magnitudes", false).toBool());
 	setFlagEphemerisHorizontalCoordinates(conf->value("astrocalc/flag_ephemeris_horizontal", false).toBool());
@@ -283,6 +286,7 @@ void SolarSystem::init()
 
 	texPointer = StelApp::getInstance().getTextureManager().createTexture(StelFileMgr::getInstallationDir()+"/textures/pointeur4.png");
 	texEphemerisMarker = StelApp::getInstance().getTextureManager().createTexture(StelFileMgr::getInstallationDir()+"/textures/disk.png");
+	texEphemerisNowMarker = StelApp::getInstance().getTextureManager().createTexture(StelFileMgr::getInstallationDir()+"/textures/gear.png");
 	texEphemerisCometMarker = StelApp::getInstance().getTextureManager().createTexture(StelFileMgr::getInstallationDir()+"/textures/cometIcon.png");
 	Planet::hintCircleTex = StelApp::getInstance().getTextureManager().createTexture(StelFileMgr::getInstallationDir()+"/textures/planet-indicator.png");
 	
@@ -1453,6 +1457,7 @@ void SolarSystem::drawEphemerisMarkers(const StelCore *core)
 	const bool showMagnitudes = getFlagEphemerisMagnitudes();
 	const bool showSkippedData = getFlagEphemerisSkipData();
 	const bool skipMarkers = getFlagEphemerisSkipMarkers();
+	const bool isNowVisible = getFlagEphemerisNow();
 	const int dataStep = getEphemerisDataStep();
 	const int sizeCoeff = getEphemerisLineThickness() - 1;
 	QString info = "";
@@ -1462,6 +1467,26 @@ void SolarSystem::drawEphemerisMarkers(const StelCore *core)
 
 	if (getFlagEphemerisLine() && getFlagEphemerisScaleMarkers())
 		baseSize = 3.f; // The line lies through center of marker
+
+	if (isNowVisible)
+	{
+		const int limit = getEphemerisDataLimit();
+		const int nsize = static_cast<int>(fsize/limit);
+		sPainter.setBlending(true, GL_ONE, GL_ONE);
+		texEphemerisNowMarker->bind();
+		Vec3d pos;
+		Vec3f win;
+		for (int i =0; i < limit; i++)
+		{
+			sPainter.setColor(getEphemerisMarkerColor(AstroCalcDialog::EphemerisList[i*nsize].colorIndex));
+			if (getFlagEphemerisHorizontalCoordinates())
+				pos = AstroCalcDialog::EphemerisList[i*nsize].sso->getAltAzPosAuto(core);
+			else
+				pos = AstroCalcDialog::EphemerisList[i*nsize].sso->getJ2000EquatorialPos(core);
+			if (prj->project(pos, win))
+				sPainter.drawSprite2dMode(static_cast<float>(win[0]), static_cast<float>(win[1]), 6.f, 0.f);
+		}
+	}
 
 	for (int i =0; i < fsize; i++)
 	{
@@ -2314,6 +2339,21 @@ void SolarSystem::setFlagEphemerisAlwaysOn(bool b)
 		ephemerisAlwaysOn = b;
 		conf->setValue("astrocalc/flag_ephemeris_alwayson", b); // Immediate saving of state
 		emit ephemerisAlwaysOnChanged(b);
+	}
+}
+
+bool SolarSystem::getFlagEphemerisNow() const
+{
+	return ephemerisNow;
+}
+
+void SolarSystem::setFlagEphemerisNow(bool b)
+{
+	if (b != ephemerisNow)
+	{
+		ephemerisNow = b;
+		conf->setValue("astrocalc/flag_ephemeris_now", b); // Immediate saving of state
+		emit ephemerisNowChanged(b);
 	}
 }
 

--- a/src/core/modules/SolarSystem.hpp
+++ b/src/core/modules/SolarSystem.hpp
@@ -98,6 +98,7 @@ class SolarSystem : public StelObjectModule
 	Q_PROPERTY(bool ephemerisSmartDates		READ getFlagEphemerisSmartDates		WRITE setFlagEphemerisSmartDates	NOTIFY ephemerisSmartDatesChanged)
 	Q_PROPERTY(bool ephemerisScaleMarkersDisplayed	READ getFlagEphemerisScaleMarkers	WRITE setFlagEphemerisScaleMarkers	NOTIFY ephemerisScaleMarkersChanged)
 	Q_PROPERTY(bool ephemerisAlwaysOn		READ getFlagEphemerisAlwaysOn		WRITE setFlagEphemerisAlwaysOn		NOTIFY ephemerisAlwaysOnChanged)
+	Q_PROPERTY(bool ephemerisNow			READ getFlagEphemerisNow		WRITE setFlagEphemerisNow		NOTIFY ephemerisNowChanged)
 	// Great Red Spot (GRS) properties
 	Q_PROPERTY(int grsLongitude			READ getGrsLongitude			WRITE setGrsLongitude			NOTIFY grsLongitudeChanged)
 	Q_PROPERTY(double grsDrift			READ getGrsDrift			WRITE setGrsDrift			NOTIFY grsDriftChanged)
@@ -771,6 +772,7 @@ signals:
 	void ephemerisMagnitudesChanged(bool b);
 	void ephemerisLineChanged(bool b);
 	void ephemerisAlwaysOnChanged(bool b);
+	void ephemerisNowChanged(bool b);
 	void ephemerisLineThicknessChanged(int v);
 	void ephemerisSkipDataChanged(bool b);
 	void ephemerisSkipMarkersChanged(bool b);
@@ -910,6 +912,11 @@ private slots:
 	void setFlagEphemerisAlwaysOn(bool b);
 	//! Get the current value of the flag which makes ephemeris lines and marks always on
 	bool getFlagEphemerisAlwaysOn() const;
+
+	//! Set flag, which enables ephemeris marks on position "now"
+	void setFlagEphemerisNow(bool b);
+	//! Get the current value of the flag which makes ephemeris marks on position "now"
+	bool getFlagEphemerisNow() const;
 
 	//! Set the thickness of ephemeris line
 	void setEphemerisLineThickness(int v);
@@ -1083,6 +1090,7 @@ private:
 	StelTextureSP texPointer;
 	StelTextureSP texEphemerisMarker;
 	StelTextureSP texEphemerisCometMarker;
+	StelTextureSP texEphemerisNowMarker;
 
 	bool flagShow;
 	bool flagPointer;                           // show red cross selection pointer?
@@ -1100,6 +1108,7 @@ private:
 	bool ephemerisHorizontalCoordinates;
 	bool ephemerisLineDisplayed;
 	bool ephemerisAlwaysOn;
+	bool ephemerisNow;
 	int ephemerisLineThickness;
 	bool ephemerisSkipDataDisplayed;
 	bool ephemerisSkipMarkersDisplayed;

--- a/src/gui/AstroCalcDialog.cpp
+++ b/src/gui/AstroCalcDialog.cpp
@@ -139,6 +139,7 @@ AstroCalcDialog::AstroCalcDialog(QObject* parent)
 
 AstroCalcDialog::~AstroCalcDialog()
 {
+	EphemerisList.clear();
 	if (currentTimeLine)
 	{
 		currentTimeLine->stop();

--- a/src/gui/AstroCalcDialog.cpp
+++ b/src/gui/AstroCalcDialog.cpp
@@ -1969,6 +1969,7 @@ void AstroCalcDialog::generateEphemeris()
 			item.objDate = JD;
 			item.magnitude = obj->getVMagnitudeWithExtinction(core);
 			item.isComet = obj->getPlanetType()==Planet::isComet;
+			item.sso = obj;
 			EphemerisList.append(item);
 
 			Vec3d observerHelioPos = core->getObserverHeliocentricEclipticPos();

--- a/src/gui/AstroCalcDialog.hpp
+++ b/src/gui/AstroCalcDialog.hpp
@@ -59,6 +59,7 @@ struct Ephemeris
 	QString objDateStr;
 	float magnitude;
 	bool isComet;
+	PlanetP sso;
 };
 Q_DECLARE_METATYPE(Ephemeris)
 

--- a/src/gui/AstroCalcExtraEphemerisDialog.cpp
+++ b/src/gui/AstroCalcExtraEphemerisDialog.cpp
@@ -57,7 +57,8 @@ void AstroCalcExtraEphemerisDialog::createDialogContent()
 	connectIntProperty(ui->dataStepSpinBox,		"SolarSystem.ephemerisDataStep");
 	connectBoolProperty(ui->smartDatesCheckBox,	"SolarSystem.ephemerisSmartDates");
 	connectBoolProperty(ui->scaleMarkersCheckBox,	"SolarSystem.ephemerisScaleMarkersDisplayed");
-	connectBoolProperty(ui->alwaysOnCheckBox, "SolarSystem.ephemerisAlwaysOn");
+	connectBoolProperty(ui->alwaysOnCheckBox,	"SolarSystem.ephemerisAlwaysOn");
+	connectBoolProperty(ui->currentLocationCheckBox,"SolarSystem.ephemerisNow" );
 	connectIntProperty(ui->lineThicknessSpinBox,	"SolarSystem.ephemerisLineThickness");
 
 	setOptionStatus();

--- a/src/gui/astroCalcExtraEphemerisDialog.ui
+++ b/src/gui/astroCalcExtraEphemerisDialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>305</width>
-    <height>155</height>
+    <height>209</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
@@ -223,6 +223,13 @@
        <widget class="QCheckBox" name="scaleMarkersCheckBox">
         <property name="text">
          <string>Use small markers, when line is enabled</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="currentLocationCheckBox">
+        <property name="text">
+         <string>Show marker for current location</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
### Description
This pull request adds the ability to show current locations of objects which already have computed ephemeris.

Fixes #2937 (issue)

### Screenshots (if appropriate):
![stellarium-007](https://github.com/Stellarium/stellarium/assets/88731/b73eea4a-9294-4e2b-969d-5dc267204971)

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### How Has This Been Tested?
- Run Stellarium
- Open AstroCalc/Ephemeris tool and compute ephemeris
- Open "Extra options..." windows and mark "Show marker for current location"
- See the screen

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
