### PR TITLE
No need for ATL headers since it's not being used

### DIFF
--- a/plugins/TelescopeControl/src/ASCOM/ASCOMDevice.cpp
+++ b/plugins/TelescopeControl/src/ASCOM/ASCOMDevice.cpp
@@ -17,7 +17,6 @@
  */
 
 #include "ASCOMDevice.hpp"
-#include <atlcomcli.h>
 #include <comdef.h>
 
 ASCOMDevice::ASCOMDevice(QObject* parent, QString ascomDeviceId) : QObject(parent),

--- a/plugins/TelescopeControl/src/common/ASCOMSupport.cpp
+++ b/plugins/TelescopeControl/src/common/ASCOMSupport.cpp
@@ -23,7 +23,6 @@
 
 #ifdef Q_OS_WIN
 
-#include <atlcomcli.h>
 #include <comdef.h>
 #include <QRegularExpression>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
ATL headers were added, but not used. Only regular COM is being used and some OLE, but it is already included by `../common/OLE.hpp`

### Fixes 
Building in environments where ATL headers are not available.

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] Housekeeping

### How Has This Been Tested?
Built with Visual Studio
Windows 11 x64

**Test Configuration**:
* Operating system: Windows 11 x64 10.0.22621.2361


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
