### PR TITLE
Fix crash in StelTexture destructor on exit

### DIFF
--- a/src/core/StelTexture.hpp
+++ b/src/core/StelTexture.hpp
@@ -22,6 +22,7 @@
 
 #include <QOpenGLFunctions>
 #include <QSharedPointer>
+#include <QPointer>
 #include <QObject>
 #include <QImage>
 
@@ -143,7 +144,7 @@ private:
 	static GLData loadFromData( const QByteArray &data, const int decimateBy);
 
 	//! Private constructor
-	StelTexture(StelTextureMgr* mgr);
+	StelTexture();
 
 	//! Wrap an existing GL texture with this object
 	void wrapGLTexture(GLuint texId);
@@ -173,7 +174,7 @@ private:
 	void startAsyncLoader(T (*functionPointer)(Params...), Args&&...args);
 
 	//! The parent texture manager
-	StelTextureMgr* textureMgr = nullptr;
+	static QPointer<StelTextureMgr> textureMgr;
 
 	QOpenGLFunctions* gl = nullptr;
 	StelTextureParams loadParams;

--- a/src/core/StelTextureMgr.cpp
+++ b/src/core/StelTextureMgr.cpp
@@ -46,6 +46,7 @@ StelTextureMgr::StelTextureMgr(QObject *parent)
 	ctx->functions()->glGetIntegerv(GL_MAX_TEXTURE_SIZE, &maxTexSize);
 	if (maxTexSize<8192)
 		qDebug() << "Max texture size:" << maxTexSize;
+	StelTexture::textureMgr = this;
 }
 
 StelTextureSP StelTextureMgr::createTexture(const QString& afilename, const StelTexture::StelTextureParams& params)
@@ -67,7 +68,7 @@ StelTextureSP StelTextureMgr::createTexture(const QString& afilename, const Stel
 	StelTextureSP cache = lookupCache(canPath);
 	if(!cache.isNull()) return cache;
 
-	StelTextureSP tex = StelTextureSP(new StelTexture(this));
+	StelTextureSP tex = StelTextureSP(new StelTexture);
 	tex->fullPath = canPath;
 
 	QImage image(tex->fullPath);
@@ -159,7 +160,7 @@ StelTextureSP StelTextureMgr::createTextureThread(const QString& url, const Stel
 	StelTextureSP cache = lookupCache(canPath);
 	if(!cache.isNull()) return cache;
 
-	StelTextureSP tex = StelTextureSP(new StelTexture(this));
+	StelTextureSP tex = StelTextureSP(new StelTexture);
 	tex->loadParams = params;
 	tex->fullPath = canPath;
 	if (!lazyLoading)
@@ -175,7 +176,7 @@ StelTextureSP StelTextureMgr::createTextureThread(const QString& url, const Stel
 //! Create a texture from a QImage.
 StelTextureSP StelTextureMgr::createTexture(const QImage &image, const StelTexture::StelTextureParams& params)
 {
-	StelTextureSP tex = StelTextureSP(new StelTexture(this));
+	StelTextureSP tex = StelTextureSP(new StelTexture);
 	tex->loadParams = params;
 	bool r = tex->glLoad(image);
 	Q_ASSERT(r);
@@ -202,7 +203,7 @@ StelTextureSP StelTextureMgr::wrapperForGLTexture(GLuint texId)
 
 
 	//no existing tex with this ID found, create a new wrapper
-	StelTextureSP newTex(new StelTexture(this));
+	StelTextureSP newTex(new StelTexture);
 	newTex->wrapGLTexture(texId);
 	if(!newTex->errorOccured)
 	{
@@ -230,7 +231,7 @@ StelTextureSP StelTextureMgr::getDitheringTexture(const int samplerToBindTo)
 
 	const auto texId = ForTextureMgr::makeDitherPatternTexture(gl);
 
-	ditheringTexture.reset(new StelTexture(this));
+	ditheringTexture.reset(new StelTexture);
 	ditheringTexture->wrapGLTexture(texId);
 	if(!ditheringTexture->errorOccured)
 	{

--- a/src/core/StelTextureMgr.hpp
+++ b/src/core/StelTextureMgr.hpp
@@ -34,7 +34,7 @@ class QThreadPool;
 //! @class StelTextureMgr
 //! Manage textures loading.
 //! It provides method for loading images in a separate thread.
-class StelTextureMgr : QObject
+class StelTextureMgr : public QObject
 {
 	Q_OBJECT
 public:


### PR DESCRIPTION
On deletion of `StelApp` `StelTextureMgr` is deleted, after which some instances of `StelTexture` are deleted. But `StelTexture` destructor logs VRAM usage via `StelTextureMgr`, accessing a no longer existing object.

This commit turns the nonstatic raw pointer to texture manager into a static weak pointer (`QPointer`), so that it was possible to check whether texture manager still exists before trying to access it. Making it static is supposed to prevent useless copying of this smart pointer while the texture manager is effectively a singleton.

Fixes #3427