### PR TITLE
Scale the pixel sizes in the stylesheet according to GUI font size

### DIFF
--- a/data/gui/normalStyle.css
+++ b/data/gui/normalStyle.css
@@ -409,11 +409,18 @@ QCheckBox:disabled {
 }
 
 QCheckBox::indicator,
-QListWidget::indicator,
-QListView::indicator,
 QGroupBox::indicator {
 	width: 16px;
 	height: 16px;
+	margin: 0;
+	background: none;
+}
+
+/* FIXME: these should configured the same way as QCheckBox and QGroupBox
+ * indicators, but there's a problem with spacing discussed at
+ * https://stackoverflow.com/q/77422984 */
+QListWidget::indicator,
+QListView::indicator {
 	margin: 0;
 	background: none;
 }

--- a/src/gui/StelGui.hpp
+++ b/src/gui/StelGui.hpp
@@ -312,6 +312,7 @@ private slots:
 	void copySelectedObjectInfo(void);
 
 private:
+	void updateStelStyle();
 	//! convenience method to find an action in the StelActionMgr.
 	StelAction* getAction(const QString& actionName) const;
 


### PR DESCRIPTION
This is another step into the direction of scaling the GUI without kludges. The style itself is still not perfect (namely, the spacing is not scaled yet), but this is already an improvement, see the following screenshots.

#### Original 2× font size

![Screenshot_2023-11-03_11-28-57](https://github.com/Stellarium/stellarium/assets/6376882/5a09e596-51d8-4d73-b441-5a3bb41e7268)

#### This PR 2× font size

![Screenshot_2023-11-03_11-29-50](https://github.com/Stellarium/stellarium/assets/6376882/b2bf8b44-93f6-426d-9281-464c85f64f1e)

#### Original 1× font size at 200% via Qt scale factor

![Screenshot_2023-11-03_11-31-32](https://github.com/Stellarium/stellarium/assets/6376882/f3a6e56a-e223-435b-9b99-b6484164fa12)

#### Original 1.5× font size

![Screenshot_2023-11-03_11-39-00](https://github.com/Stellarium/stellarium/assets/6376882/45717471-db23-4009-b62c-b51722d67aba)

#### This PR 1.5× font size

![Screenshot_2023-11-03_11-38-14](https://github.com/Stellarium/stellarium/assets/6376882/ad2d90fb-7e67-4318-831b-5423cb4d525c)

#### Original 1× font size at 150% via Qt scale factor

![Screenshot_2023-11-03_11-37-24](https://github.com/Stellarium/stellarium/assets/6376882/16532c78-c8b4-4290-aee0-c90c1e3d1e8c)