### PR TITLE
Use single lines between table cells

### DIFF
--- a/data/gui/normalHtml.css
+++ b/data/gui/normalHtml.css
@@ -8,6 +8,7 @@ table.nomenclature {
         border-color: black;
         border-style: solid;
         border-width: 1px;
+        border-collapse: collapse;
 }
 
 table.nomenclature tr td, table.nomenclature tr th {


### PR DESCRIPTION
This looks cleaner IMO. See the screenshots:

### Original

![Screenshot_2024-05-08_15-29-39](https://github.com/Stellarium/stellarium/assets/6376882/84efacac-8f5c-4832-a96a-662f6f58b102)

### After this patch

![Screenshot_2024-05-08_15-28-39](https://github.com/Stellarium/stellarium/assets/6376882/0d1d25ea-5ff2-4973-834c-cba079e16b56)
