### PR TITLE
Turn dithering into a global post-processing effect

### DIFF
--- a/src/core/StelApp.cpp
+++ b/src/core/StelApp.cpp
@@ -19,6 +19,7 @@
 
 #include "StelApp.hpp"
 
+#include "Dithering.hpp"
 #include "StelCore.hpp"
 #include "StelMainView.hpp"
 #include "StelSplashScreen.hpp"
@@ -79,8 +80,12 @@
 #include <QNetworkDiskCache>
 #include <QNetworkProxy>
 #include <QNetworkReply>
+#include <QOpenGLBuffer>
 #include <QOpenGLContext>
+#include <QOpenGLShaderProgram>
+#include <QOpenGLVertexArrayObject>
 #include <QOpenGLFramebufferObject>
+#include <QOpenGLFunctions_3_3_Core>
 #include <QString>
 #include <QStringList>
 #include <QSysInfo>
@@ -657,6 +662,9 @@ void StelApp::init(QSettings* conf)
 
 	// Animation
 	animationScale = confSettings->value("gui/pointer_animation_speed", 1.).toDouble();
+
+	ditherPatternTex = StelApp::getInstance().getTextureManager().getDitheringTexture(0);
+	setupPostProcessor();
 	
 #ifdef ENABLE_SPOUT
 	//qDebug() << "Property spout is" << qApp->property("spout").toString();
@@ -803,6 +811,218 @@ void StelApp::applyRenderBuffer(GLuint drawFbo)
 	viewportEffect->paintViewportBuffer(renderBuffer);
 }
 
+void StelApp::setupPostProcessor()
+{
+	postProcessorVBO.reset(new QOpenGLBuffer(QOpenGLBuffer::VertexBuffer));
+	postProcessorVBO->create();
+	postProcessorVBO->bind();
+	const GLfloat vertices[]=
+	{
+		// full screen quad
+		-1, -1,
+		 1, -1,
+		-1,  1,
+		 1,  1,
+	};
+	GL(gl->glBufferData(GL_ARRAY_BUFFER, sizeof vertices, vertices, GL_STATIC_DRAW));
+
+	postProcessorVAO.reset(new QOpenGLVertexArrayObject);
+	postProcessorVAO->create();
+	postProcessorVAO->bind();
+	gl->glVertexAttribPointer(0, 2, GL_FLOAT, false, 0, 0);
+	postProcessorVBO->release();
+	gl->glEnableVertexAttribArray(0);
+	postProcessorVAO->release();
+
+	postProcessorProgram.reset(new QOpenGLShaderProgram);
+	postProcessorProgram->addShaderFromSourceCode(QOpenGLShader::Vertex,
+		StelOpenGL::globalShaderPrefix(StelOpenGL::VERTEX_SHADER) + R"(
+ATTRIBUTE vec3 vertex;
+VARYING vec2 texcoord;
+void main()
+{
+	gl_Position = vec4(vertex, 1.);
+	texcoord = 0.5*vertex.xy+0.5;
+}
+)");
+	postProcessorProgram->addShaderFromSourceCode(QOpenGLShader::Fragment,
+		StelOpenGL::globalShaderPrefix(StelOpenGL::FRAGMENT_SHADER) +
+		makeDitheringShader() + R"(
+VARYING vec2 texcoord;
+uniform sampler2D tex;
+
+void main()
+{
+	vec4 rgba = texture2D(tex, texcoord);
+	FRAG_COLOR = vec4(dither(rgba.rgb), rgba.a);
+}
+)");
+	StelPainter::linkProg(postProcessorProgram.get(), "Post-processing program");
+	postProcessorProgram->bind();
+	postProcessorUniformLocations.tex           = postProcessorProgram->uniformLocation("tex");
+	postProcessorUniformLocations.rgbMaxValue   = postProcessorProgram->uniformLocation("rgbMaxValue");
+	postProcessorUniformLocations.ditherPattern = postProcessorProgram->uniformLocation("ditherPattern");
+	postProcessorProgram->release();
+
+	if(StelMainView::getInstance().getGLInformation().isHighGraphicsMode)
+	{
+		postProcessorProgramMS.reset(new QOpenGLShaderProgram);
+		postProcessorProgramMS->addShaderFromSourceCode(QOpenGLShader::Vertex,
+			StelOpenGL::globalShaderPrefix(StelOpenGL::VERTEX_SHADER) + R"(
+ATTRIBUTE vec3 vertex;
+void main()
+{
+	gl_Position = vec4(vertex, 1.);
+}
+)");
+		postProcessorProgramMS->addShaderFromSourceCode(QOpenGLShader::Fragment,
+			StelOpenGL::globalShaderPrefix(StelOpenGL::FRAGMENT_SHADER) +
+			makeDitheringShader() + R"(
+uniform sampler2DMS tex;
+uniform int numMultiSamples;
+
+void main()
+{
+	vec4 rgba = vec4(0);
+	for(int n = 0; n < numMultiSamples; ++n)
+		rgba += texelFetch(tex, ivec2(gl_FragCoord.xy), n);
+	rgba /= float(numMultiSamples);
+	FRAG_COLOR = vec4(dither(rgba.rgb), rgba.a);
+}
+)");
+		StelPainter::linkProg(postProcessorProgramMS.get(), "Multisampled post-processing program");
+		postProcessorProgramMS->bind();
+		postProcessorUniformLocationsMS.tex               = postProcessorProgramMS->uniformLocation("tex");
+		postProcessorUniformLocationsMS.rgbMaxValue       = postProcessorProgramMS->uniformLocation("rgbMaxValue");
+		postProcessorUniformLocationsMS.ditherPattern     = postProcessorProgramMS->uniformLocation("ditherPattern");
+		postProcessorUniformLocationsMS.numMultiSamples   = postProcessorProgramMS->uniformLocation("numMultiSamples");
+		postProcessorProgramMS->release();
+	}
+}
+
+void StelApp::highGraphicsModeDraw()
+{
+#if !QT_CONFIG(opengles2)
+	const auto targetFBO = currentFbo;
+	StelProjector::StelProjectorParams params = core->getCurrentStelProjectorParams();
+	const auto w = params.viewportXywh[2] * params.devicePixelsPerPixel;
+	const auto h = params.viewportXywh[3] * params.devicePixelsPerPixel;
+	StelOpenGL::checkGLErrors(__FILE__, __LINE__);
+	if(!sceneFBO || sceneFBO->size() != QSize(w,h))
+	{
+		qDebug().nospace() << "Creating scene FBO with size " << w << "x" << h;
+		const auto internalFormat = GL_RGBA16;
+		QOpenGLFramebufferObjectFormat format;
+		format.setAttachment(QOpenGLFramebufferObject::CombinedDepthStencil);
+		format.setInternalTextureFormat(internalFormat);
+		sceneFBO.reset(new QOpenGLFramebufferObject(w, h, format));
+		GLint maxSamples = 1;
+		GL(gl->glGetIntegerv(GL_MAX_SAMPLES, &maxSamples));
+		const auto samples = confSettings->value("video/multisampling", 0).toInt();
+		numMultiSamples = std::min(samples, maxSamples);
+		if(numMultiSamples > 1)
+		{
+			const auto gl = StelOpenGL::highGraphicsFunctions();
+			if(sceneMultisampledFBO)
+			{
+				GL(gl->glDeleteFramebuffers(1, &sceneMultisampledFBO));
+				GL(gl->glDeleteTextures(1, &sceneMultisampledTex));
+				GL(gl->glDeleteRenderbuffers(1, &sceneMultisampledRenderbuffer));
+			}
+			GL(gl->glGenFramebuffers(1, &sceneMultisampledFBO));
+			GL(gl->glGenTextures(1, &sceneMultisampledTex));
+			GL(gl->glGenRenderbuffers(1, &sceneMultisampledRenderbuffer));
+
+			GL(gl->glBindTexture(GL_TEXTURE_2D_MULTISAMPLE, sceneMultisampledTex));
+			GL(gl->glTexImage2DMultisample(GL_TEXTURE_2D_MULTISAMPLE, numMultiSamples,
+			                                        internalFormat, w, h, true));
+
+			GL(gl->glBindRenderbuffer(GL_RENDERBUFFER, sceneMultisampledRenderbuffer));
+			GL(gl->glRenderbufferStorageMultisample(GL_RENDERBUFFER, numMultiSamples,
+			                                                 GL_DEPTH24_STENCIL8, w, h));
+
+			GL(gl->glBindFramebuffer(GL_FRAMEBUFFER, sceneMultisampledFBO));
+			GL(gl->glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
+			                              GL_TEXTURE_2D_MULTISAMPLE, sceneMultisampledTex, 0));
+			GL(gl->glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT,
+			                                 GL_RENDERBUFFER, sceneMultisampledRenderbuffer));
+			const auto status = gl->glCheckFramebufferStatus(GL_FRAMEBUFFER);
+			if(status != GL_FRAMEBUFFER_COMPLETE)
+			{
+				qCritical().nospace() << __FILE__ << ":" << __LINE__
+				                      << ": warning: framebuffer incomplete, status: "
+				                      << status;
+			}
+		}
+	}
+
+	if(sceneMultisampledFBO)
+	{
+		GL(gl->glBindFramebuffer(GL_FRAMEBUFFER, sceneMultisampledFBO));
+		currentFbo = sceneMultisampledFBO;
+	}
+	else
+	{
+		sceneFBO->bind();
+		currentFbo = sceneFBO->handle();
+	}
+	StelOpenGL::checkGLErrors(__FILE__, __LINE__);
+
+	GL(gl->glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT));
+
+	const QList<StelModule*> modules = moduleMgr->getCallOrders(StelModule::ActionDraw);
+
+	for(auto* module : modules)
+	{
+		module->draw(core);
+	}
+
+	if(sceneMultisampledFBO)
+	{
+		GL(gl->glBindFramebuffer(GL_FRAMEBUFFER, targetFBO));
+		postProcessorProgramMS->bind();
+
+		const int sceneTexSampler = 0;
+		GL(gl->glActiveTexture(GL_TEXTURE0 + sceneTexSampler));
+		GL(gl->glBindTexture(GL_TEXTURE_2D_MULTISAMPLE, sceneMultisampledTex));
+		postProcessorProgramMS->setUniformValue(postProcessorUniformLocationsMS.tex, sceneTexSampler);
+
+		const int ditherTexSampler = 1;
+		ditherPatternTex->bind(ditherTexSampler);
+		postProcessorProgramMS->setUniformValue(postProcessorUniformLocationsMS.ditherPattern, ditherTexSampler);
+		const auto rgbMaxValue=calcRGBMaxValue(core->getDitheringMode());
+		postProcessorProgramMS->setUniformValue(postProcessorUniformLocationsMS.rgbMaxValue,
+		                                        rgbMaxValue[0], rgbMaxValue[1], rgbMaxValue[2]);
+		postProcessorProgramMS->setUniformValue(postProcessorUniformLocationsMS.numMultiSamples, numMultiSamples);
+	}
+	else
+	{
+		GL(gl->glBindFramebuffer(GL_FRAMEBUFFER, targetFBO));
+		postProcessorProgram->bind();
+
+		const int sceneTexSampler = 0;
+		GL(gl->glActiveTexture(GL_TEXTURE0 + sceneTexSampler));
+		GL(gl->glBindTexture(GL_TEXTURE_2D, sceneFBO->texture()));
+		postProcessorProgram->setUniformValue(postProcessorUniformLocations.tex, sceneTexSampler);
+
+		const int ditherTexSampler = 1;
+		ditherPatternTex->bind(ditherTexSampler);
+		postProcessorProgram->setUniformValue(postProcessorUniformLocations.ditherPattern, ditherTexSampler);
+		const auto rgbMaxValue=calcRGBMaxValue(core->getDitheringMode());
+		postProcessorProgram->setUniformValue(postProcessorUniformLocations.rgbMaxValue,
+		                                      rgbMaxValue[0], rgbMaxValue[1], rgbMaxValue[2]);
+
+	}
+
+	postProcessorVAO->bind();
+	GL(gl->glEnable(GL_BLEND));
+	GL(gl->glBlendFunc(GL_ONE,GL_ONE));
+	GL(gl->glDrawArrays(GL_TRIANGLE_STRIP, 0, 4));
+	GL(gl->glDisable(GL_BLEND));
+	postProcessorVAO->release();
+#endif
+}
+
 //! Main drawing function called at each frame
 void StelApp::draw()
 {
@@ -819,11 +1039,19 @@ void StelApp::draw()
 
 	core->preDraw();
 
-	const QList<StelModule*> modules = moduleMgr->getCallOrders(StelModule::ActionDraw);
-	for (auto* module : modules)
+	if(StelMainView::getInstance().getGLInformation().isHighGraphicsMode)
 	{
-		module->draw(core);
+		highGraphicsModeDraw();
 	}
+	else
+	{
+		const QList<StelModule*> modules = moduleMgr->getCallOrders(StelModule::ActionDraw);
+		for (auto* module : modules)
+		{
+			module->draw(core);
+		}
+	}
+
 	core->postDraw();
 #ifdef ENABLE_SPOUT
 	// At this point, the sky scene has been drawn, but no GUI panels.

--- a/src/core/StelApp.hpp
+++ b/src/core/StelApp.hpp
@@ -20,10 +20,13 @@
 #ifndef STELAPP_HPP
 #define STELAPP_HPP
 
+#include <memory>
+#include <qopengl.h>
 #include <qguiapplication.h>
 #include <QString>
 #include <QObject>
 #include <QRandomGenerator>
+#include "StelTextureTypes.hpp"
 #include "StelModule.hpp"
 #include "VecMath.hpp"
 
@@ -37,6 +40,9 @@ class StelMainView;
 class StelSkyCultureMgr;
 class StelViewportEffect;
 class QOpenGLFramebufferObject;
+class QOpenGLVertexArrayObject;
+class QOpenGLShaderProgram;
+class QOpenGLBuffer;
 class QOpenGLFunctions;
 class QSettings;
 class QNetworkAccessManager;
@@ -368,6 +374,9 @@ private:
 	//! @param drawFbo the OpenGL fbo we need to render into.
 	void applyRenderBuffer(quint32 drawFbo=0);
 
+	void setupPostProcessor();
+	void highGraphicsModeDraw();
+
 	QString getVersion() const;
 
 	// The StelApp singleton
@@ -470,9 +479,32 @@ private:
 	QList<StelProgressController*> progressControllers;
 
 	int screenFontSize;
+	int numMultiSamples = 1;
 
 	// Framebuffer object used for viewport effects.
 	QOpenGLFramebufferObject* renderBuffer;
+	std::unique_ptr<QOpenGLBuffer> postProcessorVBO;
+	std::unique_ptr<QOpenGLVertexArrayObject> postProcessorVAO;
+	std::unique_ptr<QOpenGLShaderProgram> postProcessorProgram;
+	std::unique_ptr<QOpenGLShaderProgram> postProcessorProgramMS; // multisampled
+	std::unique_ptr<QOpenGLFramebufferObject> sceneFBO;
+	GLuint sceneMultisampledFBO = 0;
+	GLuint sceneMultisampledTex = 0;
+	GLuint sceneMultisampledRenderbuffer = 0;
+	StelTextureSP ditherPatternTex;
+	struct PostProcessorUniformLocations
+	{
+		int tex;
+		int ditherPattern;
+		int rgbMaxValue;
+	} postProcessorUniformLocations;
+	struct PostProcessorUniformLocationsMS
+	{
+		int tex;
+		int ditherPattern;
+		int rgbMaxValue;
+		int numMultiSamples;
+	} postProcessorUniformLocationsMS;
 	StelViewportEffect* viewportEffect;
 	QOpenGLFunctions* gl;
 	

--- a/src/core/StelPainter.cpp
+++ b/src/core/StelPainter.cpp
@@ -2133,13 +2133,12 @@ void StelPainter::initGLShaders()
 	QOpenGLShader fshader2(QOpenGLShader::Fragment);
 	const auto fsrc2 =
 		StelOpenGL::globalShaderPrefix(StelOpenGL::FRAGMENT_SHADER) +
-		makeDitheringShader()+
 		"VARYING mediump vec2 texc;\n"
 		"uniform sampler2D tex;\n"
 		"uniform mediump vec4 texColor;\n"
 		"void main(void)\n"
 		"{\n"
-		"    FRAG_COLOR = dither(texture2D(tex, texc)*texColor);\n"
+		"    FRAG_COLOR = texture2D(tex, texc)*texColor;\n"
 		"}\n";
 	fshader2.compileSourceCode(fsrc2);
 	if (!fshader2.log().isEmpty())
@@ -2154,8 +2153,6 @@ void StelPainter::initGLShaders()
 	texturesShaderVars.vertex = texturesShaderProgram->attributeLocation("vertex");
 	texturesShaderVars.texColor = texturesShaderProgram->uniformLocation("texColor");
 	texturesShaderVars.texture = texturesShaderProgram->uniformLocation("tex");
-	texturesShaderVars.ditherPattern = texturesShaderProgram->uniformLocation("ditherPattern");
-	texturesShaderVars.rgbMaxValue = texturesShaderProgram->uniformLocation("rgbMaxValue");
 
 	// Texture shader program + interpolated color per vertex
 	QOpenGLShader vshader4(QOpenGLShader::Vertex);
@@ -2180,7 +2177,6 @@ void StelPainter::initGLShaders()
 	QOpenGLShader fshader4(QOpenGLShader::Fragment);
 	const auto fsrc4 =
 		StelOpenGL::globalShaderPrefix(StelOpenGL::FRAGMENT_SHADER) +
-		makeDitheringShader()+
 		makeSaturationShader()+
 		"VARYING mediump vec2 texc;\n"
 		"VARYING mediump vec4 outColor;\n"
@@ -2188,7 +2184,7 @@ void StelPainter::initGLShaders()
 		"uniform lowp float saturation;\n"
 		"void main(void)\n"
 		"{\n"
-		"    FRAG_COLOR = dither(texture2D(tex, texc)*outColor);\n"
+		"    FRAG_COLOR = texture2D(tex, texc)*outColor;\n"
 		"    if (saturation != 1.0)\n"
 		"        FRAG_COLOR.rgb = saturate(FRAG_COLOR.rgb, saturation);\n"
 		"}\n";
@@ -2205,8 +2201,6 @@ void StelPainter::initGLShaders()
 	texturesColorShaderVars.vertex = texturesColorShaderProgram->attributeLocation("vertex");
 	texturesColorShaderVars.color = texturesColorShaderProgram->attributeLocation("color");
 	texturesColorShaderVars.texture = texturesColorShaderProgram->uniformLocation("tex");
-	texturesColorShaderVars.ditherPattern = texturesColorShaderProgram->uniformLocation("ditherPattern");
-	texturesColorShaderVars.rgbMaxValue = texturesColorShaderProgram->uniformLocation("rgbMaxValue");
 	texturesColorShaderVars.saturation = texturesColorShaderProgram->uniformLocation("saturation");
 
 	if(StelMainView::getInstance().getGLInformation().isCoreProfile)
@@ -2577,7 +2571,6 @@ void StelPainter::drawFromArray(DrawingMode mode, int count, int offset, bool do
 #endif
 
 	const auto core = StelApp::getInstance().getCore();
-	const auto rgbMaxValue=calcRGBMaxValue(core->getDitheringMode());
 	if (!texCoordArray.enabled && !colorArray.enabled && !normalArray.enabled)
 	{
 		pr = coreProfileWideLineMode ? wideLineShaderProgram : basicShaderProgram;
@@ -2629,13 +2622,6 @@ void StelPainter::drawFromArray(DrawingMode mode, int count, int offset, bool do
 		pr->setAttributeBuffer(texturesShaderVars.texCoord, texCoordArray.type, texCoordDataOffset, texCoordArray.size);
 		pr->enableAttributeArray(texturesShaderVars.texCoord);
 		//pr->setUniformValue(texturesShaderVars.texture, 0);    // use texture unit 0
-		const int ditherTexSampler = 1;
-		if(!ditherPatternTex)
-			ditherPatternTex = StelApp::getInstance().getTextureManager().getDitheringTexture(ditherTexSampler);
-		else
-			ditherPatternTex->bind(ditherTexSampler);
-		pr->setUniformValue(texturesShaderVars.ditherPattern, ditherTexSampler);
-		pr->setUniformValue(texturesShaderVars.rgbMaxValue, rgbMaxValue[0], rgbMaxValue[1], rgbMaxValue[2]);
 	}
 	else if (texCoordArray.enabled && colorArray.enabled && !normalArray.enabled && !wideLineMode)
 	{
@@ -2663,13 +2649,6 @@ void StelPainter::drawFromArray(DrawingMode mode, int count, int offset, bool do
 		pr->setAttributeBuffer(texturesColorShaderVars.color, colorArray.type, colorDataOffset, colorArray.size);
 		pr->enableAttributeArray(texturesColorShaderVars.color);
 		//pr->setUniformValue(texturesShaderVars.texture, 0);    // use texture unit 0
-		const int ditherTexSampler = 1;
-		if(!ditherPatternTex)
-			ditherPatternTex = StelApp::getInstance().getTextureManager().getDitheringTexture(ditherTexSampler);
-		else
-			ditherPatternTex->bind(ditherTexSampler);
-		pr->setUniformValue(texturesColorShaderVars.ditherPattern, ditherTexSampler);
-		pr->setUniformValue(texturesColorShaderVars.rgbMaxValue, rgbMaxValue[0], rgbMaxValue[1], rgbMaxValue[2]);
 		pr->setUniformValue(texturesColorShaderVars.saturation, saturation);
 	}
 	else if (!texCoordArray.enabled && colorArray.enabled && !normalArray.enabled)

--- a/src/core/StelPainter.hpp
+++ b/src/core/StelPainter.hpp
@@ -429,8 +429,6 @@ private:
 		int vertex;
 		int texColor;
 		int texture;
-		int ditherPattern;
-		int rgbMaxValue;
 	};
 	static TexturesShaderVars texturesShaderVars;
 	static QOpenGLShaderProgram* texturesColorShaderProgram;
@@ -440,8 +438,6 @@ private:
 		int vertex;
 		int color;
 		int texture;
-		int ditherPattern;
-		int rgbMaxValue;
 		int saturation;
 	};
 	static TexturesColorShaderVars texturesColorShaderVars;
@@ -465,8 +461,6 @@ private:
 		int vertex;
 	};
 	static ColorfulWideLineShaderVars colorfulWideLineShaderVars;
-
-	StelTextureSP ditherPatternTex;
 
 	static bool multisamplingEnabled;
 

--- a/src/core/modules/Atmosphere.hpp
+++ b/src/core/modules/Atmosphere.hpp
@@ -22,6 +22,7 @@
 #ifndef ATMOSPHERE_HPP
 #define ATMOSPHERE_HPP
 
+#include <stdexcept>
 #include "StelCore.hpp"
 #include "StelFader.hpp"
 

--- a/src/core/modules/AtmospherePreetham.cpp
+++ b/src/core/modules/AtmospherePreetham.cpp
@@ -26,7 +26,6 @@
 #include "StelTextureMgr.hpp"
 #include "StelCore.hpp"
 #include "StelPainter.hpp"
-#include "Dithering.hpp"
 #include "Skylight.hpp"
 
 #include <QFile>
@@ -67,11 +66,10 @@ AtmospherePreetham::AtmospherePreetham(Skylight& sky)
 	QOpenGLShader fShader(QOpenGLShader::Fragment);
 	if (!fShader.compileSourceCode(
 					StelOpenGL::globalShaderPrefix(StelOpenGL::FRAGMENT_SHADER) +
-					makeDitheringShader()+
 					"VARYING mediump vec3 resultSkyColor;\n"
 					"void main()\n"
 					"{\n"
-					 "   FRAG_COLOR = vec4(dither(resultSkyColor), 1.);\n"
+					 "   FRAG_COLOR = vec4(resultSkyColor, 1.);\n"
 					 "}"))
 	{
 		qFatal("Error while compiling Preetham atmosphere fragment shader: %s", fShader.log().toLatin1().constData());
@@ -86,8 +84,6 @@ AtmospherePreetham::AtmospherePreetham(Skylight& sky)
 	StelPainter::linkProg(atmoShaderProgram, "Preetham atmosphere");
 
 	GL(atmoShaderProgram->bind());
-	GL(shaderAttribLocations.ditherPattern = atmoShaderProgram->uniformLocation("ditherPattern"));
-	GL(shaderAttribLocations.rgbMaxValue = atmoShaderProgram->uniformLocation("rgbMaxValue"));
 	GL(shaderAttribLocations.alphaWaOverAlphaDa = atmoShaderProgram->uniformLocation("alphaWaOverAlphaDa"));
 	GL(shaderAttribLocations.oneOverGamma = atmoShaderProgram->uniformLocation("oneOverGamma"));
 	GL(shaderAttribLocations.term2TimesOneOverMaxdLpOneOverGamma = atmoShaderProgram->uniformLocation("term2TimesOneOverMaxdLpOneOverGamma"));
@@ -446,16 +442,6 @@ void AtmospherePreetham::draw(StelCore* core)
 	GL(atmoShaderProgram->setUniformValue(shaderAttribLocations.projectionMatrix,
 					      QMatrix4x4(m[0], m[4], m[8], m[12], m[1], m[5], m[9], m[13], m[2], m[6], m[10], m[14], m[3], m[7], m[11], m[15])));
 
-	const auto rgbMaxValue=calcRGBMaxValue(core->getDitheringMode());
-	GL(atmoShaderProgram->setUniformValue(shaderAttribLocations.rgbMaxValue, rgbMaxValue[0], rgbMaxValue[1], rgbMaxValue[2]));
-
-	const int ditherTexSampler = 1;
-	if(!ditherPatternTex)
-		ditherPatternTex = StelApp::getInstance().getTextureManager().getDitheringTexture(ditherTexSampler);
-	else
-		GL(ditherPatternTex->bind(ditherTexSampler));
-	GL(atmoShaderProgram->setUniformValue(shaderAttribLocations.ditherPattern, ditherTexSampler));
-	
 
 	// And draw everything at once
 	bindVAO();

--- a/src/core/modules/AtmospherePreetham.hpp
+++ b/src/core/modules/AtmospherePreetham.hpp
@@ -71,8 +71,6 @@ private:
 	//! Vertex shader used for xyYToRGB computation
 	class QOpenGLShaderProgram* atmoShaderProgram;
 	struct {
-		int ditherPattern;
-		int rgbMaxValue;
 		int alphaWaOverAlphaDa;
 		int oneOverGamma;
 		int term2TimesOneOverMaxdLpOneOverGamma; // original
@@ -87,8 +85,6 @@ private:
 		int skyColor;
 		int doSRGB;
 	} shaderAttribLocations;
-
-	StelTextureSP ditherPatternTex;
 
 	//! Binds actual VAO if it's supported, sets up the relevant state manually otherwise.
 	void bindVAO();

--- a/src/core/modules/AtmosphereShowMySky.cpp
+++ b/src/core/modules/AtmosphereShowMySky.cpp
@@ -28,7 +28,6 @@
 #include "StelTextureMgr.hpp"
 #include "StelCore.hpp"
 #include "StelPainter.hpp"
-#include "Dithering.hpp"
 #include "StelTranslator.hpp"
 #include "TextureAverageComputer.hpp"
 
@@ -270,14 +269,13 @@ uniform sampler2D luminanceXYZW;
 in vec2 texCoord;
 out vec4 color;
 
-vec3 dither(vec3);
 vec3 xyYToRGB(float x, float y, float Y);
 
 void main()
 {
 	vec3 XYZ=texture(luminanceXYZW, texCoord).xyz;
 	vec3 srgb=xyYToRGB(XYZ.x/(XYZ.x+XYZ.y+XYZ.z), XYZ.y/(XYZ.x+XYZ.y+XYZ.z), XYZ.y);
-	color=vec4(dither(srgb),1);
+	color=vec4(srgb,1);
 }
 )";
 
@@ -286,17 +284,12 @@ void main()
 							"ShowMySky atmosphere luminance-to-screen vertex shader");
 		luminanceToScreenProgram_->addShader(&vShader);
 
-		QOpenGLShader ditherShader(QOpenGLShader::Fragment);
-		const auto fPrefix = StelOpenGL::globalShaderPrefix(StelOpenGL::FRAGMENT_SHADER);
-		handleCompileStatus(ditherShader.compileSourceCode(fPrefix + makeDitheringShader()),
-							ditherShader, "ShowMySky atmosphere dithering shader");
-		luminanceToScreenProgram_->addShader(&ditherShader);
-
 		QOpenGLShader toneReproducerShader(QOpenGLShader::Fragment);
 		auto xyYToRGBFile = QFile(":/shaders/xyYToRGB.glsl");
 		if(!xyYToRGBFile.open(QFile::ReadOnly))
 			throw InitFailure("Failed to open atmosphere tone reproducer fragment shader file");
 		const auto xyYToRGBShader = xyYToRGBFile.readAll();
+		const auto fPrefix = StelOpenGL::globalShaderPrefix(StelOpenGL::FRAGMENT_SHADER);
 		handleCompileStatus(toneReproducerShader.compileSourceCode(fPrefix + xyYToRGBShader),
 							toneReproducerShader, "ShowMySky atmosphere tone reproducer fragment shader");
 		luminanceToScreenProgram_->addShader(&toneReproducerShader);
@@ -461,8 +454,6 @@ AtmosphereShowMySky::AtmosphereShowMySky(const double initialAltitude)
 		prog.bind();
 
 		shaderAttribLocations.doSRGB                 = prog.uniformLocation("doSRGB");
-		shaderAttribLocations.rgbMaxValue            = prog.uniformLocation("rgbMaxValue");
-		shaderAttribLocations.ditherPattern          = prog.uniformLocation("ditherPattern");
 		shaderAttribLocations.oneOverGamma           = prog.uniformLocation("oneOverGamma");
 		shaderAttribLocations.brightnessScale        = prog.uniformLocation("brightnessScale");
 		shaderAttribLocations.luminanceTexture       = prog.uniformLocation("luminanceXYZW");
@@ -822,21 +813,11 @@ void AtmosphereShowMySky::draw(StelCore* core)
 	StelPainter sPainter(core->getProjection2d());
 	sPainter.setBlending(true, GL_ONE, GL_ONE);
 
-	const auto rgbMaxValue=calcRGBMaxValue(core->getDitheringMode());
-	GL(luminanceToScreenProgram_->setUniformValue(shaderAttribLocations.rgbMaxValue, rgbMaxValue[0], rgbMaxValue[1], rgbMaxValue[2]));
-
 	auto& gl = *StelOpenGL::highGraphicsFunctions();
 	GL(gl.glActiveTexture(GL_TEXTURE0));
 	GL(gl.glBindTexture(GL_TEXTURE_2D, renderer_->getLuminanceTexture()));
 	GL(gl.glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR));
 	GL(luminanceToScreenProgram_->setUniformValue(shaderAttribLocations.luminanceTexture, 0));
-
-	const int ditherTexSampler = 1;
-	if(!ditherPatternTex_)
-		ditherPatternTex_ = StelApp::getInstance().getTextureManager().getDitheringTexture(ditherTexSampler);
-	else
-		GL(ditherPatternTex_->bind(ditherTexSampler));
-	GL(luminanceToScreenProgram_->setUniformValue(shaderAttribLocations.ditherPattern, ditherTexSampler));
 
 	GL(gl.glBindVertexArray(mainVAO_));
 	GL(gl.glDrawArrays(GL_TRIANGLE_STRIP, 0, 4));

--- a/src/core/modules/AtmosphereShowMySky.hpp
+++ b/src/core/modules/AtmosphereShowMySky.hpp
@@ -94,8 +94,6 @@ private:
 
 	struct {
 		int doSRGB;
-		int rgbMaxValue;
-		int ditherPattern;
 		int oneOverGamma;
 		int brightnessScale;
 		int luminanceTexture;
@@ -105,7 +103,6 @@ private:
 		int flagUseTmGamma;                      // switch between their use, true to use the first expression.
 	} shaderAttribLocations;
 
-	StelTextureSP ditherPatternTex_;
 	StelProjectorP prevProjector_;
 	std::unique_ptr<TextureAverageComputer> textureAverager_;
 

--- a/src/core/modules/Landscape.hpp
+++ b/src/core/modules/Landscape.hpp
@@ -231,7 +231,6 @@ protected:
 	std::unique_ptr<QOpenGLVertexArrayObject> vao;
 	std::unique_ptr<QOpenGLBuffer> vbo;
 	StelProjectorP prevProjector;
-	StelTextureSP ditherPatternTex;
 	std::unique_ptr<QOpenGLShaderProgram> renderProgram;
 
 	double radius;
@@ -363,9 +362,7 @@ private:
 		int tanMode;
 		int calibrated;
 		int brightness;
-		int rgbMaxValue;
 		int whatToRender;
-		int ditherPattern;
 		int decorAngleShift;
 		int firstSideInBatch;
 		int sidePresenceMask;
@@ -442,8 +439,6 @@ private:
 		int texFov;
 		int mapTex;
 		int brightness;
-		int rgbMaxValue;
-		int ditherPattern;
 		int projectionMatrixInverse;
 	} shaderVars;
 };
@@ -508,9 +503,7 @@ private:
 		int mapTex;
 		int mapTexTop;
 		int brightness;
-		int rgbMaxValue;
 		int mapTexBottom;
-		int ditherPattern;
 		int bottomCapColor;
 		int projectionMatrixInverse;
 	} shaderVars;

--- a/src/core/modules/MilkyWay.hpp
+++ b/src/core/modules/MilkyWay.hpp
@@ -124,8 +124,6 @@ private:
 		int mainTex;
 		int brightness;
 		int saturation;
-		int rgbMaxValue;
-		int ditherPattern;
 		int bortleIntensity;
 		int extinctionEnabled;
 		int projectionMatrixInverse;
@@ -133,7 +131,6 @@ private:
 
 	std::unique_ptr<QOpenGLVertexArrayObject> vao;
 	std::unique_ptr<QOpenGLBuffer> vbo;
-	StelTextureSP ditherPatternTex;
 	StelProjectorP prevProjector;
 	std::unique_ptr<QOpenGLShaderProgram> renderProgram;
 };

--- a/src/core/modules/ZodiacalLight.cpp
+++ b/src/core/modules/ZodiacalLight.cpp
@@ -109,8 +109,6 @@ void ZodiacalLight::init()
 	setupCurrentVAO();
 	releaseVAO();
 
-	ditherPatternTex = StelApp::getInstance().getTextureManager().getDitheringTexture(0);
-
 	QString displayGroup = N_("Display Options");
 	addAction("actionShow_ZodiacalLight", displayGroup, N_("Zodiacal Light"), "flagZodiacalLightDisplayed", "Ctrl+Shift+Z");
 
@@ -264,7 +262,6 @@ void main()
 			StelOpenGL::globalShaderPrefix(StelOpenGL::FRAGMENT_SHADER) +
 			projector->getUnProjectShader() +
 			extinction.getForwardTransformShader() +
-			makeDitheringShader()+
 			R"(
 VARYING highp vec3 ndcPos;
 uniform sampler2D mainTex;
@@ -303,7 +300,7 @@ void main(void)
 	}
 
     vec4 color = texture2D(mainTex, texc)*vec4(brightness,1)*extinctionFactor;
-	FRAG_COLOR = dither(color);
+	FRAG_COLOR = color;
 }
 )";
 		ok = renderProgram->addShaderFromSourceCode(QOpenGLShader::Fragment, frag);
@@ -321,8 +318,6 @@ void main(void)
 		shaderVars.mainTex          = renderProgram->uniformLocation("mainTex");
 		shaderVars.lambdaSun        = renderProgram->uniformLocation("lambdaSun");
 		shaderVars.brightness       = renderProgram->uniformLocation("brightness");
-		shaderVars.rgbMaxValue      = renderProgram->uniformLocation("rgbMaxValue");
-		shaderVars.ditherPattern    = renderProgram->uniformLocation("ditherPattern");
 		shaderVars.bortleIntensity  = renderProgram->uniformLocation("bortleIntensity");
 		shaderVars.extinctionEnabled= renderProgram->uniformLocation("extinctionEnabled");
 		shaderVars.projectionMatrixInverse = renderProgram->uniformLocation("projectionMatrixInverse");
@@ -389,14 +384,9 @@ void main(void)
 	mainTex->bind(mainTexSampler);
 	renderProgram->setUniformValue(shaderVars.mainTex, mainTexSampler);
 
-	const int ditherTexSampler = 1;
-	ditherPatternTex->bind(ditherTexSampler);
-	renderProgram->setUniformValue(shaderVars.ditherPattern, ditherTexSampler);
-
 	renderProgram->setUniformValue(shaderVars.projectionMatrixInverse, projector->getProjectionMatrix().toQMatrix().inverted());
 	renderProgram->setUniformValue(shaderVars.brightness, c.toQVector());
 	renderProgram->setUniformValue(shaderVars.lambdaSun, GLfloat(lambdaSun));
-	renderProgram->setUniformValue(shaderVars.rgbMaxValue, calcRGBMaxValue(core->getDitheringMode()).toQVector());
 
 	projector->setUnProjectUniforms(*renderProgram);
 	extinction.setForwardTransformUniforms(*renderProgram);

--- a/src/core/modules/ZodiacalLight.hpp
+++ b/src/core/modules/ZodiacalLight.hpp
@@ -149,15 +149,12 @@ private:
 		int mainTex;
 		int lambdaSun;
 		int brightness;
-		int rgbMaxValue;
-		int ditherPattern;
 		int bortleIntensity;
 		int extinctionEnabled;
 		int projectionMatrixInverse;
 	} shaderVars;
 	std::unique_ptr<QOpenGLVertexArrayObject> vao;
 	std::unique_ptr<QOpenGLBuffer> vbo;
-	StelTextureSP ditherPatternTex;
 	StelProjectorP prevProjector;
 	std::unique_ptr<QOpenGLShaderProgram> renderProgram;
 };

--- a/src/gui/ConfigurationDialog.cpp
+++ b/src/gui/ConfigurationDialog.cpp
@@ -2021,19 +2021,28 @@ void ConfigurationDialog::populateDitherList()
 
 	ditherCombo->blockSignals(true);
 	ditherCombo->clear();
-	ditherCombo->addItem(qc_("None","disabled"), "disabled");
-	ditherCombo->addItem(q_("5/6/5 bits"), "color565");
-	ditherCombo->addItem(q_("6/6/6 bits"), "color666");
-	ditherCombo->addItem(q_("8/8/8 bits"), "color888");
-	ditherCombo->addItem(q_("10/10/10 bits"), "color101010");
+	if(StelMainView::getInstance().getGLInformation().isHighGraphicsMode)
+	{
+		ditherCombo->addItem(qc_("None","disabled"), "disabled");
+		ditherCombo->addItem(q_("5/6/5 bits"), "color565");
+		ditherCombo->addItem(q_("6/6/6 bits"), "color666");
+		ditherCombo->addItem(q_("8/8/8 bits"), "color888");
+		ditherCombo->addItem(q_("10/10/10 bits"), "color101010");
 
-	// show current setting
-	QSettings* conf = StelApp::getInstance().getSettings();
-	Q_ASSERT(conf);
-	QVariant selectedDitherFormat = conf->value("video/dithering_mode", "disabled");
+		// show current setting
+		QSettings* conf = StelApp::getInstance().getSettings();
+		Q_ASSERT(conf);
+		QVariant selectedDitherFormat = conf->value("video/dithering_mode", "disabled");
 
-	int index = ditherCombo->findData(selectedDitherFormat, Qt::UserRole, Qt::MatchCaseSensitive);
-	ditherCombo->setCurrentIndex(index);
+		int index = ditherCombo->findData(selectedDitherFormat, Qt::UserRole, Qt::MatchCaseSensitive);
+		ditherCombo->setCurrentIndex(index);
+	}
+	else
+	{
+		ditherCombo->addItem(q_("Unsupported"), "disabled");
+		ditherCombo->setDisabled(true);
+		ditherCombo->setToolTip(q_("Unsupported in low-graphics mode"));
+	}
 	ditherCombo->blockSignals(false);
 }
 


### PR DESCRIPTION
### Description

This is the first step towards future HDR rendering. The whole rendering pipeline is split into two stages:
1. Rendering of the scene in deeper color (RGBA16 for now)
2. Post-processing

Currently post-processing comprises only dithering and resolution of multisampling samples. This in particular makes multisampling a one-place configuration, so the filters like e.g. spherical mirror will get antialiased image automagically without special setup (before this commit spherical mirror image was aliased). Also, application of dithering only once reduces interference of the dithering noise (e.g. when two images are blended together), and generally makes the result more correct.

Low-graphics modes such as ANGLE, OpenGL<3.3, OpenGL Compatibility Profile, etc. will use the old way of rendering, i.e. without the intermediate deep-color FBO. Thus they will not have dithering nor multisampling.

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

### How Has This Been Tested?

**Test Configuration**:
* Operating system: Ubuntu 20.04
* Graphics Card: Intel UHD Graphics 620

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
