### PR TITLE
GUI scalability and styling improvements

### DIFF
--- a/data/gui/normalStyle.css
+++ b/data/gui/normalStyle.css
@@ -311,40 +311,47 @@ QTabBar QToolButton {
 	background-color: rgb(31, 31, 31);
 }
 
-
 /*
- * QPushButton
+ * QPushButton and QToolButton
  */
 
+QToolButton {
+	padding: 2px;
+}
+
+
 QPushButton {
+	padding: 2px 8px;
+}
+
+QPushButton, QToolButton {
 	border: 1px solid rgb(0, 0, 0);
 	border-radius: 2px;
-	padding: 2px 8px;
 	color: rgb(31, 31, 31);
         font-size: 100%;
 	background-color: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 rgb(183, 184, 185), stop: 1 rgb(111, 113, 114));
 }
 
-QPushButton:disabled {
+QPushButton:disabled, QToolButton:disabled {
         color: rgb(61, 61, 61);
         border: 1px solid rgb(61, 61, 61);
 	background: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 rgb(150, 150, 153), stop: 1 rgb(120, 120, 120));
 }
 
-QPushButton:flat {
+QPushButton:flat, QToolButton:flat {
 	border: none; /* no border for a flat push button */
 	background: transparent;
 }
 
-QPushButton:hover {
+QPushButton:hover, QToolButton:hover {
 	background-color: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 rgb(183, 184, 165), stop: 1 rgb(111, 113, 94));
 }
 
-QPushButton:pressed {
+QPushButton:pressed, QToolButton:pressed {
 	background-color: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 rgb(41, 41, 49), stop: 0.2 rgb(73, 74, 84), stop: 1 rgb(58, 60, 73));
 }
 
-QPushButton:checked {
+QPushButton:checked, QToolButton:checked {
 	background-color: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 rgb(41, 41, 49), stop: 0.2 rgb(73, 74, 84), stop: 1 rgb(58, 60, 73));
 }
 

--- a/data/gui/normalStyle.css
+++ b/data/gui/normalStyle.css
@@ -758,12 +758,18 @@ QScrollBar::left-arrow {
 
 QSlider {
 	background: none;
+	height: 14px;
 }
 
 QSlider::groove:horizontal {
 	border: none;
-	height: 4px; /* the groove expands to the size of the slider by default. by giving it a height, it has a fixed size */
-	background: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 rgb(0, 0, 0), stop: 1 rgb(54, 54, 54));
+	background: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1,
+	                            stop: 0 rgba(0,0,0,0),
+	                            stop: 0.3571 rgba(0,0,0,0),
+	                            stop: 0.3572 rgb(0, 0, 0),
+	                            stop: 0.6429 rgb(54, 54, 54),
+	                            stop: 0.6430 rgba(0,0,0,0),
+	                            stop: 1 rgba(0,0,0,0));
 	margin: 0;
 }
 
@@ -771,7 +777,7 @@ QSlider::handle:horizontal {
 	border: 1px solid rgb(0, 0, 0);
 	border-radius: 2px;
 	width: 32px;
-	margin: -5px 0; /* handle is placed by default on the contents rect of the groove. Expand outside the groove */
+	margin: 0;
 	color: rgb(31, 31, 31);
 	background-color: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 rgb(183, 184, 185), stop: 1 rgb(111, 113, 114));
 }
@@ -781,7 +787,13 @@ QSlider::handle:horizontal:hover {
 }
 
 QSlider::groove:horizontal:disabled {
-	background: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 rgb(61, 61, 61), stop: 1 rgb(80, 80, 80));
+	background: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1,
+	                            stop: 0 rgba(0,0,0,0),
+	                            stop: 0.3571 rgba(0,0,0,0),
+	                            stop: 0.3572 rgb(61,61,61),
+	                            stop: 0.6429 rgb(80,80,80),
+	                            stop: 0.6430 rgba(0,0,0,0),
+	                            stop: 1 rgba(0,0,0,0));
 }
 
 QSlider::handle:horizontal:disabled {

--- a/src/gui/AngleSpinBox.cpp
+++ b/src/gui/AngleSpinBox.cpp
@@ -498,3 +498,48 @@ void AngleSpinBox::formatText(void)
 	lineEdit()->setCursorPosition(cursorPos);
 }
 
+QSize AngleSpinBox::minimumSizeHint() const
+{
+	QString refText;
+	const auto signPlaceholder = minRad >= 0 ? positivePrefix(currentPrefixType) : negativePrefix(currentPrefixType);
+	switch (angleSpinBoxFormat)
+	{
+		case DMSLetters:
+		case DMSSymbols:
+		case DMSLettersUnsigned:
+		case DMSSymbolsUnsigned:
+		{
+			if (angleSpinBoxFormat == DMSLetters || angleSpinBoxFormat == DMSLettersUnsigned)
+				refText = QString("%1%2d %3m %4s").arg(signPlaceholder).arg(359).arg(59)
+				                                  .arg(0, 0, 'f', decimalPlaces, ' ');
+			else
+				refText = QString("%1%2° %3' %4\"").arg(signPlaceholder).arg(359).arg(59)
+				                                   .arg(0, 0, 'f', decimalPlaces, ' ');
+			break;
+		}
+		case HMSLetters:
+		case HMSSymbols:
+		{
+			if (angleSpinBoxFormat == HMSLetters)
+				refText = QString("%1h %2m %3s").arg(23).arg(59).arg(0, 0, 'f', decimalPlaces, ' ');
+			else
+				refText = QString("%1h %2' %3\"").arg(23).arg(59).arg(0, 0, 'f', decimalPlaces, ' ');
+			break;
+		}
+		case DecimalDeg:
+		{
+			refText = QString("%1%2°").arg(signPlaceholder).arg(360, 0, 'f', decimalPlaces, ' ');
+			break;
+		}
+		default:
+		{
+			qWarning() << "AngleSpinBox::updateSizeHint - WARNING - unknown format" << static_cast<int>(angleSpinBoxFormat);
+			break;
+		}
+	}
+	const QFontMetrics fm(font());
+	const auto minWidth = fm.size(Qt::TextSingleLine, refText).width();
+	auto size = QAbstractSpinBox::minimumSizeHint();
+	size.rwidth() += minWidth;
+	return size;
+}

--- a/src/gui/AngleSpinBox.hpp
+++ b/src/gui/AngleSpinBox.hpp
@@ -115,6 +115,8 @@ public:
 	//! @return the current maximum value
 	//! @param isDegrees true if the maximum value is required in degrees, else max is returned as radians.
 	double getMaximum(const bool isDegrees) const { return maxRad * (isDegrees ? 180.0/M_PI : 1.0); }
+
+	QSize minimumSizeHint() const override;
 	
 public slots:
 	//! Set the value to default 0 angle.

--- a/src/gui/LocationDialog.cpp
+++ b/src/gui/LocationDialog.cpp
@@ -175,7 +175,6 @@ void LocationDialog::createDialogContent()
 	ui->gpsToolButton->setText(q_("Get location from GPS"));
 #endif
 	connect(ui->gpsToolButton, SIGNAL(toggled(bool)), this, SLOT(gpsEnableQueryLocation(bool)));
-	ui->gpsToolButton->setStyleSheet(QString("QToolButton{ background: gray; }")); // ? Missing default style?
 	connect(locMgr, SIGNAL(gpsQueryFinished(bool)), this, SLOT(gpsReturn(bool)));
 #else
 	ui->gpsToolButton->setEnabled(false);
@@ -975,7 +974,7 @@ void LocationDialog::resetGPSbuttonLabel()
 #else
 	ui->gpsToolButton->setText(q_("Get location from GPS"));
 #endif
-	ui->gpsToolButton->setStyleSheet(QString("QToolButton{ background: gray; }"));
+	ui->gpsToolButton->setStyleSheet("");
 }
 #endif
 


### PR DESCRIPTION
These commits prepare the GUI for transformation into a more scaling-friendly version. In particular, I'm planning to get rid of all the hard-coded pixel-based sizes that already work badly with increased font sizes, and replace them with proper `QLayout`-based size management.

My main concern, why I'm making a PR for this change, is that something might get broken or changed in an undesirable way (such as the GPS button that became flat, which is fixed by the 4th commit).

There's also a good side effect: at least on Linux/X11 the color picking buttons are now flat-colored, showing the exact color they are set to instead of the confusing desaturated gradient as there was before.