### PR TITLE
Allow line loops on Cylindrical projection.

### DIFF
--- a/plugins/Satellites/src/Satellites.cpp
+++ b/plugins/Satellites/src/Satellites.cpp
@@ -2903,7 +2903,7 @@ void Satellites::drawCircles(StelCore* core, StelPainter &painter)
 		umbra.vertex.append(pos+point);
 	}
 	painter.setColor(getUmbraColor(), 1.f);
-	painter.drawStelVertexArray(umbra, false);
+	painter.drawStelVertexArray(umbra, true);
 
 	// plot a center cross mark
 	texCross->bind();
@@ -2926,7 +2926,7 @@ void Satellites::drawCircles(StelCore* core, StelPainter &painter)
 		}
 
 		painter.setColor(getPenumbraColor(), 1.f);
-		painter.drawStelVertexArray(penumbra, false);
+		painter.drawStelVertexArray(penumbra, true);
 	}
 	painter.setProjector(saveProj);
 }

--- a/src/core/StelVertexArray.cpp
+++ b/src/core/StelVertexArray.cpp
@@ -23,7 +23,6 @@
 StelVertexArray StelVertexArray::removeDiscontinuousTriangles(const StelProjector* prj) const
 {
 	StelVertexArray ret = *this;
-	ret.primitiveType = Triangles;
 
 	if (isIndexed())
 	{
@@ -56,12 +55,14 @@ StelVertexArray StelVertexArray::removeDiscontinuousTriangles(const StelProjecto
 	else
 	{
 		ret.indices.clear();
-		const unsigned short int limit=static_cast<unsigned short int>(vertex.size());
+		Q_ASSERT(vertex.size() <= std::numeric_limits<unsigned short>::max());
+		const unsigned short limit=vertex.size();
 		// Create a 'Triangles' vertex array from this array.
 		// We have different algorithms for different original mode
 		switch (primitiveType)
 		{
 			case TriangleStrip:
+				ret.primitiveType = Triangles;
 				ret.indices.reserve(vertex.size() * 3);
 				for (unsigned short int i = 2; i < limit; ++i)
 				{

--- a/src/core/StelVertexArray.cpp
+++ b/src/core/StelVertexArray.cpp
@@ -23,6 +23,7 @@
 StelVertexArray StelVertexArray::removeDiscontinuousTriangles(const StelProjector* prj) const
 {
 	StelVertexArray ret = *this;
+	ret.primitiveType = Triangles;
 
 	if (isIndexed())
 	{
@@ -55,14 +56,13 @@ StelVertexArray StelVertexArray::removeDiscontinuousTriangles(const StelProjecto
 	else
 	{
 		ret.indices.clear();
-		unsigned short int limit;
+		const unsigned short int limit=static_cast<unsigned short int>(vertex.size());
 		// Create a 'Triangles' vertex array from this array.
 		// We have different algorithms for different original mode
 		switch (primitiveType)
 		{
 			case TriangleStrip:
 				ret.indices.reserve(vertex.size() * 3);
-				limit = static_cast<unsigned short int>(vertex.size());
 				for (unsigned short int i = 2; i < limit; ++i)
 				{
 					if (prj->intersectViewportDiscontinuity(vertex[i], vertex[i-1]) ||
@@ -83,7 +83,6 @@ StelVertexArray StelVertexArray::removeDiscontinuousTriangles(const StelProjecto
 
 			case Triangles:
 				ret.indices.reserve(vertex.size());
-				limit = static_cast<unsigned short int>(vertex.size());
 				for (unsigned short int i = 0; i < limit; i += 3)
 				{
 					if (prj->intersectViewportDiscontinuity(vertex.at(i), vertex.at(i+1)) ||
@@ -99,6 +98,23 @@ StelVertexArray StelVertexArray::removeDiscontinuousTriangles(const StelProjecto
 				}
 				break;
 
+			case LineLoop:
+			case LineStrip:
+				// convert to an indexed set of GL_LINEs, leaving those away which intersect
+				ret.primitiveType=Lines;
+				ret.indices.reserve(2*vertex.size());
+				for (unsigned short int i = 0; i < limit-1; i++)
+				{
+					if (!prj->intersectViewportDiscontinuity(vertex.at(i), vertex.at(i+1))  )
+						ret.indices << i << i+1;
+				}
+				if (primitiveType==LineLoop)
+				{
+					if (!prj->intersectViewportDiscontinuity(vertex.at(limit-1), vertex.at(0))  )
+						ret.indices << limit-1 << 0;
+				}
+				break;
+
 			default:
 				Q_ASSERT(false);
 		}
@@ -108,7 +124,6 @@ StelVertexArray StelVertexArray::removeDiscontinuousTriangles(const StelProjecto
 	// FIXME: we should use an attribute for indexed array.
 	if (ret.indices.isEmpty())
 		ret.vertex.clear();
-	ret.primitiveType = Triangles;
 
 	return ret;
 }

--- a/src/core/modules/GridLinesMgr.cpp
+++ b/src/core/modules/GridLinesMgr.cpp
@@ -931,7 +931,7 @@ void SkyLine::draw(StelCore *core) const
 				rot.transfo(point);                                                // rotate towards earth position
 				circle.vertex.append(pos+point);                                   // attach to earth centre
 			}
-			sPainter.drawStelVertexArray(circle, false); // setting true does not paint for cylindrical&friends :-(
+			sPainter.drawStelVertexArray(circle, true);
 
 			// Special case for Umbra and Penumbra labels
 			Vec3d point(dist, 0.0, 0.0);


### PR DESCRIPTION
### Description
This prevents the connection of line segments over disconnected viewport edges.

For this, I convert the LineLoop to an indexed set of GL_LINEs. 

Fixes #3503 (issue)

### Screenshots (if appropriate):

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?

Disable lunar scale-up, activate earth shadow circles (GridLinesMgr). Zoom out, place earth's shadow cycles close to screen edge.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system: Windows11
* Graphics Card: Geforce, but irrelevant

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
