### PR TITLE
Faster OBJ import

### DIFF
--- a/src/core/StelOBJ.cpp
+++ b/src/core/StelOBJ.cpp
@@ -384,7 +384,7 @@ bool StelOBJ::parseFace(const ParseParams& params, const V3Vec& posList, const V
 
 	// Find all slashes without allocating memory, including allocation for storing
 	// the result (we assume that the output vector has a reasonable amount of space reserved)
-	const auto findSlashes = [](const QStringRef& line, std::vector<int>& slashes)
+	const auto findSlashes = [](const QStringView& line, std::vector<int>& slashes)
 	{
 		slashes.clear();
 		for(int n = 0; n < line.size(); ++n)

--- a/src/core/StelOBJ.cpp
+++ b/src/core/StelOBJ.cpp
@@ -382,58 +382,62 @@ bool StelOBJ::parseFace(const ParseParams& params, const V3Vec& posList, const V
 	//note: the indices start with 1, this is fixed up later
 	#define FIX_REL(a, list) if(a<0) {a += list.size()+1; }
 
+	// Find all slashes without allocating memory, including allocation for storing
+	// the result (we assume that the output vector has a reasonable amount of space reserved)
+	const auto findSlashes = [](const QStringRef& line, std::vector<int>& slashes)
+	{
+		slashes.clear();
+		for(int n = 0; n < line.size(); ++n)
+			if(line[n] == QLatin1Char('/'))
+				slashes.push_back(n);
+	};
+
+	thread_local std::vector<int> slashes;
+	slashes.reserve(4);
 	//loop to parse each section separately
 	for(int i =0; i<vtxAmount;++i)
 	{
-		if(!params[i+1].contains('/'))
+		const auto& vertStr = params[i+1];
+		findSlashes(vertStr, slashes);
+
+		switch(slashes.size())
 		{
-			//no slash, only position
-			CHK_MODE(1)
-			CHK_OK(posIdx = params[i+1].toInt(&ok));
-			FIX_REL(posIdx, posList)
-		}
-		else
-		{
-			//split on slash
-			#if (QT_VERSION>=QT_VERSION_CHECK(6,0,0))
-			ParseParams split = params.at(i+1).split('/').toVector();
-			#else
-			ParseParams split = params.at(i+1).split('/');
-			#endif
-			switch(split.size())
-			{
-				// case 1 is handled separately above
-				case 2: //single slash, vert/tex
-					CHK_MODE(2)
-					CHK_OK(posIdx = split.at(0).toInt(&ok));
+			case 0:
+				//no slash, only position
+				CHK_MODE(1)
+				CHK_OK(posIdx = vertStr.toInt(&ok));
+				FIX_REL(posIdx, posList)
+				break;
+			case 1: //single slash, vert/tex
+				CHK_MODE(2)
+				CHK_OK(posIdx = vertStr.mid(0, slashes[0]).toInt(&ok));
+				FIX_REL(posIdx, posList)
+				CHK_OK(texIdx = vertStr.mid(slashes[0] + 1, vertStr.size() - (slashes[0] + 1)).toInt(&ok));
+				FIX_REL(texIdx, texList)
+				break;
+			case 2: //2 slashes, either v/t/n or v//n
+				if(slashes[1]-slashes[0] != 1)
+				{
+					CHK_MODE(3)
+					CHK_OK(posIdx = vertStr.mid(0, slashes[0]).toInt(&ok));
 					FIX_REL(posIdx, posList)
-					CHK_OK(texIdx = split.at(1).toInt(&ok));
+					CHK_OK(texIdx = vertStr.mid(slashes[0] + 1, slashes[1] - (slashes[0] + 1)).toInt(&ok));
 					FIX_REL(texIdx, texList)
-					break;
-				case 3: //2 slashes, either v/t/n or v//n
-					if(!split.at(1).isEmpty())
-					{
-						CHK_MODE(3)
-						CHK_OK(posIdx = split.at(0).toInt(&ok));
-						FIX_REL(posIdx, posList)
-						CHK_OK(texIdx = split.at(1).toInt(&ok));
-						FIX_REL(texIdx, texList)
-						CHK_OK(normIdx = split.at(2).toInt(&ok));
-						FIX_REL(normIdx, normList)
-					}
-					else
-					{
-						CHK_MODE(4)
-						CHK_OK(posIdx = split.at(0).toInt(&ok));
-						FIX_REL(posIdx, posList)
-						CHK_OK(normIdx = split.at(2).toInt(&ok));
-						FIX_REL(normIdx, normList)
-					}
-					break;
-				default: //invalid line
-					qCCritical(stelOBJ)<<"Invalid face statement"<<params;
-					return false;
-			}
+					CHK_OK(normIdx = vertStr.mid(slashes[1] + 1, vertStr.size() - (slashes[1] + 1)).toInt(&ok));
+					FIX_REL(normIdx, normList)
+				}
+				else
+				{
+					CHK_MODE(4)
+					CHK_OK(posIdx = vertStr.mid(0, slashes[0]).toInt(&ok));
+					FIX_REL(posIdx, posList)
+					CHK_OK(normIdx = vertStr.mid(slashes[1] + 1, vertStr.size() - (slashes[1] + 1)).toInt(&ok));
+					FIX_REL(normIdx, normList)
+				}
+				break;
+			default: //invalid line
+				qCCritical(stelOBJ)<<"Invalid face statement"<<params;
+				return false;
 		}
 
 		//create a temporary Vertex by copying the info from the lists

--- a/src/core/StelOBJ.cpp
+++ b/src/core/StelOBJ.cpp
@@ -30,8 +30,6 @@
 #include <QFileInfo>
 #include <QRegularExpression>
 #include <QTextStream>
-#include <charconv>
-#include <system_error>
 
 Q_LOGGING_CATEGORY(stelOBJ,"stel.OBJ")
 
@@ -135,18 +133,9 @@ bool StelOBJ::parseInt(const ParseParams &params, int &out, int paramsStart)
 		qCWarning(stelOBJ)<<"Additional parameters ignored in statement"<<params;
 	}
 
-	const QByteArray qba=params.at(paramsStart).toLocal8Bit();
-	//auto [ p, e ] = std::from_chars(params.at(paramsStart).constData(), params.at(paramsStart).constData() + params.at(paramsStart).size(), out[0]);
-	auto [ p, e ] = std::from_chars(qba.constData(), qba.constData() + params.at(paramsStart).size(), out);
-	if (e==std::errc())
-		return true;
-	qCCritical(stelOBJ)<<"Error parsing Vec3:"<<params;
-	return false;
-
-
-	//bool ok;
-	//out = params.at(paramsStart).toInt(&ok);
-	//return ok;
+	bool ok;
+	out = params.at(paramsStart).toInt(&ok);
+	return ok;
 }
 
 bool StelOBJ::parseString(const ParseParams &params, QString &out, int paramsStart)
@@ -182,20 +171,9 @@ bool StelOBJ::parseFloat(const ParseParams &params, float &out, int paramsStart)
 		qCWarning(stelOBJ)<<"Additional parameters ignored in statement"<<params;
 	}
 
-	const QByteArray qba=params.at(paramsStart).toLocal8Bit();
-	//auto [ p, e ] = std::from_chars(params.at(paramsStart).constData(), params.at(paramsStart).constData() + params.at(paramsStart).size(), out[0]);
-	auto [ p, e ] = std::from_chars(qba.constData(), qba.constData() + params.at(paramsStart).size(), out);
-	if (e==std::errc())
-		return true;
-	qCCritical(stelOBJ)<<"Error parsing Vec3:"<<params;
-	return false;
-
-
-
-
-	//bool ok;
-	//out = params.at(paramsStart).toFloat(&ok);
-	//return ok;
+	bool ok;
+	out = params.at(paramsStart).toFloat(&ok);
+	return ok;
 }
 
 template <typename T>
@@ -207,51 +185,20 @@ bool StelOBJ::parseVec3(const ParseParams& params, T &out, int paramsStart)
 		return false;
 	}
 
-
-	// TODO: Replace Qt's toFloat by C++17's from_chars()
-	// p=ptr, should be params.at(paramsStart).data() + params.at(paramsStart).size() on success
-	// e=error_code, should be errc()
-
-	const QByteArray qba=params.at(paramsStart).toLocal8Bit();
-	//auto [ p, e ] = std::from_chars(params.at(paramsStart).constData(), params.at(paramsStart).constData() + params.at(paramsStart).size(), out[0]);
-	auto [ p, e ] = std::from_chars(qba.constData(), qba.constData() + params.at(paramsStart).size(), out[0]);
-	if (e==std::errc())
+	bool ok = false;
+	out[0] = params.at(paramsStart).toFloat(&ok); //use double here, so that it even works for Vec3d, etc
+	if(ok)
 	{
-		const QByteArray qba=params.at(paramsStart+1).toLocal8Bit();
-		auto [ p, e ] = std::from_chars(qba.constData(), qba.constData() + params.at(paramsStart+1).size(), out[1]);
-
-		if (e==std::errc())
+		out[1] = params.at(paramsStart+1).toFloat(&ok);
+		if(ok)
 		{
-			const QByteArray qba=params.at(paramsStart+2).toLocal8Bit();
-			auto [ p, e ] = std::from_chars(qba.constData(), qba.constData() + params.at(paramsStart+2).size(), out[2]);
-			if (e==std::errc())
-				return true;
+			out[2] = params.at(paramsStart+2).toFloat(&ok);
+			return true;
 		}
 	}
 
-	//if (e == std::errc::invalid_argument)
-	//	    qWarning() << "OBJ: Invalid 3-vector: " << params;
-	//else if (e == std::errc::result_out_of_range)
-	//	    qWarning() << "This number is out of range: " << params.at(paramsStart);
-
 	qCCritical(stelOBJ)<<"Error parsing Vec3:"<<params;
 	return false;
-
-
-	//bool ok = false;
-	//out[0] = params.at(paramsStart).toFloat(&ok); //use double here, so that it even works for Vec3d, etc
-	//if(ok)
-	//{
-	//	out[1] = params.at(paramsStart+1).toFloat(&ok);
-	//	if(ok)
-	//	{
-	//		out[2] = params.at(paramsStart+2).toFloat(&ok);
-	//		return true;
-	//	}
-	//}
-
-	//qCCritical(stelOBJ)<<"Error parsing Vec3:"<<params;
-	//return false;
 }
 
 template <typename T>
@@ -263,31 +210,16 @@ bool StelOBJ::parseVec2(const ParseParams& params,T &out, int paramsStart)
 		return false;
 	}
 
-	const QByteArray qba=params.at(paramsStart).toLocal8Bit();
-	//auto [ p, e ] = std::from_chars(params.at(paramsStart).constData(), params.at(paramsStart).constData() + params.at(paramsStart).size(), out[0]);
-	auto [ p, e ] = std::from_chars(qba.constData(), qba.constData() + params.at(paramsStart).size(), out[0]);
-	if (e==std::errc())
+	bool ok = false;
+	out[0] = params.at(paramsStart).toDouble(&ok);
+	if(ok)
 	{
-		const QByteArray qba=params.at(paramsStart+1).toLocal8Bit();
-		auto [ p, e ] = std::from_chars(qba.constData(), qba.constData() + params.at(paramsStart+1).size(), out[1]);
-
-		if (e==std::errc())
-			return true;
+		out[1] = params.at(paramsStart+1).toDouble(&ok);
+		return true;
 	}
+
 	qCCritical(stelOBJ)<<"Error parsing Vec2:"<<params;
 	return false;
-
-
-	//bool ok = false;
-	//out[0] = params.at(paramsStart).toDouble(&ok);
-	//if(ok)
-	//{
-	//	out[1] = params.at(paramsStart+1).toDouble(&ok);
-	//	return true;
-	//}
-
-	//qCCritical(stelOBJ)<<"Error parsing Vec2:"<<params;
-	//return false;
 }
 
 StelOBJ::Object* StelOBJ::getCurrentObject(CurrentParserState &state)
@@ -522,7 +454,7 @@ StelOBJ::MaterialList StelOBJ::Material::loadFromFile(const QString &filename)
 		QString line = stream.readLine().simplified();
 		//split line by space		
 		#if (QT_VERSION>=QT_VERSION_CHECK(6,0,0))
-		ParseParams splits = ParseParam(line).split(' ', Qt::SkipEmptyParts).toVector();
+		ParseParams splits = ParseParam(line).split(' ', Qt::SkipEmptyParts);
 		#elif (QT_VERSION>=QT_VERSION_CHECK(5,15,0))
 		ParseParams splits = line.splitRef(' ', Qt::SkipEmptyParts);
 		#else
@@ -837,7 +769,7 @@ bool StelOBJ::load(QIODevice& device, const QString &basePath, const VertexOrder
 
 		//split line by whitespace
 		#if (QT_VERSION>=QT_VERSION_CHECK(6,0,0))
-		const ParseParams splits = ParseParam(line).split(separator, Qt::SkipEmptyParts).toVector();
+		const ParseParams splits = ParseParam(line).split(separator, Qt::SkipEmptyParts);
 		#elif (QT_VERSION>=QT_VERSION_CHECK(5,15,0))
 		const ParseParams splits = line.splitRef(separator, Qt::SkipEmptyParts);
 		#else

--- a/src/core/StelOBJ.cpp
+++ b/src/core/StelOBJ.cpp
@@ -385,49 +385,55 @@ bool StelOBJ::parseFace(const ParseParams& params, const V3Vec& posList, const V
 	//loop to parse each section separately
 	for(int i =0; i<vtxAmount;++i)
 	{
-		//split on slash
-		#if (QT_VERSION>=QT_VERSION_CHECK(6,0,0))
-		ParseParams split = params.at(i+1).split('/').toVector();
-		#else
-		ParseParams split = params.at(i+1).split('/');
-		#endif
-		switch(split.size())
+		if(!params[i+1].contains('/'))
 		{
-			case 1: //no slash, only position
-				CHK_MODE(1)
-				CHK_OK(posIdx = split.at(0).toInt(&ok));
-				FIX_REL(posIdx, posList)
-				break;
-			case 2: //single slash, vert/tex
-				CHK_MODE(2)
-				CHK_OK(posIdx = split.at(0).toInt(&ok));
-				FIX_REL(posIdx, posList)
-				CHK_OK(texIdx = split.at(1).toInt(&ok));
-				FIX_REL(texIdx, texList)
-				break;
-			case 3: //2 slashes, either v/t/n or v//n
-				if(!split.at(1).isEmpty())
-				{
-					CHK_MODE(3)
+			//no slash, only position
+			CHK_MODE(1)
+			CHK_OK(posIdx = params[i+1].toInt(&ok));
+			FIX_REL(posIdx, posList)
+		}
+		else
+		{
+			//split on slash
+			#if (QT_VERSION>=QT_VERSION_CHECK(6,0,0))
+			ParseParams split = params.at(i+1).split('/').toVector();
+			#else
+			ParseParams split = params.at(i+1).split('/');
+			#endif
+			switch(split.size())
+			{
+				// case 1 is handled separately above
+				case 2: //single slash, vert/tex
+					CHK_MODE(2)
 					CHK_OK(posIdx = split.at(0).toInt(&ok));
 					FIX_REL(posIdx, posList)
 					CHK_OK(texIdx = split.at(1).toInt(&ok));
 					FIX_REL(texIdx, texList)
-					CHK_OK(normIdx = split.at(2).toInt(&ok));
-					FIX_REL(normIdx, normList)
-				}
-				else
-				{
-					CHK_MODE(4)
-					CHK_OK(posIdx = split.at(0).toInt(&ok));
-					FIX_REL(posIdx, posList)
-					CHK_OK(normIdx = split.at(2).toInt(&ok));
-					FIX_REL(normIdx, normList)
-				}
-				break;
-			default: //invalid line
-				qCCritical(stelOBJ)<<"Invalid face statement"<<params;
-				return false;
+					break;
+				case 3: //2 slashes, either v/t/n or v//n
+					if(!split.at(1).isEmpty())
+					{
+						CHK_MODE(3)
+						CHK_OK(posIdx = split.at(0).toInt(&ok));
+						FIX_REL(posIdx, posList)
+						CHK_OK(texIdx = split.at(1).toInt(&ok));
+						FIX_REL(texIdx, texList)
+						CHK_OK(normIdx = split.at(2).toInt(&ok));
+						FIX_REL(normIdx, normList)
+					}
+					else
+					{
+						CHK_MODE(4)
+						CHK_OK(posIdx = split.at(0).toInt(&ok));
+						FIX_REL(posIdx, posList)
+						CHK_OK(normIdx = split.at(2).toInt(&ok));
+						FIX_REL(normIdx, normList)
+					}
+					break;
+				default: //invalid line
+					qCCritical(stelOBJ)<<"Invalid face statement"<<params;
+					return false;
+			}
 		}
 
 		//create a temporary Vertex by copying the info from the lists

--- a/src/core/StelOBJ.cpp
+++ b/src/core/StelOBJ.cpp
@@ -814,8 +814,7 @@ bool StelOBJ::load(QIODevice& device, const QString &basePath, const VertexOrder
 
 	VertexCache vertCache;
 	CurrentParserState state = CurrentParserState();
-	static const QRegularExpression separator("\\s");
-	separator.optimize();
+	static const QChar separator(' ');
 
 	int lineNr=0;
 


### PR DESCRIPTION
### Description
<!--- Please include a summary of the change and which issue is fixed. -->
<!--- Please also include relevant motivation and context. -->
<!--- List any dependencies that are required for this change. -->

Loading large OBJ files takes too long, easily more than a minute. With this change loading can be improved.

I had assumed it is the string manipulation, splitting/parsing/conversion to floats. Ruslan found the true cause.
To sum this up, the worst offender was using the QRegularExpression instead of simple space separator.

As a small change, I think this can be squashed and merged. 

Fixes #3620 

### Screenshots (if appropriate):

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Load a large scene, compare loading times. 

**Test Configuration**:
* Operating system: Windows 10/11, Ubuntu 22.04LTS
* Graphics Card: irrelevant

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
