### PR TITLE
Add export of an equirectangular raster eclipse map

### DIFF
--- a/src/gui/AstroCalcDialog.hpp
+++ b/src/gui/AstroCalcDialog.hpp
@@ -412,7 +412,7 @@ private slots:
 	void selectCurrentSolarEclipseContact(const QModelIndex &modelIndex);
 	void saveSolarEclipses();
 	void saveSolarEclipseCircumstances();
-	void saveSolarEclipseKML();
+	void saveSolarEclipseMap();
 
 	//! Calculating local solar eclipses to fill the list.
 	//! Algorithm taken from calculating the rises, transits and sets.
@@ -741,6 +741,7 @@ private:
 
 	EclipseMapData generateEclipseMap(double JDMid);
 	void generateKML(const EclipseMapData& data, const QString& dateString, QTextStream& stream) const;
+	void generatePNGMap(const EclipseMapData& data, const QString& filePath) const;
 
 	void enableAngularLimits(bool enable);
 

--- a/src/gui/astroCalcDialog.ui
+++ b/src/gui/astroCalcDialog.ui
@@ -2448,12 +2448,12 @@
                  </widget>
                 </item>
                 <item>
-                 <widget class="QPushButton" name="solareclipsesKMLSaveButton">
+                 <widget class="QPushButton" name="solareclipsesMapSaveButton">
                   <property name="toolTip">
-                   <string>Export KML for visibility map of selected eclipse</string>
+                   <string>Export a visibility map of the selected eclipse</string>
                   </property>
                   <property name="text">
-                   <string>Export KML...</string>
+                   <string>Export map...</string>
                   </property>
                  </widget>
                 </item>


### PR DESCRIPTION
### Description
KML is a format that requires special software to view the map it contains. This patch adds a capability to export a PNG equirectangular map instead.

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
