### PR TITLE
Remove unused global scaling ratio

### DIFF
--- a/plugins/Scenery3d/src/S3DRenderer.cpp
+++ b/plugins/Scenery3d/src/S3DRenderer.cpp
@@ -1365,7 +1365,7 @@ void S3DRenderer::drawCoordinatesText()
 	const int fontSize=debugTextFont.pixelSize();
 	const QFontMetrics fm(debugTextFont);
 
-	const float devicePixelscaling = static_cast<float>(altAzProjector->getDevicePixelsPerPixel())*StelApp::getInstance().getGlobalScalingRatio();
+	const float devicePixelscaling = static_cast<float>(altAzProjector->getDevicePixelsPerPixel());
 	float screen_x = altAzProjector->getViewportWidth()  -  240.0f*devicePixelscaling;
 	float screen_x_cs=altAzProjector->getViewportWidth()-10.f-devicePixelscaling*qMax(240, painter.getFontMetrics().boundingRect(gridName).width());
 	float screen_y = altAzProjector->getViewportHeight() -  60.0f*devicePixelscaling;

--- a/src/core/StelApp.cpp
+++ b/src/core/StelApp.cpp
@@ -255,7 +255,6 @@ StelApp::StelApp(StelMainView *parent)
 #endif
 	, stelGui(Q_NULLPTR)
 	, devicePixelsPerPixel(1.)
-	, globalScalingRatio(1.f)
 	, fps(0)
 	, frame(0)
 	, frameTimeAccum(0.)

--- a/src/core/StelApp.hpp
+++ b/src/core/StelApp.hpp
@@ -211,12 +211,6 @@ public:
 	qreal getDevicePixelsPerPixel() const {return devicePixelsPerPixel;}
 	void setDevicePixelsPerPixel(qreal dppp);
 	
-	//! Get the scaling ratio to apply on all display elements, like GUI, text etc..
-	//! When this ratio is 1, all pixel sizes used in Stellarium will look OK on a regular
-	//! computer screen with 96 pixel per inch (reference for tuning sizes).
-	float getGlobalScalingRatio() const {return globalScalingRatio;}
-	void setGlobalScalingRatio(float r) {globalScalingRatio=r;}
-
 	//! Get the fontsize used for screen text.
 	int getScreenFontSize() const { return screenFontSize; }
 	//! Change screen font size.
@@ -456,9 +450,6 @@ private:
 	// Store the ratio between real device pixel in "Device Independent Pixel"
 	// Usually this value is 1, but for a mac with retina screen this will be value 2.
 	qreal devicePixelsPerPixel;
-
-	// The scaling ratio to apply on all display elements, like GUI, text etc..
-	float globalScalingRatio;
 	
 	float fps;
 	int frame;

--- a/src/core/StelPainter.cpp
+++ b/src/core/StelPainter.cpp
@@ -672,7 +672,7 @@ StringTexture* StelPainter::getTextTexture(const QString& str, int pixelSize) co
 	if (cachedTex)
 		return cachedTex;
 	QFont tmpFont = currentFont;
-	tmpFont.setPixelSize(currentFont.pixelSize()*static_cast<int>(static_cast<float>(prj->getDevicePixelsPerPixel())*StelApp::getInstance().getGlobalScalingRatio()));
+	tmpFont.setPixelSize(currentFont.pixelSize()*static_cast<int>(prj->getDevicePixelsPerPixel()));
 	tmpFont.setStyleStrategy(QFont::NoSubpixelAntialias); // The text may rotate, which would break subpixel AA
 	QRect strRect = QFontMetrics(tmpFont).boundingRect(str);
 	int w = strRect.width()+1+static_cast<int>(0.02f*strRect.width());
@@ -1728,10 +1728,6 @@ void StelPainter::drawEllipse(double x, double y, double rX, double rY, double a
 {
 	if (rX <= 1.0 || rY <= 1.0)
 		return;
-	// Taken largely from Nebula::renderEllipticMarker()
-	const double scale = StelApp::getInstance().getGlobalScalingRatio();
-	rX *= scale;
-	rY *= scale;
 
 	//const float radiusY = 0.35 * size;
 	//const float radiusX = aspectRatio * radiusY;
@@ -1751,7 +1747,7 @@ void StelPainter::drawEllipse(double x, double y, double rX, double rY, double a
 	}
 	const auto vertCount = vertexData.size() / 2;
 	setLineSmooth(true);
-	setLineWidth(scale * std::clamp(qMax(rX, rY)/40, 1., 2.));
+	setLineWidth(std::clamp(qMax(rX, rY)/40, 1., 2.));
 	enableClientStates(true);
 	setVertexPointer(2, GL_FLOAT, vertexData.data());
 	drawFromArray(StelPainter::LineLoop, vertCount, 0, false);
@@ -1764,7 +1760,7 @@ void StelPainter::drawSprite2dMode(float x, float y, float radius)
 	static const float texCoordData[] = {0.,0., 1.,0., 0.,1., 1.,1.};
 	
 	// Takes into account device pixel density and global scale ratio, as we are drawing 2D stuff.
-	radius *= static_cast<float>(prj->getDevicePixelsPerPixel())*StelApp::getInstance().getGlobalScalingRatio();
+	radius *= static_cast<float>(prj->getDevicePixelsPerPixel());
 	
 	vertexData[0]=x-radius; vertexData[1]=y-radius;
 	vertexData[2]=x+radius; vertexData[3]=y-radius;
@@ -1779,7 +1775,7 @@ void StelPainter::drawSprite2dMode(float x, float y, float radius)
 
 void StelPainter::drawSprite2dModeNoDeviceScale(float x, float y, float radius)
 {
-	drawSprite2dMode(x, y, radius/(static_cast<float>(prj->getDevicePixelsPerPixel())*StelApp::getInstance().getGlobalScalingRatio()));
+	drawSprite2dMode(x, y, radius/(static_cast<float>(prj->getDevicePixelsPerPixel())));
 }
 
 void StelPainter::drawSprite2dMode(const Vec3d& v, float radius)
@@ -1800,7 +1796,7 @@ void StelPainter::drawSprite2dMode(float x, float y, float radius, float rotatio
 	const float sinr = std::sin(rotation * M_PI_180f);
 	
 	// Takes into account device pixel density and global scale ratio, as we are drawing 2D stuff.
-	radius *= static_cast<float>(prj->getDevicePixelsPerPixel())*StelApp::getInstance().getGlobalScalingRatio();
+	radius *= static_cast<float>(prj->getDevicePixelsPerPixel());
 	
 	for (int i = 0; i < 8; i+=2)
 	{

--- a/src/core/StelSkyDrawer.cpp
+++ b/src/core/StelSkyDrawer.cpp
@@ -530,7 +530,7 @@ void StelSkyDrawer::drawSunCorona(StelPainter* painter, const Vec3f& v, float ra
 	// For some reason we must mix color with the given alpha as well, else mixing does not work.
 	painter->setColor(color*alpha, alpha);
 	// pre-compensate the automatic scaling of sprite painting on HiDPI screens
-	radius /= static_cast<float>(painter->getProjector()->getDevicePixelsPerPixel())*StelApp::getInstance().getGlobalScalingRatio();
+	radius /= static_cast<float>(painter->getProjector()->getDevicePixelsPerPixel());
 	// Our corona image was made in 2008-08-01 near Khovd, Mongolia. It shows the correct parallactic angle for its location and time, we must add this, and subtract the ecliptic/equator angle from that date of 15.43 degrees.
 	painter->drawSprite2dMode(win[0], win[1], radius, -angle+44.65f-15.43f);
 

--- a/src/core/modules/Nebula.cpp
+++ b/src/core/modules/Nebula.cpp
@@ -731,8 +731,7 @@ void Nebula::renderDarkNebulaMarker(StelPainter& sPainter, const float x, const 
                                     float size, const Vec3f color) const
 {
 	// Take into account device pixel density and global scale ratio, as we are drawing 2D stuff.
-	const auto pixelRatio = sPainter.getProjector()->getDevicePixelsPerPixel();
-	const auto scale = pixelRatio * StelApp::getInstance().getGlobalScalingRatio();
+	const auto scale = sPainter.getProjector()->getDevicePixelsPerPixel();
 	size *= scale;
 
 	const float roundRadius = 0.35 * size;
@@ -819,8 +818,7 @@ void Nebula::renderMarkerRoundedRect(StelPainter& sPainter, const float x, const
                                      float size, const Vec3f color) const
 {
 	// Take into account device pixel density and global scale ratio, as we are drawing 2D stuff.
-	const auto pixelRatio = sPainter.getProjector()->getDevicePixelsPerPixel();
-	const auto scale = pixelRatio * StelApp::getInstance().getGlobalScalingRatio();
+	const auto scale = sPainter.getProjector()->getDevicePixelsPerPixel();
 	size *= scale;
 
 	const float roundRadius = 0.35 * size;
@@ -876,8 +874,7 @@ void Nebula::renderRoundMarker(StelPainter& sPainter, const float x, const float
                                float size, const Vec3f color, const bool crossed) const
 {
 	// Take into account device pixel density and global scale ratio, as we are drawing 2D stuff.
-	const auto pixelRatio = sPainter.getProjector()->getDevicePixelsPerPixel();
-	const auto scale = pixelRatio * StelApp::getInstance().getGlobalScalingRatio();
+	const auto scale = sPainter.getProjector()->getDevicePixelsPerPixel();
 	size *= scale;
 
 	sPainter.setBlending(true);
@@ -903,8 +900,7 @@ void Nebula::renderEllipticMarker(StelPainter& sPainter, const float x, const fl
                                   const float aspectRatio, const float angle, const Vec3f color) const
 {
 	// Take into account device pixel density and global scale ratio, as we are drawing 2D stuff.
-	const auto pixelRatio = sPainter.getProjector()->getDevicePixelsPerPixel();
-	const auto scale = pixelRatio * StelApp::getInstance().getGlobalScalingRatio();
+	const auto scale = sPainter.getProjector()->getDevicePixelsPerPixel();
 	size *= scale;
 
 	const float radiusY = 0.35 * size;
@@ -938,8 +934,7 @@ void Nebula::renderMarkerPointedCircle(StelPainter& sPainter, const float x, con
                                        float size, const Vec3f color, const bool insideRect) const
 {
 	// Take into account device pixel density and global scale ratio, as we are drawing 2D stuff.
-	const auto pixelRatio = sPainter.getProjector()->getDevicePixelsPerPixel();
-	const auto scale = pixelRatio * StelApp::getInstance().getGlobalScalingRatio();
+	const auto scale = sPainter.getProjector()->getDevicePixelsPerPixel();
 	size *= scale;
 
 	texPointElement->bind();

--- a/src/core/modules/SolarSystem.cpp
+++ b/src/core/modules/SolarSystem.cpp
@@ -512,7 +512,7 @@ void SolarSystem::drawPointer(const StelCore* core)
 
 		float screenSize = static_cast<float>(obj->getAngularRadius(core))*prj->getPixelPerRadAtCenter()*M_PI_180f*2.f;
 		
-		const float scale = static_cast<float>(prj->getDevicePixelsPerPixel())*StelApp::getInstance().getGlobalScalingRatio();
+		const float scale = static_cast<float>(prj->getDevicePixelsPerPixel());
 		screenSize+= scale * (45.f + 10.f*std::sin(2.f * static_cast<float>(StelApp::getInstance().getAnimationTime())));
 
 		texPointer->bind();


### PR DESCRIPTION
This notion was introduced in 2013 in c3742e3a3f1403f3afb264c2f9dd0134962b4894, and the corresponding setter is never called. Given the current support for HiDPI scaling via the Qt-supplied mechanism of device pixel ratio and lack of the query of the global scaling ratio in many cases where the pixel ratio is queried, I think this global scaling needlessly complicates the logic, so should be removed.