### PR TITLE
Smooth orbit lines (esp. for comets)

### DIFF
--- a/data/ssystem_1000comets.ini
+++ b/data/ssystem_1000comets.ini
@@ -7,11 +7,6 @@
 [67pchuryumovgerasimenko]
 absolute_magnitude=11
 albedo=1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=67P/Churyumov-Gerasimenko
 orbit_ArgOfPericenter=12.7758
 orbit_AscendingNode=50.1497
@@ -22,17 +17,13 @@ orbit_TimeAtPericenter=2457247.54059028
 orbit_good=1000
 radius=5
 slope_parameter=4
-tex_map=nomap.png
 type=comet
 
 [C_1995O1%28Hale-Bopp%29]
 absolute_magnitude=-2.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
 dust_brightnessfactor=1.0
 dust_lengthfactor=0.3
-dust_widthfactor=1.5
 name=C/1995 O1 (Hale-Bopp)
 orbit_ArgOfPericenter=130.58949
 orbit_AscendingNode=282.47085
@@ -44,16 +35,12 @@ orbit_TimeAtPericenter=2450539.63730
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_1996B2%28Hyakutake%29]
 absolute_magnitude=5.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
 dust_brightnessfactor=0.5
-dust_lengthfactor=0.4
 dust_widthfactor=0.5
 name=C/1996 B2 (Hyakutake)
 orbit_ArgOfPericenter=130.17407
@@ -66,17 +53,11 @@ orbit_TimeAtPericenter=2450204.89407
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_2001Q4%28NEAT%29]
 absolute_magnitude=6.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/2001 Q4 (NEAT)
 orbit_ArgOfPericenter=1.20457
 orbit_AscendingNode=210.27845
@@ -88,17 +69,11 @@ orbit_TimeAtPericenter=2453141.46585
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_2002T7%28LINEAR%29]
 absolute_magnitude=6.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/2002 T7 (LINEAR)
 orbit_ArgOfPericenter=157.73884
 orbit_AscendingNode=94.85669
@@ -110,17 +85,11 @@ orbit_TimeAtPericenter=2453118.56146
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_2003T3%28Tabur%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/2003 T3 (Tabur)
 orbit_ArgOfPericenter=43.77353
 orbit_AscendingNode=347.05761
@@ -132,17 +101,11 @@ orbit_TimeAtPericenter=2453124.50161
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_2006P1%28McNaught%29]
 absolute_magnitude=2.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/2006 P1 (McNaught)
 orbit_ArgOfPericenter=155.97496
 orbit_AscendingNode=267.41479
@@ -154,17 +117,11 @@ orbit_TimeAtPericenter=2454113.29885
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_2011L4%28PANSTARRS%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/2011 L4 (PANSTARRS)
 orbit_ArgOfPericenter=333.65160
 orbit_AscendingNode=65.66590
@@ -176,17 +133,11 @@ orbit_TimeAtPericenter=2456361.66992
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Aarseth-Brewington%281989a1_1989XXII%29]
 absolute_magnitude=7.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Aarseth-Brewington (1989a1=1989XXII)"
 orbit_ArgOfPericenter=205.26032
 orbit_AscendingNode=345.21676
@@ -198,17 +149,11 @@ orbit_TimeAtPericenter=2447888.38855
 orbit_good=1000
 radius=5
 slope_parameter=3.8
-tex_map=nomap.png
 type=comet
 
 [C_Abe%281970g_1970XV%29]
 absolute_magnitude=5.7
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Abe (1970g=1970XV)"
 orbit_ArgOfPericenter=96.57990
 orbit_AscendingNode=21.00070
@@ -220,17 +165,11 @@ orbit_TimeAtPericenter=2440880.19900
 orbit_good=1000
 radius=5
 slope_parameter=3.1
-tex_map=nomap.png
 type=comet
 
 [C_Abell%281953g_1954X%29]
 absolute_magnitude=6.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Abell (1953g=1954X)"
 orbit_ArgOfPericenter=194.38170
 orbit_AscendingNode=2.33500
@@ -242,17 +181,11 @@ orbit_TimeAtPericenter=2434930.84920
 orbit_good=1000
 radius=5
 slope_parameter=5.2
-tex_map=nomap.png
 type=comet
 
 [C_Abell%281955b_1954V%29]
 absolute_magnitude=4.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Abell (1955b=1954V)"
 orbit_ArgOfPericenter=73.75440
 orbit_AscendingNode=320.63860
@@ -264,17 +197,11 @@ orbit_TimeAtPericenter=2434825.61520
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Alcock%281959f_1959VI%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Alcock (1959f=1959VI)"
 orbit_ArgOfPericenter=300.61120
 orbit_AscendingNode=225.07140
@@ -286,17 +213,11 @@ orbit_TimeAtPericenter=2436827.38030
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Alcock%281963b_1963III%29]
 absolute_magnitude=3.9
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Alcock (1963b=1963III)"
 orbit_ArgOfPericenter=146.61730
 orbit_AscendingNode=42.76650
@@ -308,17 +229,11 @@ orbit_TimeAtPericenter=2438155.38160
 orbit_good=1000
 radius=5
 slope_parameter=5.7
-tex_map=nomap.png
 type=comet
 
 [C_Alcock%281965h_1965IX%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Alcock (1965h=1965IX)"
 orbit_ArgOfPericenter=150.52390
 orbit_AscendingNode=174.92490
@@ -330,17 +245,11 @@ orbit_TimeAtPericenter=2439059.64020
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anderson%281963IX%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anderson (1963IX)
 orbit_ArgOfPericenter=343.11000
 orbit_AscendingNode=99.62000
@@ -352,17 +261,11 @@ orbit_TimeAtPericenter=2438311.79000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%28-136%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (-136)
 orbit_ArgOfPericenter=350.00000
 orbit_AscendingNode=220.00000
@@ -374,17 +277,11 @@ orbit_TimeAtPericenter=1671502.50000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%28-146%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (-146)
 orbit_ArgOfPericenter=261.00000
 orbit_AscendingNode=329.00000
@@ -396,17 +293,11 @@ orbit_TimeAtPericenter=1667909.50000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281014%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1014)
 orbit_ArgOfPericenter=84.00000
 orbit_AscendingNode=173.00000
@@ -418,17 +309,11 @@ orbit_TimeAtPericenter=2091516.50000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281018%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1018)
 orbit_ArgOfPericenter=197.00000
 orbit_AscendingNode=184.00000
@@ -440,17 +325,11 @@ orbit_TimeAtPericenter=2093120.50000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281080%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1080)
 orbit_ArgOfPericenter=73.63000
 orbit_AscendingNode=322.20000
@@ -462,17 +341,11 @@ orbit_TimeAtPericenter=2115781.44000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281092%29]
 absolute_magnitude=3.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1092)
 orbit_ArgOfPericenter=62.00000
 orbit_AscendingNode=113.00000
@@ -484,17 +357,11 @@ orbit_TimeAtPericenter=2119962.50000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281097%29]
 absolute_magnitude=6.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1097)
 orbit_ArgOfPericenter=298.00000
 orbit_AscendingNode=351.00000
@@ -506,17 +373,11 @@ orbit_TimeAtPericenter=2122001.80000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281110%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1110)
 orbit_ArgOfPericenter=358.00000
 orbit_AscendingNode=320.00000
@@ -528,17 +389,11 @@ orbit_TimeAtPericenter=2126622.50000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281132%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1132)
 orbit_ArgOfPericenter=114.20000
 orbit_AscendingNode=212.50000
@@ -550,17 +405,11 @@ orbit_TimeAtPericenter=2134763.20000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281147%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1147)
 orbit_ArgOfPericenter=300.00000
 orbit_AscendingNode=281.00000
@@ -572,17 +421,11 @@ orbit_TimeAtPericenter=2140026.50000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281230%29]
 absolute_magnitude=6.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1230)
 orbit_ArgOfPericenter=181.00000
 orbit_AscendingNode=303.00000
@@ -594,17 +437,11 @@ orbit_TimeAtPericenter=2170677.30000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281240%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1240)
 orbit_ArgOfPericenter=331.40000
 orbit_AscendingNode=134.40000
@@ -616,17 +453,11 @@ orbit_TimeAtPericenter=2173988.06000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281245%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1245)
 orbit_ArgOfPericenter=87.00000
 orbit_AscendingNode=179.00000
@@ -638,17 +469,11 @@ orbit_TimeAtPericenter=2175884.50000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281264%29]
 absolute_magnitude=3.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1264)
 orbit_ArgOfPericenter=159.70000
 orbit_AscendingNode=150.35000
@@ -660,17 +485,11 @@ orbit_TimeAtPericenter=2182934.79000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281293%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1293)
 orbit_ArgOfPericenter=313.00000
 orbit_AscendingNode=88.00000
@@ -682,17 +501,11 @@ orbit_TimeAtPericenter=2193626.50000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281299%29]
 absolute_magnitude=2.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1299)
 orbit_ArgOfPericenter=103.88000
 orbit_AscendingNode=116.24000
@@ -704,17 +517,11 @@ orbit_TimeAtPericenter=2195607.31000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281305%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1305)
 orbit_ArgOfPericenter=56.00000
 orbit_AscendingNode=105.00000
@@ -726,17 +533,11 @@ orbit_TimeAtPericenter=2197727.50000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281337%29]
 absolute_magnitude=2.9
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1337)
 orbit_ArgOfPericenter=79.60000
 orbit_AscendingNode=96.90000
@@ -748,17 +549,11 @@ orbit_TimeAtPericenter=2209562.35000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281340%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1340)
 orbit_ArgOfPericenter=32.46000
 orbit_AscendingNode=186.95000
@@ -770,17 +565,11 @@ orbit_TimeAtPericenter=2210626.12000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281345%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1345)
 orbit_ArgOfPericenter=210.00000
 orbit_AscendingNode=149.00000
@@ -792,17 +581,11 @@ orbit_TimeAtPericenter=2212553.50000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281351%29]
 absolute_magnitude=9.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1351)
 orbit_ArgOfPericenter=165.00000
 orbit_AscendingNode=263.00000
@@ -814,17 +597,11 @@ orbit_TimeAtPericenter=2214832.50000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281362%29]
 absolute_magnitude=5.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1362)
 orbit_ArgOfPericenter=348.00000
 orbit_AscendingNode=290.00000
@@ -836,17 +613,11 @@ orbit_TimeAtPericenter=2218583.50000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281368%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1368)
 orbit_ArgOfPericenter=90.00000
 orbit_AscendingNode=216.00000
@@ -858,17 +629,11 @@ orbit_TimeAtPericenter=2220844.50000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281376%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1376)
 orbit_ArgOfPericenter=81.00000
 orbit_AscendingNode=300.00000
@@ -880,17 +645,11 @@ orbit_TimeAtPericenter=2223854.20000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281385%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1385)
 orbit_ArgOfPericenter=182.00000
 orbit_AscendingNode=288.00000
@@ -902,17 +661,11 @@ orbit_TimeAtPericenter=2227225.50000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281402%29]
 absolute_magnitude=0.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1402)
 orbit_ArgOfPericenter=91.00000
 orbit_AscendingNode=125.00000
@@ -924,17 +677,11 @@ orbit_TimeAtPericenter=2233217.50000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281433%29]
 absolute_magnitude=1.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1433)
 orbit_ArgOfPericenter=189.38600
 orbit_AscendingNode=103.55500
@@ -946,17 +693,11 @@ orbit_TimeAtPericenter=2244772.77000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281439%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1439)
 orbit_ArgOfPericenter=140.00000
 orbit_AscendingNode=191.00000
@@ -968,17 +709,11 @@ orbit_TimeAtPericenter=2246780.50000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281449%29]
 absolute_magnitude=4.6
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1449)
 orbit_ArgOfPericenter=356.70700
 orbit_AscendingNode=268.12500
@@ -990,17 +725,11 @@ orbit_TimeAtPericenter=2250648.36800
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281457II%29]
 absolute_magnitude=3.1
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1457II)
 orbit_ArgOfPericenter=183.29200
 orbit_AscendingNode=186.84200
@@ -1012,17 +741,11 @@ orbit_TimeAtPericenter=2253446.60500
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281458%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1458)
 orbit_ArgOfPericenter=258.00000
 orbit_AscendingNode=116.00000
@@ -1034,17 +757,11 @@ orbit_TimeAtPericenter=2253902.50000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281462%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1462)
 orbit_ArgOfPericenter=137.00000
 orbit_AscendingNode=315.00000
@@ -1056,17 +773,11 @@ orbit_TimeAtPericenter=2255268.50000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281468%29]
 absolute_magnitude=3.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1468)
 orbit_ArgOfPericenter=91.00000
 orbit_AscendingNode=106.00000
@@ -1078,17 +789,11 @@ orbit_TimeAtPericenter=2257524.80000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281472%29]
 absolute_magnitude=2.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1472)
 orbit_ArgOfPericenter=245.76400
 orbit_AscendingNode=292.21000
@@ -1100,17 +805,11 @@ orbit_TimeAtPericenter=2258765.93900
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281491I%29]
 absolute_magnitude=5.4
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1491I)
 orbit_ArgOfPericenter=164.90000
 orbit_AscendingNode=279.50000
@@ -1122,17 +821,11 @@ orbit_TimeAtPericenter=2265653.40000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281491II%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1491II)
 orbit_ArgOfPericenter=316.00000
 orbit_AscendingNode=165.00000
@@ -1144,17 +837,11 @@ orbit_TimeAtPericenter=2265667.20000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281499%29]
 absolute_magnitude=9.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1499)
 orbit_ArgOfPericenter=42.00000
 orbit_AscendingNode=328.00000
@@ -1166,17 +853,11 @@ orbit_TimeAtPericenter=2268818.50000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281500%29]
 absolute_magnitude=1.6
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1500)
 orbit_ArgOfPericenter=352.00000
 orbit_AscendingNode=304.00000
@@ -1188,17 +869,11 @@ orbit_TimeAtPericenter=2269052.50000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281506%29]
 absolute_magnitude=4.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1506)
 orbit_ArgOfPericenter=200.00000
 orbit_AscendingNode=155.00000
@@ -1210,17 +885,11 @@ orbit_TimeAtPericenter=2271364.00000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281532%29]
 absolute_magnitude=1.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1532)
 orbit_ArgOfPericenter=24.52000
 orbit_AscendingNode=93.12000
@@ -1232,17 +901,11 @@ orbit_TimeAtPericenter=2280912.33200
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281533%29]
 absolute_magnitude=3.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1533)
 orbit_ArgOfPericenter=21.38800
 orbit_AscendingNode=124.71700
@@ -1254,17 +917,11 @@ orbit_TimeAtPericenter=2281151.91700
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281537%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1537)
 orbit_ArgOfPericenter=287.70000
 orbit_AscendingNode=355.50000
@@ -1276,17 +933,11 @@ orbit_TimeAtPericenter=2282810.82000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281539%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1539)
 orbit_ArgOfPericenter=174.50000
 orbit_AscendingNode=54.40000
@@ -1298,17 +949,11 @@ orbit_TimeAtPericenter=2283309.10000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281556%29]
 absolute_magnitude=3.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1556)
 orbit_ArgOfPericenter=100.86800
 orbit_AscendingNode=180.73600
@@ -1320,17 +965,11 @@ orbit_TimeAtPericenter=2289499.18500
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281557%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1557)
 orbit_ArgOfPericenter=94.00000
 orbit_AscendingNode=211.00000
@@ -1342,17 +981,11 @@ orbit_TimeAtPericenter=2290016.50000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281558%29]
 absolute_magnitude=4.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1558)
 orbit_ArgOfPericenter=119.60000
 orbit_AscendingNode=340.51000
@@ -1364,17 +997,11 @@ orbit_TimeAtPericenter=2290373.54000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281577I%29]
 absolute_magnitude=-0.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1577I)
 orbit_ArgOfPericenter=255.66900
 orbit_AscendingNode=30.53800
@@ -1386,17 +1013,11 @@ orbit_TimeAtPericenter=2297356.94800
 orbit_good=1000
 radius=5
 slope_parameter=5.5
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281577II%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1577II)
 orbit_ArgOfPericenter=27.10000
 orbit_AscendingNode=35.40000
@@ -1408,17 +1029,11 @@ orbit_TimeAtPericenter=2297369.00000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281580%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1580)
 orbit_ArgOfPericenter=89.36300
 orbit_AscendingNode=24.25100
@@ -1430,17 +1045,11 @@ orbit_TimeAtPericenter=2298485.49300
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281582%29]
 absolute_magnitude=4.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1582)
 orbit_ArgOfPericenter=331.90100
 orbit_AscendingNode=232.33800
@@ -1452,17 +1061,11 @@ orbit_TimeAtPericenter=2299009.41300
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281585%29]
 absolute_magnitude=6.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1585)
 orbit_ArgOfPericenter=331.73260
 orbit_AscendingNode=42.49010
@@ -1474,17 +1077,11 @@ orbit_TimeAtPericenter=2300250.02620
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281590%29]
 absolute_magnitude=6.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1590)
 orbit_ArgOfPericenter=307.67000
 orbit_AscendingNode=170.64200
@@ -1496,17 +1093,11 @@ orbit_TimeAtPericenter=2301834.02710
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281593%29]
 absolute_magnitude=6.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1593)
 orbit_ArgOfPericenter=12.07000
 orbit_AscendingNode=169.22000
@@ -1518,17 +1109,11 @@ orbit_TimeAtPericenter=2303090.56900
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281596%29]
 absolute_magnitude=5.7
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1596)
 orbit_ArgOfPericenter=59.41700
 orbit_AscendingNode=335.26600
@@ -1540,17 +1125,11 @@ orbit_TimeAtPericenter=2304193.21430
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281618I%29]
 absolute_magnitude=6.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1618I)
 orbit_ArgOfPericenter=24.82000
 orbit_AscendingNode=298.13000
@@ -1562,17 +1141,11 @@ orbit_TimeAtPericenter=2312251.12700
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281618II%29]
 absolute_magnitude=4.6
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1618II)
 orbit_ArgOfPericenter=287.42480
 orbit_AscendingNode=80.31140
@@ -1584,17 +1157,11 @@ orbit_TimeAtPericenter=2312334.35070
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281618III%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1618III)
 orbit_ArgOfPericenter=155.90000
 orbit_AscendingNode=228.80000
@@ -1606,17 +1173,11 @@ orbit_TimeAtPericenter=2312322.40000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281639%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1639)
 orbit_ArgOfPericenter=237.40000
 orbit_AscendingNode=219.00000
@@ -1628,17 +1189,11 @@ orbit_TimeAtPericenter=2320024.90000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281652%29]
 absolute_magnitude=5.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1652)
 orbit_ArgOfPericenter=300.18000
 orbit_AscendingNode=92.30000
@@ -1650,17 +1205,11 @@ orbit_TimeAtPericenter=2324757.65300
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281661%29]
 absolute_magnitude=4.6
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1661)
 orbit_ArgOfPericenter=33.43800
 orbit_AscendingNode=85.87300
@@ -1672,17 +1221,11 @@ orbit_TimeAtPericenter=2327754.88100
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281664%29]
 absolute_magnitude=2.4
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1664)
 orbit_ArgOfPericenter=310.65690
 orbit_AscendingNode=85.33730
@@ -1694,17 +1237,11 @@ orbit_TimeAtPericenter=2329162.48340
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281665%29]
 absolute_magnitude=4.9
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1665)
 orbit_ArgOfPericenter=156.09000
 orbit_AscendingNode=232.00000
@@ -1716,17 +1253,11 @@ orbit_TimeAtPericenter=2329303.21900
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281668%29]
 absolute_magnitude=6.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1668)
 orbit_ArgOfPericenter=109.81200
 orbit_AscendingNode=2.51500
@@ -1738,17 +1269,11 @@ orbit_TimeAtPericenter=2330342.58000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281672%29]
 absolute_magnitude=3.4
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1672)
 orbit_ArgOfPericenter=109.52970
 orbit_AscendingNode=301.99130
@@ -1760,17 +1285,11 @@ orbit_TimeAtPericenter=2331806.44670
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281677%29]
 absolute_magnitude=4.4
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1677)
 orbit_ArgOfPericenter=99.16800
 orbit_AscendingNode=240.61900
@@ -1782,17 +1301,11 @@ orbit_TimeAtPericenter=2333698.02600
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281683%29]
 absolute_magnitude=5.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1683)
 orbit_ArgOfPericenter=87.80990
 orbit_AscendingNode=177.13690
@@ -1804,17 +1317,11 @@ orbit_TimeAtPericenter=2335957.09070
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281684%29]
 absolute_magnitude=5.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1684)
 orbit_ArgOfPericenter=330.30700
 orbit_AscendingNode=271.89600
@@ -1826,17 +1333,11 @@ orbit_TimeAtPericenter=2336288.26300
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281686%29]
 absolute_magnitude=5.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1686)
 orbit_ArgOfPericenter=81.91300
 orbit_AscendingNode=357.74500
@@ -1848,17 +1349,11 @@ orbit_TimeAtPericenter=2337117.82490
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281689%29]
 absolute_magnitude=6.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1689)
 orbit_ArgOfPericenter=78.14100
 orbit_AscendingNode=283.05200
@@ -1870,17 +1365,11 @@ orbit_TimeAtPericenter=2338289.15890
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281695%29]
 absolute_magnitude=6.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1695)
 orbit_ArgOfPericenter=59.12400
 orbit_AscendingNode=285.32000
@@ -1892,17 +1381,11 @@ orbit_TimeAtPericenter=2340442.26800
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281698%29]
 absolute_magnitude=5.6
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1698)
 orbit_ArgOfPericenter=151.35000
 orbit_AscendingNode=69.55000
@@ -1914,17 +1397,11 @@ orbit_TimeAtPericenter=2341532.01490
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281699I%29]
 absolute_magnitude=6.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1699I)
 orbit_ArgOfPericenter=109.52800
 orbit_AscendingNode=325.18900
@@ -1936,17 +1413,11 @@ orbit_TimeAtPericenter=2341620.39980
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281701%29]
 absolute_magnitude=5.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1701)
 orbit_ArgOfPericenter=164.96000
 orbit_AscendingNode=302.12000
@@ -1958,17 +1429,11 @@ orbit_TimeAtPericenter=2342627.41000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281702%29]
 absolute_magnitude=5.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1702)
 orbit_ArgOfPericenter=309.66300
 orbit_AscendingNode=192.57000
@@ -1980,17 +1445,11 @@ orbit_TimeAtPericenter=2342774.60700
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281706%29]
 absolute_magnitude=5.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1706)
 orbit_ArgOfPericenter=59.43200
 orbit_AscendingNode=16.58400
@@ -2002,17 +1461,11 @@ orbit_TimeAtPericenter=2344193.20600
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281707%29]
 absolute_magnitude=5.4
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1707)
 orbit_ArgOfPericenter=27.15600
 orbit_AscendingNode=56.21800
@@ -2024,17 +1477,11 @@ orbit_TimeAtPericenter=2344873.98830
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281718%29]
 absolute_magnitude=6.9
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1718)
 orbit_ArgOfPericenter=6.30020
 orbit_AscendingNode=131.19730
@@ -2046,17 +1493,11 @@ orbit_TimeAtPericenter=2348560.90570
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281723%29]
 absolute_magnitude=5.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1723)
 orbit_ArgOfPericenter=331.37600
 orbit_AscendingNode=17.40200
@@ -2068,17 +1509,11 @@ orbit_TimeAtPericenter=2350642.62790
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281729%29]
 absolute_magnitude=-3.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1729)
 orbit_ArgOfPericenter=10.40770
 orbit_AscendingNode=313.69370
@@ -2090,17 +1525,11 @@ orbit_TimeAtPericenter=2352731.14770
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281737I%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1737I)
 orbit_ArgOfPericenter=99.48000
 orbit_AscendingNode=229.41000
@@ -2112,17 +1541,11 @@ orbit_TimeAtPericenter=2355516.34700
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281737II%29]
 absolute_magnitude=4.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1737II)
 orbit_ArgOfPericenter=129.96000
 orbit_AscendingNode=135.99000
@@ -2134,17 +1557,11 @@ orbit_TimeAtPericenter=2355640.03000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281739%29]
 absolute_magnitude=3.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1739)
 orbit_ArgOfPericenter=104.75700
 orbit_AscendingNode=210.34800
@@ -2156,17 +1573,11 @@ orbit_TimeAtPericenter=2356384.41600
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281742%29]
 absolute_magnitude=3.7
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1742)
 orbit_ArgOfPericenter=328.04450
 orbit_AscendingNode=188.50310
@@ -2178,17 +1589,11 @@ orbit_TimeAtPericenter=2357351.19640
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281743I%29]
 absolute_magnitude=9.1
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1743I)
 orbit_ArgOfPericenter=26.09200
 orbit_AscendingNode=69.76200
@@ -2200,17 +1605,11 @@ orbit_TimeAtPericenter=2357687.84740
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281743II%29]
 absolute_magnitude=5.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1743II)
 orbit_ArgOfPericenter=119.04500
 orbit_AscendingNode=8.93300
@@ -2222,17 +1621,11 @@ orbit_TimeAtPericenter=2357940.64690
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281744%29]
 absolute_magnitude=0.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1744)
 orbit_ArgOfPericenter=151.47830
 orbit_AscendingNode=48.60300
@@ -2244,17 +1637,11 @@ orbit_TimeAtPericenter=2358103.33980
 orbit_good=1000
 radius=5
 slope_parameter=3.9
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281746%29]
 absolute_magnitude=5.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1746)
 orbit_ArgOfPericenter=137.02000
 orbit_AscendingNode=340.07000
@@ -2266,17 +1653,11 @@ orbit_TimeAtPericenter=2358802.80000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281747%29]
 absolute_magnitude=-0.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1747)
 orbit_ArgOfPericenter=230.28800
 orbit_AscendingNode=150.15000
@@ -2288,17 +1669,11 @@ orbit_TimeAtPericenter=2359200.41550
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281748I%29]
 absolute_magnitude=5.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1748I)
 orbit_ArgOfPericenter=17.83400
 orbit_AscendingNode=235.68300
@@ -2310,17 +1685,11 @@ orbit_TimeAtPericenter=2359622.80930
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281748II%29]
 absolute_magnitude=6.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1748II)
 orbit_ArgOfPericenter=245.66400
 orbit_AscendingNode=35.94800
@@ -2332,17 +1701,11 @@ orbit_TimeAtPericenter=2359673.88750
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281750%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1750)
 orbit_ArgOfPericenter=285.00000
 orbit_AscendingNode=303.00000
@@ -2354,17 +1717,11 @@ orbit_TimeAtPericenter=2360287.50000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281757%29]
 absolute_magnitude=6.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1757)
 orbit_ArgOfPericenter=268.70990
 orbit_AscendingNode=216.95910
@@ -2376,17 +1733,11 @@ orbit_TimeAtPericenter=2363085.32620
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%281758%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (1758)
 orbit_ArgOfPericenter=36.78000
 orbit_AscendingNode=233.51000
@@ -2398,17 +1749,11 @@ orbit_TimeAtPericenter=2363318.13700
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%28240%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (240)
 orbit_ArgOfPericenter=82.00000
 orbit_AscendingNode=213.00000
@@ -2420,17 +1765,11 @@ orbit_TimeAtPericenter=1809031.50000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%28390%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (390)
 orbit_ArgOfPericenter=23.00000
 orbit_AscendingNode=355.00000
@@ -2442,17 +1781,11 @@ orbit_TimeAtPericenter=1863752.50000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%28400%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (400)
 orbit_ArgOfPericenter=47.00000
 orbit_AscendingNode=37.00000
@@ -2464,17 +1797,11 @@ orbit_TimeAtPericenter=1867212.50000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%28442%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (442)
 orbit_ArgOfPericenter=178.00000
 orbit_AscendingNode=270.00000
@@ -2486,17 +1813,11 @@ orbit_TimeAtPericenter=1882846.50000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%28539%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (539)
 orbit_ArgOfPericenter=246.00000
 orbit_AscendingNode=32.00000
@@ -2508,17 +1829,11 @@ orbit_TimeAtPericenter=1918236.50000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%28565%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (565)
 orbit_ArgOfPericenter=79.00000
 orbit_AscendingNode=179.00000
@@ -2530,17 +1845,11 @@ orbit_TimeAtPericenter=1927619.50000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%28568%29]
 absolute_magnitude=5.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (568)
 orbit_ArgOfPericenter=35.00000
 orbit_AscendingNode=301.00000
@@ -2552,17 +1861,11 @@ orbit_TimeAtPericenter=1928759.20000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%28574%29]
 absolute_magnitude=2.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (574)
 orbit_ArgOfPericenter=342.00000
 orbit_AscendingNode=154.00000
@@ -2574,17 +1877,11 @@ orbit_TimeAtPericenter=1930794.50000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%28770%29]
 absolute_magnitude=3.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (770)
 orbit_ArgOfPericenter=88.00000
 orbit_AscendingNode=110.00000
@@ -2596,17 +1893,11 @@ orbit_TimeAtPericenter=2002456.30000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%28868%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (868)
 orbit_ArgOfPericenter=277.00000
 orbit_AscendingNode=320.00000
@@ -2618,17 +1909,11 @@ orbit_TimeAtPericenter=2038157.50000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%28905%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (905)
 orbit_ArgOfPericenter=50.00000
 orbit_AscendingNode=69.00000
@@ -2640,17 +1925,11 @@ orbit_TimeAtPericenter=2051724.50000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Anonymus%28961%29]
 absolute_magnitude=2.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Anonymus (961)
 orbit_ArgOfPericenter=85.00000
 orbit_AscendingNode=1.00000
@@ -2662,17 +1941,11 @@ orbit_TimeAtPericenter=2072424.50000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Araya%281972l_1972XII%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Araya (1972l=1972XII)"
 orbit_ArgOfPericenter=267.20890
 orbit_AscendingNode=314.18720
@@ -2684,17 +1957,11 @@ orbit_TimeAtPericenter=2441670.44480
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Arend-Roland%281956h_1957III%29]
 absolute_magnitude=5.7
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Arend-Roland (1956h=1957III)"
 orbit_ArgOfPericenter=308.78520
 orbit_AscendingNode=215.15960
@@ -2706,17 +1973,11 @@ orbit_TimeAtPericenter=2435936.53240
 orbit_good=1000
 radius=5
 slope_parameter=3.3
-tex_map=nomap.png
 type=comet
 
 [C_Austin%281982g_1982VI%29]
 absolute_magnitude=7.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Austin (1982g=1982VI)"
 orbit_ArgOfPericenter=33.82600
 orbit_AscendingNode=325.56373
@@ -2728,17 +1989,11 @@ orbit_TimeAtPericenter=2445206.22931
 orbit_good=1000
 radius=5
 slope_parameter=3.4
-tex_map=nomap.png
 type=comet
 
 [C_Austin%281984i_1984XIII%29]
 absolute_magnitude=7.7
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Austin (1984i=1984XIII)"
 orbit_ArgOfPericenter=353.12701
 orbit_AscendingNode=170.87724
@@ -2750,17 +2005,11 @@ orbit_TimeAtPericenter=2445924.63713
 orbit_good=1000
 radius=5
 slope_parameter=2.9
-tex_map=nomap.png
 type=comet
 
 [C_Austin%281989c1_1990V%29]
 absolute_magnitude=7.7
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Austin (1989c1=1990V)"
 orbit_ArgOfPericenter=61.56880
 orbit_AscendingNode=75.23083
@@ -2772,17 +2021,11 @@ orbit_TimeAtPericenter=2447991.46745
 orbit_good=1000
 radius=5
 slope_parameter=2.6
-tex_map=nomap.png
 type=comet
 
 [C_Baade%281922c_1922II%29]
 absolute_magnitude=5.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Baade (1922c=1922II)"
 orbit_ArgOfPericenter=118.30400
 orbit_AscendingNode=220.87610
@@ -2794,17 +2037,11 @@ orbit_TimeAtPericenter=2423354.02910
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Baade%281954h_1955VI%29]
 absolute_magnitude=4.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Baade (1954h=1955VI)"
 orbit_ArgOfPericenter=144.67730
 orbit_AscendingNode=264.64250
@@ -2816,17 +2053,11 @@ orbit_TimeAtPericenter=2435332.80500
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Baeker%281863VI%29]
 absolute_magnitude=4.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Baeker (1863VI)
 orbit_ArgOfPericenter=78.11050
 orbit_AscendingNode=106.23680
@@ -2838,17 +2069,11 @@ orbit_TimeAtPericenter=2401869.16770
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Baeker%281864IV%29]
 absolute_magnitude=5.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Baeker (1864IV)
 orbit_ArgOfPericenter=118.45650
 orbit_AscendingNode=204.41120
@@ -2860,17 +2085,11 @@ orbit_TimeAtPericenter=2402228.45110
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Baeker-Winnecke%281867III%29]
 absolute_magnitude=7.9
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Baeker-Winnecke (1867III)
 orbit_ArgOfPericenter=148.63460
 orbit_AscendingNode=66.14250
@@ -2882,17 +2101,11 @@ orbit_TimeAtPericenter=2403277.96080
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Bakharev-Macfarlane-Krienke%281955f_1955IV%29]
 absolute_magnitude=7.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Bakharev-Macfarlane-Krienke (1955f=1955IV)"
 orbit_ArgOfPericenter=13.22500
 orbit_AscendingNode=302.76300
@@ -2904,17 +2117,11 @@ orbit_TimeAtPericenter=2435300.04400
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Bally-Clayton%281968d_1968VII%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Bally-Clayton (1968d=1968VII)"
 orbit_ArgOfPericenter=26.86830
 orbit_AscendingNode=318.69710
@@ -2926,17 +2133,11 @@ orbit_TimeAtPericenter=2440089.34480
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Bappu-Bok-Newkirk%281949c_1949IV%29]
 absolute_magnitude=7.1
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Bappu-Bok-Newkirk (1949c=1949IV)"
 orbit_ArgOfPericenter=89.53480
 orbit_AscendingNode=309.01270
@@ -2948,17 +2149,11 @@ orbit_TimeAtPericenter=2433216.04910
 orbit_good=1000
 radius=5
 slope_parameter=5.0
-tex_map=nomap.png
 type=comet
 
 [C_Barbon%281966c_1966II%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Barbon (1966c=1966II)"
 orbit_ArgOfPericenter=136.16830
 orbit_AscendingNode=166.99230
@@ -2970,17 +2165,11 @@ orbit_TimeAtPericenter=2439233.29140
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Barnard%281881e_1881VI%29]
 absolute_magnitude=8.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Barnard (1881e=1881VI)"
 orbit_ArgOfPericenter=6.29300
 orbit_AscendingNode=275.12370
@@ -2992,17 +2181,11 @@ orbit_TimeAtPericenter=2408338.36530
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Barnard%281882c_1882III%29]
 absolute_magnitude=7.4
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Barnard (1882c=1882III)"
 orbit_ArgOfPericenter=254.29470
 orbit_AscendingNode=250.07240
@@ -3014,17 +2197,11 @@ orbit_TimeAtPericenter=2408762.97540
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Barnard%281885a_1885II%29]
 absolute_magnitude=5.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Barnard (1885a=1885II)"
 orbit_ArgOfPericenter=178.50980
 orbit_AscendingNode=93.20210
@@ -3036,17 +2213,11 @@ orbit_TimeAtPericenter=2409759.68180
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Barnard%281885e_1886II%29]
 absolute_magnitude=7.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Barnard (1885e=1886II)"
 orbit_ArgOfPericenter=119.61670
 orbit_AscendingNode=69.21210
@@ -3058,17 +2229,11 @@ orbit_TimeAtPericenter=2410030.28560
 orbit_good=1000
 radius=5
 slope_parameter=2.4
-tex_map=nomap.png
 type=comet
 
 [C_Barnard%281887c_1886VIII%29]
 absolute_magnitude=4.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Barnard (1887c=1886VIII)"
 orbit_ArgOfPericenter=31.91800
 orbit_AscendingNode=259.09720
@@ -3080,17 +2245,11 @@ orbit_TimeAtPericenter=2410239.40560
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Barnard%281887e_1887IV%29]
 absolute_magnitude=9.6
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Barnard (1887e=1887IV)"
 orbit_ArgOfPericenter=15.10810
 orbit_AscendingNode=246.12700
@@ -3102,17 +2261,11 @@ orbit_TimeAtPericenter=2410439.66300
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Barnard%281888e_1889I%29]
 absolute_magnitude=3.6
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Barnard (1888e=1889I)"
 orbit_ArgOfPericenter=340.46250
 orbit_AscendingNode=358.27490
@@ -3124,17 +2277,11 @@ orbit_TimeAtPericenter=2411034.16820
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Barnard%281888f_1888V%29]
 absolute_magnitude=5.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Barnard (1888f=1888V)"
 orbit_ArgOfPericenter=290.80400
 orbit_AscendingNode=138.39360
@@ -3146,17 +2293,11 @@ orbit_TimeAtPericenter=2410893.78240
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Barnard%281889b_1889II%29]
 absolute_magnitude=5.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Barnard (1889b=1889II)"
 orbit_ArgOfPericenter=236.07780
 orbit_AscendingNode=311.53800
@@ -3168,17 +2309,11 @@ orbit_TimeAtPericenter=2411164.81390
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Barnard%281891e_1891IV%29]
 absolute_magnitude=9.4
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Barnard (1891e=1891IV)"
 orbit_ArgOfPericenter=269.57170
 orbit_AscendingNode=218.82810
@@ -3190,17 +2325,11 @@ orbit_TimeAtPericenter=2412050.54270
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Barnard-Denning%281891a_1891I%29]
 absolute_magnitude=8.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Barnard-Denning (1891a=1891I)"
 orbit_ArgOfPericenter=178.75270
 orbit_AscendingNode=194.75630
@@ -3212,17 +2341,11 @@ orbit_TimeAtPericenter=2411850.52100
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Barnard-Hartwig%281886f_1886IX%29]
 absolute_magnitude=4.7
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Barnard-Hartwig (1886f=1886IX)"
 orbit_ArgOfPericenter=86.34450
 orbit_AscendingNode=138.27190
@@ -3234,17 +2357,11 @@ orbit_TimeAtPericenter=2410257.49680
 orbit_good=1000
 radius=5
 slope_parameter=3.8
-tex_map=nomap.png
 type=comet
 
 [C_Beljawsky%281911g_1911IV%29]
 absolute_magnitude=5.7
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Beljawsky (1911g=1911IV)"
 orbit_ArgOfPericenter=71.70460
 orbit_AscendingNode=89.19760
@@ -3256,17 +2373,11 @@ orbit_TimeAtPericenter=2419320.26380
 orbit_good=1000
 radius=5
 slope_parameter=3.7
-tex_map=nomap.png
 type=comet
 
 [C_Bennett%281969i_1970II%29]
 absolute_magnitude=4.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Bennett (1969i=1970II)"
 orbit_ArgOfPericenter=354.15100
 orbit_AscendingNode=223.95890
@@ -3278,17 +2389,11 @@ orbit_TimeAtPericenter=2440665.54460
 orbit_good=1000
 radius=5
 slope_parameter=3.6
-tex_map=nomap.png
 type=comet
 
 [C_Bennett%281974h_1974XV%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Bennett (1974h=1974XV)"
 orbit_ArgOfPericenter=324.95970
 orbit_AscendingNode=50.64460
@@ -3300,17 +2405,11 @@ orbit_TimeAtPericenter=2442383.02290
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Bester%281946k_1947I%29]
 absolute_magnitude=5.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Bester (1946k=1947I)"
 orbit_ArgOfPericenter=348.62060
 orbit_AscendingNode=34.85880
@@ -3322,17 +2421,11 @@ orbit_TimeAtPericenter=2432223.86340
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Bester%281947k_1948I%29]
 absolute_magnitude=6.7
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Bester (1947k=1948I)"
 orbit_ArgOfPericenter=350.22480
 orbit_AscendingNode=270.74910
@@ -3344,17 +2437,11 @@ orbit_TimeAtPericenter=2432597.92330
 orbit_good=1000
 radius=5
 slope_parameter=3.4
-tex_map=nomap.png
 type=comet
 
 [C_Bester%281948m_1948X%29]
 absolute_magnitude=6.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Bester (1948m=1948X)"
 orbit_ArgOfPericenter=274.20300
 orbit_AscendingNode=66.97020
@@ -3366,17 +2453,11 @@ orbit_TimeAtPericenter=2432847.36600
 orbit_good=1000
 radius=5
 slope_parameter=6.4
-tex_map=nomap.png
 type=comet
 
 [C_Bester-Hoffmeister%281959d_1959III%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Bester-Hoffmeister (1959d=1959III)"
 orbit_ArgOfPericenter=186.47930
 orbit_AscendingNode=105.06330
@@ -3388,17 +2469,11 @@ orbit_TimeAtPericenter=2436767.05560
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Beyer%281930b_1930IV%29]
 absolute_magnitude=7.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Beyer (1930b=1930IV)"
 orbit_ArgOfPericenter=24.62120
 orbit_AscendingNode=116.67030
@@ -3410,17 +2485,11 @@ orbit_TimeAtPericenter=2426084.61850
 orbit_good=1000
 radius=5
 slope_parameter=2.8
-tex_map=nomap.png
 type=comet
 
 [C_Blathwayt%281927a_1927II%29]
 absolute_magnitude=8.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Blathwayt (1927a=1927II)"
 orbit_ArgOfPericenter=231.84860
 orbit_AscendingNode=19.11640
@@ -3432,17 +2501,11 @@ orbit_TimeAtPericenter=2424926.00300
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Bode%281779%29]
 absolute_magnitude=5.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Bode (1779)
 orbit_ArgOfPericenter=62.16780
 orbit_AscendingNode=27.44380
@@ -3454,17 +2517,11 @@ orbit_TimeAtPericenter=2370830.08070
 orbit_good=1000
 radius=5
 slope_parameter=3.6
-tex_map=nomap.png
 type=comet
 
 [C_Boguslawski%281835I%29]
 absolute_magnitude=4.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Boguslawski (1835I)
 orbit_ArgOfPericenter=210.52570
 orbit_AscendingNode=60.03270
@@ -3476,17 +2533,11 @@ orbit_TimeAtPericenter=2391365.20520
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Bond%281850II%29]
 absolute_magnitude=7.9
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Bond (1850II)
 orbit_ArgOfPericenter=243.20840
 orbit_AscendingNode=207.40850
@@ -3498,17 +2549,11 @@ orbit_TimeAtPericenter=2397050.33740
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Borrelly%281873c_1873IV%29]
 absolute_magnitude=6.7
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Borrelly (1873c=1873IV)"
 orbit_ArgOfPericenter=193.77840
 orbit_AscendingNode=231.66410
@@ -3520,17 +2565,11 @@ orbit_TimeAtPericenter=2405412.78370
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Borrelly%281874d_1874V%29]
 absolute_magnitude=9.4
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Borrelly (1874d=1874V)"
 orbit_ArgOfPericenter=92.62190
 orbit_AscendingNode=252.57410
@@ -3542,17 +2581,11 @@ orbit_TimeAtPericenter=2405762.84360
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Borrelly%281874f_1874VI%29]
 absolute_magnitude=7.6
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Borrelly (1874f=1874VI)"
 orbit_ArgOfPericenter=16.27450
 orbit_AscendingNode=283.01890
@@ -3564,17 +2597,11 @@ orbit_TimeAtPericenter=2405815.94280
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Borrelly%281877a_1877I%29]
 absolute_magnitude=8.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Borrelly (1877a=1877I)"
 orbit_ArgOfPericenter=347.16450
 orbit_AscendingNode=188.26530
@@ -3586,17 +2613,11 @@ orbit_TimeAtPericenter=2406639.17860
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Borrelly%281889g_1890I%29]
 absolute_magnitude=8.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Borrelly (1889g=1890I)"
 orbit_ArgOfPericenter=199.85310
 orbit_AscendingNode=9.32080
@@ -3608,17 +2629,11 @@ orbit_TimeAtPericenter=2411394.47640
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Borrelly%281903c_1903IV%29]
 absolute_magnitude=6.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Borrelly (1903c=1903IV)"
 orbit_ArgOfPericenter=127.25780
 orbit_AscendingNode=294.21090
@@ -3630,17 +2645,11 @@ orbit_TimeAtPericenter=2416354.60870
 orbit_good=1000
 radius=5
 slope_parameter=2.4
-tex_map=nomap.png
 type=comet
 
 [C_Borrelly%281912c_1912III%29]
 absolute_magnitude=8.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Borrelly (1912c=1912III)"
 orbit_ArgOfPericenter=99.67950
 orbit_AscendingNode=144.31510
@@ -3652,17 +2661,11 @@ orbit_TimeAtPericenter=2419696.95840
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Borrelly-Brooks%281900b_1900II%29]
 absolute_magnitude=8.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Borrelly-Brooks (1900b=1900II)"
 orbit_ArgOfPericenter=12.42570
 orbit_AscendingNode=328.71360
@@ -3674,17 +2677,11 @@ orbit_TimeAtPericenter=2415235.20050
 orbit_good=1000
 radius=5
 slope_parameter=3.8
-tex_map=nomap.png
 type=comet
 
 [C_Bouvard-Herschel-Lee%281797%29]
 absolute_magnitude=8.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Bouvard-Herschel-Lee (1797)
 orbit_ArgOfPericenter=279.68600
 orbit_AscendingNode=331.39700
@@ -3696,17 +2693,11 @@ orbit_TimeAtPericenter=2377591.11420
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Bowell%281980b_1982I%29]
 absolute_magnitude=5.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Bowell (1980b=1982I)"
 orbit_ArgOfPericenter=134.88879
 orbit_AscendingNode=114.05380
@@ -3718,17 +2709,11 @@ orbit_TimeAtPericenter=2445040.79297
 orbit_good=1000
 radius=5
 slope_parameter=3.3
-tex_map=nomap.png
 type=comet
 
 [C_Bradfield%281972f_1972III%29]
 absolute_magnitude=8.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Bradfield (1972f=1972III)"
 orbit_ArgOfPericenter=257.69580
 orbit_AscendingNode=159.59910
@@ -3740,17 +2725,11 @@ orbit_TimeAtPericenter=2441404.20050
 orbit_good=1000
 radius=5
 slope_parameter=5.0
-tex_map=nomap.png
 type=comet
 
 [C_Bradfield%281974b_1974III%29]
 absolute_magnitude=7.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Bradfield (1974b=1974III)"
 orbit_ArgOfPericenter=333.13020
 orbit_AscendingNode=143.03790
@@ -3762,17 +2741,11 @@ orbit_TimeAtPericenter=2442124.85630
 orbit_good=1000
 radius=5
 slope_parameter=3.1
-tex_map=nomap.png
 type=comet
 
 [C_Bradfield%281975d_1975V%29]
 absolute_magnitude=6.7
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Bradfield (1975d=1975V)"
 orbit_ArgOfPericenter=264.12720
 orbit_AscendingNode=157.21200
@@ -3784,17 +2757,11 @@ orbit_TimeAtPericenter=2442507.07930
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Bradfield%281975p_1975XI%29]
 absolute_magnitude=8.9
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Bradfield (1975p=1975XI)"
 orbit_ArgOfPericenter=358.09720
 orbit_AscendingNode=270.61240
@@ -3806,17 +2773,11 @@ orbit_TimeAtPericenter=2442767.68130
 orbit_good=1000
 radius=5
 slope_parameter=2.9
-tex_map=nomap.png
 type=comet
 
 [C_Bradfield%281976d_1976V%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Bradfield (1976d=1976V)"
 orbit_ArgOfPericenter=221.75500
 orbit_AscendingNode=69.49500
@@ -3828,17 +2789,11 @@ orbit_TimeAtPericenter=2442833.56100
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Bradfield%281978c_1978VII%29]
 absolute_magnitude=7.4
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Bradfield (1978c=1978VII)"
 orbit_ArgOfPericenter=48.71310
 orbit_AscendingNode=259.79420
@@ -3850,17 +2805,11 @@ orbit_TimeAtPericenter=2443585.19060
 orbit_good=1000
 radius=5
 slope_parameter=3.2
-tex_map=nomap.png
 type=comet
 
 [C_Bradfield%281978o_1978XVIII%29]
 absolute_magnitude=8.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Bradfield (1978o=1978XVIII)"
 orbit_ArgOfPericenter=240.44980
 orbit_AscendingNode=357.72020
@@ -3872,17 +2821,11 @@ orbit_TimeAtPericenter=2443780.58810
 orbit_good=1000
 radius=5
 slope_parameter=3.3
-tex_map=nomap.png
 type=comet
 
 [C_Bradfield%281979l_1979X%29]
 absolute_magnitude=8.1
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Bradfield (1979l=1979X)"
 orbit_ArgOfPericenter=257.57300
 orbit_AscendingNode=102.51030
@@ -3894,17 +2837,11 @@ orbit_TimeAtPericenter=2444229.09920
 orbit_good=1000
 radius=5
 slope_parameter=3.7
-tex_map=nomap.png
 type=comet
 
 [C_Bradfield%281980t_1980XV%29]
 absolute_magnitude=6.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Bradfield (1980t=1980XV)"
 orbit_ArgOfPericenter=358.28550
 orbit_AscendingNode=114.64650
@@ -3916,17 +2853,11 @@ orbit_TimeAtPericenter=2444603.04170
 orbit_good=1000
 radius=5
 slope_parameter=1.5
-tex_map=nomap.png
 type=comet
 
 [C_Bradfield%281987s_1987XXIX%29]
 absolute_magnitude=6.1
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Bradfield (1987s=1987XXIX)"
 orbit_ArgOfPericenter=73.91102
 orbit_AscendingNode=267.38484
@@ -3938,17 +2869,11 @@ orbit_TimeAtPericenter=2447106.77408
 orbit_good=1000
 radius=5
 slope_parameter=2.9
-tex_map=nomap.png
 type=comet
 
 [C_Bradfield%281992b_1992VII%29]
 absolute_magnitude=9.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Bradfield (1992b=1992VII)"
 orbit_ArgOfPericenter=15.35539
 orbit_AscendingNode=274.63430
@@ -3960,17 +2885,11 @@ orbit_TimeAtPericenter=2448701.03924
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Bremiker%281840IV%29]
 absolute_magnitude=6.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Bremiker (1840IV)
 orbit_ArgOfPericenter=133.52020
 orbit_AscendingNode=250.51200
@@ -3982,17 +2901,11 @@ orbit_TimeAtPericenter=2393423.56520
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Brooks%281885c_1885III%29]
 absolute_magnitude=9.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Brooks (1885c=1885III)"
 orbit_ArgOfPericenter=42.85400
 orbit_AscendingNode=205.66690
@@ -4004,17 +2917,11 @@ orbit_TimeAtPericenter=2409764.15730
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Brooks%281885f_1885V%29]
 absolute_magnitude=6.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Brooks (1885f=1885V)"
 orbit_ArgOfPericenter=35.60010
 orbit_AscendingNode=263.10570
@@ -4026,17 +2933,11 @@ orbit_TimeAtPericenter=2409871.50500
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Brooks%281886a_1886V%29]
 absolute_magnitude=7.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Brooks (1886a=1886V)"
 orbit_ArgOfPericenter=201.28930
 orbit_AscendingNode=193.50590
@@ -4048,17 +2949,11 @@ orbit_TimeAtPericenter=2410065.38540
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Brooks%281886b_1886III%29]
 absolute_magnitude=4.9
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Brooks (1886b=1886III)"
 orbit_ArgOfPericenter=38.56500
 orbit_AscendingNode=288.66800
@@ -4070,17 +2965,11 @@ orbit_TimeAtPericenter=2410031.45100
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Brooks%281887b_1887II%29]
 absolute_magnitude=5.4
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Brooks (1887b=1887II)"
 orbit_ArgOfPericenter=159.42960
 orbit_AscendingNode=280.81440
@@ -4092,17 +2981,11 @@ orbit_TimeAtPericenter=2410348.39070
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Brooks%281888c_1888III%29]
 absolute_magnitude=7.6
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Brooks (1888c=1888III)"
 orbit_ArgOfPericenter=59.21030
 orbit_AscendingNode=102.36080
@@ -4114,17 +2997,11 @@ orbit_TimeAtPericenter=2410850.13640
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Brooks%281890a_1890II%29]
 absolute_magnitude=3.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Brooks (1890a=1890II)"
 orbit_ArgOfPericenter=68.93150
 orbit_AscendingNode=321.18150
@@ -4136,17 +3013,11 @@ orbit_TimeAtPericenter=2411520.53750
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Brooks%281892d_1892VI%29]
 absolute_magnitude=5.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Brooks (1892d=1892VI)"
 orbit_ArgOfPericenter=252.66860
 orbit_AscendingNode=265.32190
@@ -4158,17 +3029,11 @@ orbit_TimeAtPericenter=2412461.08640
 orbit_good=1000
 radius=5
 slope_parameter=4.2
-tex_map=nomap.png
 type=comet
 
 [C_Brooks%281892g_1893I%29]
 absolute_magnitude=8.1
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Brooks (1892g=1893I)"
 orbit_ArgOfPericenter=85.21620
 orbit_AscendingNode=186.44580
@@ -4180,17 +3045,11 @@ orbit_TimeAtPericenter=2412470.49490
 orbit_good=1000
 radius=5
 slope_parameter=2.6
-tex_map=nomap.png
 type=comet
 
 [C_Brooks%281893c_1893IV%29]
 absolute_magnitude=6.7
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Brooks (1893c=1893IV)"
 orbit_ArgOfPericenter=347.45170
 orbit_AscendingNode=175.71570
@@ -4202,17 +3061,11 @@ orbit_TimeAtPericenter=2412726.22230
 orbit_good=1000
 radius=5
 slope_parameter=4.4
-tex_map=nomap.png
 type=comet
 
 [C_Brooks%281898i_1898X%29]
 absolute_magnitude=9.1
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Brooks (1898i=1898X)"
 orbit_ArgOfPericenter=123.54210
 orbit_AscendingNode=97.03800
@@ -4224,17 +3077,11 @@ orbit_TimeAtPericenter=2414617.15240
 orbit_good=1000
 radius=5
 slope_parameter=3.4
-tex_map=nomap.png
 type=comet
 
 [C_Brooks%281904a_1904I%29]
 absolute_magnitude=3.6
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Brooks (1904a=1904I)"
 orbit_ArgOfPericenter=53.53460
 orbit_AscendingNode=276.42760
@@ -4246,17 +3093,11 @@ orbit_TimeAtPericenter=2416547.13940
 orbit_good=1000
 radius=5
 slope_parameter=3.2
-tex_map=nomap.png
 type=comet
 
 [C_Brooks%281906a_1905VI%29]
 absolute_magnitude=5.1
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Brooks (1906a=1905VI)"
 orbit_ArgOfPericenter=89.85700
 orbit_AscendingNode=287.01200
@@ -4268,17 +3109,11 @@ orbit_TimeAtPericenter=2417202.29630
 orbit_good=1000
 radius=5
 slope_parameter=9.6
-tex_map=nomap.png
 type=comet
 
 [C_Brooks%281911c_1911V%29]
 absolute_magnitude=5.1
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Brooks (1911c=1911V)"
 orbit_ArgOfPericenter=153.01480
 orbit_AscendingNode=293.50000
@@ -4290,17 +3125,11 @@ orbit_TimeAtPericenter=2419337.73680
 orbit_good=1000
 radius=5
 slope_parameter=3.4
-tex_map=nomap.png
 type=comet
 
 [C_Brooks-Swift%281883a_1883I%29]
 absolute_magnitude=7.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Brooks-Swift (1883a=1883I)"
 orbit_ArgOfPericenter=110.90110
 orbit_AscendingNode=279.07360
@@ -4312,17 +3141,11 @@ orbit_TimeAtPericenter=2408860.95330
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Brorsen%281846VII%29]
 absolute_magnitude=8.1
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Brorsen (1846VII)
 orbit_ArgOfPericenter=99.73860
 orbit_AscendingNode=263.30200
@@ -4334,17 +3157,11 @@ orbit_TimeAtPericenter=2395453.47100
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Brorsen%281851III%29]
 absolute_magnitude=7.6
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Brorsen (1851III)
 orbit_ArgOfPericenter=87.26840
 orbit_AscendingNode=225.06730
@@ -4356,17 +3173,11 @@ orbit_TimeAtPericenter=2397361.24580
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Brorsen%281851IV%29]
 absolute_magnitude=6.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Brorsen (1851IV)
 orbit_ArgOfPericenter=294.44180
 orbit_AscendingNode=45.73180
@@ -4378,17 +3189,11 @@ orbit_TimeAtPericenter=2397396.79620
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Bruhns%281853IV%29]
 absolute_magnitude=7.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Bruhns (1853IV)
 orbit_ArgOfPericenter=277.84610
 orbit_AscendingNode=221.42020
@@ -4400,17 +3205,11 @@ orbit_TimeAtPericenter=2398143.62440
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Bruhns%281855IV%29]
 absolute_magnitude=8.1
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Bruhns (1855IV)
 orbit_ArgOfPericenter=325.58390
 orbit_AscendingNode=52.93220
@@ -4422,17 +3221,11 @@ orbit_TimeAtPericenter=2398913.38720
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Bruhns%281858IV%29]
 absolute_magnitude=8.6
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Bruhns (1858IV)
 orbit_ArgOfPericenter=98.86180
 orbit_AscendingNode=326.25230
@@ -4444,17 +3237,11 @@ orbit_TimeAtPericenter=2399836.29560
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Bruhns%281863I%29]
 absolute_magnitude=8.4
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Bruhns (1863I)
 orbit_ArgOfPericenter=74.46020
 orbit_AscendingNode=118.14060
@@ -4466,17 +3253,11 @@ orbit_TimeAtPericenter=2401540.49020
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Bruhns%281864V%29]
 absolute_magnitude=9.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Bruhns (1864V)
 orbit_ArgOfPericenter=178.50420
 orbit_AscendingNode=342.08500
@@ -4488,17 +3269,11 @@ orbit_TimeAtPericenter=2402233.71880
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Burnham%281958a_1958III%29]
 absolute_magnitude=9.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Burnham (1958a=1958III)"
 orbit_ArgOfPericenter=16.45590
 orbit_AscendingNode=150.50540
@@ -4510,17 +3285,11 @@ orbit_TimeAtPericenter=2436309.80360
 orbit_good=1000
 radius=5
 slope_parameter=1.5
-tex_map=nomap.png
 type=comet
 
 [C_Burnham%281959k_1960II%29]
 absolute_magnitude=7.7
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Burnham (1959k=1960II)"
 orbit_ArgOfPericenter=306.65250
 orbit_AscendingNode=251.95720
@@ -4532,17 +3301,11 @@ orbit_TimeAtPericenter=2437014.49560
 orbit_good=1000
 radius=5
 slope_parameter=4.2
-tex_map=nomap.png
 type=comet
 
 [C_Burnham%281960a_1959VII%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Burnham (1960a=1959VII)"
 orbit_ArgOfPericenter=273.24090
 orbit_AscendingNode=83.08330
@@ -4554,17 +3317,11 @@ orbit_TimeAtPericenter=2436839.22750
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Burnham-Slaughter%281958e_1959I%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Burnham-Slaughter (1958e=1959I)"
 orbit_ArgOfPericenter=100.74010
 orbit_AscendingNode=323.07830
@@ -4576,17 +3333,11 @@ orbit_TimeAtPericenter=2436639.01980
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Bus%281981d_1981XIV%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Bus (1981d=1981XIV)"
 orbit_ArgOfPericenter=189.83480
 orbit_AscendingNode=23.55690
@@ -4598,17 +3349,11 @@ orbit_TimeAtPericenter=2444816.25390
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Campbell%281914e_1914IV%29]
 absolute_magnitude=6.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Campbell (1914e=1914IV)"
 orbit_ArgOfPericenter=270.34600
 orbit_AscendingNode=0.88450
@@ -4620,17 +3365,11 @@ orbit_TimeAtPericenter=2420349.97080
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Candy%281960n_1961II%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Candy (1960n=1961II)"
 orbit_ArgOfPericenter=136.61440
 orbit_AscendingNode=176.57970
@@ -4642,17 +3381,11 @@ orbit_TimeAtPericenter=2437339.41750
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Carrasco%281932c_1931V%29]
 absolute_magnitude=6.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Carrasco (1932c=1931V)"
 orbit_ArgOfPericenter=110.30240
 orbit_AscendingNode=18.09960
@@ -4664,17 +3397,11 @@ orbit_TimeAtPericenter=2426676.09560
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Cernis%281983l_1983XII%29]
 absolute_magnitude=0.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Cernis (1983l=1983XII)"
 orbit_ArgOfPericenter=186.21904
 orbit_AscendingNode=208.88389
@@ -4686,17 +3413,11 @@ orbit_TimeAtPericenter=2445536.71984
 orbit_good=1000
 radius=5
 slope_parameter=6.9
-tex_map=nomap.png
 type=comet
 
 [C_Cernis-Kiuchi-Nakamura%281990b_1990III%29]
 absolute_magnitude=6.7
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Cernis-Kiuchi-Nakamura (1990b=1990III)"
 orbit_ArgOfPericenter=100.62248
 orbit_AscendingNode=347.74558
@@ -4708,17 +3429,11 @@ orbit_TimeAtPericenter=2447967.82636
 orbit_good=1000
 radius=5
 slope_parameter=13.8
-tex_map=nomap.png
 type=comet
 
 [C_Cernis-Petrauskas%281980k_1980IV%29]
 absolute_magnitude=7.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Cernis-Petrauskas (1980k=1980IV)"
 orbit_ArgOfPericenter=337.76728
 orbit_AscendingNode=159.93849
@@ -4730,17 +3445,11 @@ orbit_TimeAtPericenter=2444412.94938
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Cesco%281974e_1974VIII%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Cesco (1974e=1974VIII)"
 orbit_ArgOfPericenter=176.74060
 orbit_AscendingNode=165.03040
@@ -4752,17 +3461,11 @@ orbit_TimeAtPericenter=2442180.46310
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Chacornac%281852II%29]
 absolute_magnitude=9.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Chacornac (1852II)
 orbit_ArgOfPericenter=37.21120
 orbit_AscendingNode=318.57600
@@ -4774,17 +3477,11 @@ orbit_TimeAtPericenter=2397598.58730
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Chase%281898j_1898VIII%29]
 absolute_magnitude=5.6
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Chase (1898j=1898VIII)"
 orbit_ArgOfPericenter=4.62510
 orbit_AscendingNode=96.56110
@@ -4796,17 +3493,11 @@ orbit_TimeAtPericenter=2414553.11770
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Churyumov-Solodovnikov%281986i_1986IX%29]
 absolute_magnitude=7.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Churyumov-Solodovnikov (1986i=1986IX)"
 orbit_ArgOfPericenter=157.75009
 orbit_AscendingNode=133.91723
@@ -4818,17 +3509,11 @@ orbit_TimeAtPericenter=2446557.00393
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Coddington-Pauly%281898c_1898VII%29]
 absolute_magnitude=5.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Coddington-Pauly (1898c=1898VII)"
 orbit_ArgOfPericenter=233.26240
 orbit_AscendingNode=74.71250
@@ -4840,17 +3525,11 @@ orbit_TimeAtPericenter=2414547.04530
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Coggia%281870b_1870II%29]
 absolute_magnitude=3.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Coggia (1870b=1870II)"
 orbit_ArgOfPericenter=354.93670
 orbit_AscendingNode=14.06020
@@ -4862,17 +3541,11 @@ orbit_TimeAtPericenter=2404308.16760
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Coggia%281874c_1874III%29]
 absolute_magnitude=5.4
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Coggia (1874c=1874III)"
 orbit_ArgOfPericenter=152.37450
 orbit_AscendingNode=119.79880
@@ -4884,17 +3557,11 @@ orbit_TimeAtPericenter=2405713.85830
 orbit_good=1000
 radius=5
 slope_parameter=5.2
-tex_map=nomap.png
 type=comet
 
 [C_Coggia%281874e_1874IV%29]
 absolute_magnitude=6.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Coggia (1874e=1874IV)"
 orbit_ArgOfPericenter=149.59280
 orbit_AscendingNode=216.92240
@@ -4906,17 +3573,11 @@ orbit_TimeAtPericenter=2405722.70160
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Coggia%281877e_1877VI%29]
 absolute_magnitude=6.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Coggia (1877e=1877VI)"
 orbit_ArgOfPericenter=143.21150
 orbit_AscendingNode=252.01340
@@ -4928,17 +3589,11 @@ orbit_TimeAtPericenter=2406874.21820
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Coggia%281890b_1890III%29]
 absolute_magnitude=8.6
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Coggia (1890b=1890III)"
 orbit_ArgOfPericenter=85.65830
 orbit_AscendingNode=15.13730
@@ -4950,17 +3605,11 @@ orbit_TimeAtPericenter=2411557.53730
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Colla%281847II%29]
 absolute_magnitude=4.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Colla (1847II)
 orbit_ArgOfPericenter=32.35880
 orbit_AscendingNode=175.38640
@@ -4972,17 +3621,11 @@ orbit_TimeAtPericenter=2395817.72980
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Cunningham%281940c_1941I%29]
 absolute_magnitude=6.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Cunningham (1940c=1941I)"
 orbit_ArgOfPericenter=199.57630
 orbit_AscendingNode=295.88730
@@ -4994,17 +3637,11 @@ orbit_TimeAtPericenter=2430010.73400
 orbit_good=1000
 radius=5
 slope_parameter=3.4
-tex_map=nomap.png
 type=comet
 
 [C_Daido-Fujikawa%281970a_1970I%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Daido-Fujikawa (1970a=1970I)"
 orbit_ArgOfPericenter=266.64970
 orbit_AscendingNode=29.90650
@@ -5016,17 +3653,11 @@ orbit_TimeAtPericenter=2440633.30530
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Daniel%281907d_1907IV%29]
 absolute_magnitude=4.4
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Daniel (1907d=1907IV)"
 orbit_ArgOfPericenter=294.45100
 orbit_AscendingNode=143.58850
@@ -5038,17 +3669,11 @@ orbit_TimeAtPericenter=2417822.96170
 orbit_good=1000
 radius=5
 slope_parameter=3.0
-tex_map=nomap.png
 type=comet
 
 [C_Davidson%281889e_1889IV%29]
 absolute_magnitude=6.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Davidson (1889e=1889IV)"
 orbit_ArgOfPericenter=345.86850
 orbit_AscendingNode=287.01030
@@ -5060,17 +3685,11 @@ orbit_TimeAtPericenter=2411203.28400
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Delavan%281913f_1914V%29]
 absolute_magnitude=1.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Delavan (1913f=1914V)"
 orbit_ArgOfPericenter=97.46070
 orbit_AscendingNode=59.70010
@@ -5082,17 +3701,11 @@ orbit_TimeAtPericenter=2420432.26640
 orbit_good=1000
 radius=5
 slope_parameter=4.4
-tex_map=nomap.png
 type=comet
 
 [C_Denning%281890c_1890VI%29]
 absolute_magnitude=8.1
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Denning (1890c=1890VI)"
 orbit_ArgOfPericenter=163.04600
 orbit_AscendingNode=100.95940
@@ -5104,17 +3717,11 @@ orbit_TimeAtPericenter=2411635.50780
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Denning%281892b_1892II%29]
 absolute_magnitude=5.4
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Denning (1892b=1892II)"
 orbit_ArgOfPericenter=129.32530
 orbit_AscendingNode=254.24040
@@ -5126,17 +3733,11 @@ orbit_TimeAtPericenter=2412230.22750
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Dodwell-Forbes%281932n_1932X%29]
 absolute_magnitude=7.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Dodwell-Forbes (1932n=1932X)"
 orbit_ArgOfPericenter=327.34630
 orbit_AscendingNode=77.90350
@@ -5148,14 +3749,11 @@ orbit_TimeAtPericenter=2427072.03030
 orbit_good=1000
 radius=5
 slope_parameter=10.4
-tex_map=nomap.png
 type=comet
 
 [C_Donati%281858VI%29]
 absolute_magnitude=3.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
 dust_brightnessfactor=1.05
 dust_lengthfactor=1.1
 dust_widthfactor=3.5
@@ -5170,17 +3768,11 @@ orbit_TimeAtPericenter=2399952.96450
 orbit_good=1000
 radius=5
 slope_parameter=3.6
-tex_map=nomap.png
 type=comet
 
 [C_Donati%281864I%29]
 absolute_magnitude=7.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Donati (1864I)
 orbit_ArgOfPericenter=346.09510
 orbit_AscendingNode=176.18240
@@ -5192,17 +3784,11 @@ orbit_TimeAtPericenter=2402080.81180
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Donati-Toussaint%281864III%29]
 absolute_magnitude=5.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Donati-Toussaint (1864III)
 orbit_ArgOfPericenter=232.45500
 orbit_AscendingNode=32.96620
@@ -5214,17 +3800,11 @@ orbit_TimeAtPericenter=2402156.39210
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Donati-vanArsdale%281857VI%29]
 absolute_magnitude=9.9
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Donati-van Arsdale (1857VI)
 orbit_ArgOfPericenter=95.09610
 orbit_AscendingNode=140.60410
@@ -5236,17 +3816,11 @@ orbit_TimeAtPericenter=2399638.06410
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Dubiago-Bernard%281923a_1923III%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Dubiago-Bernard (1923a=1923III)"
 orbit_ArgOfPericenter=255.33010
 orbit_AscendingNode=227.04160
@@ -5258,17 +3832,11 @@ orbit_TimeAtPericenter=2423741.84810
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Dunlop%281833%29]
 absolute_magnitude=7.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Dunlop (1833)
 orbit_ArgOfPericenter=259.60490
 orbit_AscendingNode=324.86360
@@ -5280,17 +3848,11 @@ orbit_TimeAtPericenter=2390802.19120
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Eclipsecomet%281948l_1948XI%29]
 absolute_magnitude=6.1
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Eclipse comet (1948l=1948XI)"
 orbit_ArgOfPericenter=107.26170
 orbit_AscendingNode=210.33210
@@ -5302,17 +3864,11 @@ orbit_TimeAtPericenter=2432851.92710
 orbit_good=1000
 radius=5
 slope_parameter=2.9
-tex_map=nomap.png
 type=comet
 
 [C_Elias%281981c_1981XV%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Elias (1981c=1981XV)"
 orbit_ArgOfPericenter=310.24103
 orbit_AscendingNode=176.00680
@@ -5324,17 +3880,11 @@ orbit_TimeAtPericenter=2444834.72568
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Everhart%281964h_1964IX%29]
 absolute_magnitude=5.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Everhart (1964h=1964IX)"
 orbit_ArgOfPericenter=20.69240
 orbit_AscendingNode=279.74400
@@ -5346,17 +3896,11 @@ orbit_TimeAtPericenter=2438630.68630
 orbit_good=1000
 radius=5
 slope_parameter=8.5
-tex_map=nomap.png
 type=comet
 
 [C_Fabry%281885d_1886I%29]
 absolute_magnitude=6.7
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Fabry (1885d=1886I)"
 orbit_ArgOfPericenter=126.58330
 orbit_AscendingNode=37.26520
@@ -5368,17 +3912,11 @@ orbit_TimeAtPericenter=2410002.95420
 orbit_good=1000
 radius=5
 slope_parameter=2.7
-tex_map=nomap.png
 type=comet
 
 [C_Finsler%281924c_1924II%29]
 absolute_magnitude=6.4
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Finsler (1924c=1924II)"
 orbit_ArgOfPericenter=66.53190
 orbit_AscendingNode=80.42170
@@ -5390,17 +3928,11 @@ orbit_TimeAtPericenter=2424033.34260
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Finsler%281937f_1937V%29]
 absolute_magnitude=6.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Finsler (1937f=1937V)"
 orbit_ArgOfPericenter=114.82600
 orbit_AscendingNode=58.71340
@@ -5412,17 +3944,11 @@ orbit_TimeAtPericenter=2428761.16580
 orbit_good=1000
 radius=5
 slope_parameter=3.3
-tex_map=nomap.png
 type=comet
 
 [C_Forbes%281930e_1930V%29]
 absolute_magnitude=8.9
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Forbes (1930e=1930V)"
 orbit_ArgOfPericenter=320.97210
 orbit_AscendingNode=278.56680
@@ -5434,17 +3960,11 @@ orbit_TimeAtPericenter=2426106.93760
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Friend-Peltier%281945f_1945VI%29]
 absolute_magnitude=9.6
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Friend-Peltier (1945f=1945VI)"
 orbit_ArgOfPericenter=216.71600
 orbit_AscendingNode=325.50200
@@ -5456,17 +3976,11 @@ orbit_TimeAtPericenter=2431806.78100
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Fujikawa%281969d_1969VII%29]
 absolute_magnitude=7.7
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Fujikawa (1969d=1969VII)"
 orbit_ArgOfPericenter=299.02970
 orbit_AscendingNode=191.68740
@@ -5478,17 +3992,11 @@ orbit_TimeAtPericenter=2440506.94800
 orbit_good=1000
 radius=5
 slope_parameter=3.8
-tex_map=nomap.png
 type=comet
 
 [C_Furuyama%281987f1_1988IV%29]
 absolute_magnitude=6.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Furuyama (1987f1=1988IV)"
 orbit_ArgOfPericenter=233.63279
 orbit_AscendingNode=250.05874
@@ -5500,17 +4008,11 @@ orbit_TimeAtPericenter=2447223.56469
 orbit_good=1000
 radius=5
 slope_parameter=5.0
-tex_map=nomap.png
 type=comet
 
 [C_Gale%281894b_1894II%29]
 absolute_magnitude=6.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Gale (1894b=1894II)"
 orbit_ArgOfPericenter=324.18780
 orbit_AscendingNode=207.18640
@@ -5522,17 +4024,11 @@ orbit_TimeAtPericenter=2412932.38990
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Gale%281912a_1912II%29]
 absolute_magnitude=6.1
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Gale (1912a=1912II)"
 orbit_ArgOfPericenter=25.62720
 orbit_AscendingNode=297.54790
@@ -5544,17 +4040,11 @@ orbit_TimeAtPericenter=2419680.95310
 orbit_good=1000
 radius=5
 slope_parameter=3.2
-tex_map=nomap.png
 type=comet
 
 [C_Galle%281840I%29]
 absolute_magnitude=6.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Galle (1840I)
 orbit_ArgOfPericenter=72.26060
 orbit_AscendingNode=121.48420
@@ -5566,17 +4056,11 @@ orbit_TimeAtPericenter=2393109.47520
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Galle%281840II%29]
 absolute_magnitude=6.1
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Galle (1840II)
 orbit_ArgOfPericenter=156.62660
 orbit_AscendingNode=238.37080
@@ -5588,17 +4072,11 @@ orbit_TimeAtPericenter=2393178.12120
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Galle%281840III%29]
 absolute_magnitude=6.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Galle (1840III)
 orbit_ArgOfPericenter=138.04540
 orbit_AscendingNode=187.57270
@@ -5610,17 +4088,11 @@ orbit_TimeAtPericenter=2393198.43780
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Gambart%281822I%29]
 absolute_magnitude=6.7
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Gambart (1822I)
 orbit_ArgOfPericenter=344.69100
 orbit_AscendingNode=179.23600
@@ -5632,17 +4104,11 @@ orbit_TimeAtPericenter=2386656.57930
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Gambart%281825I%29]
 absolute_magnitude=5.6
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Gambart (1825I)
 orbit_ArgOfPericenter=106.18740
 orbit_AscendingNode=21.88270
@@ -5654,17 +4120,11 @@ orbit_TimeAtPericenter=2387777.52260
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Gambart%281832II%29]
 absolute_magnitude=6.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Gambart (1832II)
 orbit_ArgOfPericenter=204.62480
 orbit_AscendingNode=74.12160
@@ -5676,17 +4136,11 @@ orbit_TimeAtPericenter=2390452.57350
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Gambart%281834%29]
 absolute_magnitude=7.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Gambart (1834)
 orbit_ArgOfPericenter=50.03800
 orbit_AscendingNode=228.28910
@@ -5698,17 +4152,11 @@ orbit_TimeAtPericenter=2391006.79260
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Geddes%281932g_1932VI%29]
 absolute_magnitude=3.6
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Geddes (1932g=1932VI)"
 orbit_ArgOfPericenter=329.69950
 orbit_AscendingNode=215.39810
@@ -5720,17 +4168,11 @@ orbit_TimeAtPericenter=2426971.57470
 orbit_good=1000
 radius=5
 slope_parameter=3.8
-tex_map=nomap.png
 type=comet
 
 [C_Gehrels%281972e_1971I%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Gehrels (1972e=1971I)"
 orbit_ArgOfPericenter=128.68990
 orbit_AscendingNode=24.00840
@@ -5742,17 +4184,11 @@ orbit_TimeAtPericenter=2440958.03410
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Giacobini%281898g_1898V%29]
 absolute_magnitude=9.6
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Giacobini (1898g=1898V)"
 orbit_ArgOfPericenter=22.37530
 orbit_AscendingNode=278.99030
@@ -5764,17 +4200,11 @@ orbit_TimeAtPericenter=2414496.49660
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Giacobini%281899e_1899V%29]
 absolute_magnitude=6.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Giacobini (1899e=1899V)"
 orbit_ArgOfPericenter=10.78000
 orbit_AscendingNode=272.92330
@@ -5786,17 +4216,11 @@ orbit_TimeAtPericenter=2414912.90030
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Giacobini%281900a_1900I%29]
 absolute_magnitude=8.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Giacobini (1900a=1900I)"
 orbit_ArgOfPericenter=24.40100
 orbit_AscendingNode=41.08860
@@ -5808,17 +4232,11 @@ orbit_TimeAtPericenter=2415138.91080
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Giacobini%281902d_1903II%29]
 absolute_magnitude=5.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Giacobini (1902d=1903II)"
 orbit_ArgOfPericenter=5.82370
 orbit_AscendingNode=118.11790
@@ -5830,17 +4248,11 @@ orbit_TimeAtPericenter=2416197.47580
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Giacobini%281903a_1903I%29]
 absolute_magnitude=8.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Giacobini (1903a=1903I)"
 orbit_ArgOfPericenter=133.70930
 orbit_AscendingNode=2.95220
@@ -5852,17 +4264,11 @@ orbit_TimeAtPericenter=2416190.00570
 orbit_good=1000
 radius=5
 slope_parameter=2.7
-tex_map=nomap.png
 type=comet
 
 [C_Giacobini%281904d_1904II%29]
 absolute_magnitude=6.6
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Giacobini (1904d=1904II)"
 orbit_ArgOfPericenter=40.74530
 orbit_AscendingNode=219.09130
@@ -5874,17 +4280,11 @@ orbit_TimeAtPericenter=2416788.30480
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Giacobini%281905c_1906I%29]
 absolute_magnitude=8.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Giacobini (1905c=1906I)"
 orbit_ArgOfPericenter=199.20870
 orbit_AscendingNode=92.67850
@@ -5896,17 +4296,11 @@ orbit_TimeAtPericenter=2417233.35650
 orbit_good=1000
 radius=5
 slope_parameter=8.0
-tex_map=nomap.png
 type=comet
 
 [C_Giacobini%281907a_1907I%29]
 absolute_magnitude=1.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Giacobini (1907a=1907I)"
 orbit_ArgOfPericenter=317.10940
 orbit_AscendingNode=97.77760
@@ -5918,17 +4312,11 @@ orbit_TimeAtPericenter=2417654.10920
 orbit_good=1000
 radius=5
 slope_parameter=7.2
-tex_map=nomap.png
 type=comet
 
 [C_Gibson%281973o_1973IX%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Gibson (1973o=1973IX)"
 orbit_ArgOfPericenter=221.26260
 orbit_AscendingNode=243.90410
@@ -5940,17 +4328,11 @@ orbit_TimeAtPericenter=2441904.38100
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Gonzalez%281981g_1981VII%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Gonzalez (1981g=1981VII)"
 orbit_ArgOfPericenter=181.61120
 orbit_AscendingNode=143.27000
@@ -5962,17 +4344,11 @@ orbit_TimeAtPericenter=2444689.16160
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Goujon%281849II%29]
 absolute_magnitude=7.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Goujon (1849II)
 orbit_ArgOfPericenter=33.16550
 orbit_AscendingNode=203.96030
@@ -5984,17 +4360,11 @@ orbit_TimeAtPericenter=2396539.49230
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_GreatJanuarycomet%281910a_1910I%29]
 absolute_magnitude=5.4
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Great January comet (1910a=1910I)"
 orbit_ArgOfPericenter=320.90240
 orbit_AscendingNode=89.32950
@@ -6006,17 +4376,11 @@ orbit_TimeAtPericenter=2418689.08810
 orbit_good=1000
 radius=5
 slope_parameter=4.6
-tex_map=nomap.png
 type=comet
 
 [C_GreatJunecomet%281845III%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Great June comet (1845III)
 orbit_ArgOfPericenter=75.80000
 orbit_AscendingNode=339.27590
@@ -6028,17 +4392,11 @@ orbit_TimeAtPericenter=2395088.68320
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_GreatMarchcomet%281843I%29]
 absolute_magnitude=4.9
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Great March comet (1843I)
 orbit_ArgOfPericenter=82.63740
 orbit_AscendingNode=2.82740
@@ -6050,17 +4408,11 @@ orbit_TimeAtPericenter=2394259.41100
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_GreatSeptembercomet%281882b_1882II%29]
 absolute_magnitude=0.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Great September comet (1882b=1882II)"
 orbit_ArgOfPericenter=69.58670
 orbit_AscendingNode=346.95920
@@ -6072,17 +4424,11 @@ orbit_TimeAtPericenter=2408706.22410
 orbit_good=1000
 radius=5
 slope_parameter=3.2
-tex_map=nomap.png
 type=comet
 
 [C_Greatcomet%281759III%29]
 absolute_magnitude=7.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Great comet (1759III)
 orbit_ArgOfPericenter=301.65100
 orbit_AscendingNode=82.77800
@@ -6094,17 +4440,11 @@ orbit_TimeAtPericenter=2363871.84110
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Greatcomet%281770II%29]
 absolute_magnitude=7.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Great comet (1770II)
 orbit_ArgOfPericenter=260.36400
 orbit_AscendingNode=111.23600
@@ -6116,17 +4456,11 @@ orbit_TimeAtPericenter=2367865.23520
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Greatcomet%281784%29]
 absolute_magnitude=3.6
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Great comet (1784)
 orbit_ArgOfPericenter=336.10800
 orbit_AscendingNode=59.15300
@@ -6138,17 +4472,11 @@ orbit_TimeAtPericenter=2372673.19960
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Greatcomet%281807%29]
 absolute_magnitude=2.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Great comet (1807)
 orbit_ArgOfPericenter=4.10430
 orbit_AscendingNode=268.78190
@@ -6160,17 +4488,11 @@ orbit_TimeAtPericenter=2381313.73890
 orbit_good=1000
 radius=5
 slope_parameter=3.5
-tex_map=nomap.png
 type=comet
 
 [C_Greatcomet%281811I%29]
 absolute_magnitude=0.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Great comet (1811I)
 orbit_ArgOfPericenter=65.40600
 orbit_AscendingNode=142.35010
@@ -6182,17 +4504,11 @@ orbit_TimeAtPericenter=2382768.25620
 orbit_good=1000
 radius=5
 slope_parameter=3.6
-tex_map=nomap.png
 type=comet
 
 [C_Greatcomet%281819II%29]
 absolute_magnitude=4.7
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Great comet (1819II)
 orbit_ArgOfPericenter=13.42230
 orbit_AscendingNode=275.53530
@@ -6204,17 +4520,11 @@ orbit_TimeAtPericenter=2385613.71810
 orbit_good=1000
 radius=5
 slope_parameter=3.6
-tex_map=nomap.png
 type=comet
 
 [C_Greatcomet%281823%29]
 absolute_magnitude=4.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Great comet (1823)
 orbit_ArgOfPericenter=28.49190
 orbit_AscendingNode=304.80810
@@ -6226,17 +4536,11 @@ orbit_TimeAtPericenter=2387239.43400
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Greatcomet%281830I%29]
 absolute_magnitude=5.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Great comet (1830I)
 orbit_ArgOfPericenter=5.80600
 orbit_AscendingNode=208.05650
@@ -6248,17 +4552,11 @@ orbit_TimeAtPericenter=2389552.29510
 orbit_good=1000
 radius=5
 slope_parameter=3.4
-tex_map=nomap.png
 type=comet
 
 [C_Greatcomet%281830II%29]
 absolute_magnitude=6.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Great comet (1830II)
 orbit_ArgOfPericenter=26.89090
 orbit_AscendingNode=339.54240
@@ -6270,17 +4568,11 @@ orbit_TimeAtPericenter=2389814.66040
 orbit_good=1000
 radius=5
 slope_parameter=4.8
-tex_map=nomap.png
 type=comet
 
 [C_Greatcomet%281844III%29]
 absolute_magnitude=4.9
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Great comet (1844III)
 orbit_ArgOfPericenter=177.49800
 orbit_AscendingNode=119.89770
@@ -6292,17 +4584,11 @@ orbit_TimeAtPericenter=2394914.69140
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Greatcomet%281854II%29]
 absolute_magnitude=9.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Great comet (1854II)
 orbit_ArgOfPericenter=101.62960
 orbit_AscendingNode=316.79800
@@ -6314,17 +4600,11 @@ orbit_TimeAtPericenter=2398302.01320
 orbit_good=1000
 radius=5
 slope_parameter=6.8
-tex_map=nomap.png
 type=comet
 
 [C_Greatcomet%281860III%29]
 absolute_magnitude=5.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Great comet (1860III)
 orbit_ArgOfPericenter=76.87740
 orbit_AscendingNode=85.92980
@@ -6336,17 +4616,11 @@ orbit_TimeAtPericenter=2400578.06100
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Greatcomet%281861II%29]
 absolute_magnitude=3.9
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Great comet (1861II)
 orbit_ArgOfPericenter=330.09040
 orbit_AscendingNode=280.21090
@@ -6358,17 +4632,11 @@ orbit_TimeAtPericenter=2400938.50680
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Greatcomet%281881b_1881III%29]
 absolute_magnitude=5.6
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Great comet (1881b=1881III)"
 orbit_ArgOfPericenter=354.24220
 orbit_AscendingNode=271.92900
@@ -6380,17 +4648,11 @@ orbit_TimeAtPericenter=2408248.44070
 orbit_good=1000
 radius=5
 slope_parameter=2.6
-tex_map=nomap.png
 type=comet
 
 [C_Greatcomet%281901a_1901I%29]
 absolute_magnitude=5.9
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Great comet (1901a=1901I)"
 orbit_ArgOfPericenter=203.04440
 orbit_AscendingNode=110.32970
@@ -6402,17 +4664,11 @@ orbit_TimeAtPericenter=2415499.25130
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Greatsoutherncomet%281865I%29]
 absolute_magnitude=3.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Great southern comet (1865I)
 orbit_ArgOfPericenter=111.72390
 orbit_AscendingNode=254.12690
@@ -6424,17 +4680,11 @@ orbit_TimeAtPericenter=2402251.32530
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Greatsoutherncomet%281880a_1880I%29]
 absolute_magnitude=8.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Great southern comet (1880a=1880I)"
 orbit_ArgOfPericenter=86.24620
 orbit_AscendingNode=7.07690
@@ -6446,17 +4696,11 @@ orbit_TimeAtPericenter=2407742.61820
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Greatsoutherncomet%281887a_1887I%29]
 absolute_magnitude=6.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Great southern comet (1887a=1887I)"
 orbit_ArgOfPericenter=83.51100
 orbit_AscendingNode=3.88500
@@ -6468,17 +4712,11 @@ orbit_TimeAtPericenter=2410283.43400
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Gregory%281792II%29]
 absolute_magnitude=6.1
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Gregory (1792II)
 orbit_ArgOfPericenter=147.17500
 orbit_AscendingNode=285.46700
@@ -6490,17 +4728,11 @@ orbit_TimeAtPericenter=2375936.19800
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Grigg%281903b_1903III%29]
 absolute_magnitude=9.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Grigg (1903b=1903III)"
 orbit_ArgOfPericenter=184.94600
 orbit_AscendingNode=213.79200
@@ -6512,17 +4744,11 @@ orbit_TimeAtPericenter=2416199.42030
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Grigg-Mellish%281907b_1907II%29]
 absolute_magnitude=9.7
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Grigg-Mellish (1907b=1907II)"
 orbit_ArgOfPericenter=328.75790
 orbit_AscendingNode=189.71900
@@ -6534,17 +4760,11 @@ orbit_TimeAtPericenter=2417662.55340
 orbit_good=1000
 radius=5
 slope_parameter=8.4
-tex_map=nomap.png
 type=comet
 
 [C_Harlan%281976g_1976XIII%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Harlan (1976g=1976XIII)"
 orbit_ArgOfPericenter=193.25400
 orbit_AscendingNode=80.72060
@@ -6556,17 +4776,11 @@ orbit_TimeAtPericenter=2443085.65010
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Haro-Chavira%281954k_1956I%29]
 absolute_magnitude=5.4
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Haro-Chavira (1954k=1956I)"
 orbit_ArgOfPericenter=57.29110
 orbit_AscendingNode=72.17490
@@ -6578,17 +4792,11 @@ orbit_TimeAtPericenter=2435499.16450
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Harrington%281952e_1953I%29]
 absolute_magnitude=7.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Harrington (1952e=1953I)"
 orbit_ArgOfPericenter=191.63140
 orbit_AscendingNode=220.69040
@@ -6600,17 +4808,11 @@ orbit_TimeAtPericenter=2434382.91770
 orbit_good=1000
 radius=5
 slope_parameter=2.1
-tex_map=nomap.png
 type=comet
 
 [C_Hartley%281984v_1985XIV%29]
 absolute_magnitude=6.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Hartley (1984v=1985XIV)"
 orbit_ArgOfPericenter=255.27251
 orbit_AscendingNode=249.50971
@@ -6622,17 +4824,11 @@ orbit_TimeAtPericenter=2446336.86564
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Hartley-Good%281985l_1985XVII%29]
 absolute_magnitude=8.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Hartley-Good (1985l=1985XVII)"
 orbit_ArgOfPericenter=87.03170
 orbit_AscendingNode=357.69750
@@ -6644,17 +4840,11 @@ orbit_TimeAtPericenter=2446408.61640
 orbit_good=1000
 radius=5
 slope_parameter=3.6
-tex_map=nomap.png
 type=comet
 
 [C_Hartwig%281880d_1880III%29]
 absolute_magnitude=7.7
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Hartwig (1880d=1880III)"
 orbit_ArgOfPericenter=323.12050
 orbit_AscendingNode=46.30140
@@ -6666,17 +4856,11 @@ orbit_TimeAtPericenter=2407965.93510
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Heck-Sause%281973a_1972VIII%29]
 absolute_magnitude=-4.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Heck-Sause (1973a=1972VIII)"
 orbit_ArgOfPericenter=346.23520
 orbit_AscendingNode=175.17870
@@ -6688,17 +4872,11 @@ orbit_TimeAtPericenter=2441595.96390
 orbit_good=1000
 radius=5
 slope_parameter=12.2
-tex_map=nomap.png
 type=comet
 
 [C_Helin%281977e_1977VIII%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Helin (1977e=1977VIII)"
 orbit_ArgOfPericenter=249.35250
 orbit_AscendingNode=19.44290
@@ -6710,17 +4888,11 @@ orbit_TimeAtPericenter=2443325.47290
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Helin-Alu%281991r_1992V%29]
 absolute_magnitude=5.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Helin-Alu (1991r=1992V)"
 orbit_ArgOfPericenter=30.79473
 orbit_AscendingNode=252.94968
@@ -6732,17 +4904,11 @@ orbit_TimeAtPericenter=2448672.39305
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Helin-Alu%281992a_1992XVI%29]
 absolute_magnitude=8.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Helin-Alu (1992a=1992XVI)"
 orbit_ArgOfPericenter=239.85253
 orbit_AscendingNode=288.19735
@@ -6754,17 +4920,11 @@ orbit_TimeAtPericenter=2448812.18771
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Helin-Lawrence%281992q%29]
 absolute_magnitude=8.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Helin-Lawrence (1992q)
 orbit_ArgOfPericenter=268.85578
 orbit_AscendingNode=193.96926
@@ -6776,17 +4936,11 @@ orbit_TimeAtPericenter=2449061.61148
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Henry%281873d_1873V%29]
 absolute_magnitude=6.4
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Henry (1873d=1873V)"
 orbit_ArgOfPericenter=233.75480
 orbit_AscendingNode=177.79760
@@ -6798,17 +4952,11 @@ orbit_TimeAtPericenter=2405433.76720
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Herschel%281786II%29]
 absolute_magnitude=4.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Herschel (1786II)
 orbit_ArgOfPericenter=325.05480
 orbit_AscendingNode=196.70000
@@ -6820,17 +4968,11 @@ orbit_TimeAtPericenter=2373571.87970
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Herschel%281790I%29]
 absolute_magnitude=7.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Herschel (1790I)
 orbit_ArgOfPericenter=115.95100
 orbit_AscendingNode=178.42700
@@ -6842,17 +4984,11 @@ orbit_TimeAtPericenter=2374859.21200
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Herschel%281790III%29]
 absolute_magnitude=5.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Herschel (1790III)
 orbit_ArgOfPericenter=119.47500
 orbit_AscendingNode=35.41700
@@ -6864,17 +5000,11 @@ orbit_TimeAtPericenter=2374985.24100
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Herschel%281792I%29]
 absolute_magnitude=6.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Herschel (1792I)
 orbit_ArgOfPericenter=154.35000
 orbit_AscendingNode=192.90000
@@ -6886,17 +5016,11 @@ orbit_TimeAtPericenter=2375587.53490
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Hind%281847I%29]
 absolute_magnitude=6.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Hind (1847I)
 orbit_ArgOfPericenter=254.35240
 orbit_AscendingNode=23.12820
@@ -6908,17 +5032,11 @@ orbit_TimeAtPericenter=2395751.28440
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Honda%281947m_1947X%29]
 absolute_magnitude=9.9
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Honda (1947m=1947X)"
 orbit_ArgOfPericenter=221.24100
 orbit_AscendingNode=311.96200
@@ -6930,17 +5048,11 @@ orbit_TimeAtPericenter=2432507.40600
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Honda%281955g_1955V%29]
 absolute_magnitude=8.4
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Honda (1955g=1955V)"
 orbit_ArgOfPericenter=348.19480
 orbit_AscendingNode=338.72330
@@ -6952,17 +5064,11 @@ orbit_TimeAtPericenter=2435323.56030
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Honda%281962d_1962IV%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Honda (1962d=1962IV)"
 orbit_ArgOfPericenter=72.13440
 orbit_AscendingNode=79.12170
@@ -6974,17 +5080,11 @@ orbit_TimeAtPericenter=2437774.69860
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Honda%281968c_1968VI%29]
 absolute_magnitude=5.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Honda (1968c=1968VI)"
 orbit_ArgOfPericenter=88.70490
 orbit_AscendingNode=106.04040
@@ -6996,17 +5096,11 @@ orbit_TimeAtPericenter=2440076.42310
 orbit_good=1000
 radius=5
 slope_parameter=5.5
-tex_map=nomap.png
 type=comet
 
 [C_Honda%281968e_1968IX%29]
 absolute_magnitude=7.9
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Honda (1968e=1968IX)"
 orbit_ArgOfPericenter=282.81530
 orbit_AscendingNode=252.60030
@@ -7018,17 +5112,11 @@ orbit_TimeAtPericenter=2440164.33810
 orbit_good=1000
 radius=5
 slope_parameter=2.5
-tex_map=nomap.png
 type=comet
 
 [C_Honda-Bernasconi%281948g_1948IV%29]
 absolute_magnitude=8.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Honda-Bernasconi (1948g=1948IV)"
 orbit_ArgOfPericenter=317.06340
 orbit_AscendingNode=203.11520
@@ -7040,17 +5128,11 @@ orbit_TimeAtPericenter=2432687.40520
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [C_Houghton-Ensor%281932b_1932I%29]
 absolute_magnitude=8.9
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Houghton-Ensor (1932b=1932I)"
 orbit_ArgOfPericenter=303.51990
 orbit_AscendingNode=212.78380
@@ -7062,17 +5144,11 @@ orbit_TimeAtPericenter=2426766.42810
 orbit_good=1000
 radius=5
 slope_parameter=4.5
-tex_map=nomap.png
 type=comet
 
 [C_Hubble%281937g_1936V%29]
 absolute_magnitude=5.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Hubble (1937g=1936V)"
 orbit_ArgOfPericenter=147.46070
 orbit_AscendingNode=97.12830
@@ -7084,17 +5160,11 @@ orbit_TimeAtPericenter=2428486.74560
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Huchra%281973h_1973III%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Huchra (1973h=1973III)"
 orbit_ArgOfPericenter=123.48500
 orbit_AscendingNode=57.14920
@@ -7106,17 +5176,11 @@ orbit_TimeAtPericenter=2441753.08570
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Humason%281960e_1959X%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Humason (1960e=1959X)"
 orbit_ArgOfPericenter=46.46670
 orbit_AscendingNode=306.56690
@@ -7128,17 +5192,11 @@ orbit_TimeAtPericenter=2436913.70500
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Humason%281961e_1962VIII%29]
 absolute_magnitude=1.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Humason (1961e=1962VIII)"
 orbit_ArgOfPericenter=233.55020
 orbit_AscendingNode=154.73550
@@ -7150,17 +5208,11 @@ orbit_TimeAtPericenter=2438008.70500
 orbit_good=1000
 radius=5
 slope_parameter=4.2
-tex_map=nomap.png
 type=comet
 
 [C_IRAS%281983f_1983I%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/IRAS (1983f=1983I)"
 orbit_ArgOfPericenter=227.06895
 orbit_AscendingNode=118.92541
@@ -7172,17 +5224,11 @@ orbit_TimeAtPericenter=2445353.53044
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_IRAS%281983k_1983VI%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/IRAS (1983k=1983VI)"
 orbit_ArgOfPericenter=265.58035
 orbit_AscendingNode=171.09244
@@ -7194,17 +5240,11 @@ orbit_TimeAtPericenter=2445457.20788
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_IRAS%281983o_1983XVI%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/IRAS (1983o=1983XVI)"
 orbit_ArgOfPericenter=333.98189
 orbit_AscendingNode=200.56057
@@ -7216,17 +5256,11 @@ orbit_TimeAtPericenter=2445666.50064
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_IRAS-Araki-Alcock%281983d_1983VII%29]
 absolute_magnitude=9.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/IRAS-Araki-Alcock (1983d=1983VII)"
 orbit_ArgOfPericenter=192.84389
 orbit_AscendingNode=48.40529
@@ -7238,17 +5272,11 @@ orbit_TimeAtPericenter=2445475.75287
 orbit_good=1000
 radius=5
 slope_parameter=0.9
-tex_map=nomap.png
 type=comet
 
 [C_Ikeya%281963a_1963I%29]
 absolute_magnitude=6.4
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Ikeya (1963a=1963I)"
 orbit_ArgOfPericenter=336.28510
 orbit_AscendingNode=52.50450
@@ -7260,17 +5288,11 @@ orbit_TimeAtPericenter=2438109.97480
 orbit_good=1000
 radius=5
 slope_parameter=4.3
-tex_map=nomap.png
 type=comet
 
 [C_Ikeya%281964f_1964VIII%29]
 absolute_magnitude=7.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Ikeya (1964f=1964VIII)"
 orbit_ArgOfPericenter=290.80800
 orbit_AscendingNode=269.29650
@@ -7282,17 +5304,11 @@ orbit_TimeAtPericenter=2438608.71110
 orbit_good=1000
 radius=5
 slope_parameter=4.2
-tex_map=nomap.png
 type=comet
 
 [C_Ikeya-Everhart%281966d_1966IV%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Ikeya-Everhart (1966d=1966IV)"
 orbit_ArgOfPericenter=50.03900
 orbit_AscendingNode=106.96700
@@ -7304,14 +5320,11 @@ orbit_TimeAtPericenter=2439342.82100
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Ikeya-Seki%281965f_1965VIII%29]
 absolute_magnitude=6.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
 dust_brightnessfactor=0.00015
 dust_lengthfactor=0.00001
 dust_widthfactor=0.0005
@@ -7326,17 +5339,11 @@ orbit_TimeAtPericenter=2439054.68370
 orbit_good=1000
 radius=5
 slope_parameter=3.5
-tex_map=nomap.png
 type=comet
 
 [C_Ikeya-Seki%281967n_1968I%29]
 absolute_magnitude=4.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Ikeya-Seki (1967n=1968I)"
 orbit_ArgOfPericenter=70.87240
 orbit_AscendingNode=254.62780
@@ -7348,17 +5355,11 @@ orbit_TimeAtPericenter=2439912.20550
 orbit_good=1000
 radius=5
 slope_parameter=4.4
-tex_map=nomap.png
 type=comet
 
 [C_Jackson%281935b_1934II%29]
 absolute_magnitude=4.4
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Jackson (1935b=1934II)"
 orbit_ArgOfPericenter=124.30300
 orbit_AscendingNode=73.50400
@@ -7370,17 +5371,11 @@ orbit_TimeAtPericenter=2427687.42050
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Jensen-Shoemaker%281987g1_1988II%29]
 absolute_magnitude=9.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Jensen-Shoemaker (1987g1=1988II)"
 orbit_ArgOfPericenter=194.73899
 orbit_AscendingNode=197.64647
@@ -7392,17 +5387,11 @@ orbit_TimeAtPericenter=2447179.30948
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Johnson%281935a_1935I%29]
 absolute_magnitude=9.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Johnson (1935a=1935I)"
 orbit_ArgOfPericenter=18.38980
 orbit_AscendingNode=91.75160
@@ -7414,17 +5403,11 @@ orbit_TimeAtPericenter=2427859.96870
 orbit_good=1000
 radius=5
 slope_parameter=3.0
-tex_map=nomap.png
 type=comet
 
 [C_Johnson%281948j_1948III%29]
 absolute_magnitude=4.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Johnson (1948j=1948III)"
 orbit_ArgOfPericenter=191.83460
 orbit_AscendingNode=139.71560
@@ -7436,17 +5419,11 @@ orbit_TimeAtPericenter=2432650.45380
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Johnson%281949a_1950I%29]
 absolute_magnitude=3.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Johnson (1949a=1950I)"
 orbit_ArgOfPericenter=40.09680
 orbit_AscendingNode=221.63270
@@ -7458,17 +5435,11 @@ orbit_TimeAtPericenter=2433300.81310
 orbit_good=1000
 radius=5
 slope_parameter=6.4
-tex_map=nomap.png
 type=comet
 
 [C_Jones%281946h_1946VI%29]
 absolute_magnitude=3.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Jones (1946h=1946VI)"
 orbit_ArgOfPericenter=320.42000
 orbit_AscendingNode=237.63330
@@ -7480,17 +5451,11 @@ orbit_TimeAtPericenter=2432120.27910
 orbit_good=1000
 radius=5
 slope_parameter=5.9
-tex_map=nomap.png
 type=comet
 
 [C_Jurlof-Achmarof-Hassel%281939d_1939III%29]
 absolute_magnitude=7.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Jurlof-Achmarof-Hassel (1939d=1939III)"
 orbit_ArgOfPericenter=89.24640
 orbit_AscendingNode=311.58360
@@ -7502,17 +5467,11 @@ orbit_TimeAtPericenter=2429363.66880
 orbit_good=1000
 radius=5
 slope_parameter=3.9
-tex_map=nomap.png
 type=comet
 
 [C_Kaho-Kozik-Lis%281936b_1936III%29]
 absolute_magnitude=9.7
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Kaho-Kozik-Lis (1936b=1936III)"
 orbit_ArgOfPericenter=45.85730
 orbit_AscendingNode=264.31170
@@ -7524,17 +5483,11 @@ orbit_TimeAtPericenter=2428365.32030
 orbit_good=1000
 radius=5
 slope_parameter=6.7
-tex_map=nomap.png
 type=comet
 
 [C_Kiess%281911b_1911II%29]
 absolute_magnitude=7.9
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Kiess (1911b=1911II)"
 orbit_ArgOfPericenter=110.36780
 orbit_AscendingNode=157.96380
@@ -7546,17 +5499,11 @@ orbit_TimeAtPericenter=2419218.17620
 orbit_good=1000
 radius=5
 slope_parameter=4.2
-tex_map=nomap.png
 type=comet
 
 [C_Kilston%281966b_1966V%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Kilston (1966b=1966V)"
 orbit_ArgOfPericenter=154.48020
 orbit_AscendingNode=155.35560
@@ -7568,17 +5515,13 @@ orbit_TimeAtPericenter=2439426.57240
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Kirch%281680%29]
 absolute_magnitude=4.4
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
 dust_brightnessfactor=2.5
 dust_lengthfactor=2.4
-dust_widthfactor=1.5
 name=C/Kirch (1680)
 orbit_ArgOfPericenter=350.62020
 orbit_AscendingNode=275.93170
@@ -7590,17 +5533,11 @@ orbit_TimeAtPericenter=2335019.98760
 orbit_good=1000
 radius=5
 slope_parameter=2.1
-tex_map=nomap.png
 type=comet
 
 [C_Klinkenberg%281762%29]
 absolute_magnitude=3.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Klinkenberg (1762)
 orbit_ArgOfPericenter=115.48000
 orbit_AscendingNode=351.17000
@@ -7612,17 +5549,11 @@ orbit_TimeAtPericenter=2364765.33450
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Klinkerfues%281853III%29]
 absolute_magnitude=4.4
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Klinkerfues (1853III)
 orbit_ArgOfPericenter=170.43720
 orbit_AscendingNode=141.86980
@@ -7634,17 +5565,11 @@ orbit_TimeAtPericenter=2398098.70690
 orbit_good=1000
 radius=5
 slope_parameter=3.2
-tex_map=nomap.png
 type=comet
 
 [C_Klinkerfues%281854III%29]
 absolute_magnitude=6.4
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Klinkerfues (1854III)
 orbit_ArgOfPericenter=74.56960
 orbit_AscendingNode=349.00010
@@ -7656,17 +5581,11 @@ orbit_TimeAtPericenter=2398391.99700
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Klinkerfues%281854IV%29]
 absolute_magnitude=8.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Klinkerfues (1854IV)
 orbit_ArgOfPericenter=129.90360
 orbit_AscendingNode=325.81400
@@ -7678,17 +5597,11 @@ orbit_TimeAtPericenter=2398519.50850
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Klinkerfues%281857III%29]
 absolute_magnitude=9.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Klinkerfues (1857III)
 orbit_ArgOfPericenter=134.06190
 orbit_AscendingNode=24.99390
@@ -7700,17 +5613,11 @@ orbit_TimeAtPericenter=2399513.97430
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Klinkerfues%281857V%29]
 absolute_magnitude=4.9
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Klinkerfues (1857V)
 orbit_ArgOfPericenter=124.84150
 orbit_AscendingNode=16.25490
@@ -7722,17 +5629,11 @@ orbit_TimeAtPericenter=2399588.87990
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Klinkerfues%281863II%29]
 absolute_magnitude=5.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Klinkerfues (1863II)
 orbit_ArgOfPericenter=3.97380
 orbit_AscendingNode=252.47020
@@ -7744,17 +5645,11 @@ orbit_TimeAtPericenter=2401600.89610
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Kobayashi-Berger-Milon%281975h_1975IX%29]
 absolute_magnitude=7.4
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Kobayashi-Berger-Milon (1975h=1975IX)"
 orbit_ArgOfPericenter=116.97560
 orbit_AscendingNode=295.65260
@@ -7766,17 +5661,11 @@ orbit_TimeAtPericenter=2442660.83480
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Kohler%281977m_1977XIV%29]
 absolute_magnitude=6.7
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Kohler (1977m=1977XIV)"
 orbit_ArgOfPericenter=163.48760
 orbit_AscendingNode=181.82340
@@ -7788,17 +5677,11 @@ orbit_TimeAtPericenter=2443458.07000
 orbit_good=1000
 radius=5
 slope_parameter=6.4
-tex_map=nomap.png
 type=comet
 
 [C_Kohoutek%281969b_1970III%29]
 absolute_magnitude=8.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Kohoutek (1969b=1970III)"
 orbit_ArgOfPericenter=123.47390
 orbit_AscendingNode=301.05940
@@ -7810,17 +5693,11 @@ orbit_TimeAtPericenter=2440667.13740
 orbit_good=1000
 radius=5
 slope_parameter=2.6
-tex_map=nomap.png
 type=comet
 
 [C_Kohoutek%281973e_1973VII%29]
 absolute_magnitude=8.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Kohoutek (1973e=1973VII)"
 orbit_ArgOfPericenter=74.85840
 orbit_AscendingNode=164.11850
@@ -7832,17 +5709,11 @@ orbit_TimeAtPericenter=2441840.68140
 orbit_good=1000
 radius=5
 slope_parameter=4.9
-tex_map=nomap.png
 type=comet
 
 [C_Kohoutek%281973f_1973XII%29]
 absolute_magnitude=6.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Kohoutek (1973f=1973XII)"
 orbit_ArgOfPericenter=37.82380
 orbit_AscendingNode=257.76560
@@ -7854,17 +5725,11 @@ orbit_TimeAtPericenter=2442044.93070
 orbit_good=1000
 radius=5
 slope_parameter=2.3
-tex_map=nomap.png
 type=comet
 
 [C_Kojima%281972j_1973II%29]
 absolute_magnitude=9.1
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Kojima (1972j=1973II)"
 orbit_ArgOfPericenter=334.29800
 orbit_AscendingNode=42.48380
@@ -7876,17 +5741,11 @@ orbit_TimeAtPericenter=2441725.77750
 orbit_good=1000
 radius=5
 slope_parameter=0.9
-tex_map=nomap.png
 type=comet
 
 [C_Kopff%281906b_1905IV%29]
 absolute_magnitude=3.7
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Kopff (1906b=1905IV)"
 orbit_ArgOfPericenter=158.61760
 orbit_AscendingNode=342.90540
@@ -7898,17 +5757,11 @@ orbit_TimeAtPericenter=2417136.75450
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Kozik-Peltier%281939a_1939I%29]
 absolute_magnitude=9.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Kozik-Peltier (1939a=1939I)"
 orbit_ArgOfPericenter=169.03090
 orbit_AscendingNode=288.91200
@@ -7920,17 +5773,11 @@ orbit_TimeAtPericenter=2429301.35350
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Kresak-Peltier%281954d_1954XII%29]
 absolute_magnitude=8.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Kresak-Peltier (1954d=1954XII)"
 orbit_ArgOfPericenter=254.72110
 orbit_AscendingNode=74.87000
@@ -7942,17 +5789,11 @@ orbit_TimeAtPericenter=2434984.16610
 orbit_good=1000
 radius=5
 slope_parameter=1.3
-tex_map=nomap.png
 type=comet
 
 [C_Kritzinger%281914a_1914II%29]
 absolute_magnitude=9.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Kritzinger (1914a=1914II)"
 orbit_ArgOfPericenter=72.23210
 orbit_AscendingNode=199.41160
@@ -7964,17 +5805,11 @@ orbit_TimeAtPericenter=2420288.19380
 orbit_good=1000
 radius=5
 slope_parameter=5.1
-tex_map=nomap.png
 type=comet
 
 [C_Latyshev-Wild-Burnham%281957f_1957IX%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Latyshev-Wild-Burnham (1957f=1957IX)"
 orbit_ArgOfPericenter=277.62300
 orbit_AscendingNode=210.18600
@@ -7986,17 +5821,11 @@ orbit_TimeAtPericenter=2436177.62930
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Laugier%281842II%29]
 absolute_magnitude=8.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Laugier (1842II)
 orbit_ArgOfPericenter=240.49760
 orbit_AscendingNode=209.31140
@@ -8008,17 +5837,11 @@ orbit_TimeAtPericenter=2394185.95530
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Levy%281987y_1987XXI%29]
 absolute_magnitude=8.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Levy (1987y=1987XXI)"
 orbit_ArgOfPericenter=13.18333
 orbit_AscendingNode=143.02862
@@ -8030,17 +5853,11 @@ orbit_TimeAtPericenter=2447047.67160
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Levy%281988e_1987XXX%29]
 absolute_magnitude=4.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Levy (1988e=1987XXX)"
 orbit_ArgOfPericenter=326.52164
 orbit_AscendingNode=288.06343
@@ -8052,17 +5869,11 @@ orbit_TimeAtPericenter=2447129.44718
 orbit_good=1000
 radius=5
 slope_parameter=6.3
-tex_map=nomap.png
 type=comet
 
 [C_Levy%281990c_1990XX%29]
 absolute_magnitude=4.6
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Levy (1990c=1990XX)"
 orbit_ArgOfPericenter=242.66048
 orbit_AscendingNode=138.66269
@@ -8074,17 +5885,11 @@ orbit_TimeAtPericenter=2448189.18374
 orbit_good=1000
 radius=5
 slope_parameter=3.2
-tex_map=nomap.png
 type=comet
 
 [C_Levy-Rudenko%281984t_1984XXIII%29]
 absolute_magnitude=8.6
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Levy-Rudenko (1984t=1984XXIII)"
 orbit_ArgOfPericenter=82.74014
 orbit_AscendingNode=330.46743
@@ -8096,17 +5901,11 @@ orbit_TimeAtPericenter=2446048.75572
 orbit_good=1000
 radius=5
 slope_parameter=3.5
-tex_map=nomap.png
 type=comet
 
 [C_Liais%281860I%29]
 absolute_magnitude=7.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Liais (1860I)
 orbit_ArgOfPericenter=209.76320
 orbit_AscendingNode=325.31870
@@ -8118,17 +5917,11 @@ orbit_TimeAtPericenter=2400457.62490
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Liller%281988a_1988V%29]
 absolute_magnitude=5.7
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Liller (1988a=1988V)"
 orbit_ArgOfPericenter=57.38362
 orbit_AscendingNode=30.81800
@@ -8140,17 +5933,11 @@ orbit_TimeAtPericenter=2447251.61442
 orbit_good=1000
 radius=5
 slope_parameter=3.9
-tex_map=nomap.png
 type=comet
 
 [C_Lovas%281974c_1975VIII%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Lovas (1974c=1975VIII)"
 orbit_ArgOfPericenter=261.36400
 orbit_AscendingNode=11.67140
@@ -8162,17 +5949,11 @@ orbit_TimeAtPericenter=2442646.68130
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Lovas%281976k_1976IX%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Lovas (1976k=1976IX)"
 orbit_ArgOfPericenter=118.79600
 orbit_AscendingNode=285.33830
@@ -8184,17 +5965,11 @@ orbit_TimeAtPericenter=2442965.88760
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Lovas%281977c_1976XII%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Lovas (1977c=1976XII)"
 orbit_ArgOfPericenter=146.27720
 orbit_AscendingNode=337.47120
@@ -8206,17 +5981,11 @@ orbit_TimeAtPericenter=2443083.48250
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Machholz%281978l_1978XIII%29]
 absolute_magnitude=6.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Machholz (1978l=1978XIII)"
 orbit_ArgOfPericenter=224.76180
 orbit_AscendingNode=289.98450
@@ -8228,17 +5997,11 @@ orbit_TimeAtPericenter=2443734.17320
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Machholz%281985e_1985VIII%29]
 absolute_magnitude=8.7
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Machholz (1985e=1985VIII)"
 orbit_ArgOfPericenter=274.50831
 orbit_AscendingNode=194.72917
@@ -8250,17 +6013,11 @@ orbit_TimeAtPericenter=2446245.23876
 orbit_good=1000
 radius=5
 slope_parameter=2.2
-tex_map=nomap.png
 type=comet
 
 [C_Machholz%281988j_1988XV%29]
 absolute_magnitude=8.1
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Machholz (1988j=1988XV)"
 orbit_ArgOfPericenter=349.03519
 orbit_AscendingNode=167.03064
@@ -8272,17 +6029,11 @@ orbit_TimeAtPericenter=2447422.06824
 orbit_good=1000
 radius=5
 slope_parameter=2.1
-tex_map=nomap.png
 type=comet
 
 [C_Machholz%281992k_1992XVII%29]
 absolute_magnitude=9.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Machholz (1992k=1992XVII)"
 orbit_ArgOfPericenter=162.92437
 orbit_AscendingNode=234.43017
@@ -8294,17 +6045,11 @@ orbit_TimeAtPericenter=2448814.45771
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Mauvais%281843II%29]
 absolute_magnitude=4.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Mauvais (1843II)
 orbit_ArgOfPericenter=124.25040
 orbit_AscendingNode=158.74390
@@ -8316,17 +6061,11 @@ orbit_TimeAtPericenter=2394327.05590
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Mauvais%281844II%29]
 absolute_magnitude=4.9
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Mauvais (1844II)
 orbit_ArgOfPericenter=211.26940
 orbit_AscendingNode=33.14620
@@ -8338,17 +6077,11 @@ orbit_TimeAtPericenter=2394857.34600
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Mauvais%281847III%29]
 absolute_magnitude=5.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Mauvais (1847III)
 orbit_ArgOfPericenter=91.52650
 orbit_AscendingNode=339.70610
@@ -8360,17 +6093,11 @@ orbit_TimeAtPericenter=2395883.33860
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_McKenzie-Russell%281989f1_1989XVIII%29]
 absolute_magnitude=9.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/McKenzie-Russell (1989f1=1989XVIII)"
 orbit_ArgOfPericenter=191.75800
 orbit_AscendingNode=293.21502
@@ -8382,17 +6109,11 @@ orbit_TimeAtPericenter=2447838.19395
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_McNaught%281987b1_1987XXXII%29]
 absolute_magnitude=5.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/McNaught (1987b1=1987XXXII)"
 orbit_ArgOfPericenter=17.42629
 orbit_AscendingNode=260.64382
@@ -8404,17 +6125,11 @@ orbit_TimeAtPericenter=2447141.44452
 orbit_good=1000
 radius=5
 slope_parameter=3.8
-tex_map=nomap.png
 type=comet
 
 [C_McNaught-Hughes%281990g_1991III%29]
 absolute_magnitude=7.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/McNaught-Hughes (1990g=1991III)"
 orbit_ArgOfPericenter=18.17937
 orbit_AscendingNode=232.51257
@@ -8426,17 +6141,11 @@ orbit_TimeAtPericenter=2448315.16658
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_McNaught-Russell%281991g_1990XIX%29]
 absolute_magnitude=6.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/McNaught-Russell (1991g=1990XIX)"
 orbit_ArgOfPericenter=320.88481
 orbit_AscendingNode=161.01038
@@ -8448,17 +6157,11 @@ orbit_TimeAtPericenter=2448182.69898
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_McNaught-Russell%281991v_1992XI%29]
 absolute_magnitude=8.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/McNaught-Russell (1991v=1992XI)"
 orbit_ArgOfPericenter=257.22568
 orbit_AscendingNode=119.76525
@@ -8470,17 +6173,11 @@ orbit_TimeAtPericenter=2448745.94663
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_McNaught-Russell%281991w_1990XXII%29]
 absolute_magnitude=5.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/McNaught-Russell (1991w=1990XXII)"
 orbit_ArgOfPericenter=149.23959
 orbit_AscendingNode=149.41834
@@ -8492,17 +6189,11 @@ orbit_TimeAtPericenter=2448207.75672
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_McNaught-Russell%281993v%29]
 absolute_magnitude=9.1
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/McNaught-Russell (1993v)
 orbit_ArgOfPericenter=353.46920
 orbit_AscendingNode=165.65883
@@ -8514,17 +6205,11 @@ orbit_TimeAtPericenter=2449442.59774
 orbit_good=1000
 radius=5
 slope_parameter=3.4
-tex_map=nomap.png
 type=comet
 
 [C_McNaught-Tritton%281978XXVII%29]
 absolute_magnitude=5.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/McNaught-Tritton (1978XXVII)
 orbit_ArgOfPericenter=229.49537
 orbit_AscendingNode=71.50488
@@ -8536,17 +6221,11 @@ orbit_TimeAtPericenter=2443745.04012
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Mechain%281781I%29]
 absolute_magnitude=7.9
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Mechain (1781I)
 orbit_ArgOfPericenter=156.20200
 orbit_AscendingNode=85.35900
@@ -8558,17 +6237,11 @@ orbit_TimeAtPericenter=2371745.18890
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Mechain%281781II%29]
 absolute_magnitude=5.9
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Mechain (1781II)
 orbit_ArgOfPericenter=61.37800
 orbit_AscendingNode=79.77100
@@ -8580,17 +6253,11 @@ orbit_TimeAtPericenter=2371890.52320
 orbit_good=1000
 radius=5
 slope_parameter=4.6
-tex_map=nomap.png
 type=comet
 
 [C_Mechain%281785II%29]
 absolute_magnitude=5.6
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Mechain (1785II)
 orbit_ArgOfPericenter=127.19680
 orbit_AscendingNode=66.98880
@@ -8602,17 +6269,11 @@ orbit_TimeAtPericenter=2373116.41400
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Mechain%281787%29]
 absolute_magnitude=5.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Mechain (1787)
 orbit_ArgOfPericenter=99.15000
 orbit_AscendingNode=109.14800
@@ -8624,17 +6285,11 @@ orbit_TimeAtPericenter=2373878.82500
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Mechain%281799I%29]
 absolute_magnitude=5.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Mechain (1799I)
 orbit_ArgOfPericenter=95.82000
 orbit_AscendingNode=101.62300
@@ -8646,17 +6301,11 @@ orbit_TimeAtPericenter=2378381.19090
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Mechain%281799II%29]
 absolute_magnitude=6.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Mechain (1799II)
 orbit_ArgOfPericenter=136.47400
 orbit_AscendingNode=328.91200
@@ -8668,17 +6317,11 @@ orbit_TimeAtPericenter=2378490.89640
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Meier%281978f_1978XXI%29]
 absolute_magnitude=7.7
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Meier (1978f=1978XXI)"
 orbit_ArgOfPericenter=231.40300
 orbit_AscendingNode=348.64570
@@ -8690,17 +6333,11 @@ orbit_TimeAtPericenter=2443823.90900
 orbit_good=1000
 radius=5
 slope_parameter=0.0
-tex_map=nomap.png
 type=comet
 
 [C_Meier%281979i_1979IX%29]
 absolute_magnitude=9.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Meier (1979i=1979IX)"
 orbit_ArgOfPericenter=112.57870
 orbit_AscendingNode=296.92980
@@ -8712,17 +6349,11 @@ orbit_TimeAtPericenter=2444163.84580
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Meier%281980q_1980XII%29]
 absolute_magnitude=6.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Meier (1980q=1980XII)"
 orbit_ArgOfPericenter=87.96420
 orbit_AscendingNode=24.73750
@@ -8734,17 +6365,11 @@ orbit_TimeAtPericenter=2444583.15000
 orbit_good=1000
 radius=5
 slope_parameter=3.6
-tex_map=nomap.png
 type=comet
 
 [C_Meier%281984o_1984XX%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Meier (1984o=1984XX)"
 orbit_ArgOfPericenter=128.00498
 orbit_AscendingNode=11.00923
@@ -8756,17 +6381,11 @@ orbit_TimeAtPericenter=2445987.44862
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Mellish%281907e_1907V%29]
 absolute_magnitude=8.4
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Mellish (1907e=1907V)"
 orbit_ArgOfPericenter=294.37230
 orbit_AscendingNode=55.19420
@@ -8778,17 +6397,11 @@ orbit_TimeAtPericenter=2417833.35630
 orbit_good=1000
 radius=5
 slope_parameter=8.0
-tex_map=nomap.png
 type=comet
 
 [C_Mellish%281915a_1915II%29]
 absolute_magnitude=4.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Mellish (1915a=1915II)"
 orbit_ArgOfPericenter=247.77670
 orbit_AscendingNode=72.75880
@@ -8800,17 +6413,11 @@ orbit_TimeAtPericenter=2420696.15230
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Mellish%281915d_1915IV%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Mellish (1915d=1915IV)"
 orbit_ArgOfPericenter=118.84000
 orbit_AscendingNode=78.20000
@@ -8822,17 +6429,11 @@ orbit_TimeAtPericenter=2420784.39590
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Messier%281759II%29]
 absolute_magnitude=3.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Messier (1759II)
 orbit_ArgOfPericenter=273.92400
 orbit_AscendingNode=142.30900
@@ -8844,17 +6445,11 @@ orbit_TimeAtPericenter=2363852.00180
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Messier%281763%29]
 absolute_magnitude=9.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Messier (1763)
 orbit_ArgOfPericenter=88.57000
 orbit_AscendingNode=359.04800
@@ -8866,17 +6461,11 @@ orbit_TimeAtPericenter=2365287.87380
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Messier%281764%29]
 absolute_magnitude=7.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Messier (1764)
 orbit_ArgOfPericenter=104.85200
 orbit_AscendingNode=122.68500
@@ -8888,17 +6477,11 @@ orbit_TimeAtPericenter=2365390.57100
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Messier%281766I%29]
 absolute_magnitude=7.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Messier (1766I)
 orbit_ArgOfPericenter=100.88900
 orbit_AscendingNode=246.71900
@@ -8910,17 +6493,11 @@ orbit_TimeAtPericenter=2366126.36160
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Messier%281769%29]
 absolute_magnitude=3.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Messier (1769)
 orbit_ArgOfPericenter=329.12310
 orbit_AscendingNode=177.59410
@@ -8932,17 +6509,11 @@ orbit_TimeAtPericenter=2367454.62040
 orbit_good=1000
 radius=5
 slope_parameter=4.4
-tex_map=nomap.png
 type=comet
 
 [C_Messier%281771%29]
 absolute_magnitude=4.6
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Messier (1771)
 orbit_ArgOfPericenter=76.20570
 orbit_AscendingNode=30.31670
@@ -8954,17 +6525,11 @@ orbit_TimeAtPericenter=2368013.13490
 orbit_good=1000
 radius=5
 slope_parameter=5.2
-tex_map=nomap.png
 type=comet
 
 [C_Messier%281773%29]
 absolute_magnitude=2.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Messier (1773)
 orbit_ArgOfPericenter=314.11200
 orbit_AscendingNode=123.54000
@@ -8976,17 +6541,11 @@ orbit_TimeAtPericenter=2368883.60680
 orbit_good=1000
 radius=5
 slope_parameter=3.1
-tex_map=nomap.png
 type=comet
 
 [C_Messier%281780I%29]
 absolute_magnitude=4.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Messier (1780I)
 orbit_ArgOfPericenter=237.82100
 orbit_AscendingNode=126.52900
@@ -8998,17 +6557,11 @@ orbit_TimeAtPericenter=2371465.75240
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Messier%281788I%29]
 absolute_magnitude=7.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Messier (1788I)
 orbit_ArgOfPericenter=57.83600
 orbit_AscendingNode=159.22000
@@ -9020,17 +6573,11 @@ orbit_TimeAtPericenter=2374428.30930
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Messier%281793I%29]
 absolute_magnitude=6.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Messier (1793I)
 orbit_ArgOfPericenter=239.80300
 orbit_AscendingNode=110.68100
@@ -9042,17 +6589,11 @@ orbit_TimeAtPericenter=2376248.84100
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Messier%281798I%29]
 absolute_magnitude=8.4
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Messier (1798I)
 orbit_ArgOfPericenter=342.99500
 orbit_AscendingNode=124.22800
@@ -9064,17 +6605,11 @@ orbit_TimeAtPericenter=2377860.50830
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Messier-Mechain%281785I%29]
 absolute_magnitude=7.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Messier-Mechain (1785I)
 orbit_ArgOfPericenter=205.63800
 orbit_AscendingNode=266.51400
@@ -9086,17 +6621,11 @@ orbit_TimeAtPericenter=2373045.32550
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Metcalf%281910b_1910IV%29]
 absolute_magnitude=4.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Metcalf (1910b=1910IV)"
 orbit_ArgOfPericenter=50.96430
 orbit_AscendingNode=290.08490
@@ -9108,17 +6637,11 @@ orbit_TimeAtPericenter=2418931.28000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Metcalf%281913b_1913IV%29]
 absolute_magnitude=6.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Metcalf (1913b=1913IV)"
 orbit_ArgOfPericenter=117.70280
 orbit_AscendingNode=157.93860
@@ -9130,17 +6653,11 @@ orbit_TimeAtPericenter=2420025.05380
 orbit_good=1000
 radius=5
 slope_parameter=6.8
-tex_map=nomap.png
 type=comet
 
 [C_Metcalf%281919c_1919V%29]
 absolute_magnitude=4.7
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Metcalf (1919c=1919V)"
 orbit_ArgOfPericenter=185.74610
 orbit_AscendingNode=121.40390
@@ -9152,17 +6669,11 @@ orbit_TimeAtPericenter=2422300.30920
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Minkowski%281950b_1951I%29]
 absolute_magnitude=3.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Minkowski (1950b=1951I)"
 orbit_ArgOfPericenter=192.46080
 orbit_AscendingNode=38.18570
@@ -9174,17 +6685,11 @@ orbit_TimeAtPericenter=2433661.54290
 orbit_good=1000
 radius=5
 slope_parameter=5.0
-tex_map=nomap.png
 type=comet
 
 [C_Mitchell%281847VI%29]
 absolute_magnitude=7.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Mitchell (1847VI)
 orbit_ArgOfPericenter=276.61100
 orbit_AscendingNode=192.26860
@@ -9196,17 +6701,11 @@ orbit_TimeAtPericenter=2395980.39990
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Mitchell-Jones-Gerber%281967f_1967VII%29]
 absolute_magnitude=7.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Mitchell-Jones-Gerber (1967f=1967VII)"
 orbit_ArgOfPericenter=78.93940
 orbit_AscendingNode=31.59740
@@ -9218,17 +6717,11 @@ orbit_TimeAtPericenter=2439658.28510
 orbit_good=1000
 radius=5
 slope_parameter=3.6
-tex_map=nomap.png
 type=comet
 
 [C_Montaigne%281774%29]
 absolute_magnitude=5.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Montaigne (1774)
 orbit_ArgOfPericenter=136.53400
 orbit_AscendingNode=183.27600
@@ -9240,17 +6733,11 @@ orbit_TimeAtPericenter=2369227.44880
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Montaigne-Olbers%281780II%29]
 absolute_magnitude=6.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Montaigne-Olbers (1780II)
 orbit_ArgOfPericenter=255.16000
 orbit_AscendingNode=144.38000
@@ -9262,17 +6749,11 @@ orbit_TimeAtPericenter=2371524.84800
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Morehouse%281908c_1908III%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Morehouse (1908c=1908III)"
 orbit_ArgOfPericenter=171.58530
 orbit_AscendingNode=103.75360
@@ -9284,17 +6765,11 @@ orbit_TimeAtPericenter=2418301.75710
 orbit_good=1000
 radius=5
 slope_parameter=5.0
-tex_map=nomap.png
 type=comet
 
 [C_Mori-Sato-Fujikawa%281975j_1975XII%29]
 absolute_magnitude=4.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Mori-Sato-Fujikawa (1975j=1975XII)"
 orbit_ArgOfPericenter=246.24750
 orbit_AscendingNode=277.98000
@@ -9306,17 +6781,11 @@ orbit_TimeAtPericenter=2442772.37750
 orbit_good=1000
 radius=5
 slope_parameter=6.3
-tex_map=nomap.png
 type=comet
 
 [C_Mrkos%281948a_1948II%29]
 absolute_magnitude=7.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Mrkos (1948a=1948II)"
 orbit_ArgOfPericenter=61.92680
 orbit_AscendingNode=198.60190
@@ -9328,17 +6797,11 @@ orbit_TimeAtPericenter=2432598.19230
 orbit_good=1000
 radius=5
 slope_parameter=2.9
-tex_map=nomap.png
 type=comet
 
 [C_Mrkos%281952c_1952V%29]
 absolute_magnitude=8.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Mrkos (1952c=1952V)"
 orbit_ArgOfPericenter=144.85550
 orbit_AscendingNode=121.65380
@@ -9350,17 +6813,11 @@ orbit_TimeAtPericenter=2434172.17220
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Mrkos%281952f_1953II%29]
 absolute_magnitude=8.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Mrkos (1952f=1953II)"
 orbit_ArgOfPericenter=253.82320
 orbit_AscendingNode=342.88320
@@ -9372,17 +6829,11 @@ orbit_TimeAtPericenter=2434402.35990
 orbit_good=1000
 radius=5
 slope_parameter=0.8
-tex_map=nomap.png
 type=comet
 
 [C_Mrkos%281955e_1955III%29]
 absolute_magnitude=6.6
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Mrkos (1955e=1955III)"
 orbit_ArgOfPericenter=32.50900
 orbit_AscendingNode=48.24340
@@ -9394,17 +6845,11 @@ orbit_TimeAtPericenter=2435262.66690
 orbit_good=1000
 radius=5
 slope_parameter=3.9
-tex_map=nomap.png
 type=comet
 
 [C_Mrkos%281957d_1957V%29]
 absolute_magnitude=4.1
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Mrkos (1957d=1957V)"
 orbit_ArgOfPericenter=40.31350
 orbit_AscendingNode=67.62520
@@ -9416,17 +6861,11 @@ orbit_TimeAtPericenter=2436051.93730
 orbit_good=1000
 radius=5
 slope_parameter=3.1
-tex_map=nomap.png
 type=comet
 
 [C_Mrkos%281959j_1959IX%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Mrkos (1959j=1959IX)"
 orbit_ArgOfPericenter=84.67370
 orbit_AscendingNode=99.93960
@@ -9438,17 +6877,11 @@ orbit_TimeAtPericenter=2436885.71620
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Mrkos-Honda%281953a_1953III%29]
 absolute_magnitude=7.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Mrkos-Honda (1953a=1953III)"
 orbit_ArgOfPericenter=85.74640
 orbit_AscendingNode=275.18740
@@ -9460,17 +6893,11 @@ orbit_TimeAtPericenter=2434523.93580
 orbit_good=1000
 radius=5
 slope_parameter=7.2
-tex_map=nomap.png
 type=comet
 
 [C_Mueller%281993a%29]
 absolute_magnitude=5.6
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Mueller (1993a)
 orbit_ArgOfPericenter=130.66024
 orbit_AscendingNode=144.02147
@@ -9482,17 +6909,11 @@ orbit_TimeAtPericenter=2449365.39634
 orbit_good=1000
 radius=5
 slope_parameter=3.1
-tex_map=nomap.png
 type=comet
 
 [C_Mueller%281993d_1992XX%29]
 absolute_magnitude=5.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Mueller (1993d=1992XX)"
 orbit_ArgOfPericenter=61.87376
 orbit_AscendingNode=76.84051
@@ -9504,17 +6925,11 @@ orbit_TimeAtPericenter=2448838.06259
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Mueller%281993p%29]
 absolute_magnitude=7.7
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Mueller (1993p)
 orbit_ArgOfPericenter=261.03520
 orbit_AscendingNode=193.09095
@@ -9526,17 +6941,11 @@ orbit_TimeAtPericenter=2449437.77956
 orbit_good=1000
 radius=5
 slope_parameter=3.0
-tex_map=nomap.png
 type=comet
 
 [C_Nagata%281931b_1931III%29]
 absolute_magnitude=4.7
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Nagata (1931b=1931III)"
 orbit_ArgOfPericenter=320.14950
 orbit_AscendingNode=191.53950
@@ -9548,17 +6957,11 @@ orbit_TimeAtPericenter=2426504.26750
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Neujmin%281914c_1914III%29]
 absolute_magnitude=4.7
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Neujmin (1914c=1914III)"
 orbit_ArgOfPericenter=14.00600
 orbit_AscendingNode=270.81300
@@ -9570,17 +6973,11 @@ orbit_TimeAtPericenter=2420343.98660
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Newman%281932f_1932VII%29]
 absolute_magnitude=8.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Newman (1932f=1932VII)"
 orbit_ArgOfPericenter=69.79330
 orbit_AscendingNode=245.38980
@@ -9592,17 +6989,11 @@ orbit_TimeAtPericenter=2426975.05050
 orbit_good=1000
 radius=5
 slope_parameter=4.6
-tex_map=nomap.png
 type=comet
 
 [C_Nicollet-Pons%281821%29]
 absolute_magnitude=3.4
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Nicollet-Pons (1821)
 orbit_ArgOfPericenter=169.20600
 orbit_AscendingNode=50.48400
@@ -9614,17 +7005,11 @@ orbit_TimeAtPericenter=2386246.53660
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Nishikawa-Takamizawa-Tago%281987c_1987III%29]
 absolute_magnitude=6.6
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Nishikawa-Takamizawa-Tago (1987c=1987III)"
 orbit_ArgOfPericenter=200.40210
 orbit_AscendingNode=175.31400
@@ -9636,17 +7021,11 @@ orbit_TimeAtPericenter=2446871.84400
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Okazaki-Levy-Rudenko%281989r_1989XIX%29]
 absolute_magnitude=7.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Okazaki-Levy-Rudenko (1989r=1989XIX)"
 orbit_ArgOfPericenter=150.57043
 orbit_AscendingNode=274.81228
@@ -9658,17 +7037,11 @@ orbit_TimeAtPericenter=2447842.41458
 orbit_good=1000
 radius=5
 slope_parameter=2.3
-tex_map=nomap.png
 type=comet
 
 [C_Olbers%281796%29]
 absolute_magnitude=7.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Olbers (1796)
 orbit_ArgOfPericenter=184.29400
 orbit_AscendingNode=19.19780
@@ -9680,17 +7053,11 @@ orbit_TimeAtPericenter=2377128.77370
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Orkisz%281925c_1925I%29]
 absolute_magnitude=5.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Orkisz (1925c=1925I)"
 orbit_ArgOfPericenter=36.18540
 orbit_AscendingNode=318.41180
@@ -9702,17 +7069,11 @@ orbit_TimeAtPericenter=2424242.00650
 orbit_good=1000
 radius=5
 slope_parameter=3.2
-tex_map=nomap.png
 type=comet
 
 [C_Oterma%281942b_1942VIII%29]
 absolute_magnitude=5.7
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Oterma (1942b=1942VIII)"
 orbit_ArgOfPericenter=163.66880
 orbit_AscendingNode=280.38860
@@ -9724,17 +7085,11 @@ orbit_TimeAtPericenter=2430629.77830
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Pajdusakova%281951a_1951II%29]
 absolute_magnitude=9.7
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Pajdusakova (1951a=1951II)"
 orbit_ArgOfPericenter=68.60650
 orbit_AscendingNode=310.52110
@@ -9746,17 +7101,11 @@ orbit_TimeAtPericenter=2433676.92630
 orbit_good=1000
 radius=5
 slope_parameter=4.8
-tex_map=nomap.png
 type=comet
 
 [C_Pajdusakova-Mrkos%281948d_1948V%29]
 absolute_magnitude=4.4
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Pajdusakova-Mrkos (1948d=1948V)"
 orbit_ArgOfPericenter=66.90430
 orbit_AscendingNode=246.95430
@@ -9768,17 +7117,11 @@ orbit_TimeAtPericenter=2432688.11230
 orbit_good=1000
 radius=5
 slope_parameter=4.4
-tex_map=nomap.png
 type=comet
 
 [C_Pajdusakova-Rotbart-Weber%281946d_1946II%29]
 absolute_magnitude=9.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Pajdusakova-Rotbart-Weber (1946d=1946II)"
 orbit_ArgOfPericenter=22.26170
 orbit_AscendingNode=301.30640
@@ -9790,17 +7133,11 @@ orbit_TimeAtPericenter=2431951.93660
 orbit_good=1000
 radius=5
 slope_parameter=8.0
-tex_map=nomap.png
 type=comet
 
 [C_Palisa%281879d_1879V%29]
 absolute_magnitude=5.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Palisa (1879d=1879V)"
 orbit_ArgOfPericenter=115.44930
 orbit_AscendingNode=88.17180
@@ -9812,17 +7149,11 @@ orbit_TimeAtPericenter=2407627.62500
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Panther%281980u_1981II%29]
 absolute_magnitude=6.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Panther (1980u=1981II)"
 orbit_ArgOfPericenter=105.60340
 orbit_AscendingNode=331.29920
@@ -9834,17 +7165,11 @@ orbit_TimeAtPericenter=2444631.82300
 orbit_good=1000
 radius=5
 slope_parameter=3.3
-tex_map=nomap.png
 type=comet
 
 [C_Pechule%281880f_1880V%29]
 absolute_magnitude=5.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Pechule (1880f=1880V)"
 orbit_ArgOfPericenter=11.69490
 orbit_AscendingNode=250.34740
@@ -9856,17 +7181,11 @@ orbit_TimeAtPericenter=2408029.42000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Peltier%281933a_1933I%29]
 absolute_magnitude=9.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Peltier (1933a=1933I)"
 orbit_ArgOfPericenter=135.99190
 orbit_AscendingNode=311.76750
@@ -9878,17 +7197,11 @@ orbit_TimeAtPericenter=2427110.19900
 orbit_good=1000
 radius=5
 slope_parameter=7.5
-tex_map=nomap.png
 type=comet
 
 [C_Peltier%281936a_1936II%29]
 absolute_magnitude=6.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Peltier (1936a=1936II)"
 orbit_ArgOfPericenter=148.47110
 orbit_AscendingNode=134.24310
@@ -9900,17 +7213,11 @@ orbit_TimeAtPericenter=2428358.45520
 orbit_good=1000
 radius=5
 slope_parameter=4.8
-tex_map=nomap.png
 type=comet
 
 [C_Peltier%281952d_1952VI%29]
 absolute_magnitude=9.1
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Peltier (1952d=1952VI)"
 orbit_ArgOfPericenter=96.58920
 orbit_AscendingNode=187.94260
@@ -9922,17 +7229,11 @@ orbit_TimeAtPericenter=2434208.75730
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Peltier-Whipple%281932k_1932V%29]
 absolute_magnitude=7.6
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Peltier-Whipple (1932k=1932V)"
 orbit_ArgOfPericenter=38.47250
 orbit_AscendingNode=344.76310
@@ -9944,17 +7245,11 @@ orbit_TimeAtPericenter=2426952.35900
 orbit_good=1000
 radius=5
 slope_parameter=8.4
-tex_map=nomap.png
 type=comet
 
 [C_Pereyra%281963e_1963V%29]
 absolute_magnitude=4.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Pereyra (1963e=1963V)"
 orbit_ArgOfPericenter=86.15760
 orbit_AscendingNode=7.23880
@@ -9966,17 +7261,11 @@ orbit_TimeAtPericenter=2438265.45640
 orbit_good=1000
 radius=5
 slope_parameter=6.4
-tex_map=nomap.png
 type=comet
 
 [C_Perny%281793II%29]
 absolute_magnitude=5.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Perny (1793II)
 orbit_ArgOfPericenter=69.33470
 orbit_AscendingNode=4.47730
@@ -9988,17 +7277,11 @@ orbit_TimeAtPericenter=2376263.49830
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Perrine%281895c_1895IV%29]
 absolute_magnitude=5.7
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Perrine (1895c=1895IV)"
 orbit_ArgOfPericenter=272.67230
 orbit_AscendingNode=321.26140
@@ -10010,17 +7293,11 @@ orbit_TimeAtPericenter=2413546.32920
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Perrine%281896f_1897I%29]
 absolute_magnitude=7.7
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Perrine (1896f=1897I)"
 orbit_ArgOfPericenter=172.32770
 orbit_AscendingNode=87.22330
@@ -10032,17 +7309,11 @@ orbit_TimeAtPericenter=2413964.10400
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Perrine%281897b_1897III%29]
 absolute_magnitude=8.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Perrine (1897b=1897III)"
 orbit_ArgOfPericenter=65.90390
 orbit_AscendingNode=32.79080
@@ -10054,17 +7325,11 @@ orbit_TimeAtPericenter=2414267.64260
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Perrine%281898b_1898I%29]
 absolute_magnitude=4.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Perrine (1898b=1898I)"
 orbit_ArgOfPericenter=47.31410
 orbit_AscendingNode=263.16750
@@ -10076,17 +7341,11 @@ orbit_TimeAtPericenter=2414366.13200
 orbit_good=1000
 radius=5
 slope_parameter=5.6
-tex_map=nomap.png
 type=comet
 
 [C_Perrine%281898e_1898VI%29]
 absolute_magnitude=7.6
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Perrine (1898e=1898VI)"
 orbit_ArgOfPericenter=205.62040
 orbit_AscendingNode=259.82700
@@ -10098,17 +7357,11 @@ orbit_TimeAtPericenter=2414518.20560
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Perrine%281902b_1902III%29]
 absolute_magnitude=5.9
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Perrine (1902b=1902III)"
 orbit_ArgOfPericenter=152.97040
 orbit_AscendingNode=50.02990
@@ -10120,17 +7373,11 @@ orbit_TimeAtPericenter=2416077.85670
 orbit_good=1000
 radius=5
 slope_parameter=4.2
-tex_map=nomap.png
 type=comet
 
 [C_Perrine-Chofardet%281898h_1898IX%29]
 absolute_magnitude=6.7
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Perrine-Chofardet (1898h=1898IX)"
 orbit_ArgOfPericenter=162.36720
 orbit_AscendingNode=35.60460
@@ -10142,17 +7389,11 @@ orbit_TimeAtPericenter=2414583.53960
 orbit_good=1000
 radius=5
 slope_parameter=2.8
-tex_map=nomap.png
 type=comet
 
 [C_Perrine-Lamp%281896a_1896I%29]
 absolute_magnitude=8.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Perrine-Lamp (1896a=1896I)"
 orbit_ArgOfPericenter=358.32440
 orbit_AscendingNode=209.58860
@@ -10164,17 +7405,11 @@ orbit_TimeAtPericenter=2413590.77660
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Peters%281857IV%29]
 absolute_magnitude=9.1
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Peters (1857IV)
 orbit_ArgOfPericenter=180.94950
 orbit_AscendingNode=202.12810
@@ -10186,17 +7421,11 @@ orbit_TimeAtPericenter=2399550.99640
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Petersen%281848I%29]
 absolute_magnitude=8.1
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Petersen (1848I)
 orbit_ArgOfPericenter=260.95180
 orbit_AscendingNode=212.95170
@@ -10208,17 +7437,11 @@ orbit_TimeAtPericenter=2396279.04530
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Petersen%281849I%29]
 absolute_magnitude=4.6
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Petersen (1849I)
 orbit_ArgOfPericenter=208.01100
 orbit_AscendingNode=216.63430
@@ -10230,17 +7453,11 @@ orbit_TimeAtPericenter=2396412.35340
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Petersen%281850I%29]
 absolute_magnitude=6.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Petersen (1850I)
 orbit_ArgOfPericenter=180.54260
 orbit_AscendingNode=94.28730
@@ -10252,17 +7469,11 @@ orbit_TimeAtPericenter=2396962.52860
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Pogson%281872%29]
 absolute_magnitude=6.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Pogson (1872)
 orbit_ArgOfPericenter=63.40000
 orbit_AscendingNode=46.95000
@@ -10274,17 +7485,11 @@ orbit_TimeAtPericenter=2405144.11600
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Pons%281801%29]
 absolute_magnitude=9.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Pons (1801)
 orbit_ArgOfPericenter=219.82600
 orbit_AscendingNode=44.60100
@@ -10296,17 +7501,11 @@ orbit_TimeAtPericenter=2379081.55650
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Pons%281802%29]
 absolute_magnitude=8.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Pons (1802)
 orbit_ArgOfPericenter=21.85300
 orbit_AscendingNode=312.31280
@@ -10318,17 +7517,11 @@ orbit_TimeAtPericenter=2379478.85540
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Pons%281804%29]
 absolute_magnitude=8.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Pons (1804)
 orbit_ArgOfPericenter=331.94600
 orbit_AscendingNode=178.83600
@@ -10340,17 +7533,11 @@ orbit_TimeAtPericenter=2380000.58810
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Pons%281806II%29]
 absolute_magnitude=6.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Pons (1806II)
 orbit_ArgOfPericenter=225.21900
 orbit_AscendingNode=324.29300
@@ -10362,17 +7549,11 @@ orbit_TimeAtPericenter=2381049.91180
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Pons%281808I%29]
 absolute_magnitude=6.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Pons (1808I)
 orbit_ArgOfPericenter=253.74800
 orbit_AscendingNode=324.94600
@@ -10384,17 +7565,11 @@ orbit_TimeAtPericenter=2381550.95300
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Pons%281808II%29]
 absolute_magnitude=9.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Pons (1808II)
 orbit_ArgOfPericenter=131.55500
 orbit_AscendingNode=26.17400
@@ -10406,17 +7581,11 @@ orbit_TimeAtPericenter=2381611.16770
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Pons%281810%29]
 absolute_magnitude=6.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Pons (1810)
 orbit_ArgOfPericenter=114.92260
 orbit_AscendingNode=310.80260
@@ -10428,17 +7597,11 @@ orbit_TimeAtPericenter=2382427.23790
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Pons%281811II%29]
 absolute_magnitude=5.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Pons (1811II)
 orbit_ArgOfPericenter=314.48980
 orbit_AscendingNode=94.94260
@@ -10450,17 +7613,11 @@ orbit_TimeAtPericenter=2382828.04270
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Pons%281813I%29]
 absolute_magnitude=9.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Pons (1813I)
 orbit_ArgOfPericenter=170.57960
 orbit_AscendingNode=242.46270
@@ -10472,17 +7629,11 @@ orbit_TimeAtPericenter=2383307.52200
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Pons%281813II%29]
 absolute_magnitude=4.4
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Pons (1813II)
 orbit_ArgOfPericenter=205.15700
 orbit_AscendingNode=44.57600
@@ -10494,17 +7645,11 @@ orbit_TimeAtPericenter=2383383.58720
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Pons%281816%29]
 absolute_magnitude=8.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Pons (1816)
 orbit_ArgOfPericenter=304.33100
 orbit_AscendingNode=325.12700
@@ -10516,17 +7661,11 @@ orbit_TimeAtPericenter=2384400.34600
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Pons%281818II%29]
 absolute_magnitude=4.7
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Pons (1818II)
 orbit_ArgOfPericenter=112.35560
 orbit_AscendingNode=72.29650
@@ -10538,17 +7677,11 @@ orbit_TimeAtPericenter=2385126.96900
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Pons%281818III%29]
 absolute_magnitude=8.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Pons (1818III)
 orbit_ArgOfPericenter=348.10000
 orbit_AscendingNode=91.83500
@@ -10560,17 +7693,11 @@ orbit_TimeAtPericenter=2385408.93470
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Pons%281822III%29]
 absolute_magnitude=7.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Pons (1822III)
 orbit_ArgOfPericenter=237.76500
 orbit_AscendingNode=99.53400
@@ -10582,17 +7709,11 @@ orbit_TimeAtPericenter=2386727.83370
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Pons%281822IV%29]
 absolute_magnitude=2.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Pons (1822IV)
 orbit_ArgOfPericenter=181.09740
 orbit_AscendingNode=94.53910
@@ -10604,17 +7725,11 @@ orbit_TimeAtPericenter=2386827.76570
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [C_Pons%281825II%29]
 absolute_magnitude=6.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Pons (1825II)
 orbit_ArgOfPericenter=177.29870
 orbit_AscendingNode=194.68090
@@ -10626,17 +7741,11 @@ orbit_TimeAtPericenter=2387857.71110
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Pons%281825IV%29]
 absolute_magnitude=2.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Pons (1825IV)
 orbit_ArgOfPericenter=256.92540
 orbit_AscendingNode=217.43770
@@ -10648,17 +7757,11 @@ orbit_TimeAtPericenter=2387971.68500
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Pons%281826II%29]
 absolute_magnitude=2.4
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Pons (1826II)
 orbit_ArgOfPericenter=279.38830
 orbit_AscendingNode=199.35720
@@ -10670,17 +7773,11 @@ orbit_TimeAtPericenter=2388103.95810
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Pons%281826IV%29]
 absolute_magnitude=6.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Pons (1826IV)
 orbit_ArgOfPericenter=13.79850
 orbit_AscendingNode=45.71430
@@ -10692,17 +7789,11 @@ orbit_TimeAtPericenter=2388273.97610
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Pons%281826V%29]
 absolute_magnitude=7.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Pons (1826V)
 orbit_ArgOfPericenter=279.58920
 orbit_AscendingNode=236.85200
@@ -10714,17 +7805,11 @@ orbit_TimeAtPericenter=2388314.40740
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Pons%281827I%29]
 absolute_magnitude=6.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Pons (1827I)
 orbit_ArgOfPericenter=151.03530
 orbit_AscendingNode=186.29420
@@ -10736,17 +7821,11 @@ orbit_TimeAtPericenter=2388392.91100
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Pons%281827III%29]
 absolute_magnitude=7.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Pons (1827III)
 orbit_ArgOfPericenter=258.70070
 orbit_AscendingNode=151.40030
@@ -10758,17 +7837,11 @@ orbit_TimeAtPericenter=2388611.66700
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Quenisset%281911f_1911VI%29]
 absolute_magnitude=6.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Quenisset (1911f=1911VI)"
 orbit_ArgOfPericenter=122.03140
 orbit_AscendingNode=35.73130
@@ -10780,17 +7853,11 @@ orbit_TimeAtPericenter=2419353.34930
 orbit_good=1000
 radius=5
 slope_parameter=3.6
-tex_map=nomap.png
 type=comet
 
 [C_Reid%281918a_1918II%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Reid (1918a=1918II)"
 orbit_ArgOfPericenter=194.90300
 orbit_AscendingNode=18.14100
@@ -10802,17 +7869,11 @@ orbit_TimeAtPericenter=2421750.87940
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Reid%281921a_1921II%29]
 absolute_magnitude=6.7
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Reid (1921a=1921II)"
 orbit_ArgOfPericenter=64.49890
 orbit_AscendingNode=268.74680
@@ -10824,17 +7885,11 @@ orbit_TimeAtPericenter=2422819.94960
 orbit_good=1000
 radius=5
 slope_parameter=3.8
-tex_map=nomap.png
 type=comet
 
 [C_Reid%281922a_1921V%29]
 absolute_magnitude=6.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Reid (1922a=1921V)"
 orbit_ArgOfPericenter=183.69320
 orbit_AscendingNode=274.89050
@@ -10846,17 +7901,11 @@ orbit_TimeAtPericenter=2422991.26610
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Reid%281924a_1924I%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Reid (1924a=1924I)"
 orbit_ArgOfPericenter=271.43410
 orbit_AscendingNode=114.37710
@@ -10868,17 +7917,11 @@ orbit_TimeAtPericenter=2423858.44930
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Reid%281925b_1925III%29]
 absolute_magnitude=3.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Reid (1925b=1925III)"
 orbit_ArgOfPericenter=259.27470
 orbit_AscendingNode=6.34410
@@ -10890,17 +7933,11 @@ orbit_TimeAtPericenter=2424361.36690
 orbit_good=1000
 radius=5
 slope_parameter=5.2
-tex_map=nomap.png
 type=comet
 
 [C_Respighi%281862IV%29]
 absolute_magnitude=6.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Respighi (1862IV)
 orbit_ArgOfPericenter=230.57600
 orbit_AscendingNode=356.99640
@@ -10912,17 +7949,11 @@ orbit_TimeAtPericenter=2401503.17410
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Respighi%281863III%29]
 absolute_magnitude=6.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Respighi (1863III)
 orbit_ArgOfPericenter=55.59890
 orbit_AscendingNode=251.38340
@@ -10934,17 +7965,11 @@ orbit_TimeAtPericenter=2401616.86460
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Respighi%281863V%29]
 absolute_magnitude=8.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Respighi (1863V)
 orbit_ArgOfPericenter=115.67460
 orbit_AscendingNode=305.92780
@@ -10956,17 +7981,11 @@ orbit_TimeAtPericenter=2401867.76270
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Rondanina-Bester%281947b_1947IV%29]
 absolute_magnitude=7.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Rondanina-Bester (1947b=1947IV)"
 orbit_ArgOfPericenter=303.75480
 orbit_AscendingNode=353.21110
@@ -10978,17 +7997,11 @@ orbit_TimeAtPericenter=2432326.46280
 orbit_good=1000
 radius=5
 slope_parameter=3.8
-tex_map=nomap.png
 type=comet
 
 [C_Rordame-Quenisset%281893b_1893II%29]
 absolute_magnitude=6.6
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Rordame-Quenisset (1893b=1893II)"
 orbit_ArgOfPericenter=47.12310
 orbit_AscendingNode=338.14030
@@ -11000,17 +8013,11 @@ orbit_TimeAtPericenter=2412652.27150
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Ross%281884a_1883II%29]
 absolute_magnitude=7.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Ross (1884a=1883II)"
 orbit_ArgOfPericenter=138.60400
 orbit_AscendingNode=265.29700
@@ -11022,17 +8029,11 @@ orbit_TimeAtPericenter=2409170.29260
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Rudenko%281987u_1987XXIII%29]
 absolute_magnitude=8.6
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Rudenko (1987u=1987XXIII)"
 orbit_ArgOfPericenter=143.83958
 orbit_AscendingNode=297.87356
@@ -11044,17 +8045,11 @@ orbit_TimeAtPericenter=2447078.02812
 orbit_good=1000
 radius=5
 slope_parameter=3.8
-tex_map=nomap.png
 type=comet
 
 [C_Rudnicki%281966e_1967II%29]
 absolute_magnitude=9.7
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Rudnicki (1966e=1967II)"
 orbit_ArgOfPericenter=79.74330
 orbit_AscendingNode=75.04940
@@ -11066,17 +8061,11 @@ orbit_TimeAtPericenter=2439511.38430
 orbit_good=1000
 radius=5
 slope_parameter=3.8
-tex_map=nomap.png
 type=comet
 
 [C_Rumker%281860II%29]
 absolute_magnitude=5.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Rumker (1860II)
 orbit_ArgOfPericenter=41.21490
 orbit_AscendingNode=10.12910
@@ -11088,17 +8077,11 @@ orbit_TimeAtPericenter=2400475.56550
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Russell%281980l_1981V%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Russell (1980l=1981V)"
 orbit_ArgOfPericenter=297.19980
 orbit_AscendingNode=232.09480
@@ -11110,17 +8093,11 @@ orbit_TimeAtPericenter=2444669.66410
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Ryves%281931c_1931IV%29]
 absolute_magnitude=7.4
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Ryves (1931c=1931IV)"
 orbit_ArgOfPericenter=168.11190
 orbit_AscendingNode=101.54600
@@ -11132,17 +8109,11 @@ orbit_TimeAtPericenter=2426579.41250
 orbit_good=1000
 radius=5
 slope_parameter=4.5
-tex_map=nomap.png
 type=comet
 
 [C_R%81mker%281824I%29]
 absolute_magnitude=7.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/R\x81mker (1824I)
 orbit_ArgOfPericenter=334.08700
 orbit_AscendingNode=236.10080
@@ -11154,17 +8125,11 @@ orbit_TimeAtPericenter=2387454.51880
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Sandage%281972h_1972IX%29]
 absolute_magnitude=9.1
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Sandage (1972h=1972IX)"
 orbit_ArgOfPericenter=56.66280
 orbit_AscendingNode=224.78680
@@ -11176,17 +8141,11 @@ orbit_TimeAtPericenter=2441636.30930
 orbit_good=1000
 radius=5
 slope_parameter=0.4
-tex_map=nomap.png
 type=comet
 
 [C_Sandage%281973k_1973X%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Sandage (1973k=1973X)"
 orbit_ArgOfPericenter=72.55230
 orbit_AscendingNode=278.54590
@@ -11198,17 +8157,11 @@ orbit_TimeAtPericenter=2441994.64810
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Sawerthal%281888a_1888I%29]
 absolute_magnitude=4.7
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Sawerthal (1888a=1888I)"
 orbit_ArgOfPericenter=359.91410
 orbit_AscendingNode=246.25700
@@ -11220,17 +8173,11 @@ orbit_TimeAtPericenter=2410714.00210
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Schaeberle%281880b_1880II%29]
 absolute_magnitude=2.7
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Schaeberle (1880b=1880II)"
 orbit_ArgOfPericenter=145.17530
 orbit_AscendingNode=258.23040
@@ -11242,17 +8189,11 @@ orbit_TimeAtPericenter=2407898.70380
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Schaeberle%281881c_1881IV%29]
 absolute_magnitude=6.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Schaeberle (1881c=1881IV)"
 orbit_ArgOfPericenter=122.13560
 orbit_AscendingNode=98.01750
@@ -11264,17 +8205,11 @@ orbit_TimeAtPericenter=2408315.30600
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Schaer%281905b_1905V%29]
 absolute_magnitude=9.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Schaer (1905b=1905V)"
 orbit_ArgOfPericenter=132.70140
 orbit_AscendingNode=223.55680
@@ -11286,17 +8221,11 @@ orbit_TimeAtPericenter=2417144.76260
 orbit_good=1000
 radius=5
 slope_parameter=7.4
-tex_map=nomap.png
 type=comet
 
 [C_Schaumasse%281913a_1913II%29]
 absolute_magnitude=7.9
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Schaumasse (1913a=1913II)"
 orbit_ArgOfPericenter=52.96640
 orbit_AscendingNode=315.57140
@@ -11308,17 +8237,11 @@ orbit_TimeAtPericenter=2419903.09790
 orbit_good=1000
 radius=5
 slope_parameter=4.6
-tex_map=nomap.png
 type=comet
 
 [C_Schaumasse%281917b_1917II%29]
 absolute_magnitude=9.4
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Schaumasse (1917b=1917II)"
 orbit_ArgOfPericenter=119.15600
 orbit_AscendingNode=10.13200
@@ -11330,17 +8253,11 @@ orbit_TimeAtPericenter=2421367.21030
 orbit_good=1000
 radius=5
 slope_parameter=-1.6
-tex_map=nomap.png
 type=comet
 
 [C_Scheithauer%281824II%29]
 absolute_magnitude=6.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Scheithauer (1824II)
 orbit_ArgOfPericenter=85.23680
 orbit_AscendingNode=281.03850
@@ -11352,17 +8269,11 @@ orbit_TimeAtPericenter=2387534.06640
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Schmidt%281862II%29]
 absolute_magnitude=9.4
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Schmidt (1862II)
 orbit_ArgOfPericenter=27.18800
 orbit_AscendingNode=327.75990
@@ -11374,17 +8285,11 @@ orbit_TimeAtPericenter=2401314.02960
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Schuster%281976c_1975II%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Schuster (1976c=1975II)"
 orbit_ArgOfPericenter=193.42340
 orbit_AscendingNode=22.08720
@@ -11396,17 +8301,11 @@ orbit_TimeAtPericenter=2442428.03680
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Schweizer%281847IV%29]
 absolute_magnitude=5.7
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Schweizer (1847IV)
 orbit_ArgOfPericenter=55.45970
 orbit_AscendingNode=78.17490
@@ -11418,17 +8317,11 @@ orbit_TimeAtPericenter=2395883.34510
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Schweizer%281849III%29]
 absolute_magnitude=7.4
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Schweizer (1849III)
 orbit_ArgOfPericenter=236.58250
 orbit_AscendingNode=31.93820
@@ -11440,17 +8333,11 @@ orbit_TimeAtPericenter=2396552.21220
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Schweizer%281853II%29]
 absolute_magnitude=6.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Schweizer (1853II)
 orbit_ArgOfPericenter=199.22780
 orbit_AscendingNode=42.32030
@@ -11462,17 +8349,11 @@ orbit_TimeAtPericenter=2397983.82630
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Schweizer%281855I%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Schweizer (1855I)
 orbit_ArgOfPericenter=323.09520
 orbit_AscendingNode=191.04920
@@ -11484,17 +8365,11 @@ orbit_TimeAtPericenter=2398620.04740
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Seargent%281978m_1978XV%29]
 absolute_magnitude=8.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Seargent (1978m=1978XV)"
 orbit_ArgOfPericenter=207.75520
 orbit_AscendingNode=41.07670
@@ -11506,17 +8381,11 @@ orbit_TimeAtPericenter=2443766.34960
 orbit_good=1000
 radius=5
 slope_parameter=4.1
-tex_map=nomap.png
 type=comet
 
 [C_Secchi%281853I%29]
 absolute_magnitude=7.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Secchi (1853I)
 orbit_ArgOfPericenter=275.88680
 orbit_AscendingNode=70.94170
@@ -11528,17 +8397,11 @@ orbit_TimeAtPericenter=2397909.02130
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Seki%281961f_1961VIII%29]
 absolute_magnitude=8.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Seki (1961f=1961VIII)"
 orbit_ArgOfPericenter=126.59000
 orbit_AscendingNode=246.67040
@@ -11550,17 +8413,11 @@ orbit_TimeAtPericenter=2437583.14080
 orbit_good=1000
 radius=5
 slope_parameter=2.1
-tex_map=nomap.png
 type=comet
 
 [C_Seki%281967b_1967IV%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Seki (1967b=1967IV)"
 orbit_ArgOfPericenter=144.31610
 orbit_AscendingNode=199.84240
@@ -11572,17 +8429,11 @@ orbit_TimeAtPericenter=2439563.24250
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Seki-Lines%281962c_1962III%29]
 absolute_magnitude=5.9
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Seki-Lines (1962c=1962III)"
 orbit_ArgOfPericenter=11.47870
 orbit_AscendingNode=303.97670
@@ -11594,17 +8445,11 @@ orbit_TimeAtPericenter=2437756.16290
 orbit_good=1000
 radius=5
 slope_parameter=3.4
-tex_map=nomap.png
 type=comet
 
 [C_Shajn-ComasSola%281925a_1925VI%29]
 absolute_magnitude=2.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Shajn-Comas Sola (1925a=1925VI)"
 orbit_ArgOfPericenter=205.75950
 orbit_AscendingNode=357.84030
@@ -11616,17 +8461,11 @@ orbit_TimeAtPericenter=2424400.44640
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Shoemaker%281983p_1983XV%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Shoemaker (1983p=1983XV)"
 orbit_ArgOfPericenter=176.03678
 orbit_AscendingNode=163.98408
@@ -11638,17 +8477,11 @@ orbit_TimeAtPericenter=2445662.29309
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Shoemaker%281984f_1985XII%29]
 absolute_magnitude=7.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Shoemaker (1984f=1985XII)"
 orbit_ArgOfPericenter=235.46185
 orbit_AscendingNode=48.98517
@@ -11660,17 +8493,11 @@ orbit_TimeAtPericenter=2446313.09229
 orbit_good=1000
 radius=5
 slope_parameter=2.2
-tex_map=nomap.png
 type=comet
 
 [C_Shoemaker%281984r_1984XV%29]
 absolute_magnitude=6.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Shoemaker (1984r=1984XV)"
 orbit_ArgOfPericenter=183.25423
 orbit_AscendingNode=238.02573
@@ -11682,17 +8509,11 @@ orbit_TimeAtPericenter=2445947.06105
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Shoemaker%281986b_1986IV%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Shoemaker (1986b=1986IV)"
 orbit_ArgOfPericenter=123.58702
 orbit_AscendingNode=294.15920
@@ -11704,17 +8525,11 @@ orbit_TimeAtPericenter=2446500.79390
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Shoemaker%281987o_1986XIV%29]
 absolute_magnitude=4.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Shoemaker (1987o=1986XIV)"
 orbit_ArgOfPericenter=17.00481
 orbit_AscendingNode=267.63309
@@ -11726,17 +8541,11 @@ orbit_TimeAtPericenter=2446751.60659
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Shoemaker%281988b_1987IV%29]
 absolute_magnitude=5.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Shoemaker (1988b=1987IV)"
 orbit_ArgOfPericenter=124.22255
 orbit_AscendingNode=324.46067
@@ -11748,17 +8557,11 @@ orbit_TimeAtPericenter=2446874.62030
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Shoemaker%281989e_1989III%29]
 absolute_magnitude=8.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Shoemaker (1989e=1989III)"
 orbit_ArgOfPericenter=19.10495
 orbit_AscendingNode=136.43957
@@ -11770,17 +8573,11 @@ orbit_TimeAtPericenter=2447583.59198
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Shoemaker%281992y%29]
 absolute_magnitude=9.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Shoemaker (1992y)
 orbit_ArgOfPericenter=54.85745
 orbit_AscendingNode=54.60344
@@ -11792,17 +8589,11 @@ orbit_TimeAtPericenter=2449072.17851
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Shoemaker-Holt-Rodriquez%281988h_1989V%29]
 absolute_magnitude=8.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Shoemaker-Holt-Rodriquez (1988h=1989V)"
 orbit_ArgOfPericenter=232.13695
 orbit_AscendingNode=114.55678
@@ -11814,17 +8605,11 @@ orbit_TimeAtPericenter=2447689.95956
 orbit_good=1000
 radius=5
 slope_parameter=1.9
-tex_map=nomap.png
 type=comet
 
 [C_Shoemaker-Levy%281991a1_1992XIX%29]
 absolute_magnitude=8.4
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Shoemaker-Levy (1991a1=1992XIX)"
 orbit_ArgOfPericenter=145.23450
 orbit_AscendingNode=48.34972
@@ -11836,17 +8621,11 @@ orbit_TimeAtPericenter=2448828.00690
 orbit_good=1000
 radius=5
 slope_parameter=2.1
-tex_map=nomap.png
 type=comet
 
 [C_Shoemaker-Levy%281991d_1991XXIV%29]
 absolute_magnitude=4.6
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Shoemaker-Levy (1991d=1991XXIV)"
 orbit_ArgOfPericenter=74.36161
 orbit_AscendingNode=144.43171
@@ -11858,17 +8637,11 @@ orbit_TimeAtPericenter=2448621.68037
 orbit_good=1000
 radius=5
 slope_parameter=4.8
-tex_map=nomap.png
 type=comet
 
 [C_Shoemaker-Levy%281993h%29]
 absolute_magnitude=6.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Shoemaker-Levy (1993h)
 orbit_ArgOfPericenter=232.45129
 orbit_AscendingNode=29.63120
@@ -11880,17 +8653,11 @@ orbit_TimeAtPericenter=2449385.52718
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Skjellerup%281922d_1923I%29]
 absolute_magnitude=7.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Skjellerup (1922d=1923I)"
 orbit_ArgOfPericenter=264.49910
 orbit_AscendingNode=262.34300
@@ -11902,17 +8669,11 @@ orbit_TimeAtPericenter=2423423.72320
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Skjellerup-Maristany%281927k_1927IX%29]
 absolute_magnitude=5.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Skjellerup-Maristany (1927k=1927IX)"
 orbit_ArgOfPericenter=47.15230
 orbit_AscendingNode=77.54560
@@ -11924,17 +8685,11 @@ orbit_TimeAtPericenter=2425232.68090
 orbit_good=1000
 radius=5
 slope_parameter=5.2
-tex_map=nomap.png
 type=comet
 
 [C_Skorichenko-George%281989e1_1990VI%29]
 absolute_magnitude=6.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Skorichenko-George (1989e1=1990VI)"
 orbit_ArgOfPericenter=137.84022
 orbit_AscendingNode=279.30703
@@ -11946,17 +8701,11 @@ orbit_TimeAtPericenter=2447993.42922
 orbit_good=1000
 radius=5
 slope_parameter=2.3
-tex_map=nomap.png
 type=comet
 
 [C_Sorrells%281986n_1987II%29]
 absolute_magnitude=3.9
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Sorrells (1986n=1987II)"
 orbit_ArgOfPericenter=70.21358
 orbit_AscendingNode=74.08787
@@ -11968,17 +8717,11 @@ orbit_TimeAtPericenter=2446864.15452
 orbit_good=1000
 radius=5
 slope_parameter=6.5
-tex_map=nomap.png
 type=comet
 
 [C_Southerncomet%281947n_1947XII%29]
 absolute_magnitude=7.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Southern comet (1947n=1947XII)"
 orbit_ArgOfPericenter=196.15520
 orbit_AscendingNode=336.60770
@@ -11990,17 +8733,11 @@ orbit_TimeAtPericenter=2432522.08450
 orbit_good=1000
 radius=5
 slope_parameter=5.5
-tex_map=nomap.png
 type=comet
 
 [C_Spacewatch%281992h%29]
 absolute_magnitude=8.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Spacewatch (1992h)
 orbit_ArgOfPericenter=83.40463
 orbit_AscendingNode=202.62738
@@ -12012,17 +8749,11 @@ orbit_TimeAtPericenter=2449236.04809
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Sperra%281896e_1896IV%29]
 absolute_magnitude=8.4
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Sperra (1896e=1896IV)"
 orbit_ArgOfPericenter=41.05570
 orbit_AscendingNode=151.74160
@@ -12034,17 +8765,11 @@ orbit_TimeAtPericenter=2413751.94280
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Stearns%281927d_1927IV%29]
 absolute_magnitude=1.9
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Stearns (1927d=1927IV)"
 orbit_ArgOfPericenter=11.14070
 orbit_AscendingNode=214.95170
@@ -12056,17 +8781,11 @@ orbit_TimeAtPericenter=2424962.24910
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Suzuki-Saigusa-Mori%281975k_1975X%29]
 absolute_magnitude=9.1
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Suzuki-Saigusa-Mori (1975k=1975X)"
 orbit_ArgOfPericenter=152.02410
 orbit_AscendingNode=216.10910
@@ -12078,17 +8797,11 @@ orbit_TimeAtPericenter=2442700.86020
 orbit_good=1000
 radius=5
 slope_parameter=2.2
-tex_map=nomap.png
 type=comet
 
 [C_Suzuki-Sato-Seki%281970m_1970X%29]
 absolute_magnitude=8.1
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Suzuki-Sato-Seki (1970m=1970X)"
 orbit_ArgOfPericenter=318.52860
 orbit_AscendingNode=292.97850
@@ -12100,17 +8813,11 @@ orbit_TimeAtPericenter=2440861.29540
 orbit_good=1000
 radius=5
 slope_parameter=2.1
-tex_map=nomap.png
 type=comet
 
 [C_Swift%281878a_1878I%29]
 absolute_magnitude=8.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Swift (1878a=1878I)"
 orbit_ArgOfPericenter=177.58350
 orbit_AscendingNode=103.26720
@@ -12122,17 +8829,11 @@ orbit_TimeAtPericenter=2407186.69070
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Swift%281879c_1879II%29]
 absolute_magnitude=4.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Swift (1879c=1879II)"
 orbit_ArgOfPericenter=3.74750
 orbit_AscendingNode=46.75450
@@ -12144,17 +8845,11 @@ orbit_TimeAtPericenter=2407467.42250
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Swift%281881a_1881II%29]
 absolute_magnitude=8.4
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Swift (1881a=1881II)"
 orbit_ArgOfPericenter=173.80080
 orbit_AscendingNode=127.40970
@@ -12166,17 +8861,11 @@ orbit_TimeAtPericenter=2408221.44090
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Swift%281881g_1881VIII%29]
 absolute_magnitude=4.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Swift (1881g=1881VIII)"
 orbit_ArgOfPericenter=117.95030
 orbit_AscendingNode=182.34210
@@ -12188,17 +8877,11 @@ orbit_TimeAtPericenter=2408404.74180
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Swift%281892a_1892I%29]
 absolute_magnitude=3.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Swift (1892a=1892I)"
 orbit_ArgOfPericenter=24.50700
 orbit_AscendingNode=241.72370
@@ -12210,17 +8893,11 @@ orbit_TimeAtPericenter=2412195.65170
 orbit_good=1000
 radius=5
 slope_parameter=3.9
-tex_map=nomap.png
 type=comet
 
 [C_Swift%281896b_1896III%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Swift (1896b=1896III)"
 orbit_ArgOfPericenter=1.73930
 orbit_AscendingNode=179.00190
@@ -12232,17 +8909,11 @@ orbit_TimeAtPericenter=2413667.64730
 orbit_good=1000
 radius=5
 slope_parameter=5.4
-tex_map=nomap.png
 type=comet
 
 [C_Swift%281899a_1899I%29]
 absolute_magnitude=5.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Swift (1899a=1899I)"
 orbit_ArgOfPericenter=8.70400
 orbit_AscendingNode=25.70450
@@ -12254,17 +8925,11 @@ orbit_TimeAtPericenter=2414757.97810
 orbit_good=1000
 radius=5
 slope_parameter=5.6
-tex_map=nomap.png
 type=comet
 
 [C_Swift-Borrelly-Block%281877c_1877III%29]
 absolute_magnitude=8.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Swift-Borrelly-Block (1877c=1877III)"
 orbit_ArgOfPericenter=116.77300
 orbit_AscendingNode=347.09970
@@ -12276,17 +8941,11 @@ orbit_TimeAtPericenter=2406736.80580
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Tago-Honda-Yamamoto%281968a_1968IV%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Tago-Honda-Yamamoto (1968a=1968IV)"
 orbit_ArgOfPericenter=50.45570
 orbit_AscendingNode=232.40770
@@ -12298,17 +8957,11 @@ orbit_TimeAtPericenter=2439992.77590
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Tago-Sato-Kosaka%281969g_1969IX%29]
 absolute_magnitude=6.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Tago-Sato-Kosaka (1969g=1969IX)"
 orbit_ArgOfPericenter=267.82740
 orbit_AscendingNode=100.96290
@@ -12320,17 +8973,11 @@ orbit_TimeAtPericenter=2440576.76770
 orbit_good=1000
 radius=5
 slope_parameter=2.7
-tex_map=nomap.png
 type=comet
 
 [C_Takamizawa%281994i%29]
 absolute_magnitude=6.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Takamizawa (1994i)
 orbit_ArgOfPericenter=191.68543
 orbit_AscendingNode=50.41217
@@ -12342,17 +8989,11 @@ orbit_TimeAtPericenter=2449532.37673
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Takamizawa-Levy%281994f%29]
 absolute_magnitude=7.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Takamizawa-Levy (1994f)
 orbit_ArgOfPericenter=61.64200
 orbit_AscendingNode=306.13900
@@ -12364,17 +9005,11 @@ orbit_TimeAtPericenter=2449495.04200
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Tanaka-Machholz%281992d_1992X%29]
 absolute_magnitude=6.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Tanaka-Machholz (1992d=1992X)"
 orbit_ArgOfPericenter=65.48003
 orbit_AscendingNode=299.80867
@@ -12386,17 +9021,11 @@ orbit_TimeAtPericenter=2448735.19020
 orbit_good=1000
 radius=5
 slope_parameter=2.6
-tex_map=nomap.png
 type=comet
 
 [C_Tempel%281859%29]
 absolute_magnitude=7.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Tempel (1859)
 orbit_ArgOfPericenter=282.00450
 orbit_AscendingNode=358.61600
@@ -12408,17 +9037,11 @@ orbit_TimeAtPericenter=2400194.22610
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Tempel%281860IV%29]
 absolute_magnitude=9.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Tempel (1860IV)
 orbit_ArgOfPericenter=311.96700
 orbit_AscendingNode=46.08400
@@ -12430,17 +9053,11 @@ orbit_TimeAtPericenter=2400676.31190
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Tempel%281863IV%29]
 absolute_magnitude=5.7
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Tempel (1863IV)
 orbit_ArgOfPericenter=357.20640
 orbit_AscendingNode=98.69680
@@ -12452,17 +9069,11 @@ orbit_TimeAtPericenter=2401819.47180
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Tempel%281864II%29]
 absolute_magnitude=6.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Tempel (1864II)
 orbit_ArgOfPericenter=151.38510
 orbit_AscendingNode=96.78060
@@ -12474,17 +9085,11 @@ orbit_TimeAtPericenter=2402099.57670
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Tempel%281869II%29]
 absolute_magnitude=5.1
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Tempel (1869II)
 orbit_ArgOfPericenter=188.19870
 orbit_AscendingNode=312.63090
@@ -12496,17 +9101,11 @@ orbit_TimeAtPericenter=2403980.84960
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Tempel%281871b_1871II%29]
 absolute_magnitude=6.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Tempel (1871b=1871II)"
 orbit_ArgOfPericenter=96.32610
 orbit_AscendingNode=213.00530
@@ -12518,17 +9117,11 @@ orbit_TimeAtPericenter=2404636.03440
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Tempel%281871e_1871IV%29]
 absolute_magnitude=8.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Tempel (1871e=1871IV)"
 orbit_ArgOfPericenter=242.89050
 orbit_AscendingNode=148.23010
@@ -12540,17 +9133,11 @@ orbit_TimeAtPericenter=2404782.37220
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Tempel%281877f_1877V%29]
 absolute_magnitude=6.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Tempel (1877f=1877V)"
 orbit_ArgOfPericenter=103.24500
 orbit_AscendingNode=185.30020
@@ -12562,17 +9149,11 @@ orbit_TimeAtPericenter=2406798.07030
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Terasako%281987d_1986XVIII%29]
 absolute_magnitude=6.9
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Terasako (1987d=1986XVIII)"
 orbit_ArgOfPericenter=195.26663
 orbit_AscendingNode=97.01482
@@ -12584,17 +9165,11 @@ orbit_TimeAtPericenter=2446789.37159
 orbit_good=1000
 radius=5
 slope_parameter=2.9
-tex_map=nomap.png
 type=comet
 
 [C_Thatcher%281861I%29]
 absolute_magnitude=5.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Thatcher (1861I)
 orbit_ArgOfPericenter=213.44570
 orbit_AscendingNode=31.16960
@@ -12606,17 +9181,11 @@ orbit_TimeAtPericenter=2400930.38990
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Thiele%281906g_1906VII%29]
 absolute_magnitude=7.6
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Thiele (1906g=1906VII)"
 orbit_ArgOfPericenter=8.63200
 orbit_AscendingNode=85.40910
@@ -12628,17 +9197,11 @@ orbit_TimeAtPericenter=2417536.22640
 orbit_good=1000
 radius=5
 slope_parameter=6.8
-tex_map=nomap.png
 type=comet
 
 [C_Thiele%281985m_1985XIX%29]
 absolute_magnitude=6.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Thiele (1985m=1985XIX)"
 orbit_ArgOfPericenter=52.99170
 orbit_AscendingNode=52.30780
@@ -12650,17 +9213,11 @@ orbit_TimeAtPericenter=2446418.71110
 orbit_good=1000
 radius=5
 slope_parameter=7.8
-tex_map=nomap.png
 type=comet
 
 [C_Thomas%281968j_1969I%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Thomas (1968j=1969I)"
 orbit_ArgOfPericenter=82.57650
 orbit_AscendingNode=15.41380
@@ -12672,17 +9229,11 @@ orbit_TimeAtPericenter=2440233.74730
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Timmers%281946a_1946I%29]
 absolute_magnitude=4.7
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Timmers (1946a=1946I)"
 orbit_ArgOfPericenter=54.32310
 orbit_AscendingNode=128.96790
@@ -12694,17 +9245,11 @@ orbit_TimeAtPericenter=2431923.76320
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [C_Toba%281971a_1971V%29]
 absolute_magnitude=6.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Toba (1971a=1971V)"
 orbit_ArgOfPericenter=152.35620
 orbit_AscendingNode=103.37530
@@ -12716,17 +9261,11 @@ orbit_TimeAtPericenter=2441058.74970
 orbit_good=1000
 radius=5
 slope_parameter=6.9
-tex_map=nomap.png
 type=comet
 
 [C_Tomita-Gerber-Honda%281964c_1964VI%29]
 absolute_magnitude=7.1
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Tomita-Gerber-Honda (1964c=1964VI)"
 orbit_ArgOfPericenter=58.43940
 orbit_AscendingNode=309.18570
@@ -12738,17 +9277,11 @@ orbit_TimeAtPericenter=2438577.12160
 orbit_good=1000
 radius=5
 slope_parameter=2.1
-tex_map=nomap.png
 type=comet
 
 [C_Torres%281979e_1979VI%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Torres (1979e=1979VI)"
 orbit_ArgOfPericenter=10.10680
 orbit_AscendingNode=292.43820
@@ -12760,17 +9293,11 @@ orbit_TimeAtPericenter=2444069.90260
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Torres%281980e_1980II%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Torres (1980e=1980II)"
 orbit_ArgOfPericenter=334.97070
 orbit_AscendingNode=278.82240
@@ -12782,17 +9309,11 @@ orbit_TimeAtPericenter=2444349.35580
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Torres%281987j_1987V%29]
 absolute_magnitude=6.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Torres (1987j=1987V)"
 orbit_ArgOfPericenter=329.09171
 orbit_AscendingNode=193.79059
@@ -12804,17 +9325,11 @@ orbit_TimeAtPericenter=2446895.77488
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Tsuchinshan%281977q_1977X%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Tsuchinshan (1977q=1977X)"
 orbit_ArgOfPericenter=318.16020
 orbit_AscendingNode=4.58100
@@ -12826,17 +9341,11 @@ orbit_TimeAtPericenter=2443349.30500
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Tsuchiya-Kiuchi%281990i_1990XVII%29]
 absolute_magnitude=5.7
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Tsuchiya-Kiuchi (1990i=1990XVII)"
 orbit_ArgOfPericenter=180.92356
 orbit_AscendingNode=330.04294
@@ -12848,17 +9357,11 @@ orbit_TimeAtPericenter=2448163.24177
 orbit_good=1000
 radius=5
 slope_parameter=4.8
-tex_map=nomap.png
 type=comet
 
 [C_Tuttle%281858VII%29]
 absolute_magnitude=5.9
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Tuttle (1858VII)
 orbit_ArgOfPericenter=155.53690
 orbit_AscendingNode=161.04230
@@ -12870,17 +9373,11 @@ orbit_TimeAtPericenter=2399965.81020
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Tuttle%281861III%29]
 absolute_magnitude=9.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Tuttle (1861III)
 orbit_ArgOfPericenter=331.59270
 orbit_AscendingNode=146.33530
@@ -12892,17 +9389,11 @@ orbit_TimeAtPericenter=2401117.17440
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_VanBiesbroeck%281925i_1925VII%29]
 absolute_magnitude=5.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Van Biesbroeck (1925i=1925VII)"
 orbit_ArgOfPericenter=106.40210
 orbit_AscendingNode=334.91260
@@ -12914,17 +9405,11 @@ orbit_TimeAtPericenter=2424426.47300
 orbit_good=1000
 radius=5
 slope_parameter=4.6
-tex_map=nomap.png
 type=comet
 
 [C_VanBiesbroeck%281935d_1936I%29]
 absolute_magnitude=5.4
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Van Biesbroeck (1935d=1936I)"
 orbit_ArgOfPericenter=44.90160
 orbit_AscendingNode=299.86050
@@ -12936,17 +9421,11 @@ orbit_TimeAtPericenter=2428300.13610
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Vozarova%281954f_1954VIII%29]
 absolute_magnitude=7.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Vozarova (1954f=1954VIII)"
 orbit_ArgOfPericenter=357.25440
 orbit_AscendingNode=122.12370
@@ -12958,17 +9437,11 @@ orbit_TimeAtPericenter=2434895.43500
 orbit_good=1000
 radius=5
 slope_parameter=3.7
-tex_map=nomap.png
 type=comet
 
 [C_V%84is%84l%84%281944b_1945I%29]
 absolute_magnitude=7.4
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/V\x84is\x84l\x84 (1944b=1945I)"
 orbit_ArgOfPericenter=238.93050
 orbit_AscendingNode=28.39780
@@ -12980,17 +9453,11 @@ orbit_TimeAtPericenter=2431459.56220
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Wells%281882a_1882I%29]
 absolute_magnitude=4.1
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Wells (1882a=1882I)"
 orbit_ArgOfPericenter=208.98890
 orbit_AscendingNode=205.89160
@@ -13002,17 +9469,11 @@ orbit_TimeAtPericenter=2408607.52960
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_West%281975n_1976VI%29]
 absolute_magnitude=4.7
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/West (1975n=1976VI)"
 orbit_ArgOfPericenter=358.41900
 orbit_AscendingNode=118.23130
@@ -13024,17 +9485,11 @@ orbit_TimeAtPericenter=2442833.72160
 orbit_good=1000
 radius=5
 slope_parameter=3.2
-tex_map=nomap.png
 type=comet
 
 [C_West%281978a_1977IX%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/West (1978a=1977IX)"
 orbit_ArgOfPericenter=343.28870
 orbit_AscendingNode=210.92700
@@ -13046,17 +9501,11 @@ orbit_TimeAtPericenter=2443346.05940
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Whipple%281937b_1937IV%29]
 absolute_magnitude=6.1
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Whipple (1937b=1937IV)"
 orbit_ArgOfPericenter=107.72730
 orbit_AscendingNode=127.91510
@@ -13068,17 +9517,11 @@ orbit_TimeAtPericenter=2428704.56240
 orbit_good=1000
 radius=5
 slope_parameter=3.7
-tex_map=nomap.png
 type=comet
 
 [C_Whipple-Bernasconi-Kulin%281942a_1942IV%29]
 absolute_magnitude=6.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Whipple-Bernasconi-Kulin (1942a=1942IV)"
 orbit_ArgOfPericenter=223.41740
 orbit_AscendingNode=340.23580
@@ -13090,17 +9533,11 @@ orbit_TimeAtPericenter=2430480.33330
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Whipple-Fedtke-Tevzadze%281943I%29]
 absolute_magnitude=4.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Whipple-Fedtke-Tevzadze (1943I)
 orbit_ArgOfPericenter=39.82450
 orbit_AscendingNode=100.11800
@@ -13112,17 +9549,11 @@ orbit_TimeAtPericenter=2430762.22110
 orbit_good=1000
 radius=5
 slope_parameter=3.8
-tex_map=nomap.png
 type=comet
 
 [C_Whitaker-Thomas%281968b_1968V%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Whitaker-Thomas (1968b=1968V)"
 orbit_ArgOfPericenter=353.98330
 orbit_AscendingNode=254.01450
@@ -13134,17 +9565,11 @@ orbit_TimeAtPericenter=2440012.00310
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_White-Ortiz-Bolelli%281970f_1970VI%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/White-Ortiz-Bolelli (1970f=1970VI)"
 orbit_ArgOfPericenter=61.29350
 orbit_AscendingNode=336.31860
@@ -13156,17 +9581,11 @@ orbit_TimeAtPericenter=2440720.98590
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Wild%281967c_1967III%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Wild (1967c=1967III)"
 orbit_ArgOfPericenter=173.26590
 orbit_AscendingNode=306.14710
@@ -13178,17 +9597,11 @@ orbit_TimeAtPericenter=2439552.02860
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Wild%281968f_1968III%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Wild (1968f=1968III)"
 orbit_ArgOfPericenter=101.69300
 orbit_AscendingNode=208.50200
@@ -13200,17 +9613,11 @@ orbit_TimeAtPericenter=2439946.75200
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Wilk%281929d_1930II%29]
 absolute_magnitude=8.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Wilk (1929d=1930II)"
 orbit_ArgOfPericenter=157.49490
 orbit_AscendingNode=179.27390
@@ -13222,17 +9629,11 @@ orbit_TimeAtPericenter=2425998.80980
 orbit_good=1000
 radius=5
 slope_parameter=4.2
-tex_map=nomap.png
 type=comet
 
 [C_Wilk%281930c_1930III%29]
 absolute_magnitude=9.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Wilk (1930c=1930III)"
 orbit_ArgOfPericenter=46.95280
 orbit_AscendingNode=90.54080
@@ -13244,17 +9645,11 @@ orbit_TimeAtPericenter=2426064.29970
 orbit_good=1000
 radius=5
 slope_parameter=4.9
-tex_map=nomap.png
 type=comet
 
 [C_Wilk-Peltier%281925k_1925XI%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Wilk-Peltier (1925k=1925XI)"
 orbit_ArgOfPericenter=126.12350
 orbit_AscendingNode=141.07810
@@ -13266,17 +9661,11 @@ orbit_TimeAtPericenter=2424491.76740
 orbit_good=1000
 radius=5
 slope_parameter=5.7
-tex_map=nomap.png
 type=comet
 
 [C_Wilson%281986l_1987VII%29]
 absolute_magnitude=5.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Wilson (1986l=1987VII)"
 orbit_ArgOfPericenter=238.29640
 orbit_AscendingNode=110.95848
@@ -13288,17 +9677,11 @@ orbit_TimeAtPericenter=2446906.28093
 orbit_good=1000
 radius=5
 slope_parameter=3.0
-tex_map=nomap.png
 type=comet
 
 [C_Wilson-Harrington%281951i_1952I%29]
 absolute_magnitude=9.4
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Wilson-Harrington (1951i=1952I)"
 orbit_ArgOfPericenter=269.60660
 orbit_AscendingNode=76.18330
@@ -13310,17 +9693,11 @@ orbit_TimeAtPericenter=2434024.44860
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Wilson-Hubbard%281961d_1961V%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Wilson-Hubbard (1961d=1961V)"
 orbit_ArgOfPericenter=270.71410
 orbit_AscendingNode=298.24390
@@ -13332,17 +9709,11 @@ orbit_TimeAtPericenter=2437497.99530
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Winnecke%281868II%29]
 absolute_magnitude=7.6
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Winnecke (1868II)
 orbit_ArgOfPericenter=126.63570
 orbit_AscendingNode=53.40890
@@ -13354,17 +9725,11 @@ orbit_TimeAtPericenter=2403510.47630
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Winnecke%281871a_1871I%29]
 absolute_magnitude=5.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Winnecke (1871a=1871I)"
 orbit_ArgOfPericenter=222.51310
 orbit_AscendingNode=280.41340
@@ -13376,17 +9741,11 @@ orbit_TimeAtPericenter=2404589.59990
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Winnecke%281874b_1874II%29]
 absolute_magnitude=5.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Winnecke (1874b=1874II)"
 orbit_ArgOfPericenter=331.72890
 orbit_AscendingNode=275.16050
@@ -13398,17 +9757,11 @@ orbit_TimeAtPericenter=2405596.93550
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Winnecke%281877b_1877II%29]
 absolute_magnitude=5.7
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Winnecke (1877b=1877II)"
 orbit_ArgOfPericenter=63.12500
 orbit_AscendingNode=317.63790
@@ -13420,17 +9773,11 @@ orbit_TimeAtPericenter=2406727.65620
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Winnecke-Dien%281854V%29]
 absolute_magnitude=6.9
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/Winnecke-Dien (1854V)
 orbit_ArgOfPericenter=287.09660
 orbit_AscendingNode=239.53430
@@ -13442,17 +9789,11 @@ orbit_TimeAtPericenter=2398568.80920
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Winnecke-Tempel%281870a_1870I%29]
 absolute_magnitude=6.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Winnecke-Tempel (1870a=1870I)"
 orbit_ArgOfPericenter=198.22380
 orbit_AscendingNode=142.86680
@@ -13464,17 +9805,11 @@ orbit_TimeAtPericenter=2404258.08220
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Wirtanen%281947h_1947VI%29]
 absolute_magnitude=5.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Wirtanen (1947h=1947VI)"
 orbit_ArgOfPericenter=9.37970
 orbit_AscendingNode=311.09810
@@ -13486,17 +9821,11 @@ orbit_TimeAtPericenter=2432384.84520
 orbit_good=1000
 radius=5
 slope_parameter=6.2
-tex_map=nomap.png
 type=comet
 
 [C_Wirtanen%281948h_1949I%29]
 absolute_magnitude=6.4
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Wirtanen (1948h=1949I)"
 orbit_ArgOfPericenter=229.94330
 orbit_AscendingNode=119.90020
@@ -13508,17 +9837,11 @@ orbit_TimeAtPericenter=2433037.60910
 orbit_good=1000
 radius=5
 slope_parameter=3.9
-tex_map=nomap.png
 type=comet
 
 [C_Wirtanen%281948k_1947VIII%29]
 absolute_magnitude=4.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Wirtanen (1948k=1947VIII)"
 orbit_ArgOfPericenter=73.45240
 orbit_AscendingNode=121.41080
@@ -13530,17 +9853,11 @@ orbit_TimeAtPericenter=2432432.93100
 orbit_good=1000
 radius=5
 slope_parameter=3.9
-tex_map=nomap.png
 type=comet
 
 [C_Wirtanen%281956c_1957VI%29]
 absolute_magnitude=4.4
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Wirtanen (1956c=1957VI)"
 orbit_ArgOfPericenter=13.26950
 orbit_AscendingNode=232.94930
@@ -13552,17 +9869,11 @@ orbit_TimeAtPericenter=2436083.91370
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Wolf%281916b_1917III%29]
 absolute_magnitude=7.9
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Wolf (1916b=1917III)"
 orbit_ArgOfPericenter=120.62390
 orbit_AscendingNode=183.75660
@@ -13574,17 +9885,11 @@ orbit_TimeAtPericenter=2421396.57350
 orbit_good=1000
 radius=5
 slope_parameter=1.6
-tex_map=nomap.png
 type=comet
 
 [C_Yanaka%281989a_1988XX%29]
 absolute_magnitude=4.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Yanaka (1989a=1988XX)"
 orbit_ArgOfPericenter=351.55640
 orbit_AscendingNode=156.39202
@@ -13596,17 +9901,11 @@ orbit_TimeAtPericenter=2447466.30245
 orbit_good=1000
 radius=5
 slope_parameter=7.0
-tex_map=nomap.png
 type=comet
 
 [C_Zanotta-Brewington%281991g1_1992III%29]
 absolute_magnitude=9.1
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Zanotta-Brewington (1991g1=1992III)"
 orbit_ArgOfPericenter=197.88138
 orbit_AscendingNode=254.20349
@@ -13618,17 +9917,11 @@ orbit_TimeAtPericenter=2448653.49154
 orbit_good=1000
 radius=5
 slope_parameter=1.5
-tex_map=nomap.png
 type=comet
 
 [C_Zlatinsky%281914b_1914I%29]
 absolute_magnitude=8.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Zlatinsky (1914b=1914I)"
 orbit_ArgOfPericenter=116.39600
 orbit_AscendingNode=33.15590
@@ -13640,17 +9933,11 @@ orbit_TimeAtPericenter=2420261.37290
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_Zona%281890e_1890IV%29]
 absolute_magnitude=5.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/Zona (1890e=1890IV)"
 orbit_ArgOfPericenter=331.26910
 orbit_AscendingNode=86.22210
@@ -13662,17 +9949,11 @@ orbit_TimeAtPericenter=2411586.88270
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_d%27Arrest%281845I%29]
 absolute_magnitude=9.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/d'Arrest (1845I)
 orbit_ArgOfPericenter=114.58450
 orbit_AscendingNode=338.21320
@@ -13684,17 +9965,11 @@ orbit_TimeAtPericenter=2394940.15790
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_d%27Arrest%281857I%29]
 absolute_magnitude=7.1
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/d'Arrest (1857I)
 orbit_ArgOfPericenter=121.57060
 orbit_AscendingNode=314.45390
@@ -13706,17 +9981,11 @@ orbit_TimeAtPericenter=2399395.36910
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_deKock-Paraskevopoulos%281941c_1941IV%29]
 absolute_magnitude=6.1
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/de Kock-Paraskevopoulos (1941c=1941IV)"
 orbit_ArgOfPericenter=268.67620
 orbit_AscendingNode=42.38530
@@ -13728,17 +9997,11 @@ orbit_TimeAtPericenter=2430022.15770
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_deVico%281845II%29]
 absolute_magnitude=7.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/de Vico (1845II)
 orbit_ArgOfPericenter=205.45240
 orbit_AscendingNode=348.58210
@@ -13750,17 +10013,11 @@ orbit_TimeAtPericenter=2395043.04040
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_deVico%281846I%29]
 absolute_magnitude=6.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/de Vico (1846I)
 orbit_ArgOfPericenter=337.98200
 orbit_AscendingNode=112.58130
@@ -13772,17 +10029,11 @@ orbit_TimeAtPericenter=2395319.09390
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_deVico%281846VIII%29]
 absolute_magnitude=8.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/de Vico (1846VIII)
 orbit_ArgOfPericenter=93.97460
 orbit_AscendingNode=6.13950
@@ -13794,17 +10045,11 @@ orbit_TimeAtPericenter=2395599.77720
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_deVico-Hind%281846V%29]
 absolute_magnitude=6.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/de Vico-Hind (1846V)
 orbit_ArgOfPericenter=78.75010
 orbit_AscendingNode=162.76480
@@ -13816,17 +10061,11 @@ orbit_TimeAtPericenter=2395444.89580
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_vanArsdale%281854I%29]
 absolute_magnitude=4.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/van Arsdale (1854I)
 orbit_ArgOfPericenter=170.92590
 orbit_AscendingNode=228.38230
@@ -13838,17 +10077,11 @@ orbit_TimeAtPericenter=2398222.93510
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_vanGent%281941d_1941VIII%29]
 absolute_magnitude=6.9
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/van Gent (1941d=1941VIII)"
 orbit_ArgOfPericenter=85.32840
 orbit_AscendingNode=256.86180
@@ -13860,17 +10093,11 @@ orbit_TimeAtPericenter=2430240.68420
 orbit_good=1000
 radius=5
 slope_parameter=4.8
-tex_map=nomap.png
 type=comet
 
 [C_vanGent%281944IV%29]
 absolute_magnitude=8.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/van Gent (1944IV)
 orbit_ArgOfPericenter=336.97720
 orbit_AscendingNode=202.80200
@@ -13882,17 +10109,11 @@ orbit_TimeAtPericenter=2431289.11330
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [C_vandenBergh%281974g_1974XII%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="C/van den Bergh (1974g=1974XII)"
 orbit_ArgOfPericenter=151.76540
 orbit_AscendingNode=225.40270
@@ -13904,17 +10125,11 @@ orbit_TimeAtPericenter=2442267.27490
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Arend%281959c_1959V%29]
 absolute_magnitude=9.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Arend (1959c=1959V)"
 orbit_ArgOfPericenter=44.59290
 orbit_AscendingNode=357.60890
@@ -13926,17 +10141,11 @@ orbit_TimeAtPericenter=2436812.70300
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Arend%281967l_1967VI%29]
 absolute_magnitude=9.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Arend (1967l=1967VI)"
 orbit_ArgOfPericenter=44.68430
 orbit_AscendingNode=357.52720
@@ -13948,17 +10157,11 @@ orbit_TimeAtPericenter=2439655.15780
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Arend%281975m_1975VI%29]
 absolute_magnitude=9.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Arend (1975m=1975VI)"
 orbit_ArgOfPericenter=46.92070
 orbit_AscendingNode=355.65850
@@ -13970,17 +10173,11 @@ orbit_TimeAtPericenter=2442557.19250
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Arend%281983q_1983VIII%29]
 absolute_magnitude=9.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Arend (1983q=1983VIII)"
 orbit_ArgOfPericenter=46.92841
 orbit_AscendingNode=355.62666
@@ -13992,17 +10189,11 @@ orbit_TimeAtPericenter=2445476.89063
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Arend%281991u_1991VIII%29]
 absolute_magnitude=9.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Arend (1991u=1991VIII)"
 orbit_ArgOfPericenter=47.06857
 orbit_AscendingNode=355.49636
@@ -14014,17 +10205,11 @@ orbit_TimeAtPericenter=2448402.52201
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Arend-Rigaux%281951b_1950VII%29]
 absolute_magnitude=9.4
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Arend-Rigaux (1951b=1950VII)"
 orbit_ArgOfPericenter=326.26990
 orbit_AscendingNode=124.71420
@@ -14036,17 +10221,11 @@ orbit_TimeAtPericenter=2433634.42160
 orbit_good=1000
 radius=5
 slope_parameter=9.2
-tex_map=nomap.png
 type=comet
 
 [P_Arend-Rigaux%281958b_1957VII%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Arend-Rigaux (1958b=1957VII)"
 orbit_ArgOfPericenter=326.39830
 orbit_AscendingNode=124.62210
@@ -14058,17 +10237,11 @@ orbit_TimeAtPericenter=2436088.08560
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Arend-Rigaux%281963g_1964V%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Arend-Rigaux (1963g=1964V)"
 orbit_ArgOfPericenter=328.87210
 orbit_AscendingNode=121.58680
@@ -14080,17 +10253,11 @@ orbit_TimeAtPericenter=2438552.14970
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Arend-Rigaux%281970j_1971IV%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Arend-Rigaux (1970j=1971IV)"
 orbit_ArgOfPericenter=328.93590
 orbit_AscendingNode=121.55540
@@ -14102,17 +10269,11 @@ orbit_TimeAtPericenter=2441047.51630
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Arend-Rigaux%281977k_1978III%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Arend-Rigaux (1977k=1978III)"
 orbit_ArgOfPericenter=328.98580
 orbit_AscendingNode=121.52360
@@ -14124,17 +10285,11 @@ orbit_TimeAtPericenter=2443541.98190
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Arend-Rigaux%281991XVII%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Arend-Rigaux (1991XVII)
 orbit_ArgOfPericenter=329.05878
 orbit_AscendingNode=121.45197
@@ -14146,17 +10301,11 @@ orbit_TimeAtPericenter=2448532.21803
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Ashbrook-Jackson%281948i_1948IX%29]
 absolute_magnitude=7.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Ashbrook-Jackson (1948i=1948IX)"
 orbit_ArgOfPericenter=348.90360
 orbit_AscendingNode=2.34180
@@ -14168,17 +10317,11 @@ orbit_TimeAtPericenter=2432829.27870
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Ashbrook-Jackson%281955c_1956II%29]
 absolute_magnitude=8.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Ashbrook-Jackson (1955c=1956II)"
 orbit_ArgOfPericenter=349.08880
 orbit_AscendingNode=2.28550
@@ -14190,17 +10333,11 @@ orbit_TimeAtPericenter=2435569.67670
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Ashbrook-Jackson%281962e_1963VI%29]
 absolute_magnitude=5.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Ashbrook-Jackson (1962e=1963VI)"
 orbit_ArgOfPericenter=348.95380
 orbit_AscendingNode=2.28170
@@ -14212,17 +10349,11 @@ orbit_TimeAtPericenter=2438304.67800
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Ashbrook-Jackson%281970e_1971III%29]
 absolute_magnitude=5.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Ashbrook-Jackson (1970e=1971III)"
 orbit_ArgOfPericenter=348.82880
 orbit_AscendingNode=2.15030
@@ -14234,17 +10365,11 @@ orbit_TimeAtPericenter=2441023.94280
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Ashbrook-Jackson%281977g_1978XIV%29]
 absolute_magnitude=5.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Ashbrook-Jackson (1977g=1978XIV)"
 orbit_ArgOfPericenter=349.01380
 orbit_AscendingNode=2.05890
@@ -14256,17 +10381,11 @@ orbit_TimeAtPericenter=2443740.37860
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Ashbrook-Jackson%281985a_1986II%29]
 absolute_magnitude=5.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Ashbrook-Jackson (1985a=1986II)"
 orbit_ArgOfPericenter=348.81410
 orbit_AscendingNode=1.95330
@@ -14278,17 +10397,11 @@ orbit_TimeAtPericenter=2446454.87750
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Ashbrook-Jackson%281992j%29]
 absolute_magnitude=5.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Ashbrook-Jackson (1992j)
 orbit_ArgOfPericenter=348.68577
 orbit_AscendingNode=1.97078
@@ -14300,17 +10413,11 @@ orbit_TimeAtPericenter=2449182.55169
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Barnard1%281884b_1884II%29]
 absolute_magnitude=8.9
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Barnard 1 (1884b=1884II)"
 orbit_ArgOfPericenter=301.03740
 orbit_AscendingNode=6.07500
@@ -14322,17 +10429,11 @@ orbit_TimeAtPericenter=2409405.46800
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Barnard2%281889c_1889III%29]
 absolute_magnitude=9.4
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Barnard 2 (1889c=1889III)"
 orbit_ArgOfPericenter=60.24460
 orbit_AscendingNode=271.92500
@@ -14344,17 +10445,11 @@ orbit_TimeAtPericenter=2411174.74880
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Barnard3%281892e_1892V%29]
 absolute_magnitude=9.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Barnard 3 (1892e=1892V)"
 orbit_ArgOfPericenter=170.00130
 orbit_AscendingNode=207.33180
@@ -14366,17 +10461,11 @@ orbit_TimeAtPericenter=2412443.67460
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Biela%281772%29]
 absolute_magnitude=7.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Biela (1772)
 orbit_ArgOfPericenter=213.36200
 orbit_AscendingNode=260.22200
@@ -14388,17 +10477,11 @@ orbit_TimeAtPericenter=2368317.17500
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Biela%281806I%29]
 absolute_magnitude=7.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Biela (1806I)
 orbit_ArgOfPericenter=218.10360
 orbit_AscendingNode=253.35330
@@ -14410,17 +10493,11 @@ orbit_TimeAtPericenter=2380688.89900
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Biela%281826I%29]
 absolute_magnitude=7.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Biela (1826I)
 orbit_ArgOfPericenter=218.28940
 orbit_AscendingNode=253.25730
@@ -14432,17 +10509,11 @@ orbit_TimeAtPericenter=2388069.44980
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Biela%281832III%29]
 absolute_magnitude=8.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Biela (1832III)
 orbit_ArgOfPericenter=221.68640
 orbit_AscendingNode=249.94360
@@ -14454,17 +10525,11 @@ orbit_TimeAtPericenter=2390514.11520
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Biela%281846II%29]
 absolute_magnitude=8.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Biela (1846II)
 orbit_ArgOfPericenter=223.08660
 orbit_AscendingNode=247.41560
@@ -14476,17 +10541,11 @@ orbit_TimeAtPericenter=2395338.99420
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Biela%281852III%29]
 absolute_magnitude=8.1
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Biela (1852III)
 orbit_ArgOfPericenter=223.21760
 orbit_AscendingNode=247.28050
@@ -14498,17 +10557,11 @@ orbit_TimeAtPericenter=2397755.04320
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Blanpain%281819IV%29]
 absolute_magnitude=8.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Blanpain (1819IV)
 orbit_ArgOfPericenter=350.22030
 orbit_AscendingNode=79.15410
@@ -14520,17 +10573,11 @@ orbit_TimeAtPericenter=2385759.34740
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Boethin%281975a_1975I%29]
 absolute_magnitude=9.6
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Boethin (1975a=1975I)"
 orbit_ArgOfPericenter=11.11360
 orbit_AscendingNode=26.97450
@@ -14542,17 +10589,11 @@ orbit_TimeAtPericenter=2442418.12180
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Boethin%281985n_1986I%29]
 absolute_magnitude=7.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Boethin (1985n=1986I)"
 orbit_ArgOfPericenter=11.64868
 orbit_AscendingNode=25.81206
@@ -14564,17 +10605,11 @@ orbit_TimeAtPericenter=2446446.95220
 orbit_good=1000
 radius=5
 slope_parameter=5.9
-tex_map=nomap.png
 type=comet
 
 [P_Borrelly%281904e_1905II%29]
 absolute_magnitude=9.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Borrelly (1904e=1905II)"
 orbit_ArgOfPericenter=352.35190
 orbit_AscendingNode=77.38120
@@ -14586,17 +10621,11 @@ orbit_TimeAtPericenter=2416862.79440
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Borrelly%281911e_1911VIII%29]
 absolute_magnitude=9.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Borrelly (1911e=1911VIII)"
 orbit_ArgOfPericenter=352.37450
 orbit_AscendingNode=77.37550
@@ -14608,17 +10637,11 @@ orbit_TimeAtPericenter=2419388.98970
 orbit_good=1000
 radius=5
 slope_parameter=3.3
-tex_map=nomap.png
 type=comet
 
 [P_Borrelly%281918c_1918IV%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Borrelly (1918c=1918IV)"
 orbit_ArgOfPericenter=352.39810
 orbit_AscendingNode=77.37060
@@ -14630,17 +10653,11 @@ orbit_TimeAtPericenter=2421914.59780
 orbit_good=1000
 radius=5
 slope_parameter=4.4
-tex_map=nomap.png
 type=comet
 
 [P_Borrelly%281932i_1932IV%29]
 absolute_magnitude=9.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Borrelly (1932i=1932IV)"
 orbit_ArgOfPericenter=352.55060
 orbit_AscendingNode=77.30820
@@ -14652,17 +10669,11 @@ orbit_TimeAtPericenter=2426946.79280
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Borrelly%281960k_1960V%29]
 absolute_magnitude=9.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Borrelly (1960k=1960V)"
 orbit_ArgOfPericenter=350.97620
 orbit_AscendingNode=76.19340
@@ -14674,17 +10685,11 @@ orbit_TimeAtPericenter=2437098.73750
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Borrelly%281967m_1967VIII%29]
 absolute_magnitude=9.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Borrelly (1967m=1967VIII)"
 orbit_ArgOfPericenter=351.03030
 orbit_AscendingNode=76.14100
@@ -14696,17 +10701,11 @@ orbit_TimeAtPericenter=2439659.21530
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Borrelly%281973m_1974VII%29]
 absolute_magnitude=9.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Borrelly (1973m=1974VII)"
 orbit_ArgOfPericenter=352.67310
 orbit_AscendingNode=75.11850
@@ -14718,17 +10717,11 @@ orbit_TimeAtPericenter=2442180.15290
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Borrelly%281980i_1981IV%29]
 absolute_magnitude=7.9
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Borrelly (1980i=1981IV)"
 orbit_ArgOfPericenter=352.77020
 orbit_AscendingNode=75.05870
@@ -14740,17 +10733,11 @@ orbit_TimeAtPericenter=2444655.50910
 orbit_good=1000
 radius=5
 slope_parameter=3.4
-tex_map=nomap.png
 type=comet
 
 [P_Borrelly%281987p_1987XXXIII%29]
 absolute_magnitude=6.7
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Borrelly (1987p=1987XXXIII)"
 orbit_ArgOfPericenter=353.32470
 orbit_AscendingNode=74.74595
@@ -14762,17 +10749,11 @@ orbit_TimeAtPericenter=2447147.82565
 orbit_good=1000
 radius=5
 slope_parameter=7.6
-tex_map=nomap.png
 type=comet
 
 [P_Borrelly%281994%29]
 absolute_magnitude=9.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Borrelly (1994)
 orbit_ArgOfPericenter=353.34589
 orbit_AscendingNode=74.73634
@@ -14784,17 +10765,11 @@ orbit_TimeAtPericenter=2449657.99226
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Bradfield1%281984a_1983XIX%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Bradfield 1 (1984a=1983XIX)"
 orbit_ArgOfPericenter=219.16071
 orbit_AscendingNode=356.15972
@@ -14806,17 +10781,11 @@ orbit_TimeAtPericenter=2445696.29249
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Brewington%281992p_1992XIV%29]
 absolute_magnitude=6.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Brewington (1992p=1992XIV)"
 orbit_ArgOfPericenter=47.84036
 orbit_AscendingNode=343.03322
@@ -14828,17 +10797,11 @@ orbit_TimeAtPericenter=2448781.29266
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Brooks1%281886c_1886IV%29]
 absolute_magnitude=8.9
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Brooks 1 (1886c=1886IV)"
 orbit_ArgOfPericenter=176.84990
 orbit_AscendingNode=54.46560
@@ -14850,17 +10813,11 @@ orbit_TimeAtPericenter=2410064.71220
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Brooks2%281889d_1889V%29]
 absolute_magnitude=7.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Brooks 2 (1889d=1889V)"
 orbit_ArgOfPericenter=343.63810
 orbit_AscendingNode=18.79080
@@ -14872,17 +10829,11 @@ orbit_TimeAtPericenter=2411276.35400
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Brooks2%281896c_1896VI%29]
 absolute_magnitude=8.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Brooks 2 (1896c=1896VI)"
 orbit_ArgOfPericenter=343.81860
 orbit_AscendingNode=18.74430
@@ -14894,17 +10845,11 @@ orbit_TimeAtPericenter=2413868.13560
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Brooks2%281960h_1960VI%29]
 absolute_magnitude=9.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Brooks 2 (1960h=1960VI)"
 orbit_ArgOfPericenter=197.09380
 orbit_AscendingNode=176.89180
@@ -14916,17 +10861,11 @@ orbit_TimeAtPericenter=2437102.61660
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Brooks2%281973j_1974I%29]
 absolute_magnitude=9.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Brooks 2 (1973j=1974I)"
 orbit_ArgOfPericenter=198.15070
 orbit_AscendingNode=176.28570
@@ -14938,17 +10877,11 @@ orbit_TimeAtPericenter=2442051.49300
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Brooks2%281980f_1980IX%29]
 absolute_magnitude=9.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Brooks 2 (1980f=1980IX)"
 orbit_ArgOfPericenter=198.22370
 orbit_AscendingNode=176.23250
@@ -14960,17 +10893,11 @@ orbit_TimeAtPericenter=2444568.86640
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Brooks2%281987m_1987XXIV%29]
 absolute_magnitude=9.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Brooks 2 (1987m=1987XXIV)"
 orbit_ArgOfPericenter=198.13930
 orbit_AscendingNode=176.25000
@@ -14982,17 +10909,11 @@ orbit_TimeAtPericenter=2447085.05380
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Brooks2%281994%29]
 absolute_magnitude=9.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Brooks 2 (1994)
 orbit_ArgOfPericenter=197.98970
 orbit_AscendingNode=176.24640
@@ -15004,17 +10925,11 @@ orbit_TimeAtPericenter=2449596.58820
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Brorsen%281846III%29]
 absolute_magnitude=7.7
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Brorsen (1846III)
 orbit_ArgOfPericenter=13.80210
 orbit_AscendingNode=104.12410
@@ -15026,17 +10941,11 @@ orbit_TimeAtPericenter=2395353.36850
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Brorsen%281857II%29]
 absolute_magnitude=7.7
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Brorsen (1857II)
 orbit_ArgOfPericenter=14.02090
 orbit_AscendingNode=103.05220
@@ -15048,17 +10957,11 @@ orbit_TimeAtPericenter=2399403.24620
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Brorsen%281868I%29]
 absolute_magnitude=9.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Brorsen (1868I)
 orbit_ArgOfPericenter=14.82500
 orbit_AscendingNode=102.32870
@@ -15070,17 +10973,11 @@ orbit_TimeAtPericenter=2403440.42120
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Brorsen%281873e_1873VI%29]
 absolute_magnitude=9.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Brorsen (1873e=1873VI)"
 orbit_ArgOfPericenter=14.85100
 orbit_AscendingNode=102.30880
@@ -15092,17 +10989,11 @@ orbit_TimeAtPericenter=2405442.48030
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Brorsen%281879a_1879I%29]
 absolute_magnitude=9.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Brorsen (1879a=1879I)"
 orbit_ArgOfPericenter=14.93410
 orbit_AscendingNode=102.28010
@@ -15114,17 +11005,11 @@ orbit_TimeAtPericenter=2407439.53410
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Brorsen-Metcalf%281847V%29]
 absolute_magnitude=9.6
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Brorsen-Metcalf (1847V)
 orbit_ArgOfPericenter=129.35730
 orbit_AscendingNode=311.26420
@@ -15136,17 +11021,11 @@ orbit_TimeAtPericenter=2395914.54740
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Brorsen-Metcalf%281919b_1919III%29]
 absolute_magnitude=8.7
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Brorsen-Metcalf (1919b=1919III)"
 orbit_ArgOfPericenter=129.47360
 orbit_AscendingNode=311.19850
@@ -15158,17 +11037,11 @@ orbit_TimeAtPericenter=2422248.86280
 orbit_good=1000
 radius=5
 slope_parameter=5.0
-tex_map=nomap.png
 type=comet
 
 [P_Brorsen-Metcalf%281989o_1989X%29]
 absolute_magnitude=8.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Brorsen-Metcalf (1989o=1989X)"
 orbit_ArgOfPericenter=129.62476
 orbit_AscendingNode=310.87639
@@ -15180,17 +11053,11 @@ orbit_TimeAtPericenter=2447781.43841
 orbit_good=1000
 radius=5
 slope_parameter=3.4
-tex_map=nomap.png
 type=comet
 
 [P_Bus%281981b_1981XI%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Bus (1981b=1981XI)"
 orbit_ArgOfPericenter=24.64410
 orbit_AscendingNode=181.52840
@@ -15202,17 +11069,11 @@ orbit_TimeAtPericenter=2444766.85650
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Bus%281987f_1987XXXIV%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Bus (1987f=1987XXXIV)"
 orbit_ArgOfPericenter=24.56050
 orbit_AscendingNode=181.49100
@@ -15224,17 +11085,11 @@ orbit_TimeAtPericenter=2447149.01160
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Bus%281993b%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Bus (1993b)
 orbit_ArgOfPericenter=24.42094
 orbit_AscendingNode=181.50592
@@ -15246,17 +11101,11 @@ orbit_TimeAtPericenter=2449531.64437
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Chernykh%281977l_1978IV%29]
 absolute_magnitude=7.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Chernykh (1977l=1978IV)"
 orbit_ArgOfPericenter=266.70370
 orbit_AscendingNode=134.11490
@@ -15268,17 +11117,11 @@ orbit_TimeAtPericenter=2443554.44100
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Chernykh%281991o_1992II%29]
 absolute_magnitude=6.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Chernykh (1991o=1992II)"
 orbit_ArgOfPericenter=263.19480
 orbit_AscendingNode=129.74316
@@ -15290,17 +11133,11 @@ orbit_TimeAtPericenter=2448646.94168
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Churyumov-Gerasimenko%281969h_1969IV%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Churyumov-Gerasimenko (1969h=1969IV)"
 orbit_ArgOfPericenter=11.20450
 orbit_AscendingNode=50.35440
@@ -15312,17 +11149,11 @@ orbit_TimeAtPericenter=2440475.53700
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Churyumov-Gerasimenko%281975i_1976VII%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Churyumov-Gerasimenko (1975i=1976VII)"
 orbit_ArgOfPericenter=11.31660
 orbit_AscendingNode=50.37190
@@ -15334,17 +11165,11 @@ orbit_TimeAtPericenter=2442875.73230
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Churyumov-Gerasimenko%281988i_1989VI%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Churyumov-Gerasimenko (1988i=1989VI)"
 orbit_ArgOfPericenter=11.38230
 orbit_AscendingNode=50.35500
@@ -15356,17 +11181,11 @@ orbit_TimeAtPericenter=2447695.89240
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Churyumov-Gerasimenko%281996%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Churyumov-Gerasimenko (1996)
 orbit_ArgOfPericenter=11.34336
 orbit_AscendingNode=50.35070
@@ -15378,17 +11197,11 @@ orbit_TimeAtPericenter=2450100.16177
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Ciffreo%281985p_1985XVI%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Ciffreo (1985p=1985XVI)"
 orbit_ArgOfPericenter=357.89970
 orbit_AscendingNode=53.09980
@@ -15400,17 +11213,11 @@ orbit_TimeAtPericenter=2446368.60560
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Ciffreo%281992s%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Ciffreo (1992s)
 orbit_ArgOfPericenter=358.00903
 orbit_AscendingNode=53.03451
@@ -15422,17 +11229,11 @@ orbit_TimeAtPericenter=2449010.56492
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Clark%281983w_1984VIII%29]
 absolute_magnitude=8.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Clark (1983w=1984VIII)"
 orbit_ArgOfPericenter=209.00370
 orbit_AscendingNode=59.07580
@@ -15444,17 +11245,11 @@ orbit_TimeAtPericenter=2445849.54090
 orbit_good=1000
 radius=5
 slope_parameter=6.9
-tex_map=nomap.png
 type=comet
 
 [P_ComasSola%281926f_1927III%29]
 absolute_magnitude=9.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Comas Sola (1926f=1927III)"
 orbit_ArgOfPericenter=38.48250
 orbit_AscendingNode=65.92930
@@ -15466,17 +11261,11 @@ orbit_TimeAtPericenter=2424961.69800
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_ComasSola%281935c_1935IV%29]
 absolute_magnitude=8.6
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Comas Sola (1935c=1935IV)"
 orbit_ArgOfPericenter=38.78760
 orbit_AscendingNode=65.70570
@@ -15488,17 +11277,11 @@ orbit_TimeAtPericenter=2428082.07590
 orbit_good=1000
 radius=5
 slope_parameter=5.4
-tex_map=nomap.png
 type=comet
 
 [P_ComasSola%281951h_1952VII%29]
 absolute_magnitude=8.6
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Comas Sola (1951h=1952VII)"
 orbit_ArgOfPericenter=39.94580
 orbit_AscendingNode=62.91070
@@ -15510,17 +11293,11 @@ orbit_TimeAtPericenter=2434266.28050
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_ComasSola%281960f_1961III%29]
 absolute_magnitude=8.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Comas Sola (1960f=1961III)"
 orbit_ArgOfPericenter=40.01890
 orbit_AscendingNode=62.84480
@@ -15532,17 +11309,11 @@ orbit_TimeAtPericenter=2437393.54440
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_ComasSola%281968g_1969VIII%29]
 absolute_magnitude=8.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Comas Sola (1968g=1969VIII)"
 orbit_ArgOfPericenter=40.06370
 orbit_AscendingNode=62.75190
@@ -15554,17 +11325,11 @@ orbit_TimeAtPericenter=2440523.56310
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_ComasSola%281977n_1978XVII%29]
 absolute_magnitude=8.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Comas Sola (1977n=1978XVII)"
 orbit_ArgOfPericenter=42.83900
 orbit_AscendingNode=62.42600
@@ -15576,17 +11341,11 @@ orbit_TimeAtPericenter=2443775.72660
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_ComasSola%281986j_1987XVIII%29]
 absolute_magnitude=8.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Comas Sola (1986j=1987XVIII)"
 orbit_ArgOfPericenter=45.51770
 orbit_AscendingNode=60.38160
@@ -15598,17 +11357,11 @@ orbit_TimeAtPericenter=2447026.19180
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_ComasSola%281996%29]
 absolute_magnitude=8.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Comas Sola (1996)
 orbit_ArgOfPericenter=45.74126
 orbit_AscendingNode=60.19716
@@ -15620,17 +11373,11 @@ orbit_TimeAtPericenter=2450244.96545
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Crommelin%281457I%29]
 absolute_magnitude=6.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Crommelin (1457I)
 orbit_ArgOfPericenter=194.62500
 orbit_AscendingNode=256.80300
@@ -15642,17 +11389,11 @@ orbit_TimeAtPericenter=2253244.97900
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Crommelin%281625%29]
 absolute_magnitude=5.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Crommelin (1625)
 orbit_ArgOfPericenter=196.45000
 orbit_AscendingNode=247.86000
@@ -15664,17 +11405,11 @@ orbit_TimeAtPericenter=2314608.50000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Crommelin%281818I%29]
 absolute_magnitude=9.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Crommelin (1818I)
 orbit_ArgOfPericenter=195.60900
 orbit_AscendingNode=251.34900
@@ -15686,17 +11421,11 @@ orbit_TimeAtPericenter=2385106.70000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Crommelin%281928b_1928III%29]
 absolute_magnitude=9.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Crommelin (1928b=1928III)"
 orbit_ArgOfPericenter=195.89270
 orbit_AscendingNode=250.36480
@@ -15708,17 +11437,11 @@ orbit_TimeAtPericenter=2425555.46960
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Crommelin%281983n_1984IV%29]
 absolute_magnitude=9.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Crommelin (1983n=1984IV)"
 orbit_ArgOfPericenter=195.85443
 orbit_AscendingNode=250.19098
@@ -15730,17 +11453,11 @@ orbit_TimeAtPericenter=2445750.67073
 orbit_good=1000
 radius=5
 slope_parameter=4.2
-tex_map=nomap.png
 type=comet
 
 [P_Daniel%281909e_1909IV%29]
 absolute_magnitude=6.7
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Daniel (1909e=1909IV)"
 orbit_ArgOfPericenter=3.49700
 orbit_AscendingNode=71.54050
@@ -15752,17 +11469,11 @@ orbit_TimeAtPericenter=2418639.72760
 orbit_good=1000
 radius=5
 slope_parameter=8.4
-tex_map=nomap.png
 type=comet
 
 [P_Denning-Fujikawa%281881f_1881V%29]
 absolute_magnitude=9.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Denning-Fujikawa (1881f=1881V)"
 orbit_ArgOfPericenter=312.47600
 orbit_AscendingNode=66.93500
@@ -15774,17 +11485,11 @@ orbit_TimeAtPericenter=2408337.24900
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Encke%281786I%29]
 absolute_magnitude=9.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Encke (1786I)
 orbit_ArgOfPericenter=182.20200
 orbit_AscendingNode=336.46900
@@ -15796,17 +11501,11 @@ orbit_TimeAtPericenter=2373413.86000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Encke%281795%29]
 absolute_magnitude=8.4
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Encke (1795)
 orbit_ArgOfPericenter=182.25800
 orbit_AscendingNode=336.44800
@@ -15818,17 +11517,11 @@ orbit_TimeAtPericenter=2377025.46300
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Encke%281805%29]
 absolute_magnitude=8.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Encke (1805)
 orbit_ArgOfPericenter=182.31630
 orbit_AscendingNode=336.44470
@@ -15840,17 +11533,11 @@ orbit_TimeAtPericenter=2380647.48640
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Encke%281819I%29]
 absolute_magnitude=8.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Encke (1819I)
 orbit_ArgOfPericenter=182.42190
 orbit_AscendingNode=336.39710
@@ -15862,17 +11549,11 @@ orbit_TimeAtPericenter=2385462.25400
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Encke%281822II%29]
 absolute_magnitude=9.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Encke (1822II)
 orbit_ArgOfPericenter=182.77150
 orbit_AscendingNode=336.21360
@@ -15884,17 +11565,11 @@ orbit_TimeAtPericenter=2386674.95770
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Encke%281825III%29]
 absolute_magnitude=7.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Encke (1825III)
 orbit_ArgOfPericenter=182.77890
 orbit_AscendingNode=336.20570
@@ -15906,17 +11581,11 @@ orbit_TimeAtPericenter=2387886.27170
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Encke%281829%29]
 absolute_magnitude=8.6
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Encke (1829)
 orbit_ArgOfPericenter=182.79830
 orbit_AscendingNode=336.19300
@@ -15928,17 +11597,11 @@ orbit_TimeAtPericenter=2389097.74340
 orbit_good=1000
 radius=5
 slope_parameter=5.3
-tex_map=nomap.png
 type=comet
 
 [P_Encke%281832I%29]
 absolute_magnitude=9.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Encke (1832I)
 orbit_ArgOfPericenter=182.79030
 orbit_AscendingNode=336.20740
@@ -15950,17 +11613,11 @@ orbit_TimeAtPericenter=2390307.97900
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Encke%281835II%29]
 absolute_magnitude=7.7
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Encke (1835II)
 orbit_ArgOfPericenter=182.78640
 orbit_AscendingNode=336.20770
@@ -15972,17 +11629,11 @@ orbit_TimeAtPericenter=2391517.35530
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Encke%281838%29]
 absolute_magnitude=9.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Encke (1838)
 orbit_ArgOfPericenter=182.81960
 orbit_AscendingNode=336.18850
@@ -15994,17 +11645,11 @@ orbit_TimeAtPericenter=2392728.00910
 orbit_good=1000
 radius=5
 slope_parameter=4.2
-tex_map=nomap.png
 type=comet
 
 [P_Encke%281842I%29]
 absolute_magnitude=9.4
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Encke (1842I)
 orbit_ArgOfPericenter=182.82080
 orbit_AscendingNode=336.18320
@@ -16016,17 +11661,11 @@ orbit_TimeAtPericenter=2393938.02000
 orbit_good=1000
 radius=5
 slope_parameter=4.3
-tex_map=nomap.png
 type=comet
 
 [P_Encke%281845IV%29]
 absolute_magnitude=8.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Encke (1845IV)
 orbit_ArgOfPericenter=183.40350
 orbit_AscendingNode=335.80180
@@ -16038,17 +11677,11 @@ orbit_TimeAtPericenter=2395153.61640
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Encke%281848II%29]
 absolute_magnitude=8.9
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Encke (1848II)
 orbit_ArgOfPericenter=183.40490
 orbit_AscendingNode=335.79900
@@ -16060,17 +11693,11 @@ orbit_TimeAtPericenter=2396358.08050
 orbit_good=1000
 radius=5
 slope_parameter=5.1
-tex_map=nomap.png
 type=comet
 
 [P_Encke%281852I%29]
 absolute_magnitude=9.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Encke (1852I)
 orbit_ArgOfPericenter=183.43810
 orbit_AscendingNode=335.78080
@@ -16082,17 +11709,11 @@ orbit_TimeAtPericenter=2397562.70200
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Encke%281855III%29]
 absolute_magnitude=9.4
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Encke (1855III)
 orbit_ArgOfPericenter=183.42120
 orbit_AscendingNode=335.78440
@@ -16104,17 +11725,11 @@ orbit_TimeAtPericenter=2398766.03860
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Encke%281858VIII%29]
 absolute_magnitude=8.7
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Encke (1858VIII)
 orbit_ArgOfPericenter=183.45680
 orbit_AscendingNode=335.76840
@@ -16126,17 +11741,11 @@ orbit_TimeAtPericenter=2399971.36580
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Encke%281862I%29]
 absolute_magnitude=9.1
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Encke (1862I)
 orbit_ArgOfPericenter=183.47990
 orbit_AscendingNode=335.75790
@@ -16148,17 +11757,11 @@ orbit_TimeAtPericenter=2401178.24690
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Encke%281865II%29]
 absolute_magnitude=9.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Encke (1865II)
 orbit_ArgOfPericenter=183.50010
 orbit_AscendingNode=335.74840
@@ -16170,17 +11773,11 @@ orbit_TimeAtPericenter=2402384.92210
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Encke%281868III%29]
 absolute_magnitude=9.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Encke (1868III)
 orbit_ArgOfPericenter=183.65560
 orbit_AscendingNode=335.68020
@@ -16192,17 +11789,11 @@ orbit_TimeAtPericenter=2403590.62160
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Encke%281871c_1871V%29]
 absolute_magnitude=8.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Encke (1871c=1871V)"
 orbit_ArgOfPericenter=183.64250
 orbit_AscendingNode=335.68310
@@ -16214,17 +11805,11 @@ orbit_TimeAtPericenter=2404790.80360
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Encke%281875a_1875II%29]
 absolute_magnitude=9.9
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Encke (1875a=1875II)"
 orbit_ArgOfPericenter=183.65800
 orbit_AscendingNode=335.67540
@@ -16236,17 +11821,11 @@ orbit_TimeAtPericenter=2405991.99010
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Encke%281881d_1881VII%29]
 absolute_magnitude=9.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Encke (1881d=1881VII)"
 orbit_ArgOfPericenter=183.91110
 orbit_AscendingNode=335.53910
@@ -16258,17 +11837,11 @@ orbit_TimeAtPericenter=2408400.30340
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Encke%281884d_1885I%29]
 absolute_magnitude=9.7
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Encke (1884d=1885I)"
 orbit_ArgOfPericenter=183.91430
 orbit_AscendingNode=335.53180
@@ -16280,17 +11853,11 @@ orbit_TimeAtPericenter=2409608.63710
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Encke%281888b_1888II%29]
 absolute_magnitude=9.7
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Encke (1888b=1888II)"
 orbit_ArgOfPericenter=183.93860
 orbit_AscendingNode=335.51780
@@ -16302,17 +11869,11 @@ orbit_TimeAtPericenter=2410816.96990
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Encke%281891c_1891III%29]
 absolute_magnitude=8.7
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Encke (1891c=1891III)"
 orbit_ArgOfPericenter=183.95370
 orbit_AscendingNode=335.51710
@@ -16324,17 +11885,11 @@ orbit_TimeAtPericenter=2412023.92540
 orbit_good=1000
 radius=5
 slope_parameter=3.4
-tex_map=nomap.png
 type=comet
 
 [P_Encke%281894d_1895I%29]
 absolute_magnitude=9.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Encke (1894d=1895I)"
 orbit_ArgOfPericenter=183.95160
 orbit_AscendingNode=335.51500
@@ -16346,17 +11901,11 @@ orbit_TimeAtPericenter=2413229.74960
 orbit_good=1000
 radius=5
 slope_parameter=4.1
-tex_map=nomap.png
 type=comet
 
 [P_Encke%281901b_1901II%29]
 absolute_magnitude=9.1
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Encke (1901b=1901II)"
 orbit_ArgOfPericenter=183.98110
 orbit_AscendingNode=335.49350
@@ -16368,17 +11917,11 @@ orbit_TimeAtPericenter=2415643.46510
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Encke%281904b_1905I%29]
 absolute_magnitude=9.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Encke (1904b=1905I)"
 orbit_ArgOfPericenter=184.63050
 orbit_AscendingNode=335.05420
@@ -16390,17 +11933,11 @@ orbit_TimeAtPericenter=2416857.88060
 orbit_good=1000
 radius=5
 slope_parameter=5.8
-tex_map=nomap.png
 type=comet
 
 [P_Encke%281960i_1961I%29]
 absolute_magnitude=9.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Encke (1960i=1961I)"
 orbit_ArgOfPericenter=185.23010
 orbit_AscendingNode=334.71890
@@ -16412,17 +11949,11 @@ orbit_TimeAtPericenter=2437336.09490
 orbit_good=1000
 radius=5
 slope_parameter=1.9
-tex_map=nomap.png
 type=comet
 
 [P_Faye%281843III%29]
 absolute_magnitude=4.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Faye (1843III)
 orbit_ArgOfPericenter=200.03040
 orbit_AscendingNode=211.01400
@@ -16434,17 +11965,11 @@ orbit_TimeAtPericenter=2394491.14370
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Faye%281851I%29]
 absolute_magnitude=5.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Faye (1851I)
 orbit_ArgOfPericenter=200.14920
 orbit_AscendingNode=210.93680
@@ -16456,17 +11981,11 @@ orbit_TimeAtPericenter=2397214.94330
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Faye%281858V%29]
 absolute_magnitude=8.1
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Faye (1858V)
 orbit_ArgOfPericenter=200.14250
 orbit_AscendingNode=210.97350
@@ -16478,17 +11997,11 @@ orbit_TimeAtPericenter=2399935.88500
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Faye%281866II%29]
 absolute_magnitude=6.4
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Faye (1866II)
 orbit_ArgOfPericenter=200.20620
 orbit_AscendingNode=210.90740
@@ -16500,17 +12013,11 @@ orbit_TimeAtPericenter=2402646.97570
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Faye%281873f_1873III%29]
 absolute_magnitude=7.4
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Faye (1873f=1873III)"
 orbit_ArgOfPericenter=200.36440
 orbit_AscendingNode=210.79730
@@ -16522,17 +12029,11 @@ orbit_TimeAtPericenter=2405358.48470
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Faye%281880c_1881I%29]
 absolute_magnitude=7.4
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Faye (1880c=1881I)"
 orbit_ArgOfPericenter=201.18800
 orbit_AscendingNode=210.59510
@@ -16544,17 +12045,11 @@ orbit_TimeAtPericenter=2408103.65790
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Faye%281888d_1888IV%29]
 absolute_magnitude=7.4
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Faye (1888d=1888IV)"
 orbit_ArgOfPericenter=201.21220
 orbit_AscendingNode=210.57300
@@ -16566,17 +12061,11 @@ orbit_TimeAtPericenter=2410869.68040
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Faye%281895b_1896II%29]
 absolute_magnitude=7.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Faye (1895b=1896II)"
 orbit_ArgOfPericenter=201.26820
 orbit_AscendingNode=210.52380
@@ -16588,17 +12077,11 @@ orbit_TimeAtPericenter=2413638.01940
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Faye%281910e_1910V%29]
 absolute_magnitude=9.1
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Faye (1910e=1910V)"
 orbit_ArgOfPericenter=199.53100
 orbit_AscendingNode=206.77730
@@ -16610,17 +12093,11 @@ orbit_TimeAtPericenter=2418977.85310
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Faye%281932l_1932IX%29]
 absolute_magnitude=9.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Faye (1932l=1932IX)"
 orbit_ArgOfPericenter=200.06760
 orbit_AscendingNode=206.46650
@@ -16632,17 +12109,11 @@ orbit_TimeAtPericenter=2427047.73490
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Faye%281961c_1962VII%29]
 absolute_magnitude=9.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Faye (1961c=1962VII)"
 orbit_ArgOfPericenter=203.55080
 orbit_AscendingNode=199.12580
@@ -16654,17 +12125,11 @@ orbit_TimeAtPericenter=2437799.19650
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Faye%281969a_1969VI%29]
 absolute_magnitude=9.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Faye (1969a=1969VI)"
 orbit_ArgOfPericenter=203.66760
 orbit_AscendingNode=199.05000
@@ -16676,17 +12141,11 @@ orbit_TimeAtPericenter=2440502.08670
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Faye%281976i_1977IV%29]
 absolute_magnitude=7.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Faye (1976i=1977IV)"
 orbit_ArgOfPericenter=203.65730
 orbit_AscendingNode=199.08700
@@ -16698,17 +12157,11 @@ orbit_TimeAtPericenter=2443202.32390
 orbit_good=1000
 radius=5
 slope_parameter=5.8
-tex_map=nomap.png
 type=comet
 
 [P_Faye%281984h_1984XI%29]
 absolute_magnitude=7.1
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Faye (1984h=1984XI)"
 orbit_ArgOfPericenter=203.82800
 orbit_AscendingNode=198.98200
@@ -16720,17 +12173,11 @@ orbit_TimeAtPericenter=2445891.39420
 orbit_good=1000
 radius=5
 slope_parameter=6.6
-tex_map=nomap.png
 type=comet
 
 [P_Faye%281991n_1991XXI%29]
 absolute_magnitude=5.4
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Faye (1991n=1991XXI)"
 orbit_ArgOfPericenter=203.95376
 orbit_AscendingNode=198.88006
@@ -16742,17 +12189,11 @@ orbit_TimeAtPericenter=2448576.69368
 orbit_good=1000
 radius=5
 slope_parameter=10.6
-tex_map=nomap.png
 type=comet
 
 [P_Finlay%281886e_1886VII%29]
 absolute_magnitude=9.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Finlay (1886e=1886VII)"
 orbit_ArgOfPericenter=315.23150
 orbit_AscendingNode=53.23940
@@ -16764,17 +12205,11 @@ orbit_TimeAtPericenter=2410233.38970
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Finlay%281906d_1906V%29]
 absolute_magnitude=9.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Finlay (1906d=1906V)"
 orbit_ArgOfPericenter=315.90260
 orbit_AscendingNode=52.88940
@@ -16786,17 +12221,11 @@ orbit_TimeAtPericenter=2417462.35790
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Forbes%281961a_1961VI%29]
 absolute_magnitude=9.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Forbes (1961a=1961VI)"
 orbit_ArgOfPericenter=259.72480
 orbit_AscendingNode=25.39070
@@ -16808,17 +12237,11 @@ orbit_TimeAtPericenter=2437505.25770
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Forbes%281974a_1974IX%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Forbes (1974a=1974IX)"
 orbit_ArgOfPericenter=259.91860
 orbit_AscendingNode=25.20180
@@ -16830,17 +12253,11 @@ orbit_TimeAtPericenter=2442187.35590
 orbit_good=1000
 radius=5
 slope_parameter=5.4
-tex_map=nomap.png
 type=comet
 
 [P_Forbes%281980a_1980VI%29]
 absolute_magnitude=9.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Forbes (1980a=1980VI)"
 orbit_ArgOfPericenter=262.53880
 orbit_AscendingNode=23.01820
@@ -16852,17 +12269,11 @@ orbit_TimeAtPericenter=2444507.27420
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Forbes%281986g_1987I%29]
 absolute_magnitude=9.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Forbes (1986g=1987I)"
 orbit_ArgOfPericenter=262.71600
 orbit_AscendingNode=22.91070
@@ -16874,17 +12285,11 @@ orbit_TimeAtPericenter=2446797.16270
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Forbes%281993f%29]
 absolute_magnitude=9.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Forbes (1993f)
 orbit_ArgOfPericenter=310.55534
 orbit_AscendingNode=333.73834
@@ -16896,17 +12301,11 @@ orbit_TimeAtPericenter=2449061.13221
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Gale%281927f_1927VI%29]
 absolute_magnitude=9.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Gale (1927f=1927VI)"
 orbit_ArgOfPericenter=209.84140
 orbit_AscendingNode=67.42190
@@ -16918,17 +12317,11 @@ orbit_TimeAtPericenter=2425046.05510
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Gehrels1%281972k_1973I%29]
 absolute_magnitude=8.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Gehrels 1 (1972k=1973I)"
 orbit_ArgOfPericenter=28.93120
 orbit_AscendingNode=14.63000
@@ -16940,17 +12333,11 @@ orbit_TimeAtPericenter=2441707.18480
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Gehrels1%281987v_1987XVI%29]
 absolute_magnitude=8.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Gehrels 1 (1987v=1987XVI)"
 orbit_ArgOfPericenter=28.48141
 orbit_AscendingNode=12.86813
@@ -16962,17 +12349,11 @@ orbit_TimeAtPericenter=2447017.74370
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Gehrels2%281973n_1973XI%29]
 absolute_magnitude=9.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Gehrels 2 (1973n=1973XI)"
 orbit_ArgOfPericenter=183.33480
 orbit_AscendingNode=215.61370
@@ -16984,17 +12365,11 @@ orbit_TimeAtPericenter=2442018.11240
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Gehrels2%281981f_1981XVII%29]
 absolute_magnitude=9.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Gehrels 2 (1981f=1981XVII)"
 orbit_ArgOfPericenter=183.46670
 orbit_AscendingNode=215.53470
@@ -17006,17 +12381,11 @@ orbit_TimeAtPericenter=2444927.32550
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Gehrels2%281989n_1989XVII%29]
 absolute_magnitude=9.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Gehrels 2 (1989n=1989XVII)"
 orbit_ArgOfPericenter=183.54068
 orbit_AscendingNode=215.52509
@@ -17028,17 +12397,11 @@ orbit_TimeAtPericenter=2447833.63874
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Gehrels3%281975o_1977VII%29]
 absolute_magnitude=6.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Gehrels 3 (1975o=1977VII)"
 orbit_ArgOfPericenter=231.47710
 orbit_AscendingNode=242.54800
@@ -17050,17 +12413,11 @@ orbit_TimeAtPericenter=2443256.68380
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Gehrels3%281984l_1985IV%29]
 absolute_magnitude=6.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Gehrels 3 (1984l=1985IV)"
 orbit_ArgOfPericenter=231.30350
 orbit_AscendingNode=242.44690
@@ -17072,17 +12429,11 @@ orbit_TimeAtPericenter=2446219.87220
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Gehrels3%281992v%29]
 absolute_magnitude=6.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Gehrels 3 (1992v)
 orbit_ArgOfPericenter=231.87906
 orbit_AscendingNode=242.33098
@@ -17094,17 +12445,11 @@ orbit_TimeAtPericenter=2449193.92080
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Giacobini%281896d_1896V%29]
 absolute_magnitude=9.9
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Giacobini (1896d=1896V)"
 orbit_ArgOfPericenter=140.52020
 orbit_AscendingNode=194.18830
@@ -17116,17 +12461,11 @@ orbit_TimeAtPericenter=2413861.03420
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Giacobini-Zinner%281965g_1966I%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Giacobini-Zinner (1965g=1966I)"
 orbit_ArgOfPericenter=172.91990
 orbit_AscendingNode=195.96500
@@ -17138,17 +12477,11 @@ orbit_TimeAtPericenter=2439212.78440
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Giacobini-Zinner%281972d_1972VI%29]
 absolute_magnitude=9.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Giacobini-Zinner (1972d=1972VI)"
 orbit_ArgOfPericenter=171.90390
 orbit_AscendingNode=195.13110
@@ -17160,17 +12493,11 @@ orbit_TimeAtPericenter=2441534.38490
 orbit_good=1000
 radius=5
 slope_parameter=4.8
-tex_map=nomap.png
 type=comet
 
 [P_Giacobini-Zinner%281978h_1979III%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Giacobini-Zinner (1978h=1979III)"
 orbit_ArgOfPericenter=171.97350
 orbit_AscendingNode=195.06940
@@ -17182,17 +12509,11 @@ orbit_TimeAtPericenter=2443917.27400
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Giacobini-Zinner%281984e_1985XIII%29]
 absolute_magnitude=9.6
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Giacobini-Zinner (1984e=1985XIII)"
 orbit_ArgOfPericenter=172.48430
 orbit_AscendingNode=194.70670
@@ -17204,17 +12525,11 @@ orbit_TimeAtPericenter=2446313.70600
 orbit_good=1000
 radius=5
 slope_parameter=4.8
-tex_map=nomap.png
 type=comet
 
 [P_Giacobini-Zinner%281991m_1992IX%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Giacobini-Zinner (1991m=1992IX)"
 orbit_ArgOfPericenter=172.52103
 orbit_AscendingNode=194.68221
@@ -17226,17 +12541,11 @@ orbit_TimeAtPericenter=2448725.72790
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Giclas%281978k_1978XXII%29]
 absolute_magnitude=9.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Giclas (1978k=1978XXII)"
 orbit_ArgOfPericenter=247.18580
 orbit_AscendingNode=141.54590
@@ -17248,17 +12557,11 @@ orbit_TimeAtPericenter=2443833.65950
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Giclas%281985g_1985XV%29]
 absolute_magnitude=6.9
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Giclas (1985g=1985XV)"
 orbit_ArgOfPericenter=276.31670
 orbit_AscendingNode=111.94340
@@ -17270,17 +12573,11 @@ orbit_TimeAtPericenter=2446339.73490
 orbit_good=1000
 radius=5
 slope_parameter=10.0
-tex_map=nomap.png
 type=comet
 
 [P_Giclas%281992l_1992XXV%29]
 absolute_magnitude=9.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Giclas (1992l=1992XXV)"
 orbit_ArgOfPericenter=276.44052
 orbit_AscendingNode=111.87256
@@ -17292,17 +12589,11 @@ orbit_TimeAtPericenter=2448878.59190
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Grigg-Skjellerup%281902c_1902II%29]
 absolute_magnitude=9.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Grigg-Skjellerup (1902c=1902II)"
 orbit_ArgOfPericenter=350.73200
 orbit_AscendingNode=221.26500
@@ -17314,17 +12605,11 @@ orbit_TimeAtPericenter=2415934.00300
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Gunn%281953VIII%29]
 absolute_magnitude=5.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Gunn (1953VIII)
 orbit_ArgOfPericenter=173.91720
 orbit_AscendingNode=79.73710
@@ -17336,17 +12621,11 @@ orbit_TimeAtPericenter=2434517.89070
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Gunn%281970p_1969II%29]
 absolute_magnitude=5.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Gunn (1970p=1969II)"
 orbit_ArgOfPericenter=197.11880
 orbit_AscendingNode=68.03790
@@ -17358,17 +12637,11 @@ orbit_TimeAtPericenter=2440330.38660
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Gunn%281976III%29]
 absolute_magnitude=5.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Gunn (1976III)
 orbit_ArgOfPericenter=197.47950
 orbit_AscendingNode=67.97700
@@ -17380,17 +12653,11 @@ orbit_TimeAtPericenter=2442819.32600
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Gunn%281982X%29]
 absolute_magnitude=5.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Gunn (1982X)
 orbit_ArgOfPericenter=196.98250
 orbit_AscendingNode=67.88510
@@ -17402,17 +12669,11 @@ orbit_TimeAtPericenter=2445300.39000
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Gunn%281989XI%29]
 absolute_magnitude=5.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Gunn (1989XI)
 orbit_ArgOfPericenter=196.93778
 orbit_AscendingNode=67.86766
@@ -17424,17 +12685,11 @@ orbit_TimeAtPericenter=2447794.47985
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Gunn%281996%29]
 absolute_magnitude=5.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Gunn (1996)
 orbit_ArgOfPericenter=196.78269
 orbit_AscendingNode=67.85453
@@ -17446,17 +12701,11 @@ orbit_TimeAtPericenter=2450288.90090
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Halley%28-11%29]
 absolute_magnitude=0.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=1P/Halley
 iau_designation=-11 Q1
 perihelion_code=-11
@@ -17471,17 +12720,11 @@ orbit_good=1000
 model=1682q1halley_MLfix.obj
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Halley%28-163%29]
 absolute_magnitude=-0.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=1P/Halley
 iau_designation=-163 U1
 perihelion_code=-163
@@ -17496,17 +12739,11 @@ orbit_good=1000
 model=1682q1halley_MLfix.obj
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Halley%28-239%29]
 absolute_magnitude=0.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=1P/Halley
 iau_designation=-239 K1
 perihelion_code=-239
@@ -17521,17 +12758,11 @@ orbit_good=1000
 model=1682q1halley_MLfix.obj
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Halley%28-314%29]
 absolute_magnitude=0.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=1P/Halley
 perihelion_code=-314
 orbit_ArgOfPericenter=86.86997
@@ -17545,17 +12776,11 @@ orbit_good=1000
 model=1682q1halley_MLfix.obj
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Halley%28-390%29]
 absolute_magnitude=0.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=1P/Halley
 perihelion_code=-390
 orbit_ArgOfPericenter=86.80007
@@ -17569,17 +12794,11 @@ orbit_good=1000
 model=1682q1halley_MLfix.obj
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Halley%28-86%29]
 absolute_magnitude=0.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=1P/Halley
 iau_designation=-86 Q1
 perihelion_code=-86
@@ -17594,17 +12813,11 @@ orbit_good=1000
 model=1682q1halley_MLfix.obj
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Halley%281066%29]
 absolute_magnitude=0.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=1P/Halley
 iau_designation=1066 G1
 perihelion_code=1066
@@ -17619,17 +12832,11 @@ orbit_good=1000
 model=1682q1halley_MLfix.obj
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Halley%281145%29]
 absolute_magnitude=2.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=1P/Halley
 iau_designation=1145 G1
 perihelion_code=1145
@@ -17644,17 +12851,11 @@ orbit_good=1000
 model=1682q1halley_MLfix.obj
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Halley%281222%29]
 absolute_magnitude=2.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=1P/Halley
 iau_designation=1222 R1
 perihelion_code=1222
@@ -17669,17 +12870,11 @@ orbit_good=1000
 model=1682q1halley_MLfix.obj
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Halley%281301%29]
 absolute_magnitude=3.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=1P/Halley
 iau_designation=1301 R1
 perihelion_code=1301
@@ -17694,17 +12889,11 @@ orbit_good=1000
 model=1682q1halley_MLfix.obj
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Halley%281378%29]
 absolute_magnitude=3.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=1P/Halley
 iau_designation=1378 S1
 perihelion_code=1378
@@ -17719,17 +12908,11 @@ orbit_good=1000
 model=1682q1halley_MLfix.obj
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Halley%28141%29]
 absolute_magnitude=0.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=1P/Halley
 iau_designation=141 F1
 perihelion_code=141
@@ -17744,17 +12927,11 @@ orbit_good=1000
 model=1682q1halley_MLfix.obj
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Halley%281456%29]
 absolute_magnitude=4.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=1P/Halley
 iau_designation=1456 K1
 perihelion_code=1456
@@ -17769,17 +12946,11 @@ orbit_good=1000
 model=1682q1halley_MLfix.obj
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Halley%281531%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=1P/Halley
 iau_designation=1531 P1
 perihelion_code=1531
@@ -17794,17 +12965,11 @@ orbit_good=1000
 model=1682q1halley_MLfix.obj
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Halley%281607%29]
 absolute_magnitude=3.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=1P/Halley
 iau_designation=1607 S1
 perihelion_code=1607
@@ -17819,17 +12984,11 @@ orbit_good=1000
 model=1682q1halley_MLfix.obj
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Halley%281682%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=1P/Halley
 iau_designation=1682 Q1
 perihelion_code=1682
@@ -17844,17 +13003,11 @@ orbit_good=1000
 model=1682q1halley_MLfix.obj
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Halley%281759I%29]
 absolute_magnitude=3.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=1P/Halley
 iau_designation=1758 Y1
 perihelion_code=1759I
@@ -17869,17 +13022,11 @@ orbit_good=1000
 model=1682q1halley_MLfix.obj
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Halley%281835III%29]
 absolute_magnitude=5.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=1P/Halley 
 iau_designation=1835 P1
 perihelion_code=1835III
@@ -17894,17 +13041,11 @@ orbit_good=1000
 model=1682q1halley_MLfix.obj
 radius=5
 slope_parameter=5.0
-tex_map=nomap.png
 type=comet
 
 [P_Halley%281909c_1910II%29]
 absolute_magnitude=4.9
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=1P/Halley (1909c=1910II)
 discovery_code=1909c
 iau_designation=1909 R1
@@ -17920,17 +13061,11 @@ orbit_good=1000
 model=1682q1halley_MLfix.obj
 radius=5
 slope_parameter=5.4
-tex_map=nomap.png
 type=comet
 
 [P_Halley%281982i_1986III%29]
 absolute_magnitude=4.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=1P/Halley
 discovery_code=1982i
 iau_designation=1982 U1
@@ -17946,17 +13081,11 @@ orbit_good=4000
 model=1682q1halley_MLfix.obj
 radius=5
 slope_parameter=4.9
-tex_map=nomap.png
 type=comet
 
 [P_Halley%28218%29]
 absolute_magnitude=0.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=1P/Halley
 iau_designation=218 H1
 perihelion_code=218
@@ -17971,17 +13100,11 @@ orbit_good=1000
 model=1682q1halley_MLfix.obj
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Halley%28295%29]
 absolute_magnitude=1.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=1P/Halley
 iau_designation=295 J1
 perihelion_code=295
@@ -17996,17 +13119,11 @@ orbit_good=1000
 model=1682q1halley_MLfix.obj
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Halley%28374%29]
 absolute_magnitude=1.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=1P/Halley
 iau_designation=374 E1
 perihelion_code=374
@@ -18021,17 +13138,11 @@ orbit_good=1000
 model=1682q1halley_MLfix.obj
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Halley%28451%29]
 absolute_magnitude=1.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=1P/Halley
 iau_designation=451 L1
 perihelion_code=451
@@ -18046,17 +13157,11 @@ orbit_good=1000
 model=1682q1halley_MLfix.obj
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Halley%28530%29]
 absolute_magnitude=1.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=1P/Halley
 iau_designation=530 Q1
 perihelion_code=530
@@ -18071,17 +13176,11 @@ orbit_good=1000
 model=1682q1halley_MLfix.obj
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Halley%28607%29]
 absolute_magnitude=2.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=1P/Halley
 iau_designation=607 H1
 perihelion_code=607
@@ -18096,17 +13195,11 @@ orbit_good=1000
 model=1682q1halley_MLfix.obj
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Halley%2866%29]
 absolute_magnitude=0.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=1P/Halley
 iau_designation=66 B1
 perihelion_code=66
@@ -18121,17 +13214,11 @@ orbit_good=1000
 model=1682q1halley_MLfix.obj
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Halley%28684%29]
 absolute_magnitude=2.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=1P/Halley
 iau_designation=684 R1
 perihelion_code=684
@@ -18146,17 +13233,11 @@ orbit_good=1000
 model=1682q1halley_MLfix.obj
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Halley%28760%29]
 absolute_magnitude=2.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=1P/Halley
 iau_designation=760 K1
 perihelion_code=760
@@ -18171,17 +13252,11 @@ orbit_good=1000
 model=1682q1halley_MLfix.obj
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Halley%28837%29]
 absolute_magnitude=2.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=1P/Halley
 iau_designation=837 F1
 perihelion_code=837
@@ -18196,17 +13271,11 @@ orbit_good=1000
 model=1682q1halley_MLfix.obj
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Halley%28912%29]
 absolute_magnitude=1.7
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=1P/Halley
 iau_designation=912 J1
 perihelion_code=912
@@ -18221,17 +13290,11 @@ orbit_good=1000
 model=1682q1halley_MLfix.obj
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Halley%28989%29]
 absolute_magnitude=3.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=1P/Halley
 iau_designation=989 N1
 perihelion_code=989
@@ -18246,17 +13309,11 @@ orbit_good=1000
 model=1682q1halley_MLfix.obj
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Hartley-IRAS%281983v_1984III%29]
 absolute_magnitude=7.1
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=161P/Hartley-IRAS
 discovery_code=1983v
 perihelion_code=1984III
@@ -18270,17 +13327,11 @@ orbit_TimeAtPericenter=2445708.20946
 orbit_good=1000
 radius=5
 slope_parameter=3.0
-tex_map=nomap.png
 type=comet
 
 [P_Hartley2%281991t_1991XV%29]
 absolute_magnitude=8.7
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=103P/Hartley 2
 discovery_code=1991t
 perihelion_code=1991XV
@@ -18294,17 +13345,11 @@ orbit_TimeAtPericenter=2448511.15424
 orbit_good=1000
 radius=5
 slope_parameter=4.8
-tex_map=nomap.png
 type=comet
 
 [P_Hartley3%281993m%29]
 absolute_magnitude=9.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=110P/Hartley 3
 discovery_code=1993m
 orbit_ArgOfPericenter=168.45499
@@ -18317,17 +13362,11 @@ orbit_TimeAtPericenter=2449493.13148
 orbit_good=1000
 radius=5
 slope_parameter=22.0
-tex_map=nomap.png
 type=comet
 
 [P_Helfenzrieder%281766II%29]
 absolute_magnitude=6.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=D/Helfenzrieder
 iau_designation=1766 G1
 perihelion_code=1766II
@@ -18341,17 +13380,11 @@ orbit_TimeAtPericenter=2366195.40880
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Helin-Lawrence%281993l%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=152P/Helin-Lawrence
 perihelion_code=1993l
 orbit_ArgOfPericenter=163.70129
@@ -18364,17 +13397,11 @@ orbit_TimeAtPericenter=2449168.89583
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Helin-Roman-Alu1%281989w_1987XXXVII%29]
 absolute_magnitude=8.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=117P/Helin-Roman-Alu 1
 discovery_code=1989w
 perihelion_code=1987XXXVII
@@ -18388,17 +13415,11 @@ orbit_TimeAtPericenter=2447081.06492
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Helin-Roman-Crockett%281996%29]
 absolute_magnitude=7.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=111P/Helin-Roman-Crockett (1996)
 orbit_ArgOfPericenter=10.08445
 orbit_AscendingNode=91.36717
@@ -18410,17 +13431,11 @@ orbit_TimeAtPericenter=2450388.67585
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Herschel-Rigollet%281788II%29]
 absolute_magnitude=7.1
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=35P/Herschel-Rigollet
 perihelion_code=1788II
 orbit_ArgOfPericenter=29.57200
@@ -18433,17 +13448,11 @@ orbit_TimeAtPericenter=2374438.13700
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Herschel-Rigollet%281939h_1939VI%29]
 absolute_magnitude=8.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=35P/Herschel-Rigollet
 discovery_code=1939h
 perihelion_code=1939VI
@@ -18457,17 +13466,11 @@ orbit_TimeAtPericenter=2429484.96400
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Holmes%281892f_1892III%29]
 absolute_magnitude=3.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=17P/Holmes
 discovery_code=1892f
 perihelion_code=1892III
@@ -18481,17 +13484,11 @@ orbit_TimeAtPericenter=2412263.39050
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Holmes%281899d_1899II%29]
 absolute_magnitude=9.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=17P/Holmes
 discovery_code=1899d
 perihelion_code=1899II
@@ -18505,17 +13502,11 @@ orbit_TimeAtPericenter=2414773.09850
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Holmes%281906f_1906III%29]
 absolute_magnitude=9.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=17P/Holmes
 discovery_code=1906f
 perihelion_code=1906III
@@ -18529,17 +13520,11 @@ orbit_TimeAtPericenter=2417284.24610
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Holmes%281964i_1964X%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=17P/Holmes
 discovery_code=1964i
 perihelion_code=1964X
@@ -18553,17 +13538,11 @@ orbit_TimeAtPericenter=2438715.43060
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Holmes%281971b_1972I%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=17P/Holmes
 discovery_code=1971b
 perihelion_code=1972I
@@ -18577,17 +13556,11 @@ orbit_TimeAtPericenter=2441347.32500
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Holmes%281979f_1979IV%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=17P/Holmes
 discovery_code=1979f
 perihelion_code=1979IV
@@ -18601,17 +13574,11 @@ orbit_TimeAtPericenter=2443927.16810
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Holmes%281986f_1986V%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=17P/Holmes
 discovery_code=1986f
 perihelion_code=1986V
@@ -18625,17 +13592,11 @@ orbit_TimeAtPericenter=2446503.63520
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Holmes%281993i%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=17P/Holmes
 discovery_code=1993i
 orbit_ArgOfPericenter=23.23183
@@ -18648,17 +13609,11 @@ orbit_TimeAtPericenter=2449088.24671
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Howell%281981k_1981X%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=88P/Howell
 discovery_code=1981k
 perihelion_code=1981X
@@ -18672,17 +13627,11 @@ orbit_TimeAtPericenter=2444728.85780
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Howell%281987h_1987VI%29]
 absolute_magnitude=8.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=88P/Howell
 discovery_code=1987h
 perihelion_code=1987VI
@@ -18696,17 +13645,11 @@ orbit_TimeAtPericenter=2446900.03760
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Howell%281992c%29]
 absolute_magnitude=8.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=88P/Howell
 discovery_code=1992c
 orbit_ArgOfPericenter=234.68175
@@ -18719,17 +13662,11 @@ orbit_TimeAtPericenter=2449044.59601
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_IRAS%281983j_1983XIV%29]
 absolute_magnitude=9.4
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=126P/IRAS
 discovery_code=1983j
 perihelion_code=1983XIV
@@ -18743,17 +13680,11 @@ orbit_TimeAtPericenter=2445570.30205
 orbit_good=1000
 radius=5
 slope_parameter=4.2
-tex_map=nomap.png
 type=comet
 
 [P_IRAS%281996%29]
 absolute_magnitude=9.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/IRAS (1996)
 orbit_ArgOfPericenter=356.88629
 orbit_AscendingNode=357.00322
@@ -18765,17 +13696,11 @@ orbit_TimeAtPericenter=2450388.15110
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Johnson%281949d_1949II%29]
 absolute_magnitude=9.6
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Johnson (1949d=1949II)"
 orbit_ArgOfPericenter=206.13510
 orbit_AscendingNode=118.18560
@@ -18787,17 +13712,11 @@ orbit_TimeAtPericenter=2433176.01770
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Johnson%281956f_1956V%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Johnson (1956f=1956V)"
 orbit_ArgOfPericenter=206.01660
 orbit_AscendingNode=118.16570
@@ -18809,17 +13728,11 @@ orbit_TimeAtPericenter=2435681.40400
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Johnson%281963c_1963IV%29]
 absolute_magnitude=7.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Johnson (1963c=1963IV)"
 orbit_ArgOfPericenter=206.04520
 orbit_AscendingNode=118.15450
@@ -18831,17 +13744,11 @@ orbit_TimeAtPericenter=2438189.68080
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Johnson%281970h_1970IV%29]
 absolute_magnitude=7.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Johnson (1970h=1970IV)"
 orbit_ArgOfPericenter=206.00080
 orbit_AscendingNode=117.85750
@@ -18853,17 +13760,11 @@ orbit_TimeAtPericenter=2440675.54300
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Johnson%281976h_1977I%29]
 absolute_magnitude=7.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Johnson (1976h=1977I)"
 orbit_ArgOfPericenter=206.20930
 orbit_AscendingNode=117.79550
@@ -18875,17 +13776,11 @@ orbit_TimeAtPericenter=2443151.93200
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Johnson%281983h_1983XVIII%29]
 absolute_magnitude=7.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Johnson (1983h=1983XVIII)"
 orbit_ArgOfPericenter=208.15310
 orbit_AscendingNode=116.72460
@@ -18897,17 +13792,11 @@ orbit_TimeAtPericenter=2445671.71940
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Johnson%281990h_1990XXIII%29]
 absolute_magnitude=7.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Johnson (1990h=1990XXIII)"
 orbit_ArgOfPericenter=208.27665
 orbit_AscendingNode=116.67362
@@ -18919,17 +13808,11 @@ orbit_TimeAtPericenter=2448214.46313
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Kearns-Kwee%281963d_1963VIII%29]
 absolute_magnitude=5.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Kearns-Kwee (1963d=1963VIII)"
 orbit_ArgOfPericenter=131.19450
 orbit_AscendingNode=315.43880
@@ -18941,17 +13824,11 @@ orbit_TimeAtPericenter=2438370.51190
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Kearns-Kwee%281971c_1972XI%29]
 absolute_magnitude=5.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Kearns-Kwee (1971c=1972XI)"
 orbit_ArgOfPericenter=131.24780
 orbit_AscendingNode=315.40650
@@ -18963,17 +13840,11 @@ orbit_TimeAtPericenter=2441649.93490
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Kearns-Kwee%281981h_1981XX%29]
 absolute_magnitude=5.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Kearns-Kwee (1981h=1981XX)"
 orbit_ArgOfPericenter=131.37510
 orbit_AscendingNode=315.26190
@@ -18985,17 +13856,11 @@ orbit_TimeAtPericenter=2444938.90730
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Kearns-Kwee%281989u_1990XXV%29]
 absolute_magnitude=5.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Kearns-Kwee (1989u=1990XXV)"
 orbit_ArgOfPericenter=131.83466
 orbit_AscendingNode=315.02756
@@ -19007,17 +13872,11 @@ orbit_TimeAtPericenter=2448218.10779
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Kohoutek%281975c_1975III%29]
 absolute_magnitude=9.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Kohoutek (1975c=1975III)"
 orbit_ArgOfPericenter=169.75010
 orbit_AscendingNode=273.19350
@@ -19029,17 +13888,11 @@ orbit_TimeAtPericenter=2442430.68280
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Kohoutek%281980j_1981IX%29]
 absolute_magnitude=9.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Kohoutek (1980j=1981IX)"
 orbit_ArgOfPericenter=169.88980
 orbit_AscendingNode=273.12580
@@ -19051,17 +13904,11 @@ orbit_TimeAtPericenter=2444711.39680
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Kohoutek%281994%29]
 absolute_magnitude=9.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Kohoutek (1994)
 orbit_ArgOfPericenter=175.86468
 orbit_AscendingNode=268.92507
@@ -19073,17 +13920,11 @@ orbit_TimeAtPericenter=2449533.40113
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Kopff%281906e_1906IV%29]
 absolute_magnitude=9.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Kopff (1906e=1906IV)"
 orbit_ArgOfPericenter=19.80500
 orbit_AscendingNode=264.30280
@@ -19095,17 +13936,11 @@ orbit_TimeAtPericenter=2417333.67720
 orbit_good=1000
 radius=5
 slope_parameter=3.4
-tex_map=nomap.png
 type=comet
 
 [P_Kopff%281919a_1919I%29]
 absolute_magnitude=8.6
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Kopff (1919a=1919I)"
 orbit_ArgOfPericenter=19.72120
 orbit_AscendingNode=264.26720
@@ -19117,17 +13952,11 @@ orbit_TimeAtPericenter=2422138.22470
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Kopff%281932e_1932III%29]
 absolute_magnitude=9.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Kopff (1932e=1932III)"
 orbit_ArgOfPericenter=19.71730
 orbit_AscendingNode=264.20640
@@ -19139,17 +13968,11 @@ orbit_TimeAtPericenter=2426940.91210
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Kopff%281945b_1945V%29]
 absolute_magnitude=9.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Kopff (1945b=1945V)"
 orbit_ArgOfPericenter=31.54090
 orbit_AscendingNode=253.11990
@@ -19161,17 +13984,11 @@ orbit_TimeAtPericenter=2431678.77250
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Kopff%281958d_1958I%29]
 absolute_magnitude=7.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Kopff (1958d=1958I)"
 orbit_ArgOfPericenter=161.79730
 orbit_AscendingNode=120.91550
@@ -19183,17 +14000,11 @@ orbit_TimeAtPericenter=2436223.92920
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Kopff%281963i_1964III%29]
 absolute_magnitude=7.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Kopff (1963i=1964III)"
 orbit_ArgOfPericenter=161.92720
 orbit_AscendingNode=120.86990
@@ -19205,17 +14016,11 @@ orbit_TimeAtPericenter=2438531.66630
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Kopff%281970c_1970XI%29]
 absolute_magnitude=7.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Kopff (1970c=1970XI)"
 orbit_ArgOfPericenter=162.76190
 orbit_AscendingNode=120.38380
@@ -19227,17 +14032,11 @@ orbit_TimeAtPericenter=2440861.82270
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Kopff%281976b_1977V%29]
 absolute_magnitude=7.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Kopff (1976b=1977V)"
 orbit_ArgOfPericenter=162.91540
 orbit_AscendingNode=120.32380
@@ -19249,17 +14048,11 @@ orbit_TimeAtPericenter=2443210.46280
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Kopff%281982k_1983XIII%29]
 absolute_magnitude=3.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Kopff (1982k=1983XIII)"
 orbit_ArgOfPericenter=162.82050
 orbit_AscendingNode=120.29880
@@ -19271,17 +14064,11 @@ orbit_TimeAtPericenter=2445556.79950
 orbit_good=1000
 radius=5
 slope_parameter=10.0
-tex_map=nomap.png
 type=comet
 
 [P_Kopff%281988k_1990I%29]
 absolute_magnitude=7.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Kopff (1988k=1990I)"
 orbit_ArgOfPericenter=162.82910
 orbit_AscendingNode=120.28910
@@ -19293,17 +14080,11 @@ orbit_TimeAtPericenter=2447911.87250
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Kopff%281996%29]
 absolute_magnitude=7.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Kopff (1996)
 orbit_ArgOfPericenter=162.77037
 orbit_AscendingNode=120.27903
@@ -19315,17 +14096,11 @@ orbit_TimeAtPericenter=2450266.69980
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Kowal-Vavrova%281983t_1983III%29]
 absolute_magnitude=9.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Kowal-Vavrova (1983t=1983III)"
 orbit_ArgOfPericenter=19.49680
 orbit_AscendingNode=201.84720
@@ -19337,17 +14112,11 @@ orbit_TimeAtPericenter=2445426.92060
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Kowal1%281977f_1977III%29]
 absolute_magnitude=6.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Kowal 1 (1977f=1977III)"
 orbit_ArgOfPericenter=172.07929
 orbit_AscendingNode=28.46465
@@ -19359,17 +14128,11 @@ orbit_TimeAtPericenter=2443142.37462
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Kowal1%281991i_1992VI%29]
 absolute_magnitude=6.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Kowal 1 (1991i=1992VI)"
 orbit_ArgOfPericenter=174.65303
 orbit_AscendingNode=28.12065
@@ -19381,17 +14144,11 @@ orbit_TimeAtPericenter=2448694.59574
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Levy%281991q_1991XI%29]
 absolute_magnitude=7.7
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Levy (1991q=1991XI)"
 orbit_ArgOfPericenter=41.47730
 orbit_AscendingNode=328.72372
@@ -19403,17 +14160,11 @@ orbit_TimeAtPericenter=2448445.69321
 orbit_good=1000
 radius=5
 slope_parameter=4.6
-tex_map=nomap.png
 type=comet
 
 [P_Lexell%281770I%29]
 absolute_magnitude=7.7
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Lexell (1770I)
 orbit_ArgOfPericenter=224.85900
 orbit_AscendingNode=133.92600
@@ -19425,17 +14176,11 @@ orbit_TimeAtPericenter=2367764.54090
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Longmore%281975g_1974XIV%29]
 absolute_magnitude=9.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Longmore (1975g=1974XIV)"
 orbit_ArgOfPericenter=196.27470
 orbit_AscendingNode=15.00920
@@ -19447,17 +14192,11 @@ orbit_TimeAtPericenter=2442355.93180
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Longmore%281981a_1981XVI%29]
 absolute_magnitude=9.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Longmore (1981a=1981XVI)"
 orbit_ArgOfPericenter=195.91200
 orbit_AscendingNode=15.01270
@@ -19469,17 +14208,11 @@ orbit_TimeAtPericenter=2444899.27190
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Longmore%281987c1_1988XVIII%29]
 absolute_magnitude=9.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Longmore (1987c1=1988XVIII)"
 orbit_ArgOfPericenter=195.69710
 orbit_AscendingNode=15.00300
@@ -19491,17 +14224,11 @@ orbit_TimeAtPericenter=2447446.69050
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Longmore%281995%29]
 absolute_magnitude=9.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Longmore (1995)
 orbit_ArgOfPericenter=195.79191
 orbit_AscendingNode=14.96229
@@ -19513,17 +14240,11 @@ orbit_TimeAtPericenter=2449999.82015
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Lovas1%281980s_1980V%29]
 absolute_magnitude=8.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Lovas 1 (1980s=1980V)"
 orbit_ArgOfPericenter=72.56870
 orbit_AscendingNode=342.32310
@@ -19535,17 +14256,11 @@ orbit_TimeAtPericenter=2444485.92480
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Lovas1%281989p_1989XIII%29]
 absolute_magnitude=8.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Lovas 1 (1989p=1989XIII)"
 orbit_ArgOfPericenter=73.61660
 orbit_AscendingNode=341.71720
@@ -19557,17 +14272,11 @@ orbit_TimeAtPericenter=2447810.00460
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Mellish%281917a_1917I%29]
 absolute_magnitude=7.4
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Mellish (1917a=1917I)"
 orbit_ArgOfPericenter=121.30700
 orbit_AscendingNode=87.97990
@@ -19579,17 +14288,11 @@ orbit_TimeAtPericenter=2421329.67510
 orbit_good=1000
 radius=5
 slope_parameter=3.9
-tex_map=nomap.png
 type=comet
 
 [P_Metcalf-Brewington%281906h_1906VI%29]
 absolute_magnitude=9.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Metcalf-Brewington (1906h=1906VI)"
 orbit_ArgOfPericenter=199.78420
 orbit_AscendingNode=195.16900
@@ -19601,17 +14304,11 @@ orbit_TimeAtPericenter=2417493.57940
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Metcalf-Brewington%281991a_1991I%29]
 absolute_magnitude=2.4
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Metcalf-Brewington (1991a=1991I)"
 orbit_ArgOfPericenter=208.04861
 orbit_AscendingNode=187.08234
@@ -19623,17 +14320,11 @@ orbit_TimeAtPericenter=2448262.11458
 orbit_good=1000
 radius=5
 slope_parameter=11.1
-tex_map=nomap.png
 type=comet
 
 [P_Mueller5%281993s%29]
 absolute_magnitude=8.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Mueller 5 (1993s)
 orbit_ArgOfPericenter=29.98229
 orbit_AscendingNode=99.98515
@@ -19645,17 +14336,11 @@ orbit_TimeAtPericenter=2449607.53655
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Neujmin1%281913c_1913III%29]
 absolute_magnitude=8.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Neujmin 1 (1913c=1913III)"
 orbit_ArgOfPericenter=346.23390
 orbit_AscendingNode=348.41630
@@ -19667,17 +14352,11 @@ orbit_TimeAtPericenter=2419996.42950
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Neujmin1%281966a_1966VI%29]
 absolute_magnitude=8.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Neujmin 1 (1966a=1966VI)"
 orbit_ArgOfPericenter=346.81070
 orbit_AscendingNode=347.18420
@@ -19689,17 +14368,11 @@ orbit_TimeAtPericenter=2439468.90400
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Neujmin1%281984c_1984XIX%29]
 absolute_magnitude=8.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Neujmin 1 (1984c=1984XIX)"
 orbit_ArgOfPericenter=346.84276
 orbit_AscendingNode=346.34637
@@ -19711,17 +14384,11 @@ orbit_TimeAtPericenter=2445981.73483
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Neujmin3%281972g_1972IV%29]
 absolute_magnitude=9.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Neujmin 3 (1972g=1972IV)"
 orbit_ArgOfPericenter=146.92980
 orbit_AscendingNode=150.20210
@@ -19733,17 +14400,11 @@ orbit_TimeAtPericenter=2441454.04110
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Neujmin3%281993j%29]
 absolute_magnitude=9.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Neujmin 3 (1993j)
 orbit_ArgOfPericenter=146.97199
 orbit_AscendingNode=149.76647
@@ -19755,17 +14416,11 @@ orbit_TimeAtPericenter=2449304.53804
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Olbers%281815%29]
 absolute_magnitude=4.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Olbers (1815)
 orbit_ArgOfPericenter=65.58130
 orbit_AscendingNode=85.34050
@@ -19777,17 +14432,11 @@ orbit_TimeAtPericenter=2384089.99510
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Olbers%281887f_1887V%29]
 absolute_magnitude=5.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Olbers (1887f=1887V)"
 orbit_ArgOfPericenter=65.34670
 orbit_AscendingNode=85.36530
@@ -19799,17 +14448,11 @@ orbit_TimeAtPericenter=2410553.47410
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Olbers%281956a_1956IV%29]
 absolute_magnitude=4.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Olbers (1956a=1956IV)"
 orbit_ArgOfPericenter=64.63520
 orbit_AscendingNode=85.41210
@@ -19821,17 +14464,11 @@ orbit_TimeAtPericenter=2435643.63910
 orbit_good=1000
 radius=5
 slope_parameter=6.6
-tex_map=nomap.png
 type=comet
 
 [P_Oterma%281942VII%29]
 absolute_magnitude=7.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Oterma (1942VII)
 orbit_ArgOfPericenter=354.67470
 orbit_AscendingNode=155.17140
@@ -19843,17 +14480,11 @@ orbit_TimeAtPericenter=2430592.58590
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Oterma%281950III%29]
 absolute_magnitude=7.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Oterma (1950III)
 orbit_ArgOfPericenter=354.78920
 orbit_AscendingNode=155.13000
@@ -19865,17 +14496,11 @@ orbit_TimeAtPericenter=2433478.96980
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Oterma%281958IV%29]
 absolute_magnitude=5.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Oterma (1958IV)
 orbit_ArgOfPericenter=354.87240
 orbit_AscendingNode=155.10930
@@ -19887,17 +14512,11 @@ orbit_TimeAtPericenter=2436365.00080
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Parker-Hartley%281996%29]
 absolute_magnitude=8.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Parker-Hartley (1996)
 orbit_ArgOfPericenter=181.26917
 orbit_AscendingNode=243.54944
@@ -19909,17 +14528,11 @@ orbit_TimeAtPericenter=2450259.95291
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Perrine-Mrkos%281896g_1896VII%29]
 absolute_magnitude=9.9
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Perrine-Mrkos (1896g=1896VII)"
 orbit_ArgOfPericenter=163.87400
 orbit_AscendingNode=247.34400
@@ -19931,17 +14544,11 @@ orbit_TimeAtPericenter=2413888.62000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Perrine-Mrkos%281955i_1955VII%29]
 absolute_magnitude=9.1
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Perrine-Mrkos (1955i=1955VII)"
 orbit_ArgOfPericenter=167.83290
 orbit_AscendingNode=242.51340
@@ -19953,17 +14560,11 @@ orbit_TimeAtPericenter=2435377.88280
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Peters-Hartley%281846VI%29]
 absolute_magnitude=8.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Peters-Hartley (1846VI)
 orbit_ArgOfPericenter=340.93000
 orbit_AscendingNode=262.70000
@@ -19975,17 +14576,11 @@ orbit_TimeAtPericenter=2395451.18300
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Peters-Hartley%281990d_1990IX%29]
 absolute_magnitude=9.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Peters-Hartley (1990d=1990IX)"
 orbit_ArgOfPericenter=338.31707
 orbit_AscendingNode=259.39413
@@ -19997,17 +14592,11 @@ orbit_TimeAtPericenter=2448066.14219
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Pigott%281783%29]
 absolute_magnitude=6.9
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Pigott (1783)
 orbit_ArgOfPericenter=354.64280
 orbit_AscendingNode=57.98670
@@ -20019,17 +14608,11 @@ orbit_TimeAtPericenter=2372610.93040
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Pons-Brooks%281812%29]
 absolute_magnitude=4.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Pons-Brooks (1812)
 orbit_ArgOfPericenter=199.29380
 orbit_AscendingNode=254.93870
@@ -20041,17 +14624,11 @@ orbit_TimeAtPericenter=2383137.32870
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Pons-Brooks%281883b_1884I%29]
 absolute_magnitude=4.9
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Pons-Brooks (1883b=1884I)"
 orbit_ArgOfPericenter=199.18240
 orbit_AscendingNode=255.07450
@@ -20063,17 +14640,11 @@ orbit_TimeAtPericenter=2409201.71610
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Pons-Brooks%281953c_1954VII%29]
 absolute_magnitude=5.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Pons-Brooks (1953c=1954VII)"
 orbit_ArgOfPericenter=199.03460
 orbit_AscendingNode=255.19090
@@ -20085,17 +14656,11 @@ orbit_TimeAtPericenter=2434885.38130
 orbit_good=1000
 radius=5
 slope_parameter=4.9
-tex_map=nomap.png
 type=comet
 
 [P_Pons-Gambart%281827II%29]
 absolute_magnitude=7.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Pons-Gambart (1827II)
 orbit_ArgOfPericenter=19.19500
 orbit_AscendingNode=319.33460
@@ -20107,17 +14672,11 @@ orbit_TimeAtPericenter=2388515.13760
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Pons-Winnecke%281819III%29]
 absolute_magnitude=8.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Pons-Winnecke (1819III)
 orbit_ArgOfPericenter=161.96100
 orbit_AscendingNode=114.81400
@@ -20129,17 +14688,11 @@ orbit_TimeAtPericenter=2385635.18100
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Pons-Winnecke%281858II%29]
 absolute_magnitude=9.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Pons-Winnecke (1858II)
 orbit_ArgOfPericenter=162.17300
 orbit_AscendingNode=114.76550
@@ -20151,17 +14704,11 @@ orbit_TimeAtPericenter=2399802.03960
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Pons-Winnecke%281869I%29]
 absolute_magnitude=9.6
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Pons-Winnecke (1869I)
 orbit_ArgOfPericenter=162.42350
 orbit_AscendingNode=114.62800
@@ -20173,17 +14720,11 @@ orbit_TimeAtPericenter=2403878.94170
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Pons-Winnecke%281875b_1875I%29]
 absolute_magnitude=7.6
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Pons-Winnecke (1875b=1875I)"
 orbit_ArgOfPericenter=165.18060
 orbit_AscendingNode=112.49490
@@ -20195,17 +14736,11 @@ orbit_TimeAtPericenter=2405960.09930
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Pons-Winnecke%281886d_1886VI%29]
 absolute_magnitude=9.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Pons-Winnecke (1886d=1886VI)"
 orbit_ArgOfPericenter=172.06760
 orbit_AscendingNode=104.93250
@@ -20217,17 +14752,11 @@ orbit_TimeAtPericenter=2410154.38640
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Pons-Winnecke%281898a_1898II%29]
 absolute_magnitude=9.6
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Pons-Winnecke (1898a=1898II)"
 orbit_ArgOfPericenter=173.38590
 orbit_AscendingNode=101.55770
@@ -20239,17 +14768,11 @@ orbit_TimeAtPericenter=2414369.36860
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Pons-Winnecke%281909d_1909II%29]
 absolute_magnitude=9.7
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Pons-Winnecke (1909d=1909II)"
 orbit_ArgOfPericenter=172.29730
 orbit_AscendingNode=99.89300
@@ -20261,17 +14784,11 @@ orbit_TimeAtPericenter=2418589.29470
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Pons-Winnecke%281915b_1915III%29]
 absolute_magnitude=9.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Pons-Winnecke (1915b=1915III)"
 orbit_ArgOfPericenter=172.39500
 orbit_AscendingNode=99.83820
@@ -20283,17 +14800,11 @@ orbit_TimeAtPericenter=2420743.29010
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Pons-Winnecke%281933b_1933II%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Pons-Winnecke (1933b=1933II)"
 orbit_ArgOfPericenter=169.25240
 orbit_AscendingNode=96.85210
@@ -20305,17 +14816,11 @@ orbit_TimeAtPericenter=2427211.28910
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Reinmuth1%281928a_1928I%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Reinmuth 1 (1928a=1928I)"
 orbit_ArgOfPericenter=8.62420
 orbit_AscendingNode=125.22550
@@ -20327,17 +14832,11 @@ orbit_TimeAtPericenter=2425276.48020
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Reinmuth1%281957e_1958II%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Reinmuth 1 (1957e=1958II)"
 orbit_ArgOfPericenter=12.91410
 orbit_AscendingNode=123.56190
@@ -20349,17 +14848,11 @@ orbit_TimeAtPericenter=2436288.54020
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Reinmuth1%281965a_1965V%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Reinmuth 1 (1965a=1965V)"
 orbit_ArgOfPericenter=9.39840
 orbit_AscendingNode=121.15600
@@ -20371,17 +14864,11 @@ orbit_TimeAtPericenter=2438980.54540
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Reinmuth1%281972i_1973IV%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Reinmuth 1 (1972i=1973IV)"
 orbit_ArgOfPericenter=9.45130
 orbit_AscendingNode=121.11460
@@ -20393,17 +14880,11 @@ orbit_TimeAtPericenter=2441762.85360
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Reinmuth1%281979j_1980VIII%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Reinmuth 1 (1979j=1980VIII)"
 orbit_ArgOfPericenter=9.46245
 orbit_AscendingNode=121.10625
@@ -20415,17 +14896,11 @@ orbit_TimeAtPericenter=2444542.24198
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Reinmuth1%281987r_1988VI%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Reinmuth 1 (1987r=1988VI)"
 orbit_ArgOfPericenter=13.01884
 orbit_AscendingNode=119.14784
@@ -20437,17 +14912,11 @@ orbit_TimeAtPericenter=2447291.46986
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Reinmuth1%281995%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Reinmuth 1 (1995)
 orbit_ArgOfPericenter=13.24977
 orbit_AscendingNode=119.08039
@@ -20459,17 +14928,11 @@ orbit_TimeAtPericenter=2449963.81665
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Reinmuth2%281947j_1947VII%29]
 absolute_magnitude=9.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Reinmuth 2 (1947j=1947VII)"
 orbit_ArgOfPericenter=43.93490
 orbit_AscendingNode=297.36620
@@ -20481,17 +14944,11 @@ orbit_TimeAtPericenter=2432417.01340
 orbit_good=1000
 radius=5
 slope_parameter=6.3
-tex_map=nomap.png
 type=comet
 
 [P_Russell2%281980o_1980III%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Russell 2 (1980o=1980III)"
 orbit_ArgOfPericenter=245.17600
 orbit_AscendingNode=44.50850
@@ -20503,17 +14960,11 @@ orbit_TimeAtPericenter=2444378.55210
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Russell2%281987q_1987XI%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Russell 2 (1987q=1987XI)"
 orbit_ArgOfPericenter=245.38040
 orbit_AscendingNode=44.43180
@@ -20525,17 +14976,11 @@ orbit_TimeAtPericenter=2446980.26740
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Russell2%281994e%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Russell 2 (1994e)
 orbit_ArgOfPericenter=249.16368
 orbit_AscendingNode=41.85677
@@ -20547,17 +14992,11 @@ orbit_TimeAtPericenter=2449652.87598
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Russell3%281983i_1982IX%29]
 absolute_magnitude=8.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Russell 3 (1983i=1982IX)"
 orbit_ArgOfPericenter=353.46030
 orbit_AscendingNode=248.00000
@@ -20569,17 +15008,11 @@ orbit_TimeAtPericenter=2445296.75100
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Russell3%281989d_1990VII%29]
 absolute_magnitude=8.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Russell 3 (1989d=1990VII)"
 orbit_ArgOfPericenter=353.22426
 orbit_AscendingNode=248.01581
@@ -20591,17 +15024,11 @@ orbit_TimeAtPericenter=2448029.38599
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Schaumasse%281951l_1952III%29]
 absolute_magnitude=9.9
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Schaumasse (1951l=1952III)"
 orbit_ArgOfPericenter=51.83070
 orbit_AscendingNode=86.38170
@@ -20613,17 +15040,11 @@ orbit_TimeAtPericenter=2434053.15540
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Schaumasse%281959h_1960III%29]
 absolute_magnitude=9.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Schaumasse (1959h=1960III)"
 orbit_ArgOfPericenter=51.94640
 orbit_AscendingNode=86.24060
@@ -20635,17 +15056,11 @@ orbit_TimeAtPericenter=2437042.55520
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Schaumasse%281976XV%29]
 absolute_magnitude=9.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Schaumasse (1976XV)
 orbit_ArgOfPericenter=57.23200
 orbit_AscendingNode=80.56880
@@ -20657,17 +15072,11 @@ orbit_TimeAtPericenter=2443026.56580
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Schaumasse%281984m_1984XXII%29]
 absolute_magnitude=7.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Schaumasse (1984m=1984XXII)"
 orbit_ArgOfPericenter=57.36760
 orbit_AscendingNode=80.42300
@@ -20679,17 +15088,11 @@ orbit_TimeAtPericenter=2446040.98180
 orbit_good=1000
 radius=5
 slope_parameter=10.6
-tex_map=nomap.png
 type=comet
 
 [P_Schaumasse%281992x%29]
 absolute_magnitude=7.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Schaumasse (1992x)
 orbit_ArgOfPericenter=57.45031
 orbit_AscendingNode=80.38544
@@ -20701,17 +15104,11 @@ orbit_TimeAtPericenter=2449050.46080
 orbit_good=1000
 radius=5
 slope_parameter=11.6
-tex_map=nomap.png
 type=comet
 
 [P_Schuster%281977o_1978I%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Schuster (1977o=1978I)"
 orbit_ArgOfPericenter=353.91620
 orbit_AscendingNode=50.83700
@@ -20723,17 +15120,11 @@ orbit_TimeAtPericenter=2443515.31670
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Schuster%281992n_1992XXIV%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Schuster (1992n=1992XXIV)"
 orbit_ArgOfPericenter=355.71789
 orbit_AscendingNode=49.91790
@@ -20745,17 +15136,11 @@ orbit_TimeAtPericenter=2448871.92249
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Schwassmann-Wachmann1%281908IV%29]
 absolute_magnitude=5.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Schwassmann-Wachmann 1 (1908IV)
 orbit_ArgOfPericenter=357.09700
 orbit_AscendingNode=323.62400
@@ -20767,17 +15152,11 @@ orbit_TimeAtPericenter=2418233.19200
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Schwassmann-Wachmann1%281927i_1925II%29]
 absolute_magnitude=2.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Schwassmann-Wachmann 1 (1927i=1925II)"
 orbit_ArgOfPericenter=359.10930
 orbit_AscendingNode=323.05410
@@ -20789,17 +15168,11 @@ orbit_TimeAtPericenter=2424278.35620
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Schwassmann-Wachmann1%281941VI%29]
 absolute_magnitude=3.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Schwassmann-Wachmann 1 (1941VI)
 orbit_ArgOfPericenter=356.24930
 orbit_AscendingNode=322.00240
@@ -20811,17 +15184,11 @@ orbit_TimeAtPericenter=2430106.10940
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Schwassmann-Wachmann1%281957IV%29]
 absolute_magnitude=5.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Schwassmann-Wachmann 1 (1957IV)
 orbit_ArgOfPericenter=355.82610
 orbit_AscendingNode=321.60880
@@ -20833,17 +15200,11 @@ orbit_TimeAtPericenter=2435971.32890
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Schwassmann-Wachmann1%281974II%29]
 absolute_magnitude=5.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Schwassmann-Wachmann 1 (1974II)
 orbit_ArgOfPericenter=14.46830
 orbit_AscendingNode=319.63640
@@ -20855,17 +15216,11 @@ orbit_TimeAtPericenter=2442093.83380
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Schwassmann-Wachmann1%281989XV%29]
 absolute_magnitude=5.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Schwassmann-Wachmann 1 (1989XV)
 orbit_ArgOfPericenter=49.89705
 orbit_AscendingNode=312.12280
@@ -20877,17 +15232,11 @@ orbit_TimeAtPericenter=2447826.22231
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Schwassmann-Wachmann2%281929a_1929I%29]
 absolute_magnitude=8.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Schwassmann-Wachmann 2 (1929a=1929I)"
 orbit_ArgOfPericenter=357.74040
 orbit_AscendingNode=126.32610
@@ -20899,17 +15248,11 @@ orbit_TimeAtPericenter=2425693.69480
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Schwassmann-Wachmann2%281934c_1935III%29]
 absolute_magnitude=9.9
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Schwassmann-Wachmann 2 (1934c=1935III)"
 orbit_ArgOfPericenter=357.99480
 orbit_AscendingNode=126.28960
@@ -20921,17 +15264,11 @@ orbit_TimeAtPericenter=2428043.12720
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Schwassmann-Wachmann2%281941f_1942I%29]
 absolute_magnitude=8.9
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Schwassmann-Wachmann 2 (1941f=1942I)"
 orbit_ArgOfPericenter=358.03210
 orbit_AscendingNode=126.04000
@@ -20943,17 +15280,11 @@ orbit_TimeAtPericenter=2430404.33880
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Schwassmann-Wachmann2%281954g_1955I%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Schwassmann-Wachmann 2 (1954g=1955I)"
 orbit_ArgOfPericenter=357.87020
 orbit_AscendingNode=126.01160
@@ -20965,17 +15296,11 @@ orbit_TimeAtPericenter=2435165.69790
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Schwassmann-Wachmann2%281960j_1961VII%29]
 absolute_magnitude=7.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Schwassmann-Wachmann 2 (1960j=1961VII)"
 orbit_ArgOfPericenter=357.69680
 orbit_AscendingNode=125.99970
@@ -20987,17 +15312,11 @@ orbit_TimeAtPericenter=2437547.55180
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Schwassmann-Wachmann2%281967i_1968II%29]
 absolute_magnitude=7.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Schwassmann-Wachmann 2 (1967i=1968II)"
 orbit_ArgOfPericenter=357.66280
 orbit_AscendingNode=125.99340
@@ -21009,17 +15328,11 @@ orbit_TimeAtPericenter=2439929.77510
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Schwassmann-Wachmann2%281973l_1974XIII%29]
 absolute_magnitude=7.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Schwassmann-Wachmann 2 (1973l=1974XIII)"
 orbit_ArgOfPericenter=357.30890
 orbit_AscendingNode=125.97060
@@ -21031,17 +15344,11 @@ orbit_TimeAtPericenter=2442302.83320
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Schwassmann-Wachmann2%281979k_1981VI%29]
 absolute_magnitude=7.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Schwassmann-Wachmann 2 (1979k=1981VI)"
 orbit_ArgOfPericenter=357.45910
 orbit_AscendingNode=125.94210
@@ -21053,17 +15360,11 @@ orbit_TimeAtPericenter=2444680.53790
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Schwassmann-Wachmann2%281986h_1987XIX%29]
 absolute_magnitude=7.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Schwassmann-Wachmann 2 (1986h=1987XIX)"
 orbit_ArgOfPericenter=357.88760
 orbit_AscendingNode=125.66090
@@ -21075,17 +15376,11 @@ orbit_TimeAtPericenter=2447037.96820
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Schwassmann-Wachmann2%281994%29]
 absolute_magnitude=7.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Schwassmann-Wachmann 2 (1994)
 orbit_ArgOfPericenter=358.14236
 orbit_AscendingNode=125.62370
@@ -21097,17 +15392,11 @@ orbit_TimeAtPericenter=2449376.40914
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Shajn-Schaldach%281949e_1949VI%29]
 absolute_magnitude=7.6
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Shajn-Schaldach (1949e=1949VI)"
 orbit_ArgOfPericenter=215.37780
 orbit_AscendingNode=167.39190
@@ -21119,17 +15408,11 @@ orbit_TimeAtPericenter=2433247.62440
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Shajn-Schaldach%281971e_1971IX%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Shajn-Schaldach (1971e=1971IX)"
 orbit_ArgOfPericenter=215.12790
 orbit_AscendingNode=167.26520
@@ -21141,17 +15424,11 @@ orbit_TimeAtPericenter=2441226.44840
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Shajn-Schaldach%281978i_1979I%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Shajn-Schaldach (1978i=1979I)"
 orbit_ArgOfPericenter=215.30670
 orbit_AscendingNode=167.19390
@@ -21163,17 +15440,11 @@ orbit_TimeAtPericenter=2443882.47670
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Shajn-Schaldach%281985i_1986X%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Shajn-Schaldach (1985i=1986X)"
 orbit_ArgOfPericenter=216.52530
 orbit_AscendingNode=166.24130
@@ -21185,17 +15456,11 @@ orbit_TimeAtPericenter=2446577.86720
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Shajn-Schaldach%281993k%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Shajn-Schaldach (1993k)
 orbit_ArgOfPericenter=216.54555
 orbit_AscendingNode=166.20348
@@ -21207,17 +15472,11 @@ orbit_TimeAtPericenter=2449307.48278
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Shoemaker-Holt2%281989j_1988XI%29]
 absolute_magnitude=7.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Shoemaker-Holt 2 (1989j=1988XI)"
 orbit_ArgOfPericenter=5.86396
 orbit_AscendingNode=99.09640
@@ -21229,17 +15488,11 @@ orbit_TimeAtPericenter=2447380.94417
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Shoemaker-Holt2%281996%29]
 absolute_magnitude=7.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Shoemaker-Holt 2 (1996)
 orbit_ArgOfPericenter=5.97674
 orbit_AscendingNode=99.05196
@@ -21251,17 +15504,11 @@ orbit_TimeAtPericenter=2450315.71103
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Shoemaker-Levy9%281993e%29]
 absolute_magnitude=3.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Shoemaker-Levy 9 (1993e)
 orbit_ArgOfPericenter=355.04900
 orbit_AscendingNode=220.17910
@@ -21273,17 +15520,11 @@ orbit_TimeAtPericenter=2449441.62690
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Shoemaker1%281984q_1984XVI%29]
 absolute_magnitude=8.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Shoemaker 1 (1984q=1984XVI)"
 orbit_ArgOfPericenter=18.68590
 orbit_AscendingNode=339.31020
@@ -21295,17 +15536,11 @@ orbit_TimeAtPericenter=2445960.14870
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Shoemaker1%281991p_1991XXIII%29]
 absolute_magnitude=8.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Shoemaker 1 (1991p=1991XXIII)"
 orbit_ArgOfPericenter=18.77069
 orbit_AscendingNode=339.24962
@@ -21317,17 +15552,11 @@ orbit_TimeAtPericenter=2448608.71694
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Shoemaker3%281986a_1985XVIII%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Shoemaker 3 (1986a=1985XVIII)"
 orbit_ArgOfPericenter=14.82070
 orbit_AscendingNode=96.63430
@@ -21339,17 +15568,11 @@ orbit_TimeAtPericenter=2446418.07750
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Skiff-Kosai%281976XVI%29]
 absolute_magnitude=8.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Skiff-Kosai (1976XVI)
 orbit_ArgOfPericenter=26.44064
 orbit_AscendingNode=80.18456
@@ -21361,17 +15584,11 @@ orbit_TimeAtPericenter=2442994.56253
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Slaughter-Burnham%281959a_1958VI%29]
 absolute_magnitude=8.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Slaughter-Burnham (1959a=1958VI)"
 orbit_ArgOfPericenter=44.32320
 orbit_AscendingNode=346.25910
@@ -21383,17 +15600,11 @@ orbit_TimeAtPericenter=2436451.61090
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Slaughter-Burnham%281969f_1970V%29]
 absolute_magnitude=8.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Slaughter-Burnham (1969f=1970V)"
 orbit_ArgOfPericenter=44.25700
 orbit_AscendingNode=346.10110
@@ -21405,17 +15616,11 @@ orbit_TimeAtPericenter=2440689.66720
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Slaughter-Burnham%281981i_1981XVIII%29]
 absolute_magnitude=8.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Slaughter-Burnham (1981i=1981XVIII)"
 orbit_ArgOfPericenter=44.16670
 orbit_AscendingNode=345.93240
@@ -21427,17 +15632,11 @@ orbit_TimeAtPericenter=2444927.40490
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Slaughter-Burnham%281992w%29]
 absolute_magnitude=8.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Slaughter-Burnham (1992w)
 orbit_ArgOfPericenter=44.12054
 orbit_AscendingNode=345.73798
@@ -21449,17 +15648,11 @@ orbit_TimeAtPericenter=2449160.92522
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Smirnova-Chernykh%281967XV%29]
 absolute_magnitude=5.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Smirnova-Chernykh (1967XV)
 orbit_ArgOfPericenter=90.52220
 orbit_AscendingNode=77.14000
@@ -21471,17 +15664,11 @@ orbit_TimeAtPericenter=2439529.31630
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Smirnova-Chernykh%281975e_1975VII%29]
 absolute_magnitude=5.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Smirnova-Chernykh (1975e=1975VII)"
 orbit_ArgOfPericenter=90.17680
 orbit_AscendingNode=77.10790
@@ -21493,17 +15680,11 @@ orbit_TimeAtPericenter=2442630.72620
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Smirnova-Chernykh%281984V%29]
 absolute_magnitude=9.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Smirnova-Chernykh (1984V)
 orbit_ArgOfPericenter=90.87020
 orbit_AscendingNode=77.04170
@@ -21515,17 +15696,11 @@ orbit_TimeAtPericenter=2445751.91120
 orbit_good=1000
 radius=5
 slope_parameter=4.2
-tex_map=nomap.png
 type=comet
 
 [P_Smirnova-Chernykh%281992XXI%29]
 absolute_magnitude=5.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Smirnova-Chernykh (1992XXI)
 orbit_ArgOfPericenter=88.93837
 orbit_AscendingNode=76.83822
@@ -21537,17 +15712,11 @@ orbit_TimeAtPericenter=2448840.43495
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Spitaler%281890f_1890VII%29]
 absolute_magnitude=9.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Spitaler (1890f=1890VII)"
 orbit_ArgOfPericenter=13.38790
 orbit_AscendingNode=45.89490
@@ -21559,17 +15728,11 @@ orbit_TimeAtPericenter=2411667.59810
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Stephan-Oterma%281867I%29]
 absolute_magnitude=7.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Stephan-Oterma (1867I)
 orbit_ArgOfPericenter=357.51620
 orbit_AscendingNode=79.63710
@@ -21581,17 +15744,11 @@ orbit_TimeAtPericenter=2402987.14770
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Stephan-Oterma%281942IX%29]
 absolute_magnitude=5.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Stephan-Oterma (1942IX)
 orbit_ArgOfPericenter=358.27000
 orbit_AscendingNode=78.60840
@@ -21603,17 +15760,11 @@ orbit_TimeAtPericenter=2430712.58970
 orbit_good=1000
 radius=5
 slope_parameter=11.2
-tex_map=nomap.png
 type=comet
 
 [P_Stephan-Oterma%281980g_1980X%29]
 absolute_magnitude=5.7
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Stephan-Oterma (1980g=1980X)"
 orbit_ArgOfPericenter=358.16110
 orbit_AscendingNode=78.51200
@@ -21625,17 +15776,11 @@ orbit_TimeAtPericenter=2444578.66580
 orbit_good=1000
 radius=5
 slope_parameter=9.2
-tex_map=nomap.png
 type=comet
 
 [P_Swift-Gehrels%281981j_1981XIX%29]
 absolute_magnitude=8.7
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Swift-Gehrels (1981j=1981XIX)"
 orbit_ArgOfPericenter=84.53510
 orbit_AscendingNode=314.03140
@@ -21647,17 +15792,11 @@ orbit_TimeAtPericenter=2444935.95400
 orbit_good=1000
 radius=5
 slope_parameter=4.5
-tex_map=nomap.png
 type=comet
 
 [P_Swift-Tuttle%28-68%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Swift-Tuttle (-68)
 orbit_ArgOfPericenter=150.00000
 orbit_AscendingNode=165.00000
@@ -21669,17 +15808,11 @@ orbit_TimeAtPericenter=1696402.50000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Swift-Tuttle%281862III%29]
 absolute_magnitude=4.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Swift-Tuttle (1862III)
 orbit_ArgOfPericenter=152.76600
 orbit_AscendingNode=138.68490
@@ -21691,17 +15824,11 @@ orbit_TimeAtPericenter=2401375.90970
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Swift-Tuttle%281992t_1992XXVIII%29]
 absolute_magnitude=4.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Swift-Tuttle (1992t=1992XXVIII)"
 orbit_ArgOfPericenter=152.99742
 orbit_AscendingNode=138.74394
@@ -21713,17 +15840,11 @@ orbit_TimeAtPericenter=2448968.82426
 orbit_good=1000
 radius=5
 slope_parameter=7.5
-tex_map=nomap.png
 type=comet
 
 [P_Takamizawa%281984j_1984VII%29]
 absolute_magnitude=2.9
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Takamizawa (1984j=1984VII)"
 orbit_ArgOfPericenter=147.53860
 orbit_AscendingNode=124.22840
@@ -21735,17 +15856,11 @@ orbit_TimeAtPericenter=2445845.45280
 orbit_good=1000
 radius=5
 slope_parameter=11.8
-tex_map=nomap.png
 type=comet
 
 [P_Taylor%281915e_1916I%29]
 absolute_magnitude=8.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Taylor (1915e=1916I)"
 orbit_ArgOfPericenter=354.95020
 orbit_AscendingNode=114.35490
@@ -21757,17 +15872,11 @@ orbit_TimeAtPericenter=2420894.11830
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Tempel-Tuttle%281366%29]
 absolute_magnitude=9.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Tempel-Tuttle (1366)
 orbit_ArgOfPericenter=164.49800
 orbit_AscendingNode=224.74700
@@ -21779,17 +15888,11 @@ orbit_TimeAtPericenter=2220280.04300
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Tempel-Tuttle%281699II%29]
 absolute_magnitude=9.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Tempel-Tuttle (1699II)
 orbit_ArgOfPericenter=168.93000
 orbit_AscendingNode=230.02600
@@ -21801,17 +15904,11 @@ orbit_TimeAtPericenter=2341890.45000
 orbit_good=1000
 radius=5
 slope_parameter=8.0
-tex_map=nomap.png
 type=comet
 
 [P_Tempel-Tuttle%281866I%29]
 absolute_magnitude=8.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Tempel-Tuttle (1866I)
 orbit_ArgOfPericenter=170.91790
 orbit_AscendingNode=232.57170
@@ -21823,17 +15920,11 @@ orbit_TimeAtPericenter=2402613.12220
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Tempel-Tuttle%281965i_1965IV%29]
 absolute_magnitude=9.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Tempel-Tuttle (1965i=1965IV)"
 orbit_ArgOfPericenter=172.57950
 orbit_AscendingNode=234.43570
@@ -21845,17 +15936,11 @@ orbit_TimeAtPericenter=2438880.50100
 orbit_good=1000
 radius=5
 slope_parameter=8.0
-tex_map=nomap.png
 type=comet
 
 [P_Tempel1%281867II%29]
 absolute_magnitude=8.4
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Tempel 1 (1867II)
 orbit_ArgOfPericenter=134.92960
 orbit_AscendingNode=102.27390
@@ -21867,17 +15952,11 @@ orbit_TimeAtPericenter=2403110.71740
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Tempel1%281873a_1873I%29]
 absolute_magnitude=9.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Tempel 1 (1873a=1873I)"
 orbit_ArgOfPericenter=159.37000
 orbit_AscendingNode=79.74720
@@ -21889,17 +15968,11 @@ orbit_TimeAtPericenter=2405288.78040
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Tempel1%281966VII%29]
 absolute_magnitude=9.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Tempel 1 (1966VII)
 orbit_ArgOfPericenter=179.12500
 orbit_AscendingNode=68.37330
@@ -21911,17 +15984,11 @@ orbit_TimeAtPericenter=2439503.19980
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Tempel1%281972a_1972V%29]
 absolute_magnitude=9.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Tempel 1 (1972a=1972V)"
 orbit_ArgOfPericenter=179.19020
 orbit_AscendingNode=68.34880
@@ -21933,17 +16000,11 @@ orbit_TimeAtPericenter=2441513.89540
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Tempel1%281977i_1978II%29]
 absolute_magnitude=9.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Tempel 1 (1977i=1978II)"
 orbit_ArgOfPericenter=179.07780
 orbit_AscendingNode=68.34020
@@ -21955,17 +16016,11 @@ orbit_TimeAtPericenter=2443519.51580
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Tempel1%281982j_1983XI%29]
 absolute_magnitude=6.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Tempel 1 (1982j=1983XI)"
 orbit_ArgOfPericenter=179.04220
 orbit_AscendingNode=68.32820
@@ -21977,17 +16032,11 @@ orbit_TimeAtPericenter=2445525.29810
 orbit_good=1000
 radius=5
 slope_parameter=9.0
-tex_map=nomap.png
 type=comet
 
 [P_Tempel1%281987e1_1989I%29]
 absolute_magnitude=9.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Tempel 1 (1987e1=1989I)"
 orbit_ArgOfPericenter=178.98009
 orbit_AscendingNode=68.32735
@@ -21999,17 +16048,11 @@ orbit_TimeAtPericenter=2447530.94134
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Tempel1%281993c%29]
 absolute_magnitude=7.1
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Tempel 1 (1993c)
 orbit_ArgOfPericenter=178.86792
 orbit_AscendingNode=68.32035
@@ -22021,17 +16064,11 @@ orbit_TimeAtPericenter=2449536.80846
 orbit_good=1000
 radius=5
 slope_parameter=7.2
-tex_map=nomap.png
 type=comet
 
 [P_Tempel2%281873b_1873II%29]
 absolute_magnitude=8.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Tempel 2 (1873b=1873II)"
 orbit_ArgOfPericenter=185.18910
 orbit_AscendingNode=121.98360
@@ -22043,17 +16080,11 @@ orbit_TimeAtPericenter=2405335.33580
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Tempel2%281878b_1878III%29]
 absolute_magnitude=9.4
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Tempel 2 (1878b=1878III)"
 orbit_ArgOfPericenter=185.16680
 orbit_AscendingNode=121.98050
@@ -22065,17 +16096,11 @@ orbit_TimeAtPericenter=2407235.27210
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Tempel2%281894c_1894III%29]
 absolute_magnitude=9.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Tempel 2 (1894c=1894III)"
 orbit_ArgOfPericenter=185.11520
 orbit_AscendingNode=121.91750
@@ -22087,17 +16112,11 @@ orbit_TimeAtPericenter=2412942.24420
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Tempel2%281899c_1899IV%29]
 absolute_magnitude=9.4
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Tempel 2 (1899c=1899IV)"
 orbit_ArgOfPericenter=185.63190
 orbit_AscendingNode=121.65010
@@ -22109,17 +16128,11 @@ orbit_TimeAtPericenter=2414864.53630
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Tempel2%281904c_1904III%29]
 absolute_magnitude=9.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Tempel 2 (1904c=1904III)"
 orbit_ArgOfPericenter=185.76920
 orbit_AscendingNode=121.61480
@@ -22131,17 +16144,11 @@ orbit_TimeAtPericenter=2416795.43810
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Tempel2%281915c_1915I%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Tempel 2 (1915c=1915I)"
 orbit_ArgOfPericenter=186.71330
 orbit_AscendingNode=121.15030
@@ -22153,17 +16160,11 @@ orbit_TimeAtPericenter=2420602.07010
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Tempel2%281946b_1946III%29]
 absolute_magnitude=9.4
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Tempel 2 (1946b=1946III)"
 orbit_ArgOfPericenter=190.85610
 orbit_AscendingNode=119.41420
@@ -22175,17 +16176,11 @@ orbit_TimeAtPericenter=2432003.84200
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Tempel2%281961b_1962VI%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Tempel 2 (1961b=1962VI)"
 orbit_ArgOfPericenter=191.05270
 orbit_AscendingNode=119.27680
@@ -22197,17 +16192,11 @@ orbit_TimeAtPericenter=2437797.19010
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Tempel2%281967d_1967X%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Tempel 2 (1967d=1967X)"
 orbit_ArgOfPericenter=190.97840
 orbit_AscendingNode=119.27180
@@ -22219,17 +16208,11 @@ orbit_TimeAtPericenter=2439716.75010
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Tempel2%281972c_1972X%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Tempel 2 (1972c=1972X)"
 orbit_ArgOfPericenter=190.87280
 orbit_AscendingNode=119.27000
@@ -22241,17 +16224,11 @@ orbit_TimeAtPericenter=2441636.53800
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Tempel2%281977d_1978V%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Tempel 2 (1977d=1978V)"
 orbit_ArgOfPericenter=190.93370
 orbit_AscendingNode=119.24300
@@ -22263,17 +16240,11 @@ orbit_TimeAtPericenter=2443560.22900
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Tempel2%281982d_1983X%29]
 absolute_magnitude=6.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Tempel 2 (1982d=1983X)"
 orbit_ArgOfPericenter=190.92220
 orbit_AscendingNode=119.15810
@@ -22285,17 +16256,11 @@ orbit_TimeAtPericenter=2445487.03510
 orbit_good=1000
 radius=5
 slope_parameter=6.6
-tex_map=nomap.png
 type=comet
 
 [P_Tempel2%281987g_1988XIV%29]
 absolute_magnitude=5.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Tempel 2 (1987g=1988XIV)"
 orbit_ArgOfPericenter=191.03950
 orbit_AscendingNode=119.11850
@@ -22307,17 +16272,11 @@ orbit_TimeAtPericenter=2447421.23530
 orbit_good=1000
 radius=5
 slope_parameter=10.6
-tex_map=nomap.png
 type=comet
 
 [P_Tempel2%281994%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Tempel 2 (1994)
 orbit_ArgOfPericenter=194.85700
 orbit_AscendingNode=117.57600
@@ -22329,17 +16288,11 @@ orbit_TimeAtPericenter=2449428.31620
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Tuttle%281790II%29]
 absolute_magnitude=7.7
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Tuttle (1790II)
 orbit_ArgOfPericenter=207.04000
 orbit_AscendingNode=270.82000
@@ -22351,17 +16304,11 @@ orbit_TimeAtPericenter=2374874.84900
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Tuttle%281858I%29]
 absolute_magnitude=7.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Tuttle (1858I)
 orbit_ArgOfPericenter=206.78500
 orbit_AscendingNode=270.34510
@@ -22373,17 +16320,11 @@ orbit_TimeAtPericenter=2399734.51810
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Tuttle%281871d_1871III%29]
 absolute_magnitude=8.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Tuttle (1871d=1871III)"
 orbit_ArgOfPericenter=206.78450
 orbit_AscendingNode=270.41080
@@ -22395,17 +16336,11 @@ orbit_TimeAtPericenter=2404763.79760
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Tuttle%281885b_1885IV%29]
 absolute_magnitude=8.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Tuttle (1885b=1885IV)"
 orbit_ArgOfPericenter=206.77410
 orbit_AscendingNode=270.54390
@@ -22417,17 +16352,11 @@ orbit_TimeAtPericenter=2409796.29880
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Tuttle%281899b_1899III%29]
 absolute_magnitude=8.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Tuttle (1899b=1899III)"
 orbit_ArgOfPericenter=206.63560
 orbit_AscendingNode=270.54150
@@ -22439,17 +16368,11 @@ orbit_TimeAtPericenter=2414779.05310
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Tuttle%281912b_1912IV%29]
 absolute_magnitude=8.6
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Tuttle (1912b=1912IV)"
 orbit_ArgOfPericenter=206.94880
 orbit_AscendingNode=270.27800
@@ -22461,17 +16384,11 @@ orbit_TimeAtPericenter=2419704.47120
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Tuttle%281967a_1967V%29]
 absolute_magnitude=9.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Tuttle (1967a=1967V)"
 orbit_ArgOfPericenter=206.91220
 orbit_AscendingNode=269.78820
@@ -22483,17 +16400,11 @@ orbit_TimeAtPericenter=2439580.79070
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Tuttle%281980h_1980XIII%29]
 absolute_magnitude=8.9
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Tuttle (1980h=1980XIII)"
 orbit_ArgOfPericenter=206.89240
 orbit_AscendingNode=269.88110
@@ -22505,17 +16416,11 @@ orbit_TimeAtPericenter=2444588.20540
 orbit_good=1000
 radius=5
 slope_parameter=2.8
-tex_map=nomap.png
 type=comet
 
 [P_Tuttle%281992r%29]
 absolute_magnitude=9.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Tuttle (1992r)
 orbit_ArgOfPericenter=206.71100
 orbit_AscendingNode=269.84531
@@ -22527,17 +16432,11 @@ orbit_TimeAtPericenter=2449528.79070
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_VanBiesbroeck%281954i_1954IV%29]
 absolute_magnitude=9.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Van Biesbroeck (1954i=1954IV)"
 orbit_ArgOfPericenter=134.35150
 orbit_AscendingNode=148.97540
@@ -22549,17 +16448,11 @@ orbit_TimeAtPericenter=2434794.26530
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_VanBiesbroeck%281965d_1966III%29]
 absolute_magnitude=8.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Van Biesbroeck (1965d=1966III)"
 orbit_ArgOfPericenter=134.24730
 orbit_AscendingNode=148.83130
@@ -22571,17 +16464,11 @@ orbit_TimeAtPericenter=2439324.31730
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_VanBiesbroeck%281977s_1978XXIV%29]
 absolute_magnitude=8.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Van Biesbroeck (1977s=1978XXIV)"
 orbit_ArgOfPericenter=134.25260
 orbit_AscendingNode=148.57810
@@ -22593,17 +16480,11 @@ orbit_TimeAtPericenter=2443845.52360
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_VanBiesbroeck%281989h1_1991VI%29]
 absolute_magnitude=7.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Van Biesbroeck (1989h1=1991VI)"
 orbit_ArgOfPericenter=134.14758
 orbit_AscendingNode=148.43962
@@ -22615,17 +16496,11 @@ orbit_TimeAtPericenter=2448371.19864
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_V%84is%84l%841%281959i_1960IV%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/V\x84is\x84l\x84 1 (1959i=1960IV)"
 orbit_ArgOfPericenter=44.44150
 orbit_AscendingNode=135.42700
@@ -22637,17 +16512,11 @@ orbit_TimeAtPericenter=2437065.33680
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_V%84is%84l%841%281970q_1971VII%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/V\x84is\x84l\x84 1 (1970q=1971VII)"
 orbit_ArgOfPericenter=49.70610
 orbit_AscendingNode=134.74010
@@ -22659,17 +16528,11 @@ orbit_TimeAtPericenter=2441206.80690
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_V%84is%84l%841%281981l_1982V%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/V\x84is\x84l\x84 1 (1981l=1982V)"
 orbit_ArgOfPericenter=47.93140
 orbit_AscendingNode=134.51030
@@ -22681,17 +16544,11 @@ orbit_TimeAtPericenter=2445181.07160
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_V%84is%84l%841%281992u%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/V\x84is\x84l\x84 1 (1992u)
 orbit_ArgOfPericenter=47.36422
 orbit_AscendingNode=134.39906
@@ -22703,17 +16560,11 @@ orbit_TimeAtPericenter=2449106.67509
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Westphal%281852IV%29]
 absolute_magnitude=5.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Westphal (1852IV)
 orbit_ArgOfPericenter=57.03250
 orbit_AscendingNode=347.53820
@@ -22725,17 +16576,11 @@ orbit_TimeAtPericenter=2397774.71870
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Westphal%281913d_1913VI%29]
 absolute_magnitude=9.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Westphal (1913d=1913VI)"
 orbit_ArgOfPericenter=57.10990
 orbit_AscendingNode=347.30020
@@ -22747,17 +16592,11 @@ orbit_TimeAtPericenter=2420098.32520
 orbit_good=1000
 radius=5
 slope_parameter=-2.1
-tex_map=nomap.png
 type=comet
 
 [P_Whipple%281926VIII%29]
 absolute_magnitude=6.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Whipple (1926VIII)
 orbit_ArgOfPericenter=190.41000
 orbit_AscendingNode=188.87000
@@ -22769,17 +16608,11 @@ orbit_TimeAtPericenter=2424550.66000
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Whipple%281933f_1933IV%29]
 absolute_magnitude=6.3
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Whipple (1933f=1933IV)"
 orbit_ArgOfPericenter=190.55650
 orbit_AscendingNode=188.80130
@@ -22791,17 +16624,11 @@ orbit_TimeAtPericenter=2427285.93740
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Whipple%281940b_1941III%29]
 absolute_magnitude=9.6
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Whipple (1940b=1941III)"
 orbit_ArgOfPericenter=190.44930
 orbit_AscendingNode=188.81530
@@ -22813,17 +16640,11 @@ orbit_TimeAtPericenter=2430016.88610
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Whipple%281947g_1948VI%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Whipple (1947g=1948VI)"
 orbit_ArgOfPericenter=190.11150
 orbit_AscendingNode=188.59630
@@ -22835,17 +16656,11 @@ orbit_TimeAtPericenter=2432728.23950
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Whipple%281962f_1963II%29]
 absolute_magnitude=6.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Whipple (1962f=1963II)"
 orbit_ArgOfPericenter=189.99770
 orbit_AscendingNode=188.39160
@@ -22857,17 +16672,11 @@ orbit_TimeAtPericenter=2438148.24380
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Whipple%281969c_1970XIV%29]
 absolute_magnitude=6.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Whipple (1969c=1970XIV)"
 orbit_ArgOfPericenter=189.81790
 orbit_AscendingNode=188.39320
@@ -22879,17 +16688,11 @@ orbit_TimeAtPericenter=2440868.91900
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Whipple%281977h_1978VIII%29]
 absolute_magnitude=6.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Whipple (1977h=1978VIII)"
 orbit_ArgOfPericenter=189.97700
 orbit_AscendingNode=188.33890
@@ -22901,17 +16704,11 @@ orbit_TimeAtPericenter=2443595.04850
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Whipple%281985h_1986XII%29]
 absolute_magnitude=6.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Whipple (1985h=1986XII)"
 orbit_ArgOfPericenter=202.04508
 orbit_AscendingNode=181.80139
@@ -22923,17 +16720,11 @@ orbit_TimeAtPericenter=2446606.52336
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Whipple%281993n%29]
 absolute_magnitude=6.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Whipple (1993n)
 orbit_ArgOfPericenter=201.87999
 orbit_AscendingNode=181.79216
@@ -22945,17 +16736,11 @@ orbit_TimeAtPericenter=2449708.92725
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Wild2%281978b_1978XI%29]
 absolute_magnitude=7.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Wild 2 (1978b=1978XI)"
 orbit_ArgOfPericenter=39.87870
 orbit_AscendingNode=136.11300
@@ -22967,17 +16752,11 @@ orbit_TimeAtPericenter=2443675.37760
 orbit_good=1000
 radius=5
 slope_parameter=5.0
-tex_map=nomap.png
 type=comet
 
 [P_Wild2%281983s_1984XIV%29]
 absolute_magnitude=8.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Wild 2 (1983s=1984XIV)"
 orbit_ArgOfPericenter=40.04800
 orbit_AscendingNode=136.03820
@@ -22989,17 +16768,11 @@ orbit_TimeAtPericenter=2445932.67050
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Wild2%281989t_1990XXVIII%29]
 absolute_magnitude=9.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Wild 2 (1989t=1990XXVIII)"
 orbit_ArgOfPericenter=41.57286
 orbit_AscendingNode=135.57632
@@ -23011,17 +16784,11 @@ orbit_TimeAtPericenter=2448242.42531
 orbit_good=1000
 radius=5
 slope_parameter=3.6
-tex_map=nomap.png
 type=comet
 
 [P_Wild3%281980d_1980VII%29]
 absolute_magnitude=8.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Wild 3 (1980d=1980VII)"
 orbit_ArgOfPericenter=179.33410
 orbit_AscendingNode=72.04880
@@ -23033,17 +16800,11 @@ orbit_TimeAtPericenter=2444517.68670
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Wild3%281987e_1987XX%29]
 absolute_magnitude=8.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Wild 3 (1987e=1987XX)"
 orbit_ArgOfPericenter=179.56860
 orbit_AscendingNode=71.99370
@@ -23055,17 +16816,11 @@ orbit_TimeAtPericenter=2447039.55870
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Wild3%281994b%29]
 absolute_magnitude=8.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Wild 3 (1994b)
 orbit_ArgOfPericenter=179.24814
 orbit_AscendingNode=71.95043
@@ -23077,17 +16832,11 @@ orbit_TimeAtPericenter=2449554.71135
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Wild4%281990a_1990X%29]
 absolute_magnitude=7.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Wild 4 (1990a=1990X)"
 orbit_ArgOfPericenter=170.48786
 orbit_AscendingNode=21.45862
@@ -23099,17 +16848,11 @@ orbit_TimeAtPericenter=2448075.02483
 orbit_good=1000
 radius=5
 slope_parameter=5.1
-tex_map=nomap.png
 type=comet
 
 [P_Wild4%281996%29]
 absolute_magnitude=9.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/Wild 4 (1996)
 orbit_ArgOfPericenter=170.70894
 orbit_AscendingNode=21.41171
@@ -23121,17 +16864,11 @@ orbit_TimeAtPericenter=2450327.03722
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Wirtanen%281985q_1986VI%29]
 absolute_magnitude=8.6
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Wirtanen (1985q=1986VI)"
 orbit_ArgOfPericenter=356.04400
 orbit_AscendingNode=81.65670
@@ -23143,17 +16880,11 @@ orbit_TimeAtPericenter=2446508.63290
 orbit_good=1000
 radius=5
 slope_parameter=6.1
-tex_map=nomap.png
 type=comet
 
 [P_Wirtanen%281991s_1991XVI%29]
 absolute_magnitude=8.6
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Wirtanen (1991s=1991XVI)"
 orbit_ArgOfPericenter=356.14665
 orbit_AscendingNode=81.61342
@@ -23165,17 +16896,11 @@ orbit_TimeAtPericenter=2448520.18670
 orbit_good=1000
 radius=5
 slope_parameter=8.1
-tex_map=nomap.png
 type=comet
 
 [P_Wolf%281884c_1884III%29]
 absolute_magnitude=6.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Wolf (1884c=1884III)"
 orbit_ArgOfPericenter=172.69870
 orbit_AscendingNode=207.29640
@@ -23187,17 +16912,11 @@ orbit_TimeAtPericenter=2409498.78940
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Wolf%281891b_1891II%29]
 absolute_magnitude=7.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Wolf (1891b=1891II)"
 orbit_ArgOfPericenter=172.79850
 orbit_AscendingNode=207.20290
@@ -23209,17 +16928,11 @@ orbit_TimeAtPericenter=2411979.43180
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Wolf%281898f_1898IV%29]
 absolute_magnitude=7.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Wolf (1898f=1898IV)"
 orbit_ArgOfPericenter=172.86970
 orbit_AscendingNode=207.18990
@@ -23231,17 +16944,11 @@ orbit_TimeAtPericenter=2414475.56700
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Wolf%281911a_1912I%29]
 absolute_magnitude=9.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Wolf (1911a=1912I)"
 orbit_ArgOfPericenter=172.83170
 orbit_AscendingNode=207.19560
@@ -23253,17 +16960,11 @@ orbit_TimeAtPericenter=2419456.75780
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Wolf%281918b_1918V%29]
 absolute_magnitude=8.9
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Wolf (1918b=1918V)"
 orbit_ArgOfPericenter=172.93400
 orbit_AscendingNode=207.13510
@@ -23275,17 +16976,11 @@ orbit_TimeAtPericenter=2421941.48900
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_Wolf%281958c_1959II%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Wolf (1958c=1959II)"
 orbit_ArgOfPericenter=161.08000
 orbit_AscendingNode=203.90460
@@ -23297,17 +16992,11 @@ orbit_TimeAtPericenter=2436649.33860
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Wolf%281967j_1967XII%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Wolf (1967j=1967XII)"
 orbit_ArgOfPericenter=161.25420
 orbit_AscendingNode=203.79900
@@ -23319,17 +17008,11 @@ orbit_TimeAtPericenter=2439732.62060
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Wolf%281975f_1976II%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Wolf (1975f=1976II)"
 orbit_ArgOfPericenter=161.14530
 orbit_AscendingNode=203.80870
@@ -23341,17 +17024,11 @@ orbit_TimeAtPericenter=2442802.85730
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Wolf%281983m_1984IX%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Wolf (1983m=1984IX)"
 orbit_ArgOfPericenter=162.17730
 orbit_AscendingNode=203.51350
@@ -23363,17 +17040,11 @@ orbit_TimeAtPericenter=2445852.32470
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Wolf%281992m_1992XXII%29]
 absolute_magnitude=10.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Wolf (1992m=1992XXII)"
 orbit_ArgOfPericenter=162.29228
 orbit_AscendingNode=203.44050
@@ -23385,17 +17056,11 @@ orbit_TimeAtPericenter=2448862.62899
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Wolf-Harrington%281957g_1958V%29]
 absolute_magnitude=9.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Wolf-Harrington (1957g=1958V)"
 orbit_ArgOfPericenter=187.02640
 orbit_AscendingNode=254.22530
@@ -23407,17 +17072,11 @@ orbit_TimeAtPericenter=2436426.91740
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Wolf-Harrington%281964g_1965III%29]
 absolute_magnitude=9.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Wolf-Harrington (1964g=1965III)"
 orbit_ArgOfPericenter=187.02010
 orbit_AscendingNode=254.21500
@@ -23429,17 +17088,11 @@ orbit_TimeAtPericenter=2438807.05270
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Wolf-Harrington%281970o_1971VI%29]
 absolute_magnitude=9.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Wolf-Harrington (1970o=1971VI)"
 orbit_ArgOfPericenter=187.01260
 orbit_AscendingNode=254.20060
@@ -23451,17 +17104,11 @@ orbit_TimeAtPericenter=2441195.68020
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Wolf-Harrington%281977j_1978VI%29]
 absolute_magnitude=9.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Wolf-Harrington (1977j=1978VI)"
 orbit_ArgOfPericenter=186.98140
 orbit_AscendingNode=254.21310
@@ -23473,17 +17120,11 @@ orbit_TimeAtPericenter=2443583.39790
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Wolf-Harrington%281984g_1984XVII%29]
 absolute_magnitude=9.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Wolf-Harrington (1984g=1984XVII)"
 orbit_ArgOfPericenter=186.86330
 orbit_AscendingNode=254.21110
@@ -23495,17 +17136,11 @@ orbit_TimeAtPericenter=2445966.25750
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_Wolf-Harrington%281990e_1991V%29]
 absolute_magnitude=6.6
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/Wolf-Harrington (1990e=1991V)"
 orbit_ArgOfPericenter=186.97471
 orbit_AscendingNode=254.17122
@@ -23517,17 +17152,11 @@ orbit_TimeAtPericenter=2448351.32921
 orbit_good=1000
 radius=5
 slope_parameter=8.1
-tex_map=nomap.png
 type=comet
 
 [P_d%27Arrest%281678%29]
 absolute_magnitude=6.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/d'Arrest (1678)
 orbit_ArgOfPericenter=159.56400
 orbit_AscendingNode=168.81100
@@ -23539,17 +17168,11 @@ orbit_TimeAtPericenter=2334171.94400
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_d%27Arrest%281851II%29]
 absolute_magnitude=9.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/d'Arrest (1851II)
 orbit_ArgOfPericenter=174.53680
 orbit_AscendingNode=149.76800
@@ -23561,17 +17184,11 @@ orbit_TimeAtPericenter=2397312.67670
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_d%27Arrest%281857VII%29]
 absolute_magnitude=9.6
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/d'Arrest (1857VII)
 orbit_ArgOfPericenter=174.61760
 orbit_AscendingNode=149.71470
@@ -23583,17 +17200,11 @@ orbit_TimeAtPericenter=2399647.18310
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_d%27Arrest%281870c_1870III%29]
 absolute_magnitude=8.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/d'Arrest (1870c=1870III)"
 orbit_ArgOfPericenter=172.25110
 orbit_AscendingNode=147.52000
@@ -23605,17 +17216,11 @@ orbit_TimeAtPericenter=2404328.66770
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_d%27Arrest%281877d_1877IV%29]
 absolute_magnitude=8.8
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/d'Arrest (1877d=1877IV)"
 orbit_ArgOfPericenter=172.99100
 orbit_AscendingNode=147.12150
@@ -23627,17 +17232,11 @@ orbit_TimeAtPericenter=2406750.45450
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_d%27Arrest%281890d_1890V%29]
 absolute_magnitude=9.7
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/d'Arrest (1890d=1890V)"
 orbit_ArgOfPericenter=173.03850
 orbit_AscendingNode=147.08450
@@ -23649,17 +17248,11 @@ orbit_TimeAtPericenter=2411628.60350
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_d%27Arrest%281897a_1897II%29]
 absolute_magnitude=9.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/d'Arrest (1897a=1897II)"
 orbit_ArgOfPericenter=173.01230
 orbit_AscendingNode=147.10890
@@ -23671,17 +17264,11 @@ orbit_TimeAtPericenter=2414068.33500
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_d%27Arrest%281943III%29]
 absolute_magnitude=9.1
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/d'Arrest (1943III)
 orbit_ArgOfPericenter=174.38420
 orbit_AscendingNode=143.62100
@@ -23693,17 +17280,11 @@ orbit_TimeAtPericenter=2430989.97890
 orbit_good=1000
 radius=5
 slope_parameter=9.6
-tex_map=nomap.png
 type=comet
 
 [P_d%27Arrest%281963f_1963VII%29]
 absolute_magnitude=9.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/d'Arrest (1963f=1963VII)"
 orbit_ArgOfPericenter=174.49560
 orbit_AscendingNode=143.59950
@@ -23715,17 +17296,11 @@ orbit_TimeAtPericenter=2438325.51520
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_d%27Arrest%281970d_1970VII%29]
 absolute_magnitude=9.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/d'Arrest (1970d=1970VII)"
 orbit_ArgOfPericenter=178.83140
 orbit_AscendingNode=141.40940
@@ -23737,17 +17312,11 @@ orbit_TimeAtPericenter=2440724.91490
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_d%27Arrest%281976e_1976XI%29]
 absolute_magnitude=9.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/d'Arrest (1976e=1976XI)"
 orbit_ArgOfPericenter=178.92630
 orbit_AscendingNode=141.35240
@@ -23759,17 +17328,11 @@ orbit_TimeAtPericenter=2443003.37190
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_d%27Arrest%281982e_1982VII%29]
 absolute_magnitude=9.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/d'Arrest (1982e=1982VII)"
 orbit_ArgOfPericenter=176.96980
 orbit_AscendingNode=138.86010
@@ -23781,17 +17344,11 @@ orbit_TimeAtPericenter=2445226.76220
 orbit_good=1000
 radius=5
 slope_parameter=-0.2
-tex_map=nomap.png
 type=comet
 
 [P_d%27Arrest%281987k_1989II%29]
 absolute_magnitude=9.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/d'Arrest (1987k=1989II)"
 orbit_ArgOfPericenter=177.06770
 orbit_AscendingNode=138.80170
@@ -23803,17 +17360,11 @@ orbit_TimeAtPericenter=2447561.69180
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_d%27Arrest%281995%29]
 absolute_magnitude=9.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/d'Arrest (1995)
 orbit_ArgOfPericenter=178.03878
 orbit_AscendingNode=138.29982
@@ -23825,17 +17376,11 @@ orbit_TimeAtPericenter=2449925.86197
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_deVico%281846IV%29]
 absolute_magnitude=7.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/de Vico (1846IV)
 orbit_ArgOfPericenter=12.89950
 orbit_AscendingNode=79.01270
@@ -23847,17 +17392,11 @@ orbit_TimeAtPericenter=2395361.54460
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_deVico%281996%29]
 absolute_magnitude=7.2
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/de Vico (1996)
 orbit_ArgOfPericenter=12.99600
 orbit_AscendingNode=78.89090
@@ -23869,17 +17408,11 @@ orbit_TimeAtPericenter=2450267.71990
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_deVico-Swift%281844I%29]
 absolute_magnitude=8.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/de Vico-Swift (1844I)
 orbit_ArgOfPericenter=278.93190
 orbit_AscendingNode=65.04780
@@ -23891,17 +17424,11 @@ orbit_TimeAtPericenter=2394812.47480
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [P_deVico-Swift%281965e_1965VII%29]
 absolute_magnitude=6.4
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name="P/de Vico-Swift (1965e=1965VII)"
 orbit_ArgOfPericenter=325.35160
 orbit_AscendingNode=24.42160
@@ -23913,17 +17440,11 @@ orbit_TimeAtPericenter=2438995.74450
 orbit_good=1000
 radius=5
 slope_parameter=3.9
-tex_map=nomap.png
 type=comet
 
 [P_duToit%281974IV%29]
 absolute_magnitude=9.5
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/du Toit (1974IV)
 orbit_ArgOfPericenter=257.20730
 orbit_AscendingNode=22.14020
@@ -23935,17 +17456,11 @@ orbit_TimeAtPericenter=2442138.99690
 orbit_good=1000
 radius=5
 slope_parameter=6.0
-tex_map=nomap.png
 type=comet
 
 [P_vanHouten%281961X%29]
 absolute_magnitude=8.0
 albedo=0.1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=P/van Houten (1961X)
 orbit_ArgOfPericenter=37.80000
 orbit_AscendingNode=5.30000
@@ -23957,17 +17472,11 @@ orbit_TimeAtPericenter=2449997.00000
 orbit_good=1000
 radius=5
 slope_parameter=4.0
-tex_map=nomap.png
 type=comet
 
 [c2011l4%28panstarrs%29]
 absolute_magnitude=5.5
 albedo=1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/2011 L4 (PANSTARRS)
 orbit_ArgOfPericenter=333.6698
 orbit_AscendingNode=65.6925
@@ -23978,17 +17487,11 @@ orbit_TimeAtPericenter=2456361.64579861
 orbit_good=1000
 radius=5
 slope_parameter=4
-tex_map=nomap.png
 type=comet
 
 [c2012f6%28lemmon%29]
 absolute_magnitude=10
 albedo=1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/2012 F6 (Lemmon)
 orbit_ArgOfPericenter=304.9671
 orbit_AscendingNode=332.7281
@@ -23999,17 +17502,11 @@ orbit_TimeAtPericenter=2456376.01028935
 orbit_good=1000
 radius=5
 slope_parameter=4
-tex_map=nomap.png
 type=comet
 
 [c2012s1%28ison%29]
 absolute_magnitude=8.5
 albedo=1
-color=1.0, 1.0, 1.0
-coord_func=comet_orbit
-dust_brightnessfactor=1.5
-dust_lengthfactor=0.4
-dust_widthfactor=1.5
 name=C/2012 S1 (ISON)
 orbit_ArgOfPericenter=345.5711
 orbit_AscendingNode=295.6428
@@ -24020,6 +17517,5 @@ orbit_TimeAtPericenter=2456625.29039352
 orbit_good=1000
 radius=5
 slope_parameter=3.2
-tex_map=nomap.png
 type=comet
 

--- a/src/core/modules/Orbit.hpp
+++ b/src/core/modules/Orbit.hpp
@@ -99,16 +99,29 @@ public:
 	//! Compute the object position for a specified Julian day.
 	//! @param JDE Julian Ephemeris Day
 	//! @param v double vector of at least 3 elements. The first three will receive X/Y/Z values in AU.
-	virtual void positionAtTimevInVSOP87Coordinates(double JDE, double* v) Q_DECL_OVERRIDE;
+	void positionAtTimevInVSOP87Coordinates(double JDE, double* v) override;
+	//! Compute the object position for a specified mean anomaly.
+	//! @param meanAnomaly [radians]
+	//! @param v double vector of at least 3 elements. The first three will receive X/Y/Z values in AU.
+	void positionAtMeanAnomalyInVSOP87Coordinates(const double meanAnomaly, double *v);
+	//! Compute eccentric anomaly E from mean anomaly M. [radians]
+	double eccentricAnomaly(double M);
+	//! Compute the object position for a specified eccentric anomaly.
+	//! @param E eccentricAnomaly [radians]
+	//! @param v double vector of at least 3 elements. The first three will receive X/Y/Z values in AU.
+	//! @note: Only used for orbit computation
+	void positionAtEccentricAnomalyInVSOP87Coordinates(const double E, double *v);
 	//! updating comet tails is a bit expensive. try not to overdo it.
 	bool getUpdateTails() const { return updateTails; }
 	void setUpdateTails(const bool update){ updateTails=update; }
 	//! return speed value [AU/d] last computed by positionAtTimevInVSOP87Coordinates(JDE, v)
-	virtual Vec3d getVelocity() const Q_DECL_OVERRIDE { return rdot; }
-	virtual void getVelocity(double *vel) const Q_DECL_OVERRIDE { vel[0]=rdot[0]; vel[1]=rdot[1]; vel[2]=rdot[2];}
+	Vec3d getVelocity() const override { return rdot; }
+	void getVelocity(double *vel) const override { vel[0]=rdot[0]; vel[1]=rdot[1]; vel[2]=rdot[2];}
 	//! Returns semimajor axis [AU] for elliptic orbit, 0 for a parabolic orbit, and a negative value [AU] for hyperbolic orbit.
-	virtual double getSemimajorAxis() const Q_DECL_OVERRIDE { return (e==1. ? 0. : q / (1.-e)); }
-	virtual double getEccentricity() const Q_DECL_OVERRIDE { return e; }
+	double getSemimajorAxis() const override { return (e==1. ? 0. : q / (1.-e)); }
+	double getEccentricity() const override { return e; }
+	//! Return mean anomaly M for JDE (or W, in case of parabolae)
+	inline double meanAnomaly(const double JDE) const {return (JDE-t0)*n;};
 	//! return whether a position returned for JDE can be regarded accurate enough for telescope use.
 	//! This is limited to dates within 1 year or epoch, or within orbitGood around epoch, whichever is smaller.
 	//! If orbitGood is zero, this is always true.
@@ -144,9 +157,24 @@ private:
 	double orbitGood; //!< orb. elements are only valid for this time from perihel [days]. Don't draw the object outside. Values <=0 mean "always good" (objects on undisturbed elliptic orbit)
 	Vec3d rdot;       //!< velocity vector. Caches velocity from last position computation, [AU/d]
 	bool updateTails; //!< flag to signal that comet tails must be recomputed.
-	void InitEll(const double dt, double &rCosNu, double &rSinNu);
-	void InitPar(const double dt, double &rCosNu, double &rSinNu);
-	void InitHyp(const double dt, double &rCosNu, double &rSinNu);
+	//! Solve true anomaly nu for elliptical orbit with Laguerre-Conway's method. (May have high e)
+	//! @param M mean anomaly (meanMotion*daysFromPerihel) [radians]
+	//! @param rCosNu: r*cos(nu)
+	//! @param rSinNu: r*sin(nu)
+	void InitEll(const double M, double &rCosNu, double &rSinNu);
+	//! Initialize position computations for parabolic orbits
+	//! @param W equivalent of mean anomaly (meanMotion*daysFromPerihel) [radians]
+	//! @param rCosNu: r*cos(nu)
+	//! @param rSinNu: r*sin(nu)
+	void InitPar(const double W, double &rCosNu, double &rSinNu);
+	//! Solve true anomaly nu for hyperbolic "orbit" (better: trajectory) around the sun.
+	//! @param M mean anomaly (meanMotion*daysFromPerihel) [radians]
+	//! @param rCosNu: r*cos(nu)
+	//! @param rSinNu: r*sin(nu)
+	void InitHyp(const double M, double &rCosNu, double &rSinNu);
+	//! Inner part of positional computation.
+	//! Needed for position and orbit computations
+	void positionInVSOP87Coordinates(const double rCosNu, const double rSinNu, double *v, Vec3d &rdot);
 };
 
 //! A pseudo-orbit for "observers" linked to a planet's sphere. It allows setting distance and longitude/latitude in the VSOP87 frame.
@@ -158,9 +186,9 @@ public:
 	//! Constructor. @param distance in AU, @param longitude in radians, @param latitude in radians.
 	GimbalOrbit(double distance, double longitude, double latitude);
 	//! Compute position for a (unused) Julian day.
-	virtual void positionAtTimevInVSOP87Coordinates(double JDE, double* v) Q_DECL_OVERRIDE;
+	void positionAtTimevInVSOP87Coordinates(double JDE, double* v) override;
 	//! Returns (pseudo) semimajor axis [AU] of a circular "orbit", i.e., distance.
-	double getSemimajorAxis() const Q_DECL_OVERRIDE { return distance; }
+	double getSemimajorAxis() const override { return distance; }
 
 	//! Set minimum distance for observers (may depend on central object)
 	void setMinDistance(double dist) {minDistance=dist; distance=qMax(distance, minDistance);}


### PR DESCRIPTION
### Description
<!--- Please include a summary of the change and which issue is fixed. -->
<!--- Please also include relevant motivation and context. -->
<!--- List any dependencies that are required for this change. -->

Drawing orbit lines from 360 time steps along the orbit works well for ellipses with low eccentricity only. 
For highly elongated comet orbits, the perihel area is covered only with a few vertices, which causes a polygonal, usually vastly undersampled appearance. With the time step approach, the situation was remedied a bit by not plotting the entire orbit, but only the part which is signified by the orbit_good value in ssystem_minor.ini. 

This PR provides a solution that constructs the entire orbit for ellipses with eccentricities e<0.999, by stepping over the eccentric anomaly. This looks generally much better and allows the estimation where in the outer solar system the object has its aphel. There still remain a few "polygon orbits" when they appear close to the observer. 

Fixes # (issue)

### Screenshots (if appropriate):

![stellarium-094](https://github.com/Stellarium/stellarium/assets/18099873/78c5be8c-5a6e-4e6f-b7b8-d07e149ec451)


### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] This change requires a documentation update

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system: Windows 11
* Graphics Card: Geforce (irrelevant)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
