### PR TITLE
Add name of NGC 5139 from discoverer Edmond Halley

### DIFF
--- a/nebulae/default/names.dat
+++ b/nebulae/default/names.dat
@@ -133,6 +133,7 @@
 #      - Huygens region, Gentil… (region names of Great Orion Nebula); http://www.astrosurf.com/patricio/DS/M42-topografia.htm
 #      - The Kite Cluster (NGC 1664); https://observing.skyhound.com/archives/dec/NGC_1664.html
 #      - NGC 3310 - Bow and Arrow Galaxy; http://astroa.physics.metu.edu.tr/~umk/ccd_wshop_adelman/Astronom/GALAXY/NGC3310.HTM
+#      - NGC 5139 - dorso Equino Nebula; (1714). An Account of Several Nebulae or Lucid Spots Like Clouds, Lately Discovered among the Fixt Stars by Help of the Telescope. Philosophical Transactions of the Royal Society of London, 29(338-350), 390–392. doi:10.1098/rstl.1714.0046
 #      - NGC 6559 - Chinese Dragon Nebula; https://noirlab.edu/public/images/gemini0509b/ https://skyandtelescope.org/astronomy-news/astro-image-in-the-newsdragon-in-the-sky/
 #      - Ced 19D - Electra Nebula; http://www.irida-observatory.org/CCD/VdB20_23/VdB20_23.html
 #      - IC 423 - Teardrop Nebula; Sky and Telescope February 2017 (2017S&T...133b..75A)
@@ -664,6 +665,7 @@ NGC  5128            _("Centaurus A") # NED, TSS, BCH, SG, WSO, WSG, PSA, DN, PA
 NGC  5128            _("The Hamburger Galaxy") # SG
 NGC  5139            _("ω Cen Cluster") # WK, OGSC, TSS, BCH, DWH, SG, PSA, DN, PAS, PGH, TLO, RNGCIC
 NGC  5139            _("Omega Centauri") # U2K
+NGC  5139            _("dorso Equino Nebula") # MISC
 NGC  5152            _("Fly's Wing Galaxy") # SGN
 NGC  5153            _("Fly's Wing Galaxy") # SGN
 NGC  5189            _("Spiral Planetary Nebula") # TSS, SG, TLO

--- a/nebulae/default/names.dat
+++ b/nebulae/default/names.dat
@@ -133,7 +133,7 @@
 #      - Huygens region, Gentil… (region names of Great Orion Nebula); http://www.astrosurf.com/patricio/DS/M42-topografia.htm
 #      - The Kite Cluster (NGC 1664); https://observing.skyhound.com/archives/dec/NGC_1664.html
 #      - NGC 3310 - Bow and Arrow Galaxy; http://astroa.physics.metu.edu.tr/~umk/ccd_wshop_adelman/Astronom/GALAXY/NGC3310.HTM
-#      - NGC 5139 - dorso Equino Nebula; (1714). An Account of Several Nebulae or Lucid Spots Like Clouds, Lately Discovered among the Fixt Stars by Help of the Telescope. Philosophical Transactions of the Royal Society of London, 29(338-350), 390–392. doi:10.1098/rstl.1714.0046
+#      - NGC 5139 - in dorso Equino Nebula; (1714). An Account of Several Nebulae or Lucid Spots Like Clouds, Lately Discovered among the Fixt Stars by Help of the Telescope. Philosophical Transactions of the Royal Society of London, 29(338-350), 390–392. doi:10.1098/rstl.1714.0046
 #      - NGC 6559 - Chinese Dragon Nebula; https://noirlab.edu/public/images/gemini0509b/ https://skyandtelescope.org/astronomy-news/astro-image-in-the-newsdragon-in-the-sky/
 #      - Ced 19D - Electra Nebula; http://www.irida-observatory.org/CCD/VdB20_23/VdB20_23.html
 #      - IC 423 - Teardrop Nebula; Sky and Telescope February 2017 (2017S&T...133b..75A)
@@ -665,7 +665,7 @@ NGC  5128            _("Centaurus A") # NED, TSS, BCH, SG, WSO, WSG, PSA, DN, PA
 NGC  5128            _("The Hamburger Galaxy") # SG
 NGC  5139            _("ω Cen Cluster") # WK, OGSC, TSS, BCH, DWH, SG, PSA, DN, PAS, PGH, TLO, RNGCIC
 NGC  5139            _("Omega Centauri") # U2K
-NGC  5139            _("dorso Equino Nebula") # MISC
+NGC  5139            _("in dorso Equino Nebula") # MISC
 NGC  5152            _("Fly's Wing Galaxy") # SGN
 NGC  5153            _("Fly's Wing Galaxy") # SGN
 NGC  5189            _("Spiral Planetary Nebula") # TSS, SG, TLO


### PR DESCRIPTION
Well, still some to be confirmed. So Edmond Halley named ω Centauri as dorso Equino Nebula, right?

The latin spell seems to be "dorso equino nebula" rather than "dorfo equino nebula", and it means Horseback Nebula?

"in dorso equino nebula" or "dorso equino nebula"?

Ptolemy calls ὁ ἐπὶ τῆς ῥάχεως ἐφώσκομενος (“the one shining on the back”), perhaps he discovered its non-stellar nature.

![image](https://github.com/Stellarium/stellarium/assets/36977717/cb68e83a-8c03-450d-bcee-a6bb9d7a343e)

![image](https://github.com/Stellarium/stellarium/assets/36977717/209a0137-7ac3-4594-8283-6d3b85d90316)
