### PR TITLE
Make keyboard modifiers for mouse motions exact

### DIFF
--- a/src/core/StelMovementMgr.cpp
+++ b/src/core/StelMovementMgr.cpp
@@ -632,7 +632,8 @@ void StelMovementMgr::handleMouseClicks(QMouseEvent* event)
 			}
 			else if (event->type()==QEvent::MouseButtonPress)
 			{
-				if (event->modifiers() & Qt::ControlModifier)
+				const auto modifiers = event->modifiers() & (Qt::ControlModifier|Qt::ShiftModifier|Qt::AltModifier);
+				if (modifiers == Qt::ControlModifier)
 				{
 					dragTimeMode=true;
 					beforeTimeDragTimeRate=core->getTimeRate();

--- a/src/core/modules/CustomObjectMgr.cpp
+++ b/src/core/modules/CustomObjectMgr.cpp
@@ -58,8 +58,12 @@ void CustomObjectMgr::handleMouseClicks(class QMouseEvent* e)
 {
 	StelCore *core = StelApp::getInstance().getCore();
 	Vec3d mousePosition = core->getMouseJ2000Pos();
+	// Make sure the modifiers are exact, not just "Shift is pressed", but "Shift is pressed while Ctrl and Alt aren't"
+	const auto modifiers = e->modifiers() & (Qt::ShiftModifier | Qt::ControlModifier | Qt::AltModifier);
+	const bool modifierIsShift = modifiers == Qt::ShiftModifier;
+	const bool modifierIsShiftAlt = modifiers == (Qt::ShiftModifier | Qt::AltModifier);
 	// Shift + LeftClick -- Add custom marker
-	if (e->modifiers().testFlag(Qt::ShiftModifier) && e->button()==Qt::LeftButton && e->type()==QEvent::MouseButtonPress)
+	if (modifierIsShift && e->button()==Qt::LeftButton && e->type()==QEvent::MouseButtonPress)
 	{
 		addCustomObject(QString("%1 %2").arg(N_("Marker")).arg(countMarkers + 1), mousePosition, true);
 
@@ -67,8 +71,7 @@ void CustomObjectMgr::handleMouseClicks(class QMouseEvent* e)
 		return;
 	}
 	// Shift + Alt + RightClick -- Removes all custom markers
-	// Changed by snowsailor 5/04/2017
-	if(e->modifiers().testFlag(Qt::ShiftModifier) && e->modifiers().testFlag(Qt::AltModifier) && e->button() == Qt::RightButton && e->type() == QEvent::MouseButtonPress)
+	if(modifierIsShiftAlt && e->button() == Qt::RightButton && e->type() == QEvent::MouseButtonPress)
 	{
 		//Delete ALL custom markers
 		removeCustomObjects();
@@ -76,8 +79,7 @@ void CustomObjectMgr::handleMouseClicks(class QMouseEvent* e)
 		return;
 	}
 	// Shift + RightClick -- Removes the closest marker within a radius specified within
-	// Added by snowsailor 5/04/2017
-	if (e->modifiers().testFlag(Qt::ShiftModifier) && e->button()==Qt::RightButton && e->type()==QEvent::MouseButtonPress)
+	if (modifierIsShift && e->button()==Qt::RightButton && e->type()==QEvent::MouseButtonPress)
 	{
 		const StelProjectorP prj = core->getProjection(StelCore::FrameJ2000, StelCore::RefractionAuto);
 		Vec3d winpos;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
Currently one can set a custom marker with e.g. <kbd>Shift</kbd>+<kbd>Ctrl</kbd> modifier, which contaminates such combos rendering them impossible to use for other purposes. These commits make the modifiers exact, i.e. for custom markers no keys except <kbd>Shift</kbd> must be pressed, so e.g. <kbd>Shift</kbd>+<kbd>Ctrl</kbd>+click doesn't set a custom marker, while <kbd>Shift</kbd>+click does. Similarly for time dragging: only <kbd>Ctrl</kbd> triggers it, not when other modifiers are pressed.


### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping