### PR TITLE
Fix computation of signed phase angle to determine apparent magnitude

### DIFF
--- a/src/core/StelCore.cpp
+++ b/src/core/StelCore.cpp
@@ -1072,6 +1072,23 @@ Vec3d StelCore::getObserverHeliocentricEclipticPos() const
 	return Vec3d(matAltAzToHeliocentricEclipticJ2000[12], matAltAzToHeliocentricEclipticJ2000[13], matAltAzToHeliocentricEclipticJ2000[14]);
 }
 
+Vec3d StelCore::getObserverHeliocentricEclipticVelocity() const
+{
+	const auto& planet = *position->getHomePlanet();
+	const Vec3d planetVelocity = planet.getHeliocentricEclipticVelocity();
+	if (!flagUseTopocentricCoordinates)
+		return planetVelocity;
+
+	const auto off = position->getTopographicOffsetFromCenter();
+	const auto rotRadius = off.v[0];
+	const auto rotPeriod = planet.getSiderealDay();
+	const auto linearSpeed = 2 * M_PI * rotRadius / rotPeriod; // AU/day
+	const auto toJ2000 = matAltAzToHeliocentricEclipticJ2000.upper3x3();
+	const auto eastwardVelocity = Vec3d(0,linearSpeed,0);
+	const auto velocity = toJ2000 * eastwardVelocity;
+	return planetVelocity + velocity;
+}
+
 // Set the location to use by default at startup
 void StelCore::setDefaultLocationID(const QString& id)
 {

--- a/src/core/StelCore.hpp
+++ b/src/core/StelCore.hpp
@@ -305,6 +305,9 @@ public:
 
 	//! Return the observer heliocentric ecliptic position (GZ: presumably J2000)
 	Vec3d getObserverHeliocentricEclipticPos() const;
+	//! Return the observer heliocentric ecliptic velocity. This includes orbital and diurnal motion;
+	// diurnal motion is omitted if planetocentric coordinates are in use.
+	Vec3d getObserverHeliocentricEclipticVelocity() const;
 
 	//! Get the information on the current location
 	const StelLocation& getCurrentLocation() const;

--- a/src/core/modules/Planet.cpp
+++ b/src/core/modules/Planet.cpp
@@ -1598,6 +1598,8 @@ QVariantMap Planet::getInfoMap(const StelCore *core) const
 		map.insert("phase-angle", phaseAngle);
 		map.insert("phase-angle-dms", StelUtils::radToDmsStr(phaseAngle));
 		map.insert("phase-angle-deg", StelUtils::radToDecDegStr(phaseAngle));
+		const bool waning = isWaning(observerHelioPos, core->getObserverHeliocentricEclipticVelocity());
+		map.insert("is-waning", waning);
 		double elongation = getElongation(observerHelioPos);
 		map.insert("elongation", elongation);
 		map.insert("elongation-dms", StelUtils::radToDmsStr(elongation));

--- a/src/core/modules/Planet.hpp
+++ b/src/core/modules/Planet.hpp
@@ -433,6 +433,8 @@ public:
 
 	//! Get the phase angle (radians) for an observer at pos obsPos in heliocentric coordinates (in AU)
 	double getPhaseAngle(const Vec3d& obsPos) const;
+	//! Check whether the planet is in a waning phase, i.e. its phase angle is increasing
+	bool isWaning(const Vec3d& observerPosition, const Vec3d& observerVelocity) const;
 	//! Get the elongation angle (radians) for an observer at pos obsPos in heliocentric coordinates (in AU)
 	double getElongation(const Vec3d& obsPos) const;
 	//! Get the angular radius (degrees) of the planet spheroid (i.e. without the rings)

--- a/src/scripting/StelMainScriptAPI.hpp
+++ b/src/scripting/StelMainScriptAPI.hpp
@@ -259,6 +259,7 @@ public slots:
 	//! - phase-angle : phase angle of object in radians (for Solar system objects only!)
 	//! - phase-angle-dms : phase angle of object in DMS (for Solar system objects only!)
 	//! - phase-angle-deg : phase angle of object in decimal degrees (for Solar system objects only!)
+	//! - is-waning : whether phase angle is increasing, signifying the waning phase (for Solar system objects only!)
 	//! - elongation : elongation of object in radians (for Solar system objects only!)
 	//! - elongation-dms : elongation of object in DMS (for Solar system objects only!)
 	//! - elongation-deg : elongation of object in decimal degrees (for Solar system objects only!)


### PR DESCRIPTION
### Description

Current computation of apparent magnitude uses two similar quantities: phase angle and something that approximates it, adding a sign to indicate whether the it's a waxing or waning phase.

As I understand, the only reason of determining the sign is to make magnitude depend on what half of the Moon is illuminated, due to asymmetry in the albedo of the visible side of the Moon. So the quantity should actually be equal to the phase angle, up to a sign.

The unsigned phase angle is computed correctly, taking into account positions of the observer and the Moon. But the way the signed quantity is currently computed has some problems:

1. It has some daily ripples compared to the phase angle that shouldn't be there (possibly the shift of the observer from planet center isn't taken into account);
2. It switches sign not at the point of 0 or 180° phase, but a few dozens of minutes away from it. 

This PR implements the correct computation of whether the phase angle is increasing or decreasing (this is done in `Planet::isWaning()`). This computation uses heliocentric position and velocity of the observer (the velocity is computed in `StelCore::getObserverHeliocentricEclipticVelocity()`).

~I spent some time time trying to reverse-engineer orientation of the axes of the AltAz frame, so the first commit here documents my findings. Please check that it's actually correct.~

Also, it appeared that the computation to determine the phase angle tendency is quite nontrivial (the simple elongation-based trick mentioned in #2916 won't yield precise results), so the third commit here exports a flag to the scripting API that indicates whether the planet is in the waning phase, i.e. whether its phase angle is increasing.

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### How Has This Been Tested?

**Test Configuration**:
* Operating system: Ubuntu 20.04
* Graphics Card: Intel UHD Graphics 620

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
