### PR TITLE
Further optimization of OBJ loading

### DIFF
--- a/src/core/StelOBJ.hpp
+++ b/src/core/StelOBJ.hpp
@@ -340,6 +340,7 @@ private:
 	//! Parse a single bool
 	inline static bool parseBool(const ParseParams& params, bool& out, int paramsStart=1);
 	//! Parse a single int
+	inline static bool parseInt(const QStringView& str, int& out);
 	inline static bool parseInt(const ParseParams& params, int& out, int paramsStart=1);
 	//! Parse a single string
 	inline static bool parseString(const ParseParams &params, QString &out, int paramsStart=1);

--- a/src/core/StelOBJ.hpp
+++ b/src/core/StelOBJ.hpp
@@ -21,6 +21,8 @@
 #ifndef STELOBJ_HPP
 #define STELOBJ_HPP
 
+#include <vector>
+#include <string_view>
 #include "GeomMath.hpp"
 
 #include <qopengl.h>
@@ -299,13 +301,8 @@ public:
 	//! This is intended to be used together with splitVertexData(), when you want your own vertex format.
 	void clearVertexData();
 private:
-#if (QT_VERSION>=QT_VERSION_CHECK(6,0,0))
-	typedef QStringView ParseParam;
-	typedef QVector<QStringView> ParseParams;
-#else
-	typedef QStringRef ParseParam;
-	typedef QVector<QStringRef> ParseParams;
-#endif
+	typedef std::string_view ParseParam;
+	typedef std::vector<std::string_view> ParseParams;
 	typedef QHash<Vertex, int> VertexCache;
 
 	struct CurrentParserState
@@ -340,7 +337,7 @@ private:
 	//! Parse a single bool
 	inline static bool parseBool(const ParseParams& params, bool& out, int paramsStart=1);
 	//! Parse a single int
-	inline static bool parseInt(const QStringView& str, int& out);
+	inline static bool parseInt(const std::string_view& str, int& out);
 	inline static bool parseInt(const ParseParams& params, int& out, int paramsStart=1);
 	//! Parse a single string
 	inline static bool parseString(const ParseParams &params, QString &out, int paramsStart=1);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

It appears that `QString::toInt()` has become *much* slower in Qt 6.4.1 compared to Qt 5.15.4. For this reason I switched to `std::from_chars` for ints. Some more improvement comes from doing this for floats. Additionally, I removed the use of `QString` for parsing, so that it all now works with usual `char` units, which is more friendly to `std::from_chars` calls.

The results are as follows in the test where I simply call `StelOBJ::load()` from `main` to avoid any variability due to multithreading:

* Qt 6.4 : 16.5 s -> 3.4 s
* Qt 5.15: 4.9 s  -> 3.9 s

In the real-life scenario of loading in background during rendering the final times of loading are about 12 s (both in Qt5 and Qt6) down from about 30 s in Qt6 and 16 s in Qt5.

The only problem is that our macOS CI seems to use a relatively old compiler whose C++ standard library doesn't implement `std::from_chars` for floating-point types, and this breaks the build. One fix is to switch to a newer compiler if possible, and another is to employ `fast_float` library when the C++ standard library doesn't provide these functions.