### PR TITLE
Fix behavior of DitheringMode with QVariant in Qt5

### DIFF
--- a/src/core/Dithering.hpp
+++ b/src/core/Dithering.hpp
@@ -37,6 +37,17 @@ enum class DitheringMode
 	Color888,    //!< 24-bit color (AKA True color)
 	Color101010, //!< 30-bit color (AKA Deep color)
 };
+#if QT_VERSION < QT_VERSION_CHECK(5,14,0)
+// A similar pair of methods but templated for arbitrary enum first appears in Qt 5.14
+inline QDataStream& operator>>(QDataStream& s, DitheringMode& m)
+{
+	return s >> reinterpret_cast<std::underlying_type<DitheringMode>::type&>(m);
+}
+inline QDataStream& operator<<(QDataStream &s, const DitheringMode &m)
+{
+	return s << static_cast<typename std::underlying_type<DitheringMode>::type>(m);
+}
+#endif
 
 Vec3f calcRGBMaxValue(DitheringMode mode);
 

--- a/src/core/StelCore.cpp
+++ b/src/core/StelCore.cpp
@@ -2056,6 +2056,7 @@ void StelCore::registerMathMetaTypes()
 	qRegisterMetaType<Mat4f>();
 	qRegisterMetaType<Mat3d>();
 	qRegisterMetaType<Mat3f>();
+	qRegisterMetaType<DitheringMode>();
 
 #if (QT_VERSION<QT_VERSION_CHECK(6,0,0))
 	//registers the QDataStream operators, so that QVariants with these types can be saved
@@ -2072,6 +2073,7 @@ void StelCore::registerMathMetaTypes()
 	qRegisterMetaTypeStreamOperators<Mat4f>();
 	qRegisterMetaTypeStreamOperators<Mat3d>();
 	qRegisterMetaTypeStreamOperators<Mat3f>();
+	qRegisterMetaTypeStreamOperators<DitheringMode>();
 #endif
 	//for debugging QVariants with these types, it helps if we register the string converters
 	// This is also required for QJSEngine.


### PR DESCRIPTION
Fixes #3304

I didn't quite understand how `DitheringMode` gets into `QVariant` via the RemoteSync plugin, but at least with this change `QVariant::fromValue(DitheringMode::Color888).toString()` yields the correct string. Before this change the output string was empty. So I suppose this should be sufficient for #3304.