### PR TITLE
Fix: orbit details

### DIFF
--- a/guide/app_config_ini.tex
+++ b/guide/app_config_ini.tex
@@ -474,6 +474,8 @@ base\_font\_name & string & Verdana     & Selects the name \\
 %safe\_font\_name               & string &      & Selects the name for safe font, e.g. \emph{Verdana}\\\midrule
 base\_font\_file                & string &      & Selects the name for font file, e.g. \emph{DejaVuSans.ttf}\\
 flag\_font\_selection           & bool  & false & Show GUI elements for font selection.\\\midrule
+immediate\_save\_details        & bool  & false & Set to \emph{true} to store some detail settings in the configuration dialog immediately, 
+                                                  instead of having to press ``Save settings'' explicitly.\\\midrule
 %% TODO: Is this required? timeout=0 also keeps cursor visible.
 flag\_mouse\_cursor\_timeout    & bool  & true  & Set to \emph{false} if you want to have cursor visible at all times.\\%\midrule
 mouse\_cursor\_timeout          & float & 10    & Set to \emph{0} if you want to keep the mouse cursor visible at all times. 
@@ -889,7 +891,9 @@ flag\_isolated\_trails        & bool & Set to \emph{true} if you only want to se
 number\_isolated\_trails      & int  & Number of isolated trails for latest selected Solar system bodies [1..5].\\%\midrule
 max\_trail\_points            & int  & Limit maximum length of trails. Trails are drawn for 1 year or this number of computing steps.
                                        Default 5000, reduce if drawing trails slows down the program too much.\\
-flag\_isolated\_orbits        & bool & Set to \emph{true} if you want to see orbits only for selected planet and their moons.\\\midrule
+flag\_planets\_orbits\_only   & bool & Set to \emph{true} if you want to suppress orbits of minor bodies and moons.\\
+flag\_isolated\_orbits        & bool & Set to \emph{true} if you want to see orbits only for selected planet.\\
+flag\_orbits\_with\_moons     & bool & Set to \emph{true} if you want to see also orbits of the selected planet.\\\midrule
 line\_thickness               & int  & Set the line thickness for grids and lines. Typical value: \emph{1}\\%\midrule
 part\_thickness               & int  & Set the line thickness for line partitions. Typical value: \emph{1}\\\midrule
 flag\_azimutal\_grid          & bool & Display azimuthal grid \\%\midrule

--- a/guide/ch_interface.tex
+++ b/guide/ch_interface.tex
@@ -676,6 +676,9 @@ for changing the general appearance of the view of Solar system objects. Some hi
   \item[Planets] will increase the apparent size of major planets.
   \end{description}
 \item[Show orbits] adds a rendition of the orbit or trajectory of an SSO. 
+For efficiency, orbits are not displayed when the object is not inside the screen, 
+unless you set the ``permanently'' option. You can further fine-tune the selection 
+and appearance (width and colors) of orbits with the additional settings. 
 \item[Show trails] plots the apparent path of SSO among the stars as
   seen from the current planet.
 \item[Show planetary nomenclature] displays positions and names of

--- a/src/core/StelApp.cpp
+++ b/src/core/StelApp.cpp
@@ -445,6 +445,7 @@ void StelApp::init(QSettings* conf)
 
 	setScreenFontSize(confSettings->value("gui/screen_font_size", 13).toInt());
 	setGuiFontSize(confSettings->value("gui/gui_font_size", 13).toInt());
+	setFlagImmediateSave(confSettings->value("gui/immediate_save_details", false).toBool());
 
 	core = new StelCore();
 	if (!fuzzyEquals(saveProjW, -1.) && !fuzzyEquals(saveProjH, -1.))
@@ -1254,6 +1255,15 @@ void StelApp::setDaylightInfoColor(const Vec3f& color)
 Vec3f StelApp::getDaylightInfoColor() const
 {
 	return daylightInfoColor;
+}
+
+void StelApp::setFlagImmediateSave(bool b)
+{
+	if (flagImmediateSave!=b)
+	{
+		flagImmediateSave = b;
+		emit flagImmediateSaveChanged(b);
+	}
 }
 
 // Update translations and font for sky everywhere in the program

--- a/src/core/StelApp.cpp
+++ b/src/core/StelApp.cpp
@@ -1266,6 +1266,13 @@ void StelApp::setFlagImmediateSave(bool b)
 	}
 }
 
+void StelApp::immediateSave(const QString &key, const QVariant &value)
+{
+	if (getInstance().getFlagImmediateSave())
+		getInstance().getSettings()->setValue(key, value);
+}
+
+
 // Update translations and font for sky everywhere in the program
 void StelApp::updateI18n()
 {

--- a/src/core/StelApp.hpp
+++ b/src/core/StelApp.hpp
@@ -242,6 +242,10 @@ public:
 	static void initStatic();
 	static void deinitStatic();
 
+	//! Allow immediate storing of config.ini entries.
+	//! Storing only takes place if property StelApp.flagImmediateSave is set.
+	static void immediateSave(const QString &key, const QVariant &value);
+
 	//! Add a progression indicator to the GUI (if applicable).
 	//! @return a controller which can be used to indicate the current status.
 	//! The StelApp instance remains the owner of the controller.

--- a/src/core/StelApp.hpp
+++ b/src/core/StelApp.hpp
@@ -87,6 +87,7 @@ class StelApp : public QObject
 	Q_PROPERTY(Vec3f daylightInfoColor	READ getDaylightInfoColor	WRITE setDaylightInfoColor	 NOTIFY daylightInfoColorChanged)
 	Q_PROPERTY(int  screenFontSize          READ getScreenFontSize          WRITE setScreenFontSize          NOTIFY screenFontSizeChanged)
 	Q_PROPERTY(int  guiFontSize             READ getGuiFontSize             WRITE setGuiFontSize             NOTIFY guiFontSizeChanged)
+	Q_PROPERTY(bool flagImmediateSave       READ getFlagImmediateSave       WRITE setFlagImmediateSave       NOTIFY flagImmediateSaveChanged)
 
 	Q_PROPERTY(QString version READ getVersion CONSTANT)
 
@@ -302,6 +303,11 @@ public slots:
 	//! Get info text color
 	Vec3f getDaylightInfoColor() const;
 
+	//! Set flag for storing some settings immediately
+	void setFlagImmediateSave(bool b);
+	//! Get flag about storing some settings immediately
+	bool getFlagImmediateSave() const {return flagImmediateSave;}
+
 	//! Get the current number of frame per second.
 	//! @return the FPS averaged on the last second
 	float getFps() const {return fps;}
@@ -348,6 +354,7 @@ signals:
 	void fontChanged(QFont);
 	void overwriteInfoColorChanged(const Vec3f & color);
 	void daylightInfoColorChanged(const Vec3f & color);
+	void flagImmediateSaveChanged(bool);
 
 	//! Called just after a progress bar is added.
 	void progressBarAdded(const StelProgressController*);
@@ -515,6 +522,7 @@ private:
 	bool flagOverwriteInfoColor; // Overwrite and use color for text in info panel
 	Vec3f overwriteInfoColor;
 	Vec3f daylightInfoColor;
+	bool flagImmediateSave;       // set true to allow more immediate-mode settings. For now this is limited to detail settings, e.g. orbit or nomenclature details, DSO filter types, ...
 #ifdef 	ENABLE_SPOUT
 	SpoutSender* spoutSender;
 #endif

--- a/src/core/modules/SolarSystem.cpp
+++ b/src/core/modules/SolarSystem.cpp
@@ -2635,7 +2635,7 @@ void SolarSystem::reconfigureOrbits()
 	// 1 1 1 0   only selected planet and orbits of its moon system
 	// 1 1 1 1   only selected SSO if it is a major planet
 
-	if (!flagOrbits || (flagOrbits&&flagIsolatedOrbits&&(!selected || selected==sun)))
+	if (!flagOrbits || (/* flagOrbits && */ flagIsolatedOrbits&&(!selected || selected==sun)))
 	{
 		for (const auto& p : qAsConst(systemPlanets))
 			p->setFlagOrbits(false);
@@ -2645,73 +2645,17 @@ void SolarSystem::reconfigureOrbits()
 	if (!flagIsolatedOrbits)
 	{
 		for (const auto& p : qAsConst(systemPlanets))
-			if (!flagPlanetsOrbitsOnly || (flagPlanetsOrbitsOnly && (p->getPlanetType()==Planet::isPlanet || (p->parent && p->parent->getPlanetType()==Planet::isPlanet) )))
-				p->setFlagOrbits(true);
-			else
-				p->setFlagOrbits(false);
+			p->setFlagOrbits(!flagPlanetsOrbitsOnly || (p->getPlanetType()==Planet::isPlanet || (p->parent && p->parent->getPlanetType()==Planet::isPlanet) ));
 		return;
 	}
 	else // flagIsolatedOrbits && selected
 	{
 		// Display only orbit for selected planet and its moons.
 		for (const auto& p : qAsConst(systemPlanets))
-			if (   (p==selected && (  !flagPlanetsOrbitsOnly || (flagPlanetsOrbitsOnly && p->getPlanetType()==Planet::isPlanet ) )
-				|| (p->getPlanetType()==Planet::isMoon && p->parent==selected ) ))
-				p->setFlagOrbits(true);
-			else
-				p->setFlagOrbits(false);
+			p->setFlagOrbits(   (p==selected && (  !flagPlanetsOrbitsOnly ||  p->getPlanetType()==Planet::isPlanet )
+					 || (p->getPlanetType()==Planet::isMoon && p->parent==selected ) ));
 		return;
 	}
-
-/*
-	if (!selected || selected==sun)
-	{
-		if (flagPlanetsOrbitsOnly)
-		{
-			for (const auto& p : qAsConst(systemPlanets))
-			{
-				if (p->getPlanetType()==Planet::isPlanet)
-					p->setFlagOrbits(true);
-				else
-					p->setFlagOrbits(false);
-			}
-		}
-	}
-	else if (getFlagIsolatedOrbits()) // If a Planet is selected and orbits are on, fade out non-selected ones
-	{
-		if (flagPlanetsOrbitsOnly)
-		{
-			for (const auto& p : qAsConst(systemPlanets))
-			{
-				if (selected == p && p->getPlanetType()==Planet::isPlanet)
-					p->setFlagOrbits(b);
-				else
-					p->setFlagOrbits(false);
-			}
-		}
-		else
-		{
-			for (const auto& p : qAsConst(systemPlanets))
-			{
-				if (selected == p)
-					p->setFlagOrbits(b);
-				else
-					p->setFlagOrbits(false);
-			}
-		}
-	}
-	else
-	{
-		// A planet is selected and orbits are on - draw orbits for the planet and their moons
-		for (const auto& p : qAsConst(systemPlanets))
-		{
-			if (selected == p || selected == p->parent)
-				p->setFlagOrbits(b);
-			else
-				p->setFlagOrbits(false);
-		}
-	}
-	*/
 }
 
 void SolarSystem::setFlagIsolatedOrbits(bool b)
@@ -2719,12 +2663,8 @@ void SolarSystem::setFlagIsolatedOrbits(bool b)
 	if(b!=flagIsolatedOrbits)
 	{
 		flagIsolatedOrbits = b;
-		if (StelApp::getInstance().getFlagImmediateSave())
-			conf->setValue("viewing/flag_isolated_orbits", b);
-
+		StelApp::immediateSave("viewing/flag_isolated_orbits", b);
 		emit flagIsolatedOrbitsChanged(b);
-		// Reinstall flag for orbits to renew visibility of orbits
-		//setFlagOrbits(getFlagOrbits());
 	}
 }
 
@@ -2738,11 +2678,8 @@ void SolarSystem::setFlagPlanetsOrbitsOnly(bool b)
 	if(b!=flagPlanetsOrbitsOnly)
 	{
 		flagPlanetsOrbitsOnly = b;
-		if (StelApp::getInstance().getFlagImmediateSave())
-			conf->setValue("viewing/flag_planets_orbits_only", b);
+		StelApp::immediateSave("viewing/flag_planets_orbits_only", b);
 		emit flagPlanetsOrbitsOnlyChanged(b);
-		// Reinstall flag for orbits to renew visibility of orbits
-		//setFlagOrbits(getFlagOrbits());
 	}
 }
 
@@ -3330,8 +3267,7 @@ void SolarSystem::setFlagPermanentOrbits(bool b)
 	if (Planet::permanentDrawingOrbits!=b)
 	{
 		Planet::permanentDrawingOrbits=b;
-		if (StelApp::getInstance().getFlagImmediateSave())
-			conf->setValue("astro/flag_permanent_orbits", b);
+		StelApp::immediateSave("astro/flag_permanent_orbits", b);
 		emit flagPermanentOrbitsChanged(b);
 	}
 }
@@ -3346,8 +3282,7 @@ void SolarSystem::setOrbitsThickness(int v)
 	if (v!=Planet::orbitsThickness)
 	{
 		Planet::orbitsThickness=v;
-		if (StelApp::getInstance().getFlagImmediateSave())
-			conf->setValue("astro/object_orbits_thickness", v);
+		StelApp::immediateSave("astro/object_orbits_thickness", v);
 		emit orbitsThicknessChanged(v);
 	}
 }

--- a/src/core/modules/SolarSystem.cpp
+++ b/src/core/modules/SolarSystem.cpp
@@ -2087,7 +2087,6 @@ void SolarSystem::setSelected(PlanetP obj)
 		selected.clear();
 	// Undraw other objects hints, orbit, trails etc..
 	setFlagHints(getFlagHints());
-	//setFlagOrbits(getFlagOrbits());
 	reconfigureOrbits();
 }
 
@@ -2641,7 +2640,7 @@ void SolarSystem::reconfigureOrbits()
 	// 1 1 1 1 0  only selected SSO if it is a major planet
 	// 1 1 1 1 1  only selected SSO if it is a major planet, plus its system of moons
 
-	if (!flagOrbits || (/* flagOrbits && */ flagIsolatedOrbits&&(!selected || selected==sun)))
+	if (!flagOrbits || (flagIsolatedOrbits && (!selected || selected==sun)))
 	{
 		for (const auto& p : qAsConst(systemPlanets))
 			p->setFlagOrbits(false);
@@ -2656,7 +2655,7 @@ void SolarSystem::reconfigureOrbits()
 	}
 	else // flagIsolatedOrbits && selected
 	{
-		// Display only orbit for selected planet and its moons.
+		// Display only orbit for selected planet and, if requested, its moons.
 		for (const auto& p : qAsConst(systemPlanets))
 			p->setFlagOrbits(   (p==selected && (  !flagPlanetsOrbitsOnly ||  p->getPlanetType()==Planet::isPlanet )
 					 || (flagOrbitsWithMoons && p->getPlanetType()==Planet::isMoon && p->parent==selected ) ));

--- a/src/core/modules/SolarSystem.cpp
+++ b/src/core/modules/SolarSystem.cpp
@@ -116,6 +116,9 @@ SolarSystem::SolarSystem() : StelObjectModule()
 	planetNameFont.setPixelSize(StelApp::getInstance().getScreenFontSize());
 	connect(&StelApp::getInstance(), SIGNAL(screenFontSizeChanged(int)), this, SLOT(setFontSize(int)));
 	setObjectName("SolarSystem");
+	connect(this, SIGNAL(flagOrbitsChanged(bool)),            this, SLOT(reconfigureOrbits()));
+	connect(this, SIGNAL(flagPlanetsOrbitsOnlyChanged(bool)), this, SLOT(reconfigureOrbits()));
+	connect(this, SIGNAL(flagIsolatedOrbitsChanged(bool)),    this, SLOT(reconfigureOrbits()));
 }
 
 void SolarSystem::setFontSize(int newFontSize)
@@ -274,8 +277,8 @@ void SolarSystem::init()
 	setEphemerisJupiterMarkerColor( Vec3f(conf->value("color/ephemeris_jupiter_marker_color", "0.3,1.0,1.0").toString()));
 	setEphemerisSaturnMarkerColor(  Vec3f(conf->value("color/ephemeris_saturn_marker_color", "0.0,1.0,0.0").toString()));
 
-	setOrbitsThickness(conf->value("astro/object_orbits_thickness", 1).toBool());
-	setTrailsThickness(conf->value("astro/object_trails_thickness", 1).toBool());
+	setOrbitsThickness(conf->value("astro/object_orbits_thickness", 1).toInt());
+	setTrailsThickness(conf->value("astro/object_trails_thickness", 1).toInt());
 	recreateTrails();
 	setFlagTrails(conf->value("astro/flag_object_trails", false).toBool());
 
@@ -2050,67 +2053,6 @@ bool SolarSystem::getFlagLabels() const
 	return false;
 }
 
-void SolarSystem::setFlagOrbits(bool b)
-{
-	bool old = flagOrbits;
-	flagOrbits = b;
-	bool flagPlanetsOnly = getFlagPlanetsOrbitsOnly();
-	if (!b || !selected || selected==sun)
-	{
-		if (flagPlanetsOnly)
-		{
-			for (const auto& p : qAsConst(systemPlanets))
-			{
-				if (p->getPlanetType()==Planet::isPlanet)
-					p->setFlagOrbits(b);
-				else
-					p->setFlagOrbits(false);
-			}
-		}
-		else
-		{
-			for (const auto& p : qAsConst(systemPlanets))
-				p->setFlagOrbits(b);
-		}
-	}
-	else if (getFlagIsolatedOrbits()) // If a Planet is selected and orbits are on, fade out non-selected ones
-	{
-		if (flagPlanetsOnly)
-		{
-			for (const auto& p : qAsConst(systemPlanets))
-			{
-				if (selected == p && p->getPlanetType()==Planet::isPlanet)
-					p->setFlagOrbits(b);
-				else
-					p->setFlagOrbits(false);
-			}
-		}
-		else
-		{
-			for (const auto& p : qAsConst(systemPlanets))
-			{
-				if (selected == p)
-					p->setFlagOrbits(b);
-				else
-					p->setFlagOrbits(false);
-			}
-		}
-	}
-	else
-	{
-		// A planet is selected and orbits are on - draw orbits for the planet and their moons
-		for (const auto& p : qAsConst(systemPlanets))
-		{
-			if (selected == p || selected == p->parent)
-				p->setFlagOrbits(b);
-			else
-				p->setFlagOrbits(false);
-		}
-	}
-	if(old != flagOrbits)
-		emit flagOrbitsChanged(flagOrbits);
-}
-
 void SolarSystem::setFlagLightTravelTime(bool b)
 {
 	if(b!=flagLightTravelTime)
@@ -2142,7 +2084,8 @@ void SolarSystem::setSelected(PlanetP obj)
 		selected.clear();
 	// Undraw other objects hints, orbit, trails etc..
 	setFlagHints(getFlagHints());
-	setFlagOrbits(getFlagOrbits());
+	//setFlagOrbits(getFlagOrbits());
+	reconfigureOrbits();
 }
 
 
@@ -2668,14 +2611,120 @@ void SolarSystem::setNumberIsolatedTrails(int n)
 	emit numberIsolatedTrailsChanged(numberIsolatedTrails);
 }
 
+void SolarSystem::setFlagOrbits(bool b)
+{
+	if(b!=getFlagOrbits())
+	{
+		flagOrbits = b;
+		emit flagOrbitsChanged(b);
+	}
+}
+
+// Connect this to all signals when orbit selection or selected object has changed.
+// This method goes through all planets and sets orbit drawing as configured by several flags
+void SolarSystem::reconfigureOrbits()
+{
+	// we have: flagOrbits O, flagIsolatedOrbits I, flagPlanetsOrbitsOnly P, flagPermanentOrbits and a possibly selected planet S
+	// permanentOrbits only influences local drawing of a single planet and can be ignored here.
+	// O S I P
+	// 0 X X X   NONE
+	// 1 0 1 X   NONE
+	// 1 X 0 0   ALL
+	// 1 X 0 1   all planets only
+
+	// 1 1 1 0   only selected planet and orbits of its moon system
+	// 1 1 1 1   only selected SSO if it is a major planet
+
+	if (!flagOrbits || (flagOrbits&&flagIsolatedOrbits&&(!selected || selected==sun)))
+	{
+		for (const auto& p : qAsConst(systemPlanets))
+			p->setFlagOrbits(false);
+		return;
+	}
+	// from here, flagOrbits is certainly on
+	if (!flagIsolatedOrbits)
+	{
+		for (const auto& p : qAsConst(systemPlanets))
+			if (!flagPlanetsOrbitsOnly || (flagPlanetsOrbitsOnly && (p->getPlanetType()==Planet::isPlanet || (p->parent && p->parent->getPlanetType()==Planet::isPlanet) )))
+				p->setFlagOrbits(true);
+			else
+				p->setFlagOrbits(false);
+		return;
+	}
+	else // flagIsolatedOrbits && selected
+	{
+		// Display only orbit for selected planet and its moons.
+		for (const auto& p : qAsConst(systemPlanets))
+			if (   (p==selected && (  !flagPlanetsOrbitsOnly || (flagPlanetsOrbitsOnly && p->getPlanetType()==Planet::isPlanet ) )
+				|| (p->getPlanetType()==Planet::isMoon && p->parent==selected ) ))
+				p->setFlagOrbits(true);
+			else
+				p->setFlagOrbits(false);
+		return;
+	}
+
+/*
+	if (!selected || selected==sun)
+	{
+		if (flagPlanetsOrbitsOnly)
+		{
+			for (const auto& p : qAsConst(systemPlanets))
+			{
+				if (p->getPlanetType()==Planet::isPlanet)
+					p->setFlagOrbits(true);
+				else
+					p->setFlagOrbits(false);
+			}
+		}
+	}
+	else if (getFlagIsolatedOrbits()) // If a Planet is selected and orbits are on, fade out non-selected ones
+	{
+		if (flagPlanetsOrbitsOnly)
+		{
+			for (const auto& p : qAsConst(systemPlanets))
+			{
+				if (selected == p && p->getPlanetType()==Planet::isPlanet)
+					p->setFlagOrbits(b);
+				else
+					p->setFlagOrbits(false);
+			}
+		}
+		else
+		{
+			for (const auto& p : qAsConst(systemPlanets))
+			{
+				if (selected == p)
+					p->setFlagOrbits(b);
+				else
+					p->setFlagOrbits(false);
+			}
+		}
+	}
+	else
+	{
+		// A planet is selected and orbits are on - draw orbits for the planet and their moons
+		for (const auto& p : qAsConst(systemPlanets))
+		{
+			if (selected == p || selected == p->parent)
+				p->setFlagOrbits(b);
+			else
+				p->setFlagOrbits(false);
+		}
+	}
+	*/
+}
+
 void SolarSystem::setFlagIsolatedOrbits(bool b)
 {
 	if(b!=flagIsolatedOrbits)
 	{
 		flagIsolatedOrbits = b;
+		if (StelApp::getInstance().getFlagImmediateSave())
+			conf->setValue("viewing/flag_isolated_orbits", b);
+
 		emit flagIsolatedOrbitsChanged(b);
 		// Reinstall flag for orbits to renew visibility of orbits
-		setFlagOrbits(getFlagOrbits());
+		//setFlagOrbits(getFlagOrbits());
 	}
 }
 
@@ -2689,9 +2738,11 @@ void SolarSystem::setFlagPlanetsOrbitsOnly(bool b)
 	if(b!=flagPlanetsOrbitsOnly)
 	{
 		flagPlanetsOrbitsOnly = b;
+		if (StelApp::getInstance().getFlagImmediateSave())
+			conf->setValue("viewing/flag_planets_orbits_only", b);
 		emit flagPlanetsOrbitsOnlyChanged(b);
 		// Reinstall flag for orbits to renew visibility of orbits
-		setFlagOrbits(getFlagOrbits());
+		//setFlagOrbits(getFlagOrbits());
 	}
 }
 
@@ -3276,8 +3327,13 @@ bool SolarSystem::getFlagDrawSunHalo() const
 
 void SolarSystem::setFlagPermanentOrbits(bool b)
 {
-	Planet::permanentDrawingOrbits=b;
-	emit flagPermanentOrbitsChanged(b);
+	if (Planet::permanentDrawingOrbits!=b)
+	{
+		Planet::permanentDrawingOrbits=b;
+		if (StelApp::getInstance().getFlagImmediateSave())
+			conf->setValue("astro/flag_permanent_orbits", b);
+		emit flagPermanentOrbitsChanged(b);
+	}
 }
 
 bool SolarSystem::getFlagPermanentOrbits() const
@@ -3287,8 +3343,13 @@ bool SolarSystem::getFlagPermanentOrbits() const
 
 void SolarSystem::setOrbitsThickness(int v)
 {
-	Planet::orbitsThickness=v;
-	emit orbitsThicknessChanged(v);
+	if (v!=Planet::orbitsThickness)
+	{
+		Planet::orbitsThickness=v;
+		if (StelApp::getInstance().getFlagImmediateSave())
+			conf->setValue("astro/object_orbits_thickness", v);
+		emit orbitsThicknessChanged(v);
+	}
 }
 
 int SolarSystem::getOrbitsThickness() const

--- a/src/core/modules/SolarSystem.cpp
+++ b/src/core/modules/SolarSystem.cpp
@@ -2657,8 +2657,8 @@ void SolarSystem::reconfigureOrbits()
 	{
 		// Display only orbit for selected planet and, if requested, its moons.
 		for (const auto& p : qAsConst(systemPlanets))
-			p->setFlagOrbits(   (p==selected && (  !flagPlanetsOrbitsOnly ||  p->getPlanetType()==Planet::isPlanet )
-					 || (flagOrbitsWithMoons && p->getPlanetType()==Planet::isMoon && p->parent==selected ) ));
+			p->setFlagOrbits(   (p==selected && (  !flagPlanetsOrbitsOnly ||  p->getPlanetType()==Planet::isPlanet ) )
+					 || (flagOrbitsWithMoons && p->getPlanetType()==Planet::isMoon && p->parent==selected ) );
 		return;
 	}
 }

--- a/src/core/modules/SolarSystem.hpp
+++ b/src/core/modules/SolarSystem.hpp
@@ -53,19 +53,16 @@ class SolarSystem : public StelObjectModule
 	Q_OBJECT
 	// This is a "forwarding property" which sets labeling into all planets.
 	Q_PROPERTY(bool labelsDisplayed			READ getFlagLabels			WRITE setFlagLabels			NOTIFY labelsDisplayedChanged)
-	// was bool orbitsDisplayed
-	Q_PROPERTY(bool flagOrbits			READ getFlagOrbits			WRITE setFlagOrbits			NOTIFY flagOrbitsChanged)
 	Q_PROPERTY(bool trailsDisplayed			READ getFlagTrails			WRITE setFlagTrails			NOTIFY trailsDisplayedChanged)
 	Q_PROPERTY(int maxTrailPoints			READ getMaxTrailPoints			WRITE setMaxTrailPoints			NOTIFY maxTrailPointsChanged)
 	Q_PROPERTY(int maxTrailTimeExtent		READ getMaxTrailTimeExtent		WRITE setMaxTrailTimeExtent		NOTIFY maxTrailTimeExtentChanged)
 	Q_PROPERTY(int trailsThickness			READ getTrailsThickness			WRITE setTrailsThickness		NOTIFY trailsThicknessChanged)
-	// was bool hintsDisplayed. This is a "forwarding property" only, without own variable.
+	// This is a "forwarding property" only, without own variable.
 	Q_PROPERTY(bool flagHints			READ getFlagHints			WRITE setFlagHints			NOTIFY flagHintsChanged)
-	// was bool pointersDisplayed
 	Q_PROPERTY(bool flagPointer			READ getFlagPointer			WRITE setFlagPointer			NOTIFY flagPointerChanged)
-	// was bool nativeNamesDisplayed
 	Q_PROPERTY(bool flagNativePlanetNames		READ getFlagNativePlanetNames		WRITE setFlagNativePlanetNames		NOTIFY flagNativePlanetNamesChanged)
 	Q_PROPERTY(bool planetsDisplayed		READ getFlagPlanets			WRITE setFlagPlanets			NOTIFY flagPlanetsDisplayedChanged)
+	Q_PROPERTY(bool flagOrbits			READ getFlagOrbits			WRITE setFlagOrbits			NOTIFY flagOrbitsChanged)
 	Q_PROPERTY(bool flagPlanetsOrbitsOnly		READ getFlagPlanetsOrbitsOnly		WRITE setFlagPlanetsOrbitsOnly		NOTIFY flagPlanetsOrbitsOnlyChanged)
 	Q_PROPERTY(bool flagPermanentOrbits		READ getFlagPermanentOrbits		WRITE setFlagPermanentOrbits		NOTIFY flagPermanentOrbitsChanged)
 	Q_PROPERTY(bool flagIsolatedOrbits		READ getFlagIsolatedOrbits		WRITE setFlagIsolatedOrbits		NOTIFY flagIsolatedOrbitsChanged)
@@ -998,6 +995,8 @@ private slots:
 	//! Taking the JD dates for each ephemeride and preparation the human readable dates according to the settings for dates
 	void fillEphemerisDates();
 
+	//! When some aspect of orbit drawing changes, update their configuration
+	void reconfigureOrbits();
 private:
 	//! Search for SolarSystem objects which are close to the position given
 	//! in earth equatorial position.

--- a/src/core/modules/SolarSystem.hpp
+++ b/src/core/modules/SolarSystem.hpp
@@ -66,6 +66,7 @@ class SolarSystem : public StelObjectModule
 	Q_PROPERTY(bool flagPlanetsOrbitsOnly		READ getFlagPlanetsOrbitsOnly		WRITE setFlagPlanetsOrbitsOnly		NOTIFY flagPlanetsOrbitsOnlyChanged)
 	Q_PROPERTY(bool flagPermanentOrbits		READ getFlagPermanentOrbits		WRITE setFlagPermanentOrbits		NOTIFY flagPermanentOrbitsChanged)
 	Q_PROPERTY(bool flagIsolatedOrbits		READ getFlagIsolatedOrbits		WRITE setFlagIsolatedOrbits		NOTIFY flagIsolatedOrbitsChanged)
+	Q_PROPERTY(bool flagOrbitsWithMoons		READ getFlagOrbitsWithMoons		WRITE setFlagOrbitsWithMoons		NOTIFY flagOrbitsWithMoonsChanged)
 	Q_PROPERTY(bool flagIsolatedTrails		READ getFlagIsolatedTrails		WRITE setFlagIsolatedTrails		NOTIFY flagIsolatedTrailsChanged)
 	Q_PROPERTY(int numberIsolatedTrails		READ getNumberIsolatedTrails		WRITE setNumberIsolatedTrails		NOTIFY numberIsolatedTrailsChanged)
 	Q_PROPERTY(bool flagLightTravelTime		READ getFlagLightTravelTime		WRITE setFlagLightTravelTime		NOTIFY flagLightTravelTimeChanged)
@@ -667,6 +668,11 @@ public slots:
 	//! Get the current value of the flag which enables showing of planets orbits only or not.
 	bool getFlagPlanetsOrbitsOnly(void) const;
 
+	//! Set flag which enables showing of planets orbits together mith orbits of their moons.
+	void setFlagOrbitsWithMoons(bool b);
+	//! Get the current value of the flag for showing of planets orbits together mith orbits of their moons.
+	bool getFlagOrbitsWithMoons(void) const;
+
 	//! Set flag which enabled the showing of solar corona when atmosphere is disabled (true) of draw the corona when total solar eclipses is happened only (false)
 	void setFlagPermanentSolarCorona(bool b) {	if (flagPermanentSolarCorona!=b)	{ flagPermanentSolarCorona = b; emit flagPermanentSolarCoronaChanged(b); } }
 	//! Get the current value of the flag which enables showing of solar corona when atmosphere is disabled or when total solar eclipses is happened only.
@@ -749,6 +755,7 @@ signals:
 	void flagPlanetsOrbitsOnlyChanged(bool b);
 	void flagPermanentOrbitsChanged(bool b);
 	void flagIsolatedOrbitsChanged(bool b);
+	void flagOrbitsWithMoonsChanged(bool b);
 	void flagIsolatedTrailsChanged(bool b);
 	void numberIsolatedTrailsChanged(int n);
 	void flagLightTravelTimeChanged(bool b);
@@ -1101,6 +1108,7 @@ private:
 	int trailsThickness;
 	bool flagIsolatedOrbits;
 	bool flagPlanetsOrbitsOnly;
+	bool flagOrbitsWithMoons;
 	bool ephemerisMarkersDisplayed;
 	bool ephemerisDatesDisplayed;
 	bool ephemerisMagnitudesDisplayed;

--- a/src/gui/ConfigurationDialog.cpp
+++ b/src/gui/ConfigurationDialog.cpp
@@ -875,6 +875,7 @@ void ConfigurationDialog::saveAllSettings()
 	conf->setValue("viewing/max_trail_time_extent",			propMgr->getStelPropertyValue("SolarSystem.maxTrailTimeExtent").toInt());
 	conf->setValue("viewing/flag_isolated_orbits",			propMgr->getStelPropertyValue("SolarSystem.flagIsolatedOrbits").toBool());
 	conf->setValue("viewing/flag_planets_orbits_only",		propMgr->getStelPropertyValue("SolarSystem.flagPlanetsOrbitsOnly").toBool());
+	conf->setValue("viewing/flag_orbits_with_moons",		propMgr->getStelPropertyValue("SolarSystem.flagOrbitsWithMoons").toBool());
 	conf->setValue("astro/flag_light_travel_time",			propMgr->getStelPropertyValue("SolarSystem.flagLightTravelTime").toBool());
 	conf->setValue("viewing/flag_draw_moon_halo",			propMgr->getStelPropertyValue("SolarSystem.flagDrawMoonHalo").toBool());
 	conf->setValue("viewing/flag_draw_sun_halo",			propMgr->getStelPropertyValue("SolarSystem.flagDrawSunHalo").toBool());

--- a/src/gui/ViewDialog.cpp
+++ b/src/gui/ViewDialog.cpp
@@ -224,6 +224,7 @@ void ViewDialog::createDialogContent()
 	connectCheckBox(ui->planetOrbitCheckBox, "actionShow_Planets_Orbits");
 	connectBoolProperty(ui->planetIsolatedOrbitCheckBox, "SolarSystem.flagIsolatedOrbits");
 	connectBoolProperty(ui->planetOrbitOnlyCheckBox, "SolarSystem.flagPlanetsOrbitsOnly");
+	connectBoolProperty(ui->planetOrbitsMoonCheckBox, "SolarSystem.flagOrbitsWithMoons");
 	connectBoolProperty(ui->planetOrbitPermanentCheckBox, "SolarSystem.flagPermanentOrbits");
 	connectIntProperty(ui->planetOrbitsThicknessSpinBox, "SolarSystem.orbitsThickness");
 	connect(ui->pushButtonOrbitColors, SIGNAL(clicked(bool)), this, SLOT(showConfigureOrbitColorsDialog()));

--- a/src/gui/viewDialog.ui
+++ b/src/gui/viewDialog.ui
@@ -1685,6 +1685,9 @@
                </property>
                <item>
                 <widget class="QCheckBox" name="planetOrbitOnlyCheckBox">
+                 <property name="toolTip">
+                  <string>Hide orbits of minor bodies.</string>
+                 </property>
                  <property name="text">
                   <string>Only orbits of major planets</string>
                  </property>
@@ -1693,7 +1696,7 @@
                <item>
                 <widget class="QCheckBox" name="planetIsolatedOrbitCheckBox">
                  <property name="toolTip">
-                  <string>Deactivate this option if you want to see orbit for selected planet and its moons.</string>
+                  <string>Activate this option if you want to see orbit for selected planet and its moons.</string>
                  </property>
                  <property name="text">
                   <string>Only orbit for selected object</string>
@@ -5690,12 +5693,12 @@
  </resources>
  <connections/>
  <buttongroups>
-  <buttongroup name="buttonGroupDisplayedDSOCatalogs">
+  <buttongroup name="buttonGroupDisplayedDSOTypes">
    <property name="exclusive">
     <bool>false</bool>
    </property>
   </buttongroup>
-  <buttongroup name="buttonGroupDisplayedDSOTypes">
+  <buttongroup name="buttonGroupDisplayedDSOCatalogs">
    <property name="exclusive">
     <bool>false</bool>
    </property>

--- a/src/gui/viewDialog.ui
+++ b/src/gui/viewDialog.ui
@@ -1550,7 +1550,7 @@
                <item>
                 <widget class="QCheckBox" name="planetOrbitPermanentCheckBox">
                  <property name="toolTip">
-                  <string>Show orbit even if planet is off screen</string>
+                  <string>Show orbit even if object is off screen</string>
                  </property>
                  <property name="text">
                   <string>permanently</string>
@@ -1689,17 +1689,27 @@
                   <string>Hide orbits of minor bodies.</string>
                  </property>
                  <property name="text">
-                  <string>Only orbits of major planets</string>
+                  <string>Only orbits of major planets...</string>
                  </property>
                 </widget>
                </item>
                <item>
                 <widget class="QCheckBox" name="planetIsolatedOrbitCheckBox">
                  <property name="toolTip">
-                  <string>Activate this option if you want to see orbit for selected planet and its moons.</string>
+                  <string>Show orbit only for selected SSO</string>
                  </property>
                  <property name="text">
-                  <string>Only orbit for selected object</string>
+                  <string>Only orbit for selected object...</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QCheckBox" name="planetOrbitsMoonCheckBox">
+                 <property name="toolTip">
+                  <string>Also show moons of selected object or planets.</string>
+                 </property>
+                 <property name="text">
+                  <string>... and moons</string>
                  </property>
                 </widget>
                </item>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Please include a summary of the change and which issue is fixed. -->
<!--- Please also include relevant motivation and context. -->
<!--- List any dependencies that are required for this change. -->

As discussed in #2043, the sequence of selection around orbit details is inconsistent and buggy. 
I separated flag setting from the actual selection (which involves 4 flags and an optional selection).
We can discuss yet another finetuning option "with moons" which would influence whether the orbital system of moons would be highlighted even if the flag for only "major planets" or "only selected object" is set and the selected object is a major planet. 


Also, as first commit, I introduce a (currently hidden and manually editable only) option StelApp.flagImmediateSave. If set, this can be used to store settings immediately. The intention is to allow storing detail settings in the GUI, like orbit drawing details, DSO catalog selection or type filtering, without having to save these globally (and thereby maybe accidentally overwrite and globally store other settings that were active only during this session). My personal preference would be to get rid of the global save entirely, but I see resistance. Maybe we can offer a global switch on  "immediate save" vs "global save", when all settings have been adjusted over the next few months. 

I will amend the second commit by removing commented code and optionally adding the "with moons" option. 

After this has been merged, PR #3342 will be adjusted accordingly. 

Fixes #1842 (supersedes PR #2043)

### Screenshots (if appropriate):

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] This change requires a documentation update

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system: Windows 11
* Graphics Card: Geforce 3070Ti (irrelevant)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
