### PR TITLE
Make objects split by cylinder projections wraparound appear on one side of the screen

### DIFF
--- a/src/core/StelProjector.hpp
+++ b/src/core/StelProjector.hpp
@@ -173,6 +173,11 @@ public:
 	virtual QByteArray getBackwardTransformShader() const = 0;
 	//! Sets the necessary uniforms so that the shader returned by getBackwardTransformShader can work
 	virtual void setBackwardTransformUniforms(QOpenGLShaderProgram& program) const;
+	//! Makes the object whose center is at \p objectCenter appear only on one side of the screen for
+	//! projections with a wraparound, preventing a stretching across the whole screen.
+	virtual void enableOneSideProjection(const Vec3f& objectCenter) {}
+	//! Undoes the effect of #enableOneSideProjection.
+	virtual void disableOneSideProjection() {}
 
 	//! Determine whether a great circle connection p1 and p2 intersects with a projection discontinuity.
 	//! For many projections without discontinuity, this should return always false, but for other like

--- a/src/core/StelProjectorClasses.cpp
+++ b/src/core/StelProjectorClasses.cpp
@@ -560,7 +560,11 @@ bool StelProjectorCylinder::forward(Vec3f &v) const
 {
 	const float r = std::sqrt(v[0]*v[0] + v[1]*v[1] + v[2]*v[2]);
 	const bool rval = (-r < v[1] && v[1] < r);
-	const float alpha = std::atan2(v[0],-v[2]);
+	float alpha = std::atan2(v[0],-v[2]);
+	if(objectCenterAzimuth > 0 && alpha < 0)
+		alpha += M_PI*2;
+	if(objectCenterAzimuth < 0 && alpha > 0)
+		alpha -= M_PI*2;
 	const float delta = std::asin(v[1]/r);
 	v[0] = alpha*static_cast<float>(widthStretch);
 	v[1] = delta;
@@ -625,6 +629,18 @@ vec3 projectorBackwardTransform(vec3 v, out bool ok)
 }
 #line 1 0
 )";
+}
+
+void StelProjectorCylinder::enableOneSideProjection(const Vec3f& objectCenter)
+{
+	Vec3f transformed = objectCenter;
+	modelViewTransform->forward(transformed);
+	objectCenterAzimuth = std::atan2(transformed[0],-transformed[2]);
+}
+
+void StelProjectorCylinder::disableOneSideProjection()
+{
+	objectCenterAzimuth = 0;
 }
 
 

--- a/src/core/StelProjectorClasses.hpp
+++ b/src/core/StelProjectorClasses.hpp
@@ -127,6 +127,8 @@ public:
 	//float deltaZoom(float fov) const override;
 	QByteArray getForwardTransformShader() const override;
 	QByteArray getBackwardTransformShader() const override;
+	void enableOneSideProjection(const Vec3f& objectCenter) override;
+	void disableOneSideProjection() override;
 protected:
 	bool hasDiscontinuity() const override {return true;}
 	bool intersectViewportDiscontinuityInternal(const Vec3d& p1, const Vec3d& p2) const override
@@ -141,6 +143,10 @@ protected:
 		SphericalCap cap(capN, capD);
 		return cap.intersects(cap1) && cap.intersects(cap2) && cap.intersects(cap3);
 	}
+
+	//! Used for one-side projection, 0 means disable, <0 places the object
+	//! on the left side of the screen, >0 on the right one.
+	float objectCenterAzimuth = 0;
 };
 
 // A variant which fills the viewport with a plate carrée, regardless of screen dimensions.

--- a/src/core/modules/Planet.cpp
+++ b/src/core/modules/Planet.cpp
@@ -4079,12 +4079,15 @@ void Planet::drawSphere(StelPainter* painter, float screenRd, bool drawOnlyRing)
 	sSphere(&model, static_cast<float>(equatorialRadius), static_cast<float>(oneMinusOblateness), nb_facet, nb_facet);
 
 	QVector<float> projectedVertexArr(model.vertexArr.size());
+	const auto projector = painter->getProjector();
+	projector->enableOneSideProjection(Vec3f(0,0,0));
 	for (int i=0;i<model.vertexArr.size()/3;++i)
 	{
 		Vec3f p = *(reinterpret_cast<const Vec3f*>(model.vertexArr.constData()+i*3));
 		p *= sphereScaleF;
-		painter->getProjector()->project(p, *(reinterpret_cast<Vec3f*>(projectedVertexArr.data()+i*3)));
+		projector->project(p, *(reinterpret_cast<Vec3f*>(projectedVertexArr.data()+i*3)));
 	}
+	projector->disableOneSideProjection();
 	
 	const SolarSystem* ssm = GETSTELMODULE(SolarSystem);
 


### PR DESCRIPTION
### Description

Some projections expand azimuth dimension over the width of the screen. This makes objects that are clipped by a side of the screen appear on the other side. But currently these objects remain single objects, which results in stretching over the whole distance between one side of the projection to the other.

This commit improves on this situation by making it possible to put an object completely on one side of the screen — the one where object's center resides. This loses the second half that should appear on the opposite side of the screen, but at least avoids the stretching artifacts.

Currently this is only applied to Cylinder projection and its derivatives. Others may be tweaked similarly in subsequent commits.

Fixes #3437

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system: Ubuntu 20.04
* Graphics Card: Intel UHD Graphics 620

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
