### PR TITLE
Fall back to fast_float when C++ stdlib doesn't provide from_chars for floats

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1038,6 +1038,18 @@ IF(DOXYGEN_FOUND)
      ADD_CUSTOM_TARGET(apidoc ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} COMMENT "Generate the doxygen documentation into the doc directory.")
 ENDIF()
 
+include("cmake/Check-from_chars.cmake")
+IF(NOT FROM_CHARS_WORKS)
+    CPMFindPackage(NAME fast_float
+                   GIT_REPOSITORY https://github.com/fastfloat/fast_float
+                   VERSION 6.1.0
+                   EXCLUDE_FROM_ALL yes)
+    GET_TARGET_PROPERTY(fast_float_INCLUDE_DIRECTORIES
+                        FastFloat::fast_float INTERFACE_INCLUDE_DIRECTORIES)
+    INCLUDE_DIRECTORIES(${fast_float_INCLUDE_DIRECTORIES})
+    ADD_DEFINITIONS(-DUSE_FAST_FLOAT)
+ENDIF()
+
 ########### Top level include directories ###########
 # This will be used for all compilations in sub-directories
 INCLUDE_DIRECTORIES(

--- a/cmake/Check-from_chars.cmake
+++ b/cmake/Check-from_chars.cmake
@@ -1,0 +1,7 @@
+message(STATUS "Checking that std::from_chars for floats is supported by the C++ library")
+try_compile(FROM_CHARS_WORKS "${CMAKE_BINARY_DIR}" "${CMAKE_CURRENT_LIST_DIR}/check-from_chars.cpp")
+if(FROM_CHARS_WORKS)
+	message(STATUS "Checking that std::from_chars for floats is supported by the C++ library - yes")
+else()
+	message(STATUS "Checking that std::from_chars for floats is supported by the C++ library - NO")
+endif()

--- a/cmake/check-from_chars.cpp
+++ b/cmake/check-from_chars.cpp
@@ -1,0 +1,8 @@
+#include <charconv>
+
+int main()
+{
+	const char str[] = "1.2345e3";
+	float num;
+	std::from_chars(str, str + sizeof str - 1, num);
+}

--- a/src/core/StelOBJ.cpp
+++ b/src/core/StelOBJ.cpp
@@ -23,7 +23,15 @@
 //#include "StelTextureMgr.hpp"
 #include "StelUtils.hpp"
 
-#include <charconv>
+#if USE_FAST_FLOAT
+# include <fast_float/fast_float.h>
+using fast_float::from_chars;
+using fast_float::from_chars_result;
+#else
+# include <charconv>
+using std::from_chars;
+using std::from_chars_result;
+#endif
 
 #include <QBuffer>
 #include <QDir>
@@ -156,7 +164,7 @@ bool StelOBJ::parseBool(const ParseParams &params, bool &out, int paramsStart)
 
 bool StelOBJ::parseInt(const std::string_view& str, int& out)
 {
-	return std::from_chars(str.data(), str.data() + str.size(), out).ec == std::errc{};
+	return from_chars(str.data(), str.data() + str.size(), out).ec == std::errc{};
 }
 
 bool StelOBJ::parseInt(const ParseParams &params, int &out, int paramsStart)
@@ -209,7 +217,7 @@ bool StelOBJ::parseFloat(const ParseParams &params, float &out, int paramsStart)
 	}
 
 	const auto& str = params[paramsStart];
-	const auto res = std::from_chars(str.data(), str.data() + str.size(), out);
+	const auto res = from_chars(str.data(), str.data() + str.size(), out);
 	return res.ec == std::errc{};
 }
 
@@ -226,14 +234,14 @@ bool StelOBJ::parseVec3(const ParseParams& params, T &out, int paramsStart)
 	const auto& yStr = params[paramsStart+1];
 	const auto& zStr = params[paramsStart+2];
 
-	std::from_chars_result res;
-	res = std::from_chars(xStr.data(), xStr.data() + xStr.size(), out[0]);
+	from_chars_result res;
+	res = from_chars(xStr.data(), xStr.data() + xStr.size(), out[0]);
 	if (res.ec != std::errc{}) goto error;
 
-	res = std::from_chars(yStr.data(), yStr.data() + yStr.size(), out[1]);
+	res = from_chars(yStr.data(), yStr.data() + yStr.size(), out[1]);
 	if (res.ec != std::errc{}) goto error;
 
-	res = std::from_chars(zStr.data(), zStr.data() + zStr.size(), out[2]);
+	res = from_chars(zStr.data(), zStr.data() + zStr.size(), out[2]);
 	if (res.ec != std::errc{}) goto error;
 
 	return true;
@@ -255,11 +263,11 @@ bool StelOBJ::parseVec2(const ParseParams& params,T &out, int paramsStart)
 	const auto& xStr = params[paramsStart+0];
 	const auto& yStr = params[paramsStart+1];
 
-	std::from_chars_result res;
-	res = std::from_chars(xStr.data(), xStr.data() + xStr.size(), out[0]);
+	from_chars_result res;
+	res = from_chars(xStr.data(), xStr.data() + xStr.size(), out[0]);
 	if (res.ec != std::errc{}) goto error;
 
-	res = std::from_chars(yStr.data(), yStr.data() + yStr.size(), out[1]);
+	res = from_chars(yStr.data(), yStr.data() + yStr.size(), out[1]);
 	if (res.ec != std::errc{}) goto error;
 
 	return true;


### PR DESCRIPTION
Fixes #3656.