### PR TITLE
[CI] unit testing on not x86 architectures

### DIFF
--- a/.github/workflows/ci-more.yml
+++ b/.github/workflows/ci-more.yml
@@ -11,13 +11,12 @@ on:
 
 jobs:
   # CI on Linux (Qt5)
-  # Note: cmake in U20.04/armhf (armv7) is broken
   ci-linux-qt5:
     strategy:
       matrix:
-        arch: [aarch64, riscv64]
+        arch: [armv7, aarch64, riscv64]
     name: "Linux (${{ matrix.arch }}; qt5)"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.actor, 'transifex')"
 
     steps:
@@ -29,7 +28,7 @@ jobs:
       id: build-qt5
       with:
         arch: ${{ matrix.arch }}
-        distro: ubuntu20.04
+        distro: ubuntu22.04
 
         # Not required, but speeds up builds by storing container images in
         # a GitHub package registry.
@@ -69,7 +68,7 @@ jobs:
       matrix:
         arch: [armv7, aarch64, riscv64]
     name: "Linux (${{ matrix.arch }}; qt6)"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.actor, 'transifex')"
 
     steps:

--- a/.github/workflows/ci-more.yml
+++ b/.github/workflows/ci-more.yml
@@ -14,9 +14,7 @@ jobs:
   ci-linux-qt5:
     strategy:
       matrix:
-        include:
-          - arch: aarch64
-          - arch: riscv64
+        arch: [aarch64, riscv64]
     name: "Linux (${{ matrix.arch }}; qt5)"
     runs-on: ubuntu-20.04
     if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.actor, 'transifex')"
@@ -31,7 +29,7 @@ jobs:
 #        tar -zxvf ${{ runner.temp }}/qemu-${{ matrix.arch }}-static.tar.gz
 #        chmod +x ${PWD}/qemu-${{ matrix.arch }}-static
 
-    - name: Configure and build Stellarium
+    - name: Build and run unit tests
       uses: uraimo/run-on-arch-action@v2
       id: build
       with:
@@ -67,7 +65,7 @@ jobs:
           # Installing dependencies
           apt install -y qtbase5-private-dev qtscript5-dev libqt5svg5-dev qttools5-dev-tools qttools5-dev libqt5opengl5-dev qtmultimedia5-dev libqt5multimedia5-plugins libqt5serialport5 libqt5serialport5-dev qtpositioning5-dev libgps-dev libqt5positioning5 libqt5positioning5-plugins libqt5charts5-dev zlib1g-dev libgl1-mesa-dev libdrm-dev libexiv2-dev libnlopt-cxx-dev
           # Installing dev. env. dependencies
-          apt install -y build-essential gcc g++ cmake gettext fakeroot ccache
+          apt install -y build-essential gcc g++ cmake gettext fakeroot ccache xvfb
           # Installing optional dependencies
           # apt install -y qtwebengine5-dev libqt5webengine5 libqt5webenginecore5 libqt5webenginewidgets5
  
@@ -75,6 +73,6 @@ jobs:
         run: |
           mkdir -p build
           cd build
-          cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_TESTING=On "${{ github.workspace }}"
+          cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_TESTING=On -DENABLE_SHOWMYSKY=Off -DENABLE_QTWEBENGINE=Off "${{ github.workspace }}"
           make -j3
-          ctest --output-on-failure
+          xvfb-run ctest --output-on-failure

--- a/.github/workflows/ci-more.yml
+++ b/.github/workflows/ci-more.yml
@@ -10,7 +10,6 @@ on:
     branches: [master]
 
 jobs:
-  # CI on Linux (Qt5)
   ci-linux-qt5:
     strategy:
       matrix:
@@ -62,7 +61,6 @@ jobs:
           make -j3
           xvfb-run ctest --output-on-failure
 
-  # CI on Linux (Qt6)
   ci-linux-qt6:
     strategy:
       matrix:

--- a/.github/workflows/ci-more.yml
+++ b/.github/workflows/ci-more.yml
@@ -23,15 +23,9 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-#    - name: Download static QEMU (${{ matrix.arch }})
-#      run: |
-#        wget https://github.com/multiarch/qemu-user-static/releases/download/v7.2.0-1/qemu-${{ matrix.arch }}-static.tar.gz -O ${{ runner.temp }}/qemu-${{ matrix.arch }}-static.tar.gz
-#        tar -zxvf ${{ runner.temp }}/qemu-${{ matrix.arch }}-static.tar.gz
-#        chmod +x ${PWD}/qemu-${{ matrix.arch }}-static
-
     - name: Build and run unit tests
       uses: uraimo/run-on-arch-action@v2
-      id: build
+      id: build-qt5
       with:
         arch: ${{ matrix.arch }}
         distro: ubuntu20.04
@@ -39,15 +33,6 @@ jobs:
         # Not required, but speeds up builds by storing container images in
         # a GitHub package registry.
         githubToken: ${{ github.GITHUB_TOKEN }}
-
-        # Create an artifacts directory
-#        setup: |
-#          mkdir -p "${PWD}/artifact"
-
-        # Mount the artifacts directory as /artifact in the container
-#        dockerRunArgs: |
-#          --volume "${PWD}/artifact:/artifact"
-#          --volume "${PWD}/qemu-${{ matrix.arch }}-static:/usr/bin/qemu-static"
 
         # The shell to run commands with in the container
         shell: /bin/bash
@@ -64,6 +49,58 @@ jobs:
           ACCEPT_EULA=Y apt upgrade -o Dpkg::Options::="--force-overwrite" --yes
           # Installing dependencies
           apt install -y qtbase5-private-dev qtscript5-dev libqt5svg5-dev qttools5-dev-tools qttools5-dev libqt5opengl5-dev qtmultimedia5-dev libqt5multimedia5-plugins libqt5serialport5 libqt5serialport5-dev qtpositioning5-dev libgps-dev libqt5positioning5 libqt5positioning5-plugins libqt5charts5-dev zlib1g-dev libgl1-mesa-dev libdrm-dev libexiv2-dev libnlopt-cxx-dev
+          # Installing dev. env. dependencies
+          apt install -y build-essential gcc g++ cmake gettext fakeroot ccache xvfb
+          # Installing optional dependencies
+          # apt install -y qtwebengine5-dev libqt5webengine5 libqt5webenginecore5 libqt5webenginewidgets5
+ 
+        # Produce a binary artifact and place it in the mounted volume
+        run: |
+          mkdir -p build
+          cd build
+          cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_TESTING=On -DENABLE_SHOWMYSKY=Off -DENABLE_QTWEBENGINE=Off "${{ github.workspace }}"
+          make -j3
+          xvfb-run ctest --output-on-failure
+
+  # CI on Linux (Qt6)
+  ci-linux-qt6:
+    strategy:
+      matrix:
+        arch: [aarch64, riscv64]
+    name: "Linux (${{ matrix.arch }}; qt6)"
+    runs-on: ubuntu-20.04
+    if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.actor, 'transifex')"
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Build and run unit tests
+      uses: uraimo/run-on-arch-action@v2
+      id: build-qt6
+      with:
+        arch: ${{ matrix.arch }}
+        distro: ubuntu22.04
+
+        # Not required, but speeds up builds by storing container images in
+        # a GitHub package registry.
+        githubToken: ${{ github.GITHUB_TOKEN }}
+
+        # The shell to run commands with in the container
+        shell: /bin/bash
+
+        # Install some dependencies in the container. This speeds up builds if
+        # you are also using githubToken. Any dependencies installed here will
+        # be part of the container image that gets cached, so subsequent
+        # builds don't have to re-install them. The image layer is cached
+        # publicly in your project's package repository, so it is vital that
+        # no secrets are present in the container state or logs.
+        install: |
+          # Update installed packages
+          apt update -y
+          ACCEPT_EULA=Y apt upgrade -o Dpkg::Options::="--force-overwrite" --yes
+          # Installing dependencies
+          apt install -y qt6-base-private-dev qt6-multimedia-dev qt6-positioning-dev qt6-tools-dev qt6-tools-dev-tools qt6-base-dev-tools qt6-qpa-plugins qt6-image-formats-plugins qt6-l10n-tools libqt6charts6-dev libqt6charts6 libqt6opengl6-dev libqt6positioning6-plugins libqt6serialport6-dev qt6-base-dev libexiv2-dev libnlopt-cxx-dev zlib1g-dev libgl1-mesa-dev libdrm-dev libglx-dev libxkbcommon-x11-dev libgps-dev
           # Installing dev. env. dependencies
           apt install -y build-essential gcc g++ cmake gettext fakeroot ccache xvfb
           # Installing optional dependencies

--- a/.github/workflows/ci-more.yml
+++ b/.github/workflows/ci-more.yml
@@ -14,7 +14,7 @@ jobs:
   ci-linux-qt5:
     strategy:
       matrix:
-        arch: [aarch64, riscv64]
+        arch: [armv7, aarch64, riscv64]
     name: "Linux (${{ matrix.arch }}; qt5)"
     runs-on: ubuntu-20.04
     if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.actor, 'transifex')"
@@ -66,7 +66,7 @@ jobs:
   ci-linux-qt6:
     strategy:
       matrix:
-        arch: [aarch64, riscv64]
+        arch: [armv7, aarch64, riscv64]
     name: "Linux (${{ matrix.arch }}; qt6)"
     runs-on: ubuntu-20.04
     if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.actor, 'transifex')"

--- a/.github/workflows/ci-more.yml
+++ b/.github/workflows/ci-more.yml
@@ -11,10 +11,11 @@ on:
 
 jobs:
   # CI on Linux (Qt5)
+  # Note: cmake in U20.04/armhf (armv7) is broken
   ci-linux-qt5:
     strategy:
       matrix:
-        arch: [armv7, aarch64, riscv64]
+        arch: [aarch64, riscv64]
     name: "Linux (${{ matrix.arch }}; qt5)"
     runs-on: ubuntu-20.04
     if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.actor, 'transifex')"

--- a/.github/workflows/ci-more.yml
+++ b/.github/workflows/ci-more.yml
@@ -1,0 +1,80 @@
+#
+# Implementation of Continuous Integration process for linux and macOS by Github actions (with extra additionals...)
+#
+name: "CI"
+
+on:
+  push:
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [master]
+
+jobs:
+  # CI on Linux (Qt5)
+  ci-linux-qt5:
+    strategy:
+      matrix:
+        include:
+          - arch: aarch64
+          - arch: riscv64
+    name: "Linux (${{ matrix.arch }}; qt5)"
+    runs-on: ubuntu-20.04
+    if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.actor, 'transifex')"
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+#    - name: Download static QEMU (${{ matrix.arch }})
+#      run: |
+#        wget https://github.com/multiarch/qemu-user-static/releases/download/v7.2.0-1/qemu-${{ matrix.arch }}-static.tar.gz -O ${{ runner.temp }}/qemu-${{ matrix.arch }}-static.tar.gz
+#        tar -zxvf ${{ runner.temp }}/qemu-${{ matrix.arch }}-static.tar.gz
+#        chmod +x ${PWD}/qemu-${{ matrix.arch }}-static
+
+    - name: Build AppImage
+      uses: uraimo/run-on-arch-action@v2
+      id: build
+      with:
+        arch: ${{ matrix.arch }}
+        distro: ubuntu20.04
+
+        # Not required, but speeds up builds by storing container images in
+        # a GitHub package registry.
+        githubToken: ${{ github.GITHUB_TOKEN }}
+
+        # Create an artifacts directory
+#        setup: |
+#          mkdir -p "${PWD}/artifact"
+
+        # Mount the artifacts directory as /artifact in the container
+#        dockerRunArgs: |
+#          --volume "${PWD}/artifact:/artifact"
+#          --volume "${PWD}/qemu-${{ matrix.arch }}-static:/usr/bin/qemu-static"
+
+        # The shell to run commands with in the container
+        shell: /bin/bash
+
+        # Install some dependencies in the container. This speeds up builds if
+        # you are also using githubToken. Any dependencies installed here will
+        # be part of the container image that gets cached, so subsequent
+        # builds don't have to re-install them. The image layer is cached
+        # publicly in your project's package repository, so it is vital that
+        # no secrets are present in the container state or logs.
+        install: |
+          # Update installed packages
+          apt update -y
+          ACCEPT_EULA=Y apt upgrade -o Dpkg::Options::="--force-overwrite" --yes
+          # Installing dependencies
+          apt install -y qtbase5-private-dev qtscript5-dev libqt5svg5-dev qttools5-dev-tools qttools5-dev libqt5opengl5-dev qtmultimedia5-dev libqt5multimedia5-plugins libqt5serialport5 libqt5serialport5-dev qtpositioning5-dev libgps-dev libqt5positioning5 libqt5positioning5-plugins libqt5charts5-dev zlib1g-dev libgl1-mesa-dev libdrm-dev libexiv2-dev libnlopt-cxx-dev
+          # Installing dev. env. dependencies
+          apt install -y build-essential gcc g++ cmake gettext fakeroot ccache
+          # Installing optional dependencies
+          # apt install -y qtwebengine5-dev libqt5webengine5 libqt5webenginecore5 libqt5webenginewidgets5
+ 
+        # Produce a binary artifact and place it in the mounted volume
+        run: |
+          mkdir -p build
+          cd build
+          cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_TESTING=On "${{ github.workspace }}"
+          make -j3
+          ctest --output-on-failure

--- a/.github/workflows/ci-more.yml
+++ b/.github/workflows/ci-more.yml
@@ -31,7 +31,7 @@ jobs:
 #        tar -zxvf ${{ runner.temp }}/qemu-${{ matrix.arch }}-static.tar.gz
 #        chmod +x ${PWD}/qemu-${{ matrix.arch }}-static
 
-    - name: Build AppImage
+    - name: Configure and build Stellarium
       uses: uraimo/run-on-arch-action@v2
       id: build
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   # CI on Linux (Qt5)
   ci-linux-qt5:
-    name: "Linux (qt5)"
+    name: "Linux (amd64; qt5)"
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.actor, 'transifex')"
 
@@ -49,7 +49,7 @@ jobs:
 
   # CI on Linux (Qt6)
   ci-linux-qt6:
-    name: "Linux (qt6)"
+    name: "Linux (amd64; qt6)"
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.actor, 'transifex')"
 
@@ -86,7 +86,7 @@ jobs:
 
   # CI on macOS (Qt5)
   ci-macos-qt5:
-    name: "macOS (qt5)"
+    name: "macOS (x86_64; qt5)"
     runs-on: macos-latest
     if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.actor, 'transifex')"
 
@@ -123,7 +123,7 @@ jobs:
 
   # CI on macOS (Qt6)
   ci-macos-qt6:
-    name: "macOS (qt6)"
+    name: "macOS (x86_64; qt6)"
     runs-on: macos-latest
     if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.actor, 'transifex')"
 


### PR DESCRIPTION
### Description
This pull request contains GitHub actions for unit testing on popular not x86 architectures - armv7 (32-bit ARM), aarch64 (64-bit ARM), riscv64 (64-bit RISC-V) - for Qt5-based and Qt6-based builds at Ubuntu 22.04. Of course, the building of source within QEMU'ed dockers is slow in comparison to host systems, so we may enable it via special keyword in git messages (an optional unit testing).

Important note: Stellarium is configured without ShowMySky and QtWebEngine support

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] Housekeeping
