### PR TITLE
Following current position in Search Tool

### DIFF
--- a/src/core/StelMovementMgr.cpp
+++ b/src/core/StelMovementMgr.cpp
@@ -1610,6 +1610,7 @@ void StelMovementMgr::panView(const double deltaAz, const double deltaAlt)
 		{
 			setViewUpVector(Vec3d(0., 0., 1.));
 		}
+		emit currentDirectionChanged();
 	}
 }
 

--- a/src/core/StelMovementMgr.hpp
+++ b/src/core/StelMovementMgr.hpp
@@ -480,6 +480,7 @@ signals:
 	void flagEnableZoomKeysChanged(bool b);
 	void userMaxFovChanged(double fov);
 	void currentFovChanged(double fov);
+	void currentDirectionChanged();
 
 private slots:
 	//! Called when the selected object changes.

--- a/src/gui/SearchDialog.cpp
+++ b/src/gui/SearchDialog.cpp
@@ -394,6 +394,7 @@ void SearchDialog::createDialogContent()
 	connect(ui->AxisXSpinBox, SIGNAL(valueChanged()), this, SLOT(manualPositionChanged()));
 	connect(ui->AxisYSpinBox, SIGNAL(valueChanged()), this, SLOT(manualPositionChanged()));
 	connect(ui->goPushButton, SIGNAL(clicked(bool)), this, SLOT(manualPositionChanged()));
+	// following the current direction of FOV
 	connect(GETSTELMODULE(StelMovementMgr), SIGNAL(currentDirectionChanged()), this, SLOT(setCenterOfScreenCoordinates()));
 	setCenterOfScreenCoordinates();
 	
@@ -680,6 +681,7 @@ void SearchDialog::setCenterOfScreenCoordinates()
 	projector->unProject(centerScreen[0], centerScreen[1], centerPos);
 	double spinLong, spinLat;
 
+	// Getting coordinates (in radians) of position of the center of the screen
 	switch (getCurrentCoordinateSystem())
 	{
 		case equatorialJ2000:
@@ -724,12 +726,15 @@ void SearchDialog::setCenterOfScreenCoordinates()
 		}
 	}
 
+	// disable following the changes of spinbox
 	ui->AxisXSpinBox->blockSignals(true);
 	ui->AxisYSpinBox->blockSignals(true);
 
+	// set coordinates in spinboxes
 	ui->AxisXSpinBox->setRadians(spinLong);
 	ui->AxisYSpinBox->setRadians(spinLat);
 
+	// restore following the changes of spinbox
 	ui->AxisXSpinBox->blockSignals(false);
 	ui->AxisYSpinBox->blockSignals(false);
 }

--- a/src/gui/SearchDialog.cpp
+++ b/src/gui/SearchDialog.cpp
@@ -395,7 +395,7 @@ void SearchDialog::createDialogContent()
 	connect(ui->AxisYSpinBox, SIGNAL(valueChanged()), this, SLOT(manualPositionChanged()));
 	connect(ui->goPushButton, SIGNAL(clicked(bool)), this, SLOT(manualPositionChanged()));
 	// following the current direction of FOV
-	connect(GETSTELMODULE(StelMovementMgr), SIGNAL(currentDirectionChanged()), this, SLOT(setCenterOfScreenCoordinates()));
+	connect(GETSTELMODULE(StelMovementMgr), &StelMovementMgr::currentDirectionChanged, this, [=](){setCenterOfScreenCoordinates();});
 	setCenterOfScreenCoordinates();
 	
 	connect(ui->alphaPushButton, SIGNAL(clicked(bool)), this, SLOT(greekLetterClicked()));
@@ -675,12 +675,11 @@ void SearchDialog::setSimpleStyle()
 void SearchDialog::setCenterOfScreenCoordinates()
 {
 	StelCore *core = StelApp::getInstance().getCore();
-	const auto projector = core->getProjection(StelCore::FrameJ2000, StelCore::RefractionMode::RefractionOff);
-	Vec2i centerScreen(projector->getViewportPosX() + projector->getViewportWidth() / 2,
-			   projector->getViewportPosY() + projector->getViewportHeight() / 2);
+	const auto projector = core->getProjection(StelCore::FrameJ2000, StelCore::RefractionMode::RefractionOff);	
+	Vector2<qreal> cpos = projector->getViewportCenter();
 	Vec3d centerPos;
-	projector->unProject(centerScreen[0], centerScreen[1], centerPos);
-	double spinLong, spinLat;
+	projector->unProject(cpos[0], cpos[1], centerPos);
+	double spinLong =0., spinLat = 0.;
 
 	// Getting coordinates (in radians) of position of the center of the screen
 	switch (getCurrentCoordinateSystem())
@@ -728,16 +727,16 @@ void SearchDialog::setCenterOfScreenCoordinates()
 	}
 
 	// disable following the changes of spinbox
-	ui->AxisXSpinBox->blockSignals(true);
-	ui->AxisYSpinBox->blockSignals(true);
+	const bool axisXState = ui->AxisXSpinBox->blockSignals(true);
+	const bool axisYState = ui->AxisYSpinBox->blockSignals(true);
 
 	// set coordinates in spinboxes
 	ui->AxisXSpinBox->setRadians(spinLong);
 	ui->AxisYSpinBox->setRadians(spinLat);
 
 	// restore following the changes of spinbox
-	ui->AxisXSpinBox->blockSignals(false);
-	ui->AxisYSpinBox->blockSignals(false);
+	ui->AxisXSpinBox->blockSignals(axisXState);
+	ui->AxisYSpinBox->blockSignals(axisYState);
 }
 
 void SearchDialog::manualPositionChanged()

--- a/src/gui/SearchDialog.cpp
+++ b/src/gui/SearchDialog.cpp
@@ -353,6 +353,7 @@ void SearchDialog::setCoordinateSystem(int csID)
 	ui->AxisXSpinBox->setRadians(0.);
 	ui->AxisYSpinBox->setRadians(0.);
 	conf->setValue("search/coordinate_system", currentCoordinateSystemID);
+	setCenterOfScreenCoordinates();
 }
 
 // Initialize the dialog widgets and connect the signals/slots
@@ -393,6 +394,7 @@ void SearchDialog::createDialogContent()
 	connect(ui->AxisXSpinBox, SIGNAL(valueChanged()), this, SLOT(manualPositionChanged()));
 	connect(ui->AxisYSpinBox, SIGNAL(valueChanged()), this, SLOT(manualPositionChanged()));
 	connect(ui->goPushButton, SIGNAL(clicked(bool)), this, SLOT(manualPositionChanged()));
+	setCenterOfScreenCoordinates();
 	
 	connect(ui->alphaPushButton, SIGNAL(clicked(bool)), this, SLOT(greekLetterClicked()));
 	connect(ui->betaPushButton, SIGNAL(clicked(bool)), this, SLOT(greekLetterClicked()));
@@ -667,6 +669,69 @@ void SearchDialog::setSimpleStyle()
 	ui->coordinateSystemComboBox->setVisible(false);
 }
 
+void SearchDialog::setCenterOfScreenCoordinates()
+{
+	StelCore *core = StelApp::getInstance().getCore();
+	const auto projector = core->getProjection(StelCore::FrameJ2000, StelCore::RefractionMode::RefractionOff);
+	Vec2i centerScreen(projector->getViewportPosX() + projector->getViewportWidth() / 2,
+			   projector->getViewportPosY() + projector->getViewportHeight() / 2);
+	Vec3d centerPos;
+	projector->unProject(centerScreen[0], centerScreen[1], centerPos);
+	double spinLong, spinLat;
+
+	switch (getCurrentCoordinateSystem())
+	{
+		case equatorialJ2000:
+			StelUtils::rectToSphe(&spinLong, &spinLat, centerPos);
+			break;
+		case equatorial:
+			StelUtils::rectToSphe(&spinLong, &spinLat, core->j2000ToEquinoxEqu(centerPos, StelCore::RefractionOff));
+			break;
+		case galactic:
+			StelUtils::rectToSphe(&spinLong, &spinLat, core->j2000ToGalactic(centerPos));
+			break;
+		case supergalactic:
+			StelUtils::rectToSphe(&spinLong, &spinLat, core->j2000ToSupergalactic(centerPos));
+			break;
+		case horizontal:
+		{
+			StelUtils::rectToSphe(&spinLong, &spinLat, core->j2000ToAltAz(centerPos, StelCore::RefractionAuto));
+			spinLong = 3.*M_PI - spinLong; // N is zero, E is 90 degrees
+			if (spinLong > M_PI*2)
+				spinLong -= M_PI*2;
+			break;
+		}
+		case eclipticJ2000:
+		{
+			double lambda, beta;
+			StelUtils::rectToSphe(&spinLong, &spinLat, centerPos);
+			StelUtils::equToEcl(spinLong, spinLat, GETSTELMODULE(SolarSystem)->getEarth()->getRotObliquity(2451545.0), &lambda, &beta);
+			if (lambda<0) lambda+=2.0*M_PI;
+			spinLong = lambda;
+			spinLat = beta;
+			break;
+		}
+		case ecliptic:
+		{
+			double lambda, beta;
+			StelUtils::rectToSphe(&spinLong, &spinLat, core->j2000ToEquinoxEqu(centerPos, StelCore::RefractionOff));
+			StelUtils::equToEcl(spinLong, spinLat, GETSTELMODULE(SolarSystem)->getEarth()->getRotObliquity(core->getJDE()), &lambda, &beta);
+			if (lambda<0) lambda+=2.0*M_PI;
+			spinLong = lambda;
+			spinLat = beta;
+			break;
+		}
+	}
+
+	ui->AxisXSpinBox->blockSignals(true);
+	ui->AxisYSpinBox->blockSignals(true);
+
+	ui->AxisXSpinBox->setRadians(spinLong);
+	ui->AxisYSpinBox->setRadians(spinLat);
+
+	ui->AxisXSpinBox->blockSignals(false);
+	ui->AxisYSpinBox->blockSignals(false);
+}
 
 void SearchDialog::manualPositionChanged()
 {

--- a/src/gui/SearchDialog.cpp
+++ b/src/gui/SearchDialog.cpp
@@ -516,6 +516,7 @@ void SearchDialog::changeTab(int index)
 
 	if (index==2) // Position
 	{
+		setCenterOfScreenCoordinates();
 		if (useFOVCenterMarker)
 			GETSTELMODULE(SpecialMarkersMgr)->setFlagFOVCenterMarker(true);
 	}

--- a/src/gui/SearchDialog.cpp
+++ b/src/gui/SearchDialog.cpp
@@ -394,6 +394,7 @@ void SearchDialog::createDialogContent()
 	connect(ui->AxisXSpinBox, SIGNAL(valueChanged()), this, SLOT(manualPositionChanged()));
 	connect(ui->AxisYSpinBox, SIGNAL(valueChanged()), this, SLOT(manualPositionChanged()));
 	connect(ui->goPushButton, SIGNAL(clicked(bool)), this, SLOT(manualPositionChanged()));
+	connect(GETSTELMODULE(StelMovementMgr), SIGNAL(currentDirectionChanged()), this, SLOT(setCenterOfScreenCoordinates()));
 	setCenterOfScreenCoordinates();
 	
 	connect(ui->alphaPushButton, SIGNAL(clicked(bool)), this, SLOT(greekLetterClicked()));

--- a/src/gui/SearchDialog.cpp
+++ b/src/gui/SearchDialog.cpp
@@ -395,7 +395,7 @@ void SearchDialog::createDialogContent()
 	connect(ui->AxisYSpinBox, SIGNAL(valueChanged()), this, SLOT(manualPositionChanged()));
 	connect(ui->goPushButton, SIGNAL(clicked(bool)), this, SLOT(manualPositionChanged()));
 	// following the current direction of FOV
-	connect(GETSTELMODULE(StelMovementMgr), &StelMovementMgr::currentDirectionChanged, this, [=](){setCenterOfScreenCoordinates();});
+	connect(GETSTELMODULE(StelMovementMgr), &StelMovementMgr::currentDirectionChanged, this, &SearchDialog::setCenterOfScreenCoordinates);
 	setCenterOfScreenCoordinates();
 	
 	connect(ui->alphaPushButton, SIGNAL(clicked(bool)), this, SLOT(greekLetterClicked()));

--- a/src/gui/SearchDialog.hpp
+++ b/src/gui/SearchDialog.hpp
@@ -250,6 +250,8 @@ private slots:
 	//! Clear recent list's data
 	void recentSearchClearDataClicked();
 
+	void setCenterOfScreenCoordinates();
+
 private:
 	bool simbadSearchEnabled() const {return useSimbad;}
 	int  getSimbadQueryDist () const { return simbadDist;}

--- a/src/gui/SearchDialog.hpp
+++ b/src/gui/SearchDialog.hpp
@@ -250,6 +250,7 @@ private slots:
 	//! Clear recent list's data
 	void recentSearchClearDataClicked();
 
+	//! Setting coordinates of the center of screen in spinboxes (following axes of current coordinate system)
 	void setCenterOfScreenCoordinates();
 
 private:


### PR DESCRIPTION
### Description
This patch adding a feature to following the coordinates of the center of screen and ability to re-computing the coordinates when coordinate system is changed.

Fixes #2960 (issue)

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?
1. Run Stellarium and open Search Tool/Position
2. Try to change the coordinate system
3. Try to change the direction of view via mouse or keyboard

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
