### PR TITLE
Add support an AppImage/Qt6 packages

### DIFF
--- a/.github/workflows/.#appimage.yml
+++ b/.github/workflows/.#appimage.yml
@@ -1,0 +1,1 @@
+aw@fomalhaut.228068

--- a/.github/workflows/.#appimage.yml
+++ b/.github/workflows/.#appimage.yml
@@ -1,1 +1,0 @@
-aw@fomalhaut.228068

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -67,7 +67,7 @@ jobs:
         # Update installed packages
         sudo apt remove php8.* -y
         sudo apt update
-        sudo apt install libfuse2
+        sudo apt install libfuse2 libglx-dev
         # using force-overwrite due to
         # https://github.com/actions/virtual-environments/issues/2703
         #sudo ACCEPT_EULA=Y apt upgrade -o Dpkg::Options::="--force-overwrite" --yes

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -6,8 +6,8 @@ name: "AppImage"
 on: [push]
 
 jobs:
-  # AppImage x86_64
-  appimage-amd64:
+  # AppImage x86_64/Qt5
+  appimage-amd64-qt5:
     name: "x86_64"
     runs-on: ubuntu-20.04
     if: "contains(github.event.head_commit.message, '[publish]') || contains(github.ref, 'heads/stellarium-next') || contains(github.ref, 'heads/stellarium-stable')"
@@ -38,15 +38,59 @@ jobs:
         mkdir -p ${{ github.workspace }}/artifact
         mkdir -p ${{ github.workspace }}/builds/appimage
         cd ${{ github.workspace }}/builds/appimage
-        export APP_VERSION="latest"
+        export APP_VERSION="latest-qt5"
         mkdir -p ./AppDir/usr/lib/x86_64-linux-gnu
-        appimage-builder --recipe ${{ github.workspace }}/util/appimage/stellarium-appimage.yml --skip-test
+        appimage-builder --recipe ${{ github.workspace }}/util/appimage/stellarium-appimage-qt5.yml --skip-test
         cp ${{ github.workspace }}/builds/appimage/*.AppImage ${{ github.workspace }}/artifact
 
     - name: Upload AppImage
       uses: actions/upload-artifact@v3
       if: success()
       with:
-        name: 'Stellarium-latest-x86_64'
+        name: 'Stellarium-latest-qt5-x86_64'
+        path: ${{ github.workspace }}/artifact/*.AppImage
+
+  # AppImage x86_64/Qt6
+  appimage-amd64-qt6:
+    name: "x86_64"
+    runs-on: ubuntu-22.04
+    if: "contains(github.event.head_commit.message, '[publish]') || contains(github.ref, 'heads/stellarium-next') || contains(github.ref, 'heads/stellarium-stable')"
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Build AppImage
+      working-directory: ${{ github.workspace }}
+      shell: bash
+      run: |
+        # Update installed packages
+        sudo apt remove php7.* -y
+        sudo apt remove php8.* -y
+        sudo apt update
+        # using force-overwrite due to
+        # https://github.com/actions/virtual-environments/issues/2703
+        #sudo ACCEPT_EULA=Y apt upgrade -o Dpkg::Options::="--force-overwrite" --yes
+        # Installing dependencies
+        sudo apt install -y cmake qt6-base-dev qt6-base-private-dev qt6-tools-dev qt6-tools-dev-tools qt6-l10n-tools linguist-qt6 libqt6svg6-dev qt6-multimedia-dev libqt6serialport6-dev qt6-positioning-dev libqt6positioning6-plugins libqt6charts6-dev libqt6opengl6-dev libqt6webchannel6-dev libqt6webenginewidgets6 libqt6webenginecore6-bin libqt6webengine6-data qt6-webengine-dev qt6-webengine-dev-tools zlib1g-dev libexiv2-dev libnlopt-cxx-dev libindi-dev libindi-plugins libnova-dev
+        #sudo pip3 install appimage-builder
+        sudo wget https://github.com/AppImageCrafters/appimage-builder/releases/download/Continuous/appimage-builder-1.1.1.dev32+g2709a3b-x86_64.AppImage -O /usr/local/bin/appimage-builder
+        sudo chmod +x /usr/local/bin/appimage-builder
+        sudo wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage -O /usr/local/bin/appimagetool
+        sudo chmod +x /usr/local/bin/appimagetool
+        # Prepare to building
+        mkdir -p ${{ github.workspace }}/artifact
+        mkdir -p ${{ github.workspace }}/builds/appimage
+        cd ${{ github.workspace }}/builds/appimage
+        export APP_VERSION="latest-qt6"
+        mkdir -p ./AppDir/usr/lib/x86_64-linux-gnu
+        appimage-builder --recipe ${{ github.workspace }}/util/appimage/stellarium-appimage-qt6.yml --skip-test
+        cp ${{ github.workspace }}/builds/appimage/*.AppImage ${{ github.workspace }}/artifact
+
+    - name: Upload AppImage
+      uses: actions/upload-artifact@v3
+      if: success()
+      with:
+        name: 'Stellarium-latest-qt6-x86_64'
         path: ${{ github.workspace }}/artifact/*.AppImage
 

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -8,7 +8,7 @@ on: [push]
 jobs:
   # AppImage x86_64/Qt5
   appimage-amd64-qt5:
-    name: "x86_64"
+    name: "x86_64/qt5"
     runs-on: ubuntu-20.04
     if: "contains(github.event.head_commit.message, '[publish]') || contains(github.ref, 'heads/stellarium-next') || contains(github.ref, 'heads/stellarium-stable')"
 
@@ -52,7 +52,7 @@ jobs:
 
   # AppImage x86_64/Qt6
   appimage-amd64-qt6:
-    name: "x86_64"
+    name: "x86_64/qt6"
     runs-on: ubuntu-22.04
     if: "contains(github.event.head_commit.message, '[publish]') || contains(github.ref, 'heads/stellarium-next') || contains(github.ref, 'heads/stellarium-stable')"
 
@@ -65,9 +65,9 @@ jobs:
       shell: bash
       run: |
         # Update installed packages
-        sudo apt remove php7.* -y
         sudo apt remove php8.* -y
         sudo apt update
+        sudo apt install libfuse2
         # using force-overwrite due to
         # https://github.com/actions/virtual-environments/issues/2703
         #sudo ACCEPT_EULA=Y apt upgrade -o Dpkg::Options::="--force-overwrite" --yes

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -72,7 +72,7 @@ jobs:
         # https://github.com/actions/virtual-environments/issues/2703
         #sudo ACCEPT_EULA=Y apt upgrade -o Dpkg::Options::="--force-overwrite" --yes
         # Installing dependencies
-        sudo apt install -y cmake qt6-base-dev qt6-base-private-dev qt6-tools-dev qt6-tools-dev-tools qt6-l10n-tools linguist-qt6 libqt6svg6-dev qt6-multimedia-dev libqt6serialport6-dev qt6-positioning-dev libqt6positioning6-plugins libqt6charts6-dev libqt6opengl6-dev libqt6webchannel6-dev libqt6webenginewidgets6 libqt6webenginecore6-bin libqt6webengine6-data qt6-webengine-dev qt6-webengine-dev-tools zlib1g-dev libexiv2-dev libnlopt-cxx-dev libindi-dev libindi-plugins libnova-dev
+        sudo apt install -y cmake zlib1g-dev libgl1-mesa-dev libdrm-dev libxkbcommon-x11-dev libgps-dev gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-pulseaudio gstreamer1.0-libav gstreamer1.0-vaapi qt6-base-private-dev qt6-multimedia-dev qt6-positioning-dev qt6-tools-dev qt6-tools-dev-tools qt6-base-dev-tools qt6-qpa-plugins qt6-image-formats-plugins qt6-l10n-tools qt6-webengine-dev qt6-webengine-dev-tools libqt6charts6-dev libqt6charts6 libqt6opengl6-dev libqt6positioning6-plugins libqt6serialport6-dev qt6-base-dev libqt6webenginecore6-bin libqt6webengine6-data libexiv2-dev libnlopt-cxx-dev
         #sudo pip3 install appimage-builder
         sudo wget https://github.com/AppImageCrafters/appimage-builder/releases/download/Continuous/appimage-builder-1.1.1.dev32+g2709a3b-x86_64.AppImage -O /usr/local/bin/appimage-builder
         sudo chmod +x /usr/local/bin/appimage-builder

--- a/util/appimage/build-appimage.sh
+++ b/util/appimage/build-appimage.sh
@@ -3,7 +3,7 @@
 #
 # A tool for build an AppImage package of Stellarium
 #
-# Copyright (c) 2020-2022 Alexander Wolf
+# Copyright (c) 2020-2023 Alexander Wolf
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -75,7 +75,7 @@ then
 
     printf "\nLet's try build an AppImage for version \"%s\"\n" "$version"
 
-    appimage-builder --recipe ${ROOT}/util/appimage/stellarium-appimage.yml --skip-test
+    appimage-builder --recipe ${ROOT}/util/appimage/stellarium-appimage-qt5.yml --skip-test
 
     chmod +x ./Stellarium*.AppImage
 else

--- a/util/appimage/stellarium-appimage-qt5.yml
+++ b/util/appimage/stellarium-appimage-qt5.yml
@@ -43,6 +43,9 @@ AppDir:
       - libqt5charts5
       - libqt5opengl5
       - libgps26
+      - libexiv2-27
+      - libnlopt-cxx0
+      - libnlopt0
     exclude: []
 
   files:

--- a/util/appimage/stellarium-appimage-qt6.yml
+++ b/util/appimage/stellarium-appimage-qt6.yml
@@ -19,7 +19,7 @@ AppDir:
     arch: amd64
     sources:
       - sourceline: 'deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ jammy main restricted universe multiverse'
-        key_url: 'http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x3b4fe6acc0b21f32'
+        key_url: 'http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x871920D1991BC93C'
       - sourceline: 'deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ jammy-updates main restricted universe multiverse'
       - sourceline: 'deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ jammy-backports main restricted universe multiverse'
 

--- a/util/appimage/stellarium-appimage-qt6.yml
+++ b/util/appimage/stellarium-appimage-qt6.yml
@@ -1,7 +1,7 @@
 version: 1
 
 script:
-    - cmake ../.. -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release -DENABLE_QTWEBENGINE=Off
+    - cmake ../.. -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release
     - make -j3
     - make install DESTDIR=AppDir
 
@@ -35,14 +35,23 @@ AppDir:
       - libqt6webchannel6
       - libqt6serialport6
       - libqt6widgets6
-#      - libqt6webenginecore6
-#      - libqt6webenginecore6-bin
-#      - libqt6webenginewidgets6
-#      - libqt6webenginequick6
-#      - libqt6webenginequickdelegatesqml6
-#      - libqt6webengine6-data
+      - libqt6webenginecore6
+      - libqt6webenginecore6-bin
+      - libqt6webenginewidgets6
+      - libqt6webenginequick6
+      - libqt6webenginequickdelegatesqml6
+      - libqt6webengine6-data
       - libqt6charts6
       - libqt6opengl6
+      - libqt6openglwidgets6
+      - libqt6qml6
+      - libqt6qmlcore6
+      - libqt6quick6
+      - libqt6quickwidgets6
+      - libqt6qmlmodels6
+      - qt6-qpa-plugins
+      - qt6-gtk-platformtheme
+      - qt6-image-formats-plugins
       - libgps28
       - libexiv2-27
       - libnlopt-cxx0

--- a/util/appimage/stellarium-appimage-qt6.yml
+++ b/util/appimage/stellarium-appimage-qt6.yml
@@ -1,0 +1,88 @@
+version: 1
+
+script:
+    - cmake ../.. -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release -DENABLE_QTWEBENGINE=Off
+    - make -j3
+    - make install DESTDIR=AppDir
+
+AppDir:
+  path: ./AppDir
+
+  app_info:
+    id: org.stellarium.Stellarium
+    name: Stellarium
+    icon: stellarium
+    version: !ENV ${APP_VERSION}
+    exec: usr/bin/stellarium
+
+  apt:
+    arch: amd64
+    sources:
+      - sourceline: 'deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ jammy main restricted universe multiverse'
+        key_url: 'http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x3b4fe6acc0b21f32'
+      - sourceline: 'deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ jammy-updates main restricted universe multiverse'
+      - sourceline: 'deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ jammy-backports main restricted universe multiverse'
+
+    include:
+      - libqt6core6
+      - libqt6gui6
+      - libqt6multimedia6
+      - libqt6multimediawidgets6
+      - libqt6network6
+      - libqt6positioning6
+      - libqt6positioning6-plugins
+      - libqt6printsupport6
+      - libqt6webchannel6
+      - libqt6serialport6
+      - libqt6widgets6
+#      - libqt6webenginecore6
+#      - libqt6webenginecore6-bin
+#      - libqt6webenginewidgets6
+#      - libqt6webenginequick6
+#      - libqt6webenginequickdelegatesqml6
+#      - libqt6webengine6-data
+      - libqt6charts6
+      - libqt6opengl6
+      - libgps28
+      - libexiv2-27
+      - libnlopt-cxx0
+      - libnlopt0
+    exclude: []
+
+  files:
+    exclude:
+      - usr/lib/x86_64-linux-gnu/gconv
+      - usr/share/man
+      - usr/share/doc/*/README.*
+      - usr/share/doc/*/changelog.*
+      - usr/share/doc/*/NEWS.*
+  runtime:
+    env:
+      APPDIR_LIBRARY_PATH: $APPDIR/lib/x86_64-linux-gnu:$APPDIR/usr/lib/x86_64-linux-gnu:$APPDIR/usr/lib/x86_64-linux-gnu/pulseaudio
+
+#  test:
+#    debian:
+#      image: appimagecrafters/tests-env:debian-stable
+#      command: "./AppRun"
+#      use_host_x: True
+#    centos:
+#      image: appimagecrafters/tests-env:centos-7
+#      command: "./AppRun"
+#      use_host_x: True
+#    arch:
+#      image: appimagecrafters/tests-env:archlinux-latest
+#      command: "./AppRun"
+#      use_host_x: True
+#    fedora:
+#      image: appimagecrafters/tests-env:fedora-30
+#      command: "./AppRun"
+#      use_host_x: True
+#    ubuntu:
+#      image: appimagecrafters/tests-env:ubuntu-focal
+#      command: "./AppRun"
+#      use_host_x: True
+
+AppImage:
+  update-information: None
+  sign-key: None
+  arch: x86_64

--- a/util/appimage/stellarium-appimage-qt6.yml
+++ b/util/appimage/stellarium-appimage-qt6.yml
@@ -1,7 +1,7 @@
 version: 1
 
 script:
-    - cmake ../.. -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release
+    - cmake ../.. -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release -DENABLE_QTWEBENGINE=Off
     - make -j3
     - make install DESTDIR=AppDir
 
@@ -32,15 +32,15 @@ AppDir:
       - libqt6positioning6
       - libqt6positioning6-plugins
       - libqt6printsupport6
-      - libqt6webchannel6
+#      - libqt6webchannel6
       - libqt6serialport6
       - libqt6widgets6
-      - libqt6webenginecore6
-      - libqt6webenginecore6-bin
-      - libqt6webenginewidgets6
-      - libqt6webenginequick6
-      - libqt6webenginequickdelegatesqml6
-      - libqt6webengine6-data
+#      - libqt6webenginecore6
+#      - libqt6webenginecore6-bin
+#      - libqt6webenginewidgets6
+#      - libqt6webenginequick6
+#      - libqt6webenginequickdelegatesqml6
+#      - libqt6webengine6-data
       - libqt6charts6
       - libqt6opengl6
       - libqt6openglwidgets6


### PR DESCRIPTION
### Description
Added script and CI environment for producing Qt6-based AppImage packages (for Ubuntu 22.04+) in additional to standard Qt5-based packages.

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

