### PR TITLE
Use StelMainView as the parent for all message boxes and file dialogs

### DIFF
--- a/plugins/Satellites/src/gui/SatellitesDialog.cpp
+++ b/plugins/Satellites/src/gui/SatellitesDialog.cpp
@@ -1477,7 +1477,7 @@ void SatellitesDialog::updateTLEs(void)
 	}
 	else
 	{
-		QStringList updateFiles = QFileDialog::getOpenFileNames(nullptr,
+		QStringList updateFiles = QFileDialog::getOpenFileNames(&StelMainView::getInstance(),
 									q_("Select TLE Update File"),
 									StelFileMgr::getDesktopDir(),
 									"*.*");
@@ -1591,7 +1591,7 @@ void SatellitesDialog::savePredictedIridiumFlares()
 
 	QString defaultFilter = QString("(*.%1)").arg(defaultExtension);
 	QString dir = QString("%1/iridium_flares.%2").arg(QDir::homePath(), defaultExtension);
-	QString filePath = QFileDialog::getSaveFileName(nullptr, q_("Save predicted Iridium flares as..."), dir, filter, &defaultFilter);
+	QString filePath = QFileDialog::getSaveFileName(&StelMainView::getInstance(), q_("Save predicted Iridium flares as..."), dir, filter, &defaultFilter);
 
 	int count = ui->iridiumFlaresTreeWidget->topLevelItemCount();
 	int columns = iridiumFlaresHeader.size();

--- a/plugins/SolarSystemEditor/src/gui/ManualImportWindow.cpp
+++ b/plugins/SolarSystemEditor/src/gui/ManualImportWindow.cpp
@@ -190,7 +190,7 @@ void ManualImportWindow::selectTextureFile(QLineEdit * filePathLineEdit)
 		supportedFormats.append(QString("*.%1").arg(QString(format)));//It's a wee bit long...
 	}
 	QString fileFilter = QString("Texture files (%1)").arg(supportedFormats.join(" "));
-	QString newFilePath = QFileDialog::getOpenFileName(nullptr, QString(), texturesDirectoryPath, fileFilter);
+	QString newFilePath = QFileDialog::getOpenFileName(&StelMainView::getInstance(), QString(), texturesDirectoryPath, fileFilter);
 
 	//Is the file in one of the two "textures" directories?
 	if (newFilePath.isEmpty())

--- a/plugins/SolarSystemEditor/src/gui/MpcImportWindow.cpp
+++ b/plugins/SolarSystemEditor/src/gui/MpcImportWindow.cpp
@@ -25,6 +25,7 @@
 
 #include "StelApp.hpp"
 #include "StelFileMgr.hpp"
+#include "StelMainView.hpp"
 #include "StelJsonParser.hpp"
 #include "StelModuleMgr.hpp"
 #include "StelTranslator.hpp"
@@ -337,7 +338,7 @@ void MpcImportWindow::selectFile()
 	filter.append(" (*.txt);;");
 	filter.append(q_("All Files"));
 	filter.append(" (*.*)");
-	QString filePath = QFileDialog::getOpenFileName(nullptr, q_("Select a file"), QDir::homePath(), filter);
+	QString filePath = QFileDialog::getOpenFileName(&StelMainView::getInstance(), q_("Select a file"), QDir::homePath(), filter);
 	ui->lineEditFilePath->setText(filePath);
 }
 

--- a/plugins/SolarSystemEditor/src/gui/SolarSystemManagerWindow.cpp
+++ b/plugins/SolarSystemEditor/src/gui/SolarSystemManagerWindow.cpp
@@ -29,6 +29,7 @@
 #include "StelApp.hpp"
 #include "StelGui.hpp"
 #include "StelFileMgr.hpp"
+#include "StelMainView.hpp"
 #include "StelModuleMgr.hpp"
 #include "StelTranslator.hpp"
 #include "Planet.hpp"
@@ -207,7 +208,7 @@ void SolarSystemManagerWindow::removeObjects()
 
 void SolarSystemManagerWindow::copyConfiguration()
 {
-	QString filePath = QFileDialog::getSaveFileName(nullptr,
+	QString filePath = QFileDialog::getSaveFileName(&StelMainView::getInstance(),
 							q_("Save the minor Solar System bodies as..."),
 							QDir::homePath() + "/ssystem_minor.ini");
 	ssEditor->copySolarSystemConfigurationFileTo(filePath);
@@ -217,7 +218,7 @@ void SolarSystemManagerWindow::replaceConfiguration()
 {
 	QString filter = q_("Configuration files");
 	filter.append(" (*.ini)");
-	QString filePath = QFileDialog::getOpenFileName(nullptr, q_("Select a file to replace the Solar System minor bodies"), QDir::homePath(), filter);
+	QString filePath = QFileDialog::getOpenFileName(&StelMainView::getInstance(), q_("Select a file to replace the Solar System minor bodies"), QDir::homePath(), filter);
 	ssEditor->replaceSolarSystemConfigurationFileWith(filePath);
 }
 
@@ -225,7 +226,7 @@ void SolarSystemManagerWindow::addConfiguration()
 {
 	QString filter = q_("Configuration files");
 	filter.append(" (*.ini)");
-	QString filePath = QFileDialog::getOpenFileName(nullptr, q_("Select a file to add the Solar System minor bodies"), QDir::toNativeSeparators(StelFileMgr::getInstallationDir()+"/data/ssystem_1000comets.ini"), filter);
+	QString filePath = QFileDialog::getOpenFileName(&StelMainView::getInstance(), q_("Select a file to add the Solar System minor bodies"), QDir::toNativeSeparators(StelFileMgr::getInstallationDir()+"/data/ssystem_1000comets.ini"), filter);
 	ssEditor->addFromSolarSystemConfigurationFile(filePath);
 }
 

--- a/plugins/TelescopeControl/src/ASCOM/TelescopeClientASCOM.cpp
+++ b/plugins/TelescopeControl/src/ASCOM/TelescopeClientASCOM.cpp
@@ -26,6 +26,7 @@
 
 #include "StelCore.hpp"
 #include "StelUtils.hpp"
+#include "StelMainView.hpp"
 #include "StelTranslator.hpp"
 
 TelescopeClientASCOM::TelescopeClientASCOM(const QString& name, const QString& params, TelescopeControl::Equinox eq)
@@ -138,7 +139,7 @@ void TelescopeClientASCOM::telescopeGoto(const Vec3d& j2000Pos, StelObjectP sele
 
 	if (mAscomDevice->isParked())
 	{
-		QMessageBox::warning(nullptr, "Stellarium",
+		QMessageBox::warning(&StelMainView::getInstance(), "Stellarium",
 		  q_("Can't slew a telescope which is parked. Unpark before performing any goto command."));
 		return;
 	}

--- a/plugins/TelescopeControl/src/TelescopeControl.cpp
+++ b/plugins/TelescopeControl/src/TelescopeControl.cpp
@@ -37,6 +37,7 @@
 #include "StelFileMgr.hpp"
 #include "StelGui.hpp"
 #include "StelGuiItems.hpp"
+#include "StelMainView.hpp"
 #include "StelModuleMgr.hpp"
 #include "StelMovementMgr.hpp"
 #include "StelObject.hpp"
@@ -770,7 +771,7 @@ void TelescopeControl::loadTelescopes()
 			qWarning() << "[TelescopeControl] The existing version of telescopes.json is obsolete. Unable to rename.";
 
 		telescopeDescriptions = result;
-		QMessageBox::warning(nullptr, q_("Attention!"), q_("The existing version of the configuration data for telescopes in the Telescope Control plugin is obsolete."), QMessageBox::Ok);
+		QMessageBox::warning(&StelMainView::getInstance(), q_("Attention!"), q_("The existing version of the configuration data for telescopes in the Telescope Control plugin is obsolete."), QMessageBox::Ok);
 		return;
 	}
 

--- a/plugins/TelescopeControl/src/gui/TelescopeDialog.cpp
+++ b/plugins/TelescopeControl/src/gui/TelescopeDialog.cpp
@@ -22,6 +22,7 @@
 #include "StelApp.hpp"
 #include "StelModuleMgr.hpp"
 #include "StelStyle.hpp"
+#include "StelMainView.hpp"
 #include "StelTranslator.hpp"
 #include "TelescopeControl.hpp"
 #include "TelescopeConfigurationDialog.hpp"
@@ -1021,7 +1022,7 @@ void TelescopeDialog::updateStyle()
 
 void TelescopeDialog::buttonBrowseServerDirectoryPressed()
 {
-	QString newPath = QFileDialog::getExistingDirectory (nullptr, QString(q_("Select a directory")), telescopeManager->getServerExecutablesDirectoryPath());
+	QString newPath = QFileDialog::getExistingDirectory (&StelMainView::getInstance(), QString(q_("Select a directory")), telescopeManager->getServerExecutablesDirectoryPath());
 	//TODO: Validation? Directory exists and contains servers?
 	if(!newPath.isEmpty())
 	{

--- a/src/core/modules/NebulaMgr.cpp
+++ b/src/core/modules/NebulaMgr.cpp
@@ -27,6 +27,7 @@
 #include "Nebula.hpp"
 #include "StelTexture.hpp"
 #include "StelUtils.hpp"
+#include "StelMainView.hpp"
 #include "StelSkyDrawer.hpp"
 #include "StelTranslator.hpp"
 #include "StelTextureMgr.hpp"
@@ -1390,7 +1391,13 @@ bool NebulaMgr::loadDSOCatalog(const QString &filename)
 				++totalRecords;
 				qDebug().noquote() << "WARNING: Mismatch of DSO catalog version (" << version << ")! The expected version is" << StellariumDSOCatalogVersion;
 				qDebug().noquote() << "         See section 5.5 of the User Guide and install the right version of the catalog!";
-				QMessageBox::warning(Q_NULLPTR, q_("Attention!"), QString("%1. %2: %3 - %4: %5. %6").arg(q_("DSO catalog version mismatch"),  q_("Found"), version, q_("Expected"), StellariumDSOCatalogVersion, q_("See Logfile for instructions.")), QMessageBox::Ok);
+				QMessageBox::warning(&StelMainView::getInstance(), q_("Attention!"),
+				                     QString("%1. %2: %3 - %4: %5. %6").arg(q_("DSO catalog version mismatch"),
+				                                                            q_("Found"),
+				                                                            version,
+				                                                            q_("Expected"),
+				                                                            StellariumDSOCatalogVersion,
+				                                                            q_("See Logfile for instructions.")), QMessageBox::Ok);
 				break;
 			}
 		}

--- a/src/gui/AddRemoveLandscapesDialog.cpp
+++ b/src/gui/AddRemoveLandscapesDialog.cpp
@@ -116,7 +116,7 @@ void AddRemoveLandscapesDialog::browseForArchiveClicked()
 	// TRANSLATORS: This string is displayed in the "Files of type:" drop-down list in the standard file selection dialog.
 	QString filter = q_("ZIP archives");
 	filter += " (*.zip)";
-	QString sourceArchivePath = QFileDialog::getOpenFileName(Q_NULLPTR, caption, lastUsedDirectoryPath, filter);
+	QString sourceArchivePath = QFileDialog::getOpenFileName(&StelMainView::getInstance(), caption, lastUsedDirectoryPath, filter);
 	bool useLandscape = ui->checkBoxUseLandscape->isChecked();
 	if (!sourceArchivePath.isEmpty() && QFile::exists(sourceArchivePath))
 	{

--- a/src/gui/AstroCalcDialog.cpp
+++ b/src/gui/AstroCalcDialog.cpp
@@ -22,6 +22,7 @@
 #include "StelApp.hpp"
 #include "StelCore.hpp"
 #include "StelGui.hpp"
+#include "StelMainView.hpp"
 #include "StelModuleMgr.hpp"
 #include "StelMovementMgr.hpp"
 #include "StelObjectMgr.hpp"
@@ -629,7 +630,7 @@ void AstroCalcDialog::saveGraph(QChartView *graph)
 		dir = StelFileMgr::getUserDir();
 	QString filter = q_("Images");
 	filter.append(" (*.png)");
-	QString filename = QFileDialog::getSaveFileName(nullptr, q_("Save graph"), dir + "/stellarium-graph.png", filter);
+	QString filename = QFileDialog::getSaveFileName(&StelMainView::getInstance(), q_("Save graph"), dir + "/stellarium-graph.png", filter);
 	if (!filename.isEmpty())
 	{
 		QPixmap p = graph->grab();
@@ -4069,7 +4070,7 @@ void AstroCalcDialog::saveSolarEclipseKML()
 		QString filter = "KML";
 		filter.append(" (*.kml)");
 		QString defaultFilter("(*.kml)");
-		QString filePath = QFileDialog::getSaveFileName(nullptr,
+		QString filePath = QFileDialog::getSaveFileName(&StelMainView::getInstance(),
 								q_("Save KML as..."),
 								QDir::homePath() + "/solareclipse"+eclipseDateStr+".kml",
 								filter,
@@ -9435,7 +9436,7 @@ QPair<QString, QString> AstroCalcDialog::askTableFilePath(const QString &caption
 
 	QString dir = QString("%1/%2.%3").arg(QDir::homePath(), fileName, defaultExtension);
 	QString defaultFilter = QString("(*.%1)").arg(defaultExtension);
-	QString filePath = QFileDialog::getSaveFileName(nullptr, caption, dir, filter, &defaultFilter);
+	QString filePath = QFileDialog::getSaveFileName(&StelMainView::getInstance(), caption, dir, filter, &defaultFilter);
 
 	return QPair<QString, QString>(filePath, defaultFilter);
 }

--- a/src/gui/AtmosphereDialog.cpp
+++ b/src/gui/AtmosphereDialog.cpp
@@ -24,6 +24,7 @@
 #include "AtmosphereDialog.hpp"
 #include "StelPropertyMgr.hpp"
 #include "StelFileMgr.hpp"
+#include "StelMainView.hpp"
 #include "ui_atmosphereDialog.h"
 
 #include <QFileInfo>
@@ -166,7 +167,7 @@ void AtmosphereDialog::browsePathToModel()
 {
 	const auto mgr = StelApp::getInstance().getStelPropertyManager();
 	const auto dataDir = mgr->getProperty(DEFAULT_MODEL_PATH_PROPERTY)->getValue().toString() + "/..";
-	const auto path=QFileDialog::getExistingDirectory(nullptr, q_("Open ShowMySky model"), dataDir);
+	const auto path=QFileDialog::getExistingDirectory(&StelMainView::getInstance(), q_("Open ShowMySky model"), dataDir);
 	if(path.isNull()) return;
 
 	const auto currentModel = mgr->getProperty(MODEL_PROPERTY)->getValue().toString();

--- a/src/gui/ConfigurationDialog.cpp
+++ b/src/gui/ConfigurationDialog.cpp
@@ -764,7 +764,7 @@ void ConfigurationDialog::saveCustomSelectedInfo()
 void ConfigurationDialog::browseForScreenshotDir()
 {
 	QString oldScreenshorDir = StelFileMgr::getScreenshotDir();
-	QString newScreenshotDir = QFileDialog::getExistingDirectory(Q_NULLPTR, q_("Select screenshot directory"), oldScreenshorDir, QFileDialog::ShowDirsOnly);
+	QString newScreenshotDir = QFileDialog::getExistingDirectory(&StelMainView::getInstance(), q_("Select screenshot directory"), oldScreenshorDir, QFileDialog::ShowDirsOnly);
 
 	if (!newScreenshotDir.isEmpty()) {
 		// remove trailing slash

--- a/src/gui/ObsListDialog.cpp
+++ b/src/gui/ObsListDialog.cpp
@@ -24,6 +24,7 @@
 
 #include "StelTranslator.hpp"
 #include "StelApp.hpp"
+#include "StelMainView.hpp"
 #include "StelObjectMgr.hpp"
 #include "StelModuleMgr.hpp"
 #include "StelLocationMgr.hpp"
@@ -906,7 +907,7 @@ void ObsListDialog::exportListButtonPressed()
 	static const QString filter = "Stellarium Single Observing List (*.sol);;Stellarium Observing List (*.ol)";
 	const QString destinationDir=StelApp::getInstance().getSettings()->value("main/observinglists_dir", QDir::homePath()).toString();
 	QString selectedFilter = "Stellarium Single Observing List (*.sol)";
-	QString exportListJsonPath = QFileDialog::getSaveFileName(nullptr, q_("Export observing list as..."),
+	QString exportListJsonPath = QFileDialog::getSaveFileName(&StelMainView::getInstance(), q_("Export observing list as..."),
 							      destinationDir + "/" + JSON_FILE_BASENAME + "_" + currentListName + ".sol", filter, &selectedFilter);
 
 	QFile jsonFile(exportListJsonPath);
@@ -952,7 +953,7 @@ void ObsListDialog::importListButtonPressed()
 {
 	static const QString filter = "Stellarium Single Observing List (*.sol);;Stellarium Observing List (*.ol);;Stellarium Legacy JSON Observing List or Bookmarks (*.json)";
 	const QString destinationDir=StelApp::getInstance().getSettings()->value("main/observinglists_dir", QDir::homePath()).toString();
-	QString fileToImportJsonPath = QFileDialog::getOpenFileName(nullptr, q_("Import observing list"),
+	QString fileToImportJsonPath = QFileDialog::getOpenFileName(&StelMainView::getInstance(), q_("Import observing list"),
 								    destinationDir,
 								    filter);
 	QVariantMap map;

--- a/src/gui/ScriptConsole.cpp
+++ b/src/gui/ScriptConsole.cpp
@@ -198,7 +198,7 @@ void ScriptConsole::loadScript()
 	QString filter = q_("Stellarium Script Files");
 	filter.append(" (*.ssc *.inc);;");
 	filter.append(getFileMask());
-	QString aFile = QFileDialog::getOpenFileName(nullptr, q_("Load Script"), openDir, filter);
+	QString aFile = QFileDialog::getOpenFileName(&StelMainView::getInstance(), q_("Load Script"), openDir, filter);
 	if (aFile.isNull())
 		return;
 	scriptFileName = aFile;
@@ -224,7 +224,7 @@ void ScriptConsole::saveScript()
 	// Let's ask file name, when file is new and overwrite it in other case
 	if (scriptFileName.isEmpty())
 	{
-		QString aFile = QFileDialog::getSaveFileName(nullptr, q_("Save Script"), saveDir + "/myscript.ssc", getFileMask(), &defaultFilter);
+		QString aFile = QFileDialog::getSaveFileName(&StelMainView::getInstance(), q_("Save Script"), saveDir + "/myscript.ssc", getFileMask(), &defaultFilter);
 		if (aFile.isNull())
 			return;
 		scriptFileName = aFile;
@@ -366,7 +366,7 @@ void ScriptConsole::appendOutputLine(const QString& s)
 
 void ScriptConsole::includeBrowse()
 {
-	QString aDir = QFileDialog::getExistingDirectory(nullptr, q_("Select Script Include Directory"), StelFileMgr::getInstallationDir() + "/scripts");
+	QString aDir = QFileDialog::getExistingDirectory(&StelMainView::getInstance(), q_("Select Script Include Directory"), StelFileMgr::getInstallationDir() + "/scripts");
 	if (!aDir.isNull())
 		ui->includeEdit->setText(aDir);
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

In many cases the separate-window dialogs like message boxes and file open/save/etc. dialogs are given no parent in Stellarium. This leads to them looking very different in style and color scheme from the rest of the Stellarium GUI. The most striking difference is the light color scheme of the dialogs contrasting with the dark colors of Stellarium. Example:

![Screenshot_2023-10-05_22-17-08](https://github.com/Stellarium/stellarium/assets/6376882/38d6e1f9-68f1-46d5-9e10-475e509ba29d)

This patch changes almost all places that use `QMessageBox` and `QFileDialog` to pass `&StelMainView::getInstance()` as the parent, following the example of other places (and sometimes even the same files in other lines!). Only the message boxes used to tell about OpenGL errors are not parented since in this case this might be useless. The result looks like this:

![Screenshot_2023-10-05_22-16-24](https://github.com/Stellarium/stellarium/assets/6376882/66fac067-1b87-4248-8b26-35260a4294dc)