### PR TITLE
Add dpiAwareness option to manifest and send physicial viewport size to Spout

### DIFF
--- a/data/stellarium.exe.manifest
+++ b/data/stellarium.exe.manifest
@@ -41,8 +41,9 @@
         </security>
     </trustInfo>
     <asmv3:application>
-      <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">
+      <asmv3:windowsSettings>
         <ms_windowsSettings:dpiAware xmlns:ms_windowsSettings="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</ms_windowsSettings:dpiAware>
+        <ms_windowsSettings:dpiAwareness xmlns:ms_windowsSettings="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</ms_windowsSettings:dpiAwareness>
       </asmv3:windowsSettings>
     </asmv3:application>
 </assembly>

--- a/src/StelMainView.cpp
+++ b/src/StelMainView.cpp
@@ -929,14 +929,18 @@ void StelMainView::init()
 	stelApp->init(configuration);
 	//this makes sure the app knows how large the window is
 	connect(stelScene,SIGNAL(sceneRectChanged(QRectF)),stelApp,SLOT(glWindowHasBeenResized(QRectF)));
+#ifdef ENABLE_SPOUT
 	QObject::connect(stelScene, &StelGraphicsScene::sceneRectChanged, [&](const QRectF& rect)
 	{
         stelApp->glPhysicalWindowHasBeenResized(getPhysicalSize(rect));
 	});
+#endif
 
 	//also immediately set the current values
 	stelApp->glWindowHasBeenResized(stelScene->sceneRect());
+#ifdef ENABLE_SPOUT
 	stelApp->glPhysicalWindowHasBeenResized(getPhysicalSize(stelScene->sceneRect()));
+#endif
 
 	StelActionMgr *actionMgr = stelApp->getStelActionManager();
 	actionMgr->addAction("actionSave_Screenshot_Global", N_("Miscellaneous"), N_("Save screenshot"), this, "saveScreenShot()", "Ctrl+S");

--- a/src/StelMainView.hpp
+++ b/src/StelMainView.hpp
@@ -301,6 +301,8 @@ private:
 	//! Startup diagnostics, providing test for various circumstances of bad OS/OpenGL driver combinations
 	//! to provide feedback to the user about bad OpenGL drivers.
 	void processOpenGLdiagnosticsAndWarnings(QSettings *conf, QOpenGLContext* context) const;
+	//! Get physical dimensions given the virtual dimensions for the screen where this window is located.
+	QRectF getPhysicalSize(const QRectF& virtualRect) const;
 
 	//! The StelMainView singleton
 	static StelMainView* singleton;

--- a/src/core/StelApp.cpp
+++ b/src/core/StelApp.cpp
@@ -1067,7 +1067,7 @@ void StelApp::draw()
 }
 
 /*************************************************************************
- Call this when the size of the GL window has changed
+ Call this when the virtual size of the GL window has changed
 *************************************************************************/
 void StelApp::glWindowHasBeenResized(const QRectF& rect)
 {
@@ -1085,6 +1085,17 @@ void StelApp::glWindowHasBeenResized(const QRectF& rect)
 	}
 	// Force to recreate the viewport effect if any.
 	setViewportEffect(effect);
+#ifdef ENABLE_SPOUT
+	if (spoutSender)
+		spoutSender->resize(static_cast<uint>(rect.width()),static_cast<uint>(rect.height()));
+#endif
+}
+
+/*************************************************************************
+ Call this when the physical size of the GL window has changed
+*************************************************************************/
+void StelApp::glPhysicalWindowHasBeenResized(const QRectF& rect)
+{
 #ifdef ENABLE_SPOUT
 	if (spoutSender)
 		spoutSender->resize(static_cast<uint>(rect.width()),static_cast<uint>(rect.height()));

--- a/src/core/StelApp.hpp
+++ b/src/core/StelApp.hpp
@@ -264,8 +264,11 @@ public:
 	///////////////////////////////////////////////////////////////////////////
 	// Scriptable methods
 public slots:
-	//! Call this when the size of the GL window has changed.
+	//! Call this when the virtual size of the GL window has changed.
 	void glWindowHasBeenResized(const QRectF &rect);
+
+	//! Call this when the physical size of the GL window has changed.
+	void glPhysicalWindowHasBeenResized(const QRectF &rect);
 
 	//! Set flag for activating night vision mode.
 	void setVisionModeNight(bool);


### PR DESCRIPTION
Qt 6 defaults to PerMonitorV2 as its DPI awareness options.

### Description
The ACCESS_DENIED error was happening because the setting was being set by the manifest file and then, when the QGuiApplication instance is being created, it calls [`SetProcessDpiAwarenessContext()`](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setprocessdpiawarenesscontext#return-value) which clearly states that setting that after the manifest also sets it will lead to ACCESS_DENIED. 

Adding the options before Qt tries to set it ensures it won't try to call SetProcessDpiAwarenessContext() because the process will already be PerMonitorV2. (Qt checks the current options before trying to change it, see https://github.com/qt/qtbase/blob/v6.5.3/src/plugins/platforms/windows/qwindowscontext.cpp#L397)

Fixes #3461

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)


