### PR TITLE
First build of Stellarium for Windows on ARM on AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -39,7 +39,7 @@ environment:
     qtver: 6.5
     qtbin: msvc2019_arm64
     msvcname: Visual Studio 17 2022
-    cmake_args: -A ARM64 -DQT_HOST_PATH=C:/Qt/6.5/msvc2019_64 -DENABLE_SPOUT=OFF -DENABLE_QTWEBENGINE=OFF
+    cmake_args: -A ARM64 -DQT_HOST_PATH=C:/Qt/6.5/msvc2019_64 -DQT_PATHS=C:/Qt/6.5/msvc2019_arm64/bin/qtpaths.bat -DENABLE_SPOUT=OFF -DENABLE_QTWEBENGINE=OFF
 
 before_build:
   - ps: if($env:qtbin.contains('_64')) { $env:BITS=64 } else { $env:BITS=32 }

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -24,18 +24,25 @@ environment:
     qtver: 6.5
     qtbin: msvc2019_64
     msvcname: Visual Studio 16 2019
+    cmake_args: -A x64
   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
     qtver: 5.12
     qtbin: msvc2017_64
     msvcname: Visual Studio 15 2017 Win64
+    cmake_args: -A x64
   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
     qtver: 5.12
     qtbin: msvc2017
     msvcname: Visual Studio 15 2017
+    cmake_args:
+  - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
+    qtver: 6.5
+    qtbin: msvc2019_arm64
+    msvcname: Visual Studio 17 2022
+    cmake_args: -A ARM64 -DQT_HOST_PATH=C:/Qt/6.5/msvc2019_64 -DENABLE_SPOUT=OFF -DENABLE_QTWEBENGINE=OFF
 
 before_build:
   - ps: if($env:qtbin.contains('_64')) { $env:BITS=64 } else { $env:BITS=32 }
-  - ps: if($env:qtbin.contains('_64')) { $env:cmake_args:="-A x64" }
   - ps: if($env:qtver.contains('6.')) { $env:SSL="OpenSSL-" } else { $env:SSL="OpenSSL-1-" }
   - set PUBLISH_BINARY=false
   - set USE_EXT_LIBGLES=false
@@ -67,7 +74,7 @@ build:
   verbosity: minimal
 
 test_script:
-  - if [%PUBLISH_BINARY%]==[false] ctest --output-on-failure
+  - ps: if($env:PUBLISH_BINARY -eq "false" -and $env:qtbin -ne "msvc2019_arm64") { ctest --output-on-failure }
 
 after_test:
   - if [%PUBLISH_BINARY%]==[true] cmake --build c:\stellarium\build-%qtver%-%qtbin%\ --config %configuration% --target install

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,7 +29,7 @@ environment:
     qtver: 5.12
     qtbin: msvc2017_64
     msvcname: Visual Studio 15 2017 Win64
-    cmake_args: -A x64
+    cmake_args:
   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
     qtver: 5.12
     qtbin: msvc2017

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -611,6 +611,12 @@ IF(WIN32)
           SET(VIRTUAL_KBD_SETTING "--no-virtualkeyboard")
      ENDIF()
 
+     IF("${QT_PATHS}" STREQUAL "")
+          SET(_qt_paths "")
+     ELSE()
+          SET(_qt_paths "--qtpaths \"${QTPATHS}\"")
+     ENDIF()
+
      INSTALL(CODE
 	  "
 	  EXECUTE_PROCESS(
@@ -619,6 +625,7 @@ IF(WIN32)
 		    --no-translations
 		    --verbose 1
 		    ${VIRTUAL_KBD_SETTING}
+		    ${_qt_paths}
 		    --compiler-runtime
 		    \"\${CMAKE_INSTALL_PREFIX}/bin/stellarium.exe\"
 	       WORKING_DIRECTORY \"\${CMAKE_INSTALL_PREFIX}/bin\"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
I had absolutely no idea that AppVeyor had Qt 6 for Windows on ARM already compiled and ready for use for x-compilation in its base images!! This makes things orders of magnitude easier! We don't even have to use MSYS2 to build Stellarium for Windows on ARM!

This is a first, build only, no deployment of Windows on ARM 64 binaries.

No QtWebEngine because Qt doesn't build that for x-compilation yet. And no Spout either since there's no precompiled Spout for ARM64.

Partially fixes #2962 and #1436

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?
No unit tests run because AppVeyor does not provide Windows on ARM runners. We can only x-compile for now from x64 for ARM64.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
