### PR TITLE
Fixed find objects from search history

### DIFF
--- a/src/core/modules/CustomObjectMgr.cpp
+++ b/src/core/modules/CustomObjectMgr.cpp
@@ -148,7 +148,7 @@ float CustomObjectMgr::getSelectPriority() const
 	return CustomObject::selectPriority;
 }
 
-void CustomObjectMgr::addCustomObject(QString designation, Vec3d coordinates, bool isVisible)
+void CustomObjectMgr::addCustomObject(const QString& designation, Vec3d coordinates, bool isVisible)
 {
 	if (!designation.isEmpty())
 	{
@@ -163,7 +163,7 @@ void CustomObjectMgr::addCustomObject(QString designation, Vec3d coordinates, bo
 	}
 }
 
-void CustomObjectMgr::addCustomObject(QString designation, const QString &ra, const QString &dec, bool isVisible)
+void CustomObjectMgr::addCustomObject(const QString& designation, const QString &ra, const QString &dec, bool isVisible)
 {
 	Vec3d j2000;
 	double dRa = StelUtils::getDecAngle(ra);
@@ -173,7 +173,7 @@ void CustomObjectMgr::addCustomObject(QString designation, const QString &ra, co
 	addCustomObject(designation, j2000, isVisible);
 }
 
-void CustomObjectMgr::addCustomObjectRaDec(QString designation, const QString &ra, const QString &dec, bool isVisible)
+void CustomObjectMgr::addCustomObjectRaDec(const QString& designation, const QString &ra, const QString &dec, bool isVisible)
 {
 	Vec3d aim;
 	double dRa = StelUtils::getDecAngle(ra);
@@ -183,7 +183,7 @@ void CustomObjectMgr::addCustomObjectRaDec(QString designation, const QString &r
 	addCustomObject(designation, StelApp::getInstance().getCore()->equinoxEquToJ2000(aim, StelCore::RefractionOff), isVisible);
 }
 
-void CustomObjectMgr::addCustomObjectAltAzi(QString designation, const QString &alt, const QString &azi, bool isVisible)
+void CustomObjectMgr::addCustomObjectAltAzi(const QString& designation, const QString &alt, const QString &azi, bool isVisible)
 {
 	Vec3d aim;
 	double dAlt = StelUtils::getDecAngle(alt);

--- a/src/core/modules/CustomObjectMgr.hpp
+++ b/src/core/modules/CustomObjectMgr.hpp
@@ -180,6 +180,12 @@ private:
 	int countMarkers;
 	int radiusLimit;
 
+	QString persistentCOFile;
+	//! Loading list of saved custom objects (all of them are available in history of Search Tool)
+	void loadPersistentObjects();
+	//! Saving list of found via Search Tool custom objects
+	void savePersistentObjects();
+
 	//! Set the size of active radius around custom object markers.
 	void setActiveRadiusLimit(const int radius);
 

--- a/src/core/modules/CustomObjectMgr.hpp
+++ b/src/core/modules/CustomObjectMgr.hpp
@@ -87,7 +87,7 @@ public slots:
 	//! @param designation - designation of custom object
 	//! @param coordinates - coordinates of custom object
 	//! @param isVisible - flag of visibility of custom object
-	void addCustomObject(QString designation, Vec3d coordinates, bool isVisible=false);
+	void addCustomObject(const QString& designation, Vec3d coordinates, bool isVisible=false);
 	//! Add custom object on the sky
 	//! @param designation - designation of custom object
 	//! @param ra - right ascension angle (J2000.0) of custom object
@@ -97,7 +97,7 @@ public slots:
 	//! // example of usage in scripts
 	//! CustomObjectMgr.addCustomObject("Marker", "2h10m15s", "60d01m15s", true);
 	//! @endcode
-	void addCustomObject(QString designation, const QString& ra, const QString& dec, bool isVisible=false);
+	void addCustomObject(const QString& designation, const QString& ra, const QString& dec, bool isVisible=false);
 	//! Add custom object on the sky
 	//! @param designation - designation of custom object
 	//! @param ra - right ascension angle (on date) of custom object
@@ -107,7 +107,7 @@ public slots:
 	//! // example of usage in scripts
 	//! CustomObjectMgr.addCustomObjectRaDec("Marker", "2h10m15s", "60d01m15s", true);
 	//! @endcode
-	void addCustomObjectRaDec(QString designation, const QString& ra, const QString& dec, bool isVisible=false);
+	void addCustomObjectRaDec(const QString& designation, const QString& ra, const QString& dec, bool isVisible=false);
 	//! Add custom object on the sky
 	//! @param designation - designation of custom object
 	//! @param alt - altitude of custom object
@@ -117,7 +117,7 @@ public slots:
 	//! // example of usage in scripts
 	//! CustomObjectMgr.addCustomObjectAltAzi("Marker", "2d10m15s", "60d01m15s", true);
 	//! @endcode
-	void addCustomObjectAltAzi(QString designation, const QString& alt, const QString& azi, bool isVisible=false);
+	void addCustomObjectAltAzi(const QString& designation, const QString& alt, const QString& azi, bool isVisible=false);
 	//! Remove all custom objects
 	void removeCustomObjects();
 	//! Remove just one custom object by English name

--- a/src/core/modules/CustomObjectMgr.hpp
+++ b/src/core/modules/CustomObjectMgr.hpp
@@ -75,6 +75,14 @@ public:
 	//! @return set the event as accepted if it was intercepted
 	void handleMouseClicks(class QMouseEvent* e) override;
 
+	//! Add persistent object on the sky
+	//! @param designation - designation of custom object
+	//! @param coordinates - coordinates of custom object
+	void addPersistentObject(const QString& designation, Vec3d coordinates);
+
+	//! Remove all persistent objects
+	void removePersistentObjects();
+
 public slots:
 	///////////////////////////////////////////////////////////////////////////
 	// Other public methods
@@ -166,7 +174,7 @@ private:
 	QFont font;
 	QSettings* conf;
 	StelTextureSP texPointer;
-	QList<CustomObjectP> customObjects;
+	QList<CustomObjectP> customObjects, persistentObjects;
 
 	Vec3f hightlightColor;
 	int countMarkers;

--- a/src/gui/SearchDialog.cpp
+++ b/src/gui/SearchDialog.cpp
@@ -615,6 +615,9 @@ void SearchDialog::recentSearchClearDataClicked()
 	// Save empty list to user's data file
 	saveRecentSearches();
 
+	// Remove all SIMBAD's objects and save empty list to user's data file
+	GETSTELMODULE(CustomObjectMgr)->removePersistentObjects();
+
 	// Update search result on "Object" tab
 	onSearchTextChanged(ui->lineEditSearchSkyObject->text());
 }
@@ -1267,7 +1270,7 @@ void SearchDialog::gotoObject(const QString &nameI18n)
 		else
 		{
 			close();
-			GETSTELMODULE(CustomObjectMgr)->addCustomObject(nameI18n, simbadResults[nameI18n]);
+			GETSTELMODULE(CustomObjectMgr)->addPersistentObject(nameI18n, simbadResults[nameI18n]);
 			ui->lineEditSearchSkyObject->clear();
 			searchListModel->clearValues();
 			if (objectMgr->findAndSelect(nameI18n))


### PR DESCRIPTION
### Description
We're using custom objects to visualize locations of objects from SIMBAD (and when these objects are no exists in our database) currently and this feature in Search Tool works good for one session. In next session, these objects will be cannot found via search history - via SIMBAD only. 

This pull request is enhancing the CustomObjectsMgr class via adding code for saving SIMBAD objects into special file and restoring list of saved files in next sessions.

Fixes #3199 (issue)

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?
1. Run Stellarium
2. Open Search Tool and find some objects via SIMBAD
3. Restart Stellarium
4. Open Search Tool and use list of latest founded objects

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
