### PR TITLE
Related to Issue 705: Added altitude and azimuth entries to TelescopeTCP

### DIFF
--- a/plugins/TelescopeControl/src/TelescopeClient.cpp
+++ b/plugins/TelescopeControl/src/TelescopeClient.cpp
@@ -126,6 +126,31 @@ TelescopeClient *TelescopeClient::create(const QString &url)
 TelescopeClient::TelescopeClient(const QString &name) : nameI18n(name), name(name)
 {}
 
+
+bool TelescopeClient::GetAltAzFromJ2000Position(const Vec3d &j2000Pos,TelescopeControl::Equinox equinox ,double& alt, double &az) const
+{
+   const StelCore* core = StelApp::getInstance().getCore();
+   const  bool res = core != nullptr;
+   if(res)
+   {
+      const bool equinoxJNow = equinox == TelescopeControl::EquinoxJNow;
+      StelCore::RefractionMode mode = equinoxJNow ? StelCore::RefractionOff : StelCore::RefractionAuto;
+      const Vec3d positionJ2000 = equinoxJNow ? core->j2000ToEquinoxEqu(j2000Pos,mode) : j2000Pos;
+
+      const Vec3d position_alt_az = core->j2000ToAltAz(positionJ2000,mode);
+      StelUtils::rectToSphe(&az,&alt,position_alt_az);
+
+      const bool useSouthAzimuth = StelApp::getInstance().getFlagSouthAzimuthUsage();
+      const double direction = useSouthAzimuth ? 2. : 3.; // N is zero, E is 90 degrees
+      az = direction*M_PI - az;
+      if (az > M_PI*2.0)
+      {
+         az -= M_PI*2.0;
+      }
+   }
+   return res;
+}
+
 QString TelescopeClient::getInfoString(const StelCore* core, const InfoStringGroup& flags) const
 {
 	QString str;
@@ -259,6 +284,7 @@ void TelescopeTCP::hangup(void)
 	interpolatedPosition.reset();
 }
 
+
 //! queues a GOTO command with the specified position to the write buffer.
 //! For the data format of the command see the
 //! "Stellarium telescope control protocol" text file
@@ -270,31 +296,16 @@ void TelescopeTCP::telescopeGoto(const Vec3d &j2000Pos, StelObjectP selectObject
 		return;
 
 	Vec3d position = j2000Pos;
-   Vec3d position_alt_az = j2000Pos;
-   const StelCore* core = StelApp::getInstance().getCore();
-   position_alt_az = core->j2000ToAltAz(j2000Pos,StelCore::RefractionAuto);
+
 	if (equinox == TelescopeControl::EquinoxJNow)
 	{
 		const StelCore* core = StelApp::getInstance().getCore();
 		position = core->j2000ToEquinoxEqu(j2000Pos, StelCore::RefractionOff);
-
 	}
 
-	if (writeBufferEnd - writeBuffer + 20 < static_cast<int>(sizeof(writeBuffer)))
+
+   if (writeBufferEnd - writeBuffer + packetLength < static_cast<int>(sizeof(writeBuffer)))
 	{
-      const double a = position_alt_az[0];
-      const double b = position_alt_az[1];
-      const double x = position_alt_az[2];
-      //StelUtils::rectToSphe(&az, &alt, pos);
-      double az,alt;
-      const bool useSouthAzimuth = StelApp::getInstance().getFlagSouthAzimuthUsage();
-      StelUtils::rectToSphe(&az,&alt,position_alt_az);
-      const double direction = useSouthAzimuth ? 2. : 3.; // N is zero, E is 90 degrees
-      az = direction*M_PI - az;
-      if (az > M_PI*2)
-         az -= M_PI*2;
-      az*=M_180_PI;
-      alt*=M_180_PI;
 
 		const double ra_signed = atan2(position[1], position[0]);
 		//Workaround for the discrepancy in precision between Windows/Linux/PPC Macs and Intel Macs:
@@ -302,8 +313,20 @@ void TelescopeTCP::telescopeGoto(const Vec3d &j2000Pos, StelObjectP selectObject
 		const double dec = atan2(position[2], std::sqrt(position[0]*position[0]+position[1]*position[1]));
 		unsigned int ra_int = static_cast<unsigned int>(floor(0.5 + ra*((static_cast<unsigned int>(0x80000000))/M_PI)));
 		int dec_int = static_cast<int>(floor(0.5 + dec*((static_cast<unsigned int>(0x80000000))/M_PI)));
-		// length of packet:
-		*writeBufferEnd++ = 20;
+
+      double az = 0.0;
+      double alt = 0.0;
+      if(!GetAltAzFromJ2000Position(j2000Pos,equinox,alt,az))
+      {
+         qDebug() << "TelescopeTCP(" << name << ")::telescopeGoto: "<< ""
+                     "unable to convert j2000 position to alt az.";
+      }
+
+      unsigned int az_int = static_cast<unsigned int>(floor(0.5 + az*((static_cast<unsigned int>(0x80000000)/M_PI))));
+      int alt_int = static_cast<int>(floor(0.5 + alt*((static_cast<unsigned int>(0x80000000)/M_PI))));
+
+      // length of packet:
+      *writeBufferEnd++ = packetLength;
 		*writeBufferEnd++ = 0;
 		// type of packet:
 		*writeBufferEnd++ = 0;
@@ -341,7 +364,22 @@ void TelescopeTCP::telescopeGoto(const Vec3d &j2000Pos, StelObjectP selectObject
 		*writeBufferEnd++ = static_cast<char>(dec_int & 0xFF);
 		dec_int>>=8;
 		*writeBufferEnd++ = static_cast<char>(dec_int & 0xFF);
-
+      //alt
+      *writeBufferEnd++ = static_cast<char>(alt_int & 0xFF);
+      alt_int>>=8;
+      *writeBufferEnd++ = static_cast<char>(alt_int & 0xFF);
+      alt_int>>=8;
+      *writeBufferEnd++ = static_cast<char>(alt_int & 0xFF);
+      alt_int>>=8;
+      *writeBufferEnd++ = static_cast<char>(alt_int & 0xFF);
+      //az
+      *writeBufferEnd++ = static_cast<char>(az_int & 0xFF);
+      az_int>>=8;
+      *writeBufferEnd++ = static_cast<char>(az_int & 0xFF);
+      az_int>>=8;
+      *writeBufferEnd++ = static_cast<char>(az_int & 0xFF);
+      az_int>>=8;
+      *writeBufferEnd++ = static_cast<char>(az_int & 0xFF);
 	}
 	else
 	{

--- a/plugins/TelescopeControl/src/TelescopeClient.hpp
+++ b/plugins/TelescopeControl/src/TelescopeClient.hpp
@@ -110,7 +110,17 @@ protected:
 	QString nameI18n;
 	const QString name;
 
-	virtual QString getTelescopeInfoString(const StelCore* core, const InfoStringGroup& flags) const
+   /*!
+    * \brief Get the alt/az in rad from the j2000 position
+    * \param j2000Pos
+    * \param equinox
+    * \param alt [out]
+    * \param az  [out]
+    * \return true/false if successful or not
+    */
+   bool GetAltAzFromJ2000Position(const Vec3d &j2000Pos,TelescopeControl::Equinox equinox,double& alt, double &az) const;
+
+   virtual QString getTelescopeInfoString(const StelCore* core, const InfoStringGroup& flags) const
 	{
 		Q_UNUSED(core)
 		Q_UNUSED(flags)
@@ -231,7 +241,7 @@ private:
 	char writeBuffer[120];
 	char *writeBufferEnd;
 	int time_delay;
-
+   static constexpr int packetLength{28};
 	InterpolatedPosition interpolatedPosition;
 	bool hasKnownPosition(void) const override
 	{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Please include a summary of the change and which issue is fixed. -->
<!--- Please also include relevant motivation and context. -->
<!--- List any dependencies that are required for this change. -->
Issue 705 describes a need for sending Altitude and Azimuth with the Telescope plugin. 
I've added this functionality to the TelescopeTCP class as a starting point. The plan is to extend the other classes when I've had more time to research their specific protocols.

With this fix for TelescopeTCP the Stellarium protocol has been extended with two entries Altitude and Azimuth which means that the packet length is now 28 bytes. 

I've added a new protected method in the TelescopeClient abstract class that converts j2000pos to altitude and azimuth. This can then be used in any derived class that might need this conversion. More specifically , as mentioned above, it is now used in the TelescopeTCP class in the TelescopeGoTo method.

Fixes # (issue)
Issue 705 
### Screenshots (if appropriate):

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This was tested with a python script with a TCP server. The TCP server receives Slew commands from Stellarium and interprets and prints the contents to the console. 
Example of a print where azimuth and altitude was added:
![image](https://github.com/Stellarium/stellarium/assets/16615085/c32e8a47-e059-4ee1-a245-eddc93d6c274)

**Test Configuration**:
* Operating system: Windows 11 Home 22H2
* Graphics Card: Nvidia GeForce RTX 4070

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
