### PR TITLE
Add /utf-8 for MSVC++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -326,7 +326,7 @@ IF(WIN32)
           # C4351: "new" behaviour, member array default initialization. Required since at least C++98, but funny MSVC throws a warning.
           # C4996: deprecated POSIX names (used in zlib)
 	  # C5105: defines in macros
-          SET(STEL_MSVC_FLAGS "/wd4244 /wd4305 /wd4351 /wd4996 /wd5105")
+          SET(STEL_MSVC_FLAGS "/wd4244 /wd4305 /wd4351 /wd4996 /wd5105 /utf-8")
           # Avoid type conflict with C++17 standard
           # SET(STEL_MSVC_FLAGS "${STEL_MSVC_FLAGS} /D_HAS_STD_BYTE=0") # Don't do this in Qt6. Just avoid "using namespace std" anywhere! https://developercommunity.visualstudio.com/t/error-c2872-byte-ambiguous-symbol/93889
           # Set multiprocessing and minimal version of Windows


### PR DESCRIPTION
This change will let us write e.g. `QChar(u'°')` instead of `QChar(0x00b0)`, which would make the code more self-documenting.

Our code style still doesn't allow this, but this is a secondary thing to adjust (and I think it should be adjusted to allow such literals, because this will increase maintainability and readability). This PR is concerned with the technical side.

MSVC++ 2019 apparently has it enabled by default, but 2017 doesn't. GCC and Clang already use UTF-8 source charset by default, so this patch covers the last bit.