### PR TITLE
Rename sky culture change signal for better consistency

### DIFF
--- a/src/core/StelSkyCultureMgr.cpp
+++ b/src/core/StelSkyCultureMgr.cpp
@@ -108,7 +108,7 @@ void StelSkyCultureMgr::init()
 
 void StelSkyCultureMgr::reloadSkyCulture()
 {
-	emit currentSkyCultureChanged(currentSkyCultureDir);
+	emit currentSkyCultureIDChanged(currentSkyCultureDir);
 }
 
 //! Set the current sky culture from the passed directory
@@ -131,7 +131,7 @@ bool StelSkyCultureMgr::setCurrentSkyCultureID(const QString& cultureDir)
 	currentSkyCultureDir = scID;
 	currentSkyCulture = dirToNameEnglish[scID];
 
-	emit currentSkyCultureChanged(currentSkyCultureDir);
+	emit currentSkyCultureIDChanged(currentSkyCultureDir);
 	return result;
 }
 
@@ -149,7 +149,7 @@ bool StelSkyCultureMgr::setDefaultSkyCultureID(const QString& id)
 	Q_ASSERT(conf);
 	conf->setValue("localization/sky_culture", id);
 
-	emit defaultSkyCultureChanged(id);
+	emit defaultSkyCultureIDChanged(id);
 	return true;
 }
 	

--- a/src/core/StelSkyCultureMgr.hpp
+++ b/src/core/StelSkyCultureMgr.hpp
@@ -114,11 +114,11 @@ class StelSkyCultureMgr : public QObject
 	Q_PROPERTY(QString currentSkyCultureID
 		   READ getCurrentSkyCultureID
 		   WRITE setCurrentSkyCultureID
-		   NOTIFY currentSkyCultureChanged)
+		   NOTIFY currentSkyCultureIDChanged)
 	Q_PROPERTY(QString defaultSkyCultureID
 		   READ getDefaultSkyCultureID
 		   WRITE setDefaultSkyCultureID
-		   NOTIFY defaultSkyCultureChanged)
+		   NOTIFY defaultSkyCultureIDChanged)
 
 public:
 	StelSkyCultureMgr();
@@ -203,10 +203,10 @@ public slots:
 signals:
 	//! Emitted whenever the default sky culture changed.
 	//! @see setDefaultSkyCultureID
-	void defaultSkyCultureChanged(const QString& id);
+	void defaultSkyCultureIDChanged(const QString& id);
 
 	//! Emitted when the current sky culture changes
-	void currentSkyCultureChanged(const QString& id);
+	void currentSkyCultureIDChanged(const QString& id);
 	
 private:
 	//! Get the culture name in English associated with a specified directory.

--- a/src/core/modules/AsterismMgr.cpp
+++ b/src/core/modules/AsterismMgr.cpp
@@ -90,7 +90,7 @@ void AsterismMgr::init()
 			this, SLOT(selectedObjectChange(StelModule::StelModuleSelectAction)));
 	StelApp *app = &StelApp::getInstance();
 	connect(app, SIGNAL(languageChanged()), this, SLOT(updateI18n()));
-	connect(&app->getSkyCultureMgr(), SIGNAL(currentSkyCultureChanged(QString)), this, SLOT(updateSkyCulture(const QString&)));
+	connect(&app->getSkyCultureMgr(), &StelSkyCultureMgr::currentSkyCultureIDChanged, this, &AsterismMgr::updateSkyCulture);
 
 	QString displayGroup = N_("Display Options");
 	addAction("actionShow_Asterism_Lines", displayGroup, N_("Asterism lines"), "linesDisplayed", "Alt+A");	

--- a/src/core/modules/ConstellationMgr.cpp
+++ b/src/core/modules/ConstellationMgr.cpp
@@ -126,7 +126,7 @@ void ConstellationMgr::init()
 			this, SLOT(selectedObjectChange(StelModule::StelModuleSelectAction)));
 	StelApp *app = &StelApp::getInstance();
 	connect(app, SIGNAL(languageChanged()), this, SLOT(updateI18n()));
-	connect(&app->getSkyCultureMgr(), SIGNAL(currentSkyCultureChanged(QString)), this, SLOT(updateSkyCulture(const QString&)));
+	connect(&app->getSkyCultureMgr(), &StelSkyCultureMgr::currentSkyCultureIDChanged, this, &ConstellationMgr::updateSkyCulture);
 
 	QString displayGroup = N_("Display Options");
 	addAction("actionShow_Constellation_Lines", displayGroup, N_("Constellation lines"), "linesDisplayed", "C");

--- a/src/core/modules/NebulaMgr.cpp
+++ b/src/core/modules/NebulaMgr.cpp
@@ -352,7 +352,7 @@ void NebulaMgr::init()
 
 	StelApp *app = &StelApp::getInstance();
 	connect(app, SIGNAL(languageChanged()), this, SLOT(updateI18n()));
-	connect(&app->getSkyCultureMgr(), SIGNAL(currentSkyCultureChanged(QString)), this, SLOT(updateSkyCulture(const QString&)));
+	connect(&app->getSkyCultureMgr(), &StelSkyCultureMgr::currentSkyCultureIDChanged, this, &NebulaMgr::updateSkyCulture);
 	GETSTELMODULE(StelObjectMgr)->registerStelObjectMgr(this);
 
 	addAction("actionShow_Nebulas", N_("Display Options"), N_("Deep-sky objects"), "flagHintDisplayed", "D", "N");

--- a/src/core/modules/SolarSystem.cpp
+++ b/src/core/modules/SolarSystem.cpp
@@ -298,7 +298,7 @@ void SolarSystem::init()
 	
 	StelApp *app = &StelApp::getInstance();
 	connect(app, SIGNAL(languageChanged()), this, SLOT(updateI18n()));
-	connect(&app->getSkyCultureMgr(), SIGNAL(currentSkyCultureChanged(QString)), this, SLOT(updateSkyCulture(QString)));
+	connect(&app->getSkyCultureMgr(), &StelSkyCultureMgr::currentSkyCultureIDChanged, this, &SolarSystem::updateSkyCulture);
 	connect(&StelMainView::getInstance(), SIGNAL(reloadShadersRequested()), this, SLOT(reloadShaders()));
 	StelCore *core = app->getCore();
 	connect(core, SIGNAL(locationChanged(StelLocation)), this, SLOT(recreateTrails()));

--- a/src/core/modules/StarMgr.cpp
+++ b/src/core/modules/StarMgr.cpp
@@ -456,7 +456,7 @@ void StarMgr::init()
 		z->scaleAxis();
 	StelApp *app = &StelApp::getInstance();
 	connect(app, SIGNAL(languageChanged()), this, SLOT(updateI18n()));
-	connect(&app->getSkyCultureMgr(), SIGNAL(currentSkyCultureChanged(QString)), this, SLOT(updateSkyCulture(const QString&)));
+	connect(&app->getSkyCultureMgr(), &StelSkyCultureMgr::currentSkyCultureIDChanged, this, &StarMgr::updateSkyCulture);
 
 	QString displayGroup = N_("Display Options");
 	addAction("actionShow_Stars", displayGroup, N_("Stars"), "flagStarsDisplayed", "S");

--- a/src/gui/AstroCalcDialog.cpp
+++ b/src/gui/AstroCalcDialog.cpp
@@ -358,7 +358,7 @@ void AstroCalcDialog::createDialogContent()
 
 	// Signals and slots
 	connect(&StelApp::getInstance(), SIGNAL(languageChanged()), this, SLOT(retranslate()));
-	connect(&StelApp::getInstance().getSkyCultureMgr(), SIGNAL(currentSkyCultureChanged(QString)), this, SLOT(populateCelestialNames(QString)));
+	connect(&StelApp::getInstance().getSkyCultureMgr(), &StelSkyCultureMgr::currentSkyCultureIDChanged, this, &AstroCalcDialog::populateCelestialNames);
 	ui->stackedWidget->setCurrentIndex(0);
 	ui->stackListWidget->setCurrentRow(0);
 	connect(ui->titleBar, &TitleBar::closeClicked, this, &StelDialog::close);

--- a/src/gui/LocationDialog.cpp
+++ b/src/gui/LocationDialog.cpp
@@ -90,7 +90,7 @@ void LocationDialog::createDialogContent()
 	StelApp *app = &StelApp::getInstance();
 	connect(app, SIGNAL(languageChanged()), this, SLOT(retranslate()));
 	connect(app, SIGNAL(flagShowDecimalDegreesChanged(bool)), this, SLOT(setDisplayFormatForSpins(bool)));
-	connect(&app->getSkyCultureMgr(), SIGNAL(currentSkyCultureChanged(QString)), this, SLOT(populatePlanetList(QString)));
+	connect(&app->getSkyCultureMgr(), &StelSkyCultureMgr::currentSkyCultureIDChanged, this, &LocationDialog::populatePlanetList);
 	// Init the SpinBox entries
 	ui->longitudeSpinBox->setPrefixType(AngleSpinBox::Longitude);
 	ui->longitudeSpinBox->setMinimum(-180.0, true);

--- a/src/gui/LocationDialog.hpp
+++ b/src/gui/LocationDialog.hpp
@@ -139,9 +139,6 @@ private slots:
 	//! @arg state false to store current location as startup location.
 	void ipQueryLocation(bool state);
 
-	// Esp. for signals from StelSkyCultureMgr
-	void populatePlanetList(QString) { populatePlanetList(); }
-
 	void setDisplayFormatForSpins(bool flagDecimalDegrees);
 
 #ifdef ENABLE_GPS

--- a/src/gui/ViewDialog.cpp
+++ b/src/gui/ViewDialog.cpp
@@ -165,7 +165,7 @@ void ViewDialog::createDialogContent()
 	// TODOs after properties merge:
 	// Jupiter's GRS should become property, and recheck the other "from trunk" entries.
 	connect(ui->culturesListWidget, SIGNAL(currentTextChanged(const QString&)),&StelApp::getInstance().getSkyCultureMgr(),SLOT(setCurrentSkyCultureNameI18(QString)));
-	connect(&StelApp::getInstance().getSkyCultureMgr(), SIGNAL(currentSkyCultureChanged(QString)), this, SLOT(skyCultureChanged()));
+	connect(&StelApp::getInstance().getSkyCultureMgr(), SIGNAL(currentSkyCultureIDChanged(QString)), this, SLOT(skyCultureChanged()));
 
 	// Connect and initialize checkboxes and other widgets
 	SolarSystem* ssmgr = GETSTELMODULE(SolarSystem);
@@ -514,7 +514,8 @@ void ViewDialog::createDialogContent()
 
 	// Sky Culture
 	connect(ui->useAsDefaultSkyCultureCheckBox, SIGNAL(clicked()), this, SLOT(setCurrentCultureAsDefault()));
-	connect(&StelApp::getInstance().getSkyCultureMgr(), SIGNAL(defaultSkyCultureChanged(QString)),this,SLOT(updateDefaultSkyCulture()));
+	connect(&StelApp::getInstance().getSkyCultureMgr(), &StelSkyCultureMgr::defaultSkyCultureIDChanged,
+	        this, &ViewDialog::updateDefaultSkyCulture);
 	updateDefaultSkyCulture();
 
 	// allow to display short names and inhibit translation.


### PR DESCRIPTION
This change makes the names of all the `Q_PROPERTY` manipulation methods consistent (include the "ID" part), and this will also let me later add another signal that will pass `StelSkyCulture` structure instead of the string.

I'm not sure if this signal is used in any non-obvious ways like e.g. in scripting API, so please review this.