### PR TITLE
Allow disabling StelAudioMgr at runtime

### DIFF
--- a/guide/app_config_ini.tex
+++ b/guide/app_config_ini.tex
@@ -160,6 +160,18 @@ graphs\_first\_id              & int    & 1     & Identificator for left graph (
 graphs\_second\_id             & int    & 2     & Identificator for right graph (yellow line).\\\bottomrule
 \end{longtable}
 
+\subsection{\big[audio\big]}
+%\label{sec:config.ini:audio}
+
+This section includes settings for Audio features.
+
+\noindent%
+\begin{longtable}{l|l|l|p{65mm}}
+\toprule
+\emph{ID}         & \emph{Type} & \emph{Default} & \emph{Description}\\\midrule
+enabled           & bool        & true           & Enable sound output\\\bottomrule
+\end{longtable}
+
 \subsection{\big[color\big]}
 %\label{sec:config.ini:color}
 

--- a/guide/ch_advanced_use.tex
+++ b/guide/ch_advanced_use.tex
@@ -545,7 +545,8 @@ the file will be written to \file{\textless{}user\ directory\textgreater{}/my\_l
 -\/-mesa-mode or -m  & {[}none{]} & Use MESA as software OpenGL rendering engine.\footref{FN:WinOnly}\\
 -\/-single-buffer    & {[}none{]} & Use single-buffering. This reportedly avoids screen blanking problems with some Intel GPUs. \\
 -\/-opengl-compat or -C & {[}none{]} & Request OpenGL 3.3 Compatibility Profile. Might fix graphics problems in some driver configurations.\\
--\/-low-graphics or -L & {[}none{]} & Force low-graphics mode. May be useful on old GPUs that do support OpenGL 3.3 but perform too slowly.\\
+-\/-low-graphics or -L & {[}none{]} & Force low-graphics mode. May be useful on old GPUs that do support OpenGL 3.3 but perform too slowly.\\\midrule
+-\/-no-audio          & {[}none{]} & Disable sound output (avoids initialisation problems on Virtual Machines or special builds).\\
 \bottomrule
 \end{longtable}
 

--- a/src/CLIProcessor.cpp
+++ b/src/CLIProcessor.cpp
@@ -191,6 +191,8 @@ void CLIProcessor::parseCLIArgsPostConfig(const QStringList& argList, QSettings*
 	{
 		bool dumpOpenGLDetails = argsGetOption(argList, "-d", "--dump-opengl-details");
 		qApp->setProperty("dump_OpenGL_details", dumpOpenGLDetails);
+		bool no_audio = argsGetOption(argList, "", "--no-audio");
+		qApp->setProperty("onetime_no-audio", no_audio);
 		fullScreen = argsGetYesNoOption(argList, "-f", "--full-screen", -1);
 		landscapeId = argsGetOptionWithArg(argList, "", "--landscape", "").toString();
 		homePlanet = argsGetOptionWithArg(argList, "", "--home-planet", "").toString();

--- a/src/core/StelApp.cpp
+++ b/src/core/StelApp.cpp
@@ -563,7 +563,8 @@ void StelApp::init(QSettings* conf)
 
 	// Init audio manager
 	SplashScreen::showMessage(q_("Initializing audio..."));
-	audioMgr = new StelAudioMgr();
+	const bool audioOK = !(qApp->property("onetime_no-audio").toBool());
+	audioMgr = new StelAudioMgr(audioOK && confSettings->value("audio/enabled", true).toBool());
 
 	// Init video manager
 	SplashScreen::showMessage(q_("Initializing video..."));

--- a/src/core/StelApp.cpp
+++ b/src/core/StelApp.cpp
@@ -561,14 +561,22 @@ void StelApp::init(QSettings* conf)
 	toasts->init();
 	getModuleMgr().registerModule(toasts);
 
-	// Init audio manager
-	SplashScreen::showMessage(q_("Initializing audio..."));
+	// Init audio manager. When media support is disabled,
+	// we silently create dummy managers.
+#ifdef ENABLE_MEDIA
 	const bool audioOK = !(qApp->property("onetime_no-audio").toBool())
 			&& confSettings->value("audio/enabled", true).toBool();
+#else
+	const bool audioOK = false;
+#endif
+	if (audioOK)
+		SplashScreen::showMessage(q_("Initializing audio..."));
 	audioMgr = new StelAudioMgr(audioOK);
 
 	// Init video manager
+#ifdef ENABLE_MEDIA
 	SplashScreen::showMessage(q_("Initializing video..."));
+#endif
 	videoMgr = new StelVideoMgr(audioOK);
 	videoMgr->init();
 	getModuleMgr().registerModule(videoMgr);

--- a/src/core/StelApp.cpp
+++ b/src/core/StelApp.cpp
@@ -563,12 +563,13 @@ void StelApp::init(QSettings* conf)
 
 	// Init audio manager
 	SplashScreen::showMessage(q_("Initializing audio..."));
-	const bool audioOK = !(qApp->property("onetime_no-audio").toBool());
-	audioMgr = new StelAudioMgr(audioOK && confSettings->value("audio/enabled", true).toBool());
+	const bool audioOK = !(qApp->property("onetime_no-audio").toBool())
+			&& confSettings->value("audio/enabled", true).toBool();
+	audioMgr = new StelAudioMgr(audioOK);
 
 	// Init video manager
 	SplashScreen::showMessage(q_("Initializing video..."));
-	videoMgr = new StelVideoMgr();
+	videoMgr = new StelVideoMgr(audioOK);
 	videoMgr->init();
 	getModuleMgr().registerModule(videoMgr);
 

--- a/src/core/StelAudioMgr.cpp
+++ b/src/core/StelAudioMgr.cpp
@@ -191,7 +191,7 @@ void StelAudioMgr::loadSound(const QString& filename, const QString& id)
 {
 	qWarning() << "This build of Stellarium does not support sound - cannot load audio" << QDir::toNativeSeparators(filename) << id;
 }
-StelAudioMgr::StelAudioMgr() {}
+StelAudioMgr::StelAudioMgr(bool){}
 StelAudioMgr::~StelAudioMgr() {;}
 void StelAudioMgr::playSound(const QString&) {;}
 void StelAudioMgr::pauseSound(const QString&) {;}

--- a/src/core/StelAudioMgr.cpp
+++ b/src/core/StelAudioMgr.cpp
@@ -24,9 +24,8 @@
 
 #include <QMediaPlayer>
 
-StelAudioMgr::StelAudioMgr(bool enable)
+StelAudioMgr::StelAudioMgr(bool enable): enabled(enable)
 {
-	enabled = enable;
 #if (QT_VERSION>=QT_VERSION_CHECK(6,0,0))
 	audioOutput=(enabled ? new QAudioOutput() : nullptr);
 #endif

--- a/src/core/StelAudioMgr.cpp
+++ b/src/core/StelAudioMgr.cpp
@@ -24,10 +24,11 @@
 
 #include <QMediaPlayer>
 
-StelAudioMgr::StelAudioMgr()
+StelAudioMgr::StelAudioMgr(bool enable)
 {
+	enabled = enable;
 #if (QT_VERSION>=QT_VERSION_CHECK(6,0,0))
-	audioOutput=new QAudioOutput();
+	audioOutput=(enabled ? new QAudioOutput() : nullptr);
 #endif
 }
 
@@ -37,7 +38,7 @@ StelAudioMgr::~StelAudioMgr()
 	while (it.hasNext())
 	{
 		it.next();
-		if (it.value()!=Q_NULLPTR)
+		if (it.value()!=nullptr)
 		{
 			it.value()->stop();
 			it.remove();
@@ -45,12 +46,18 @@ StelAudioMgr::~StelAudioMgr()
 	}
 #if (QT_VERSION>=QT_VERSION_CHECK(6,0,0))
 	delete audioOutput;
-	audioOutput=Q_NULLPTR;
+	audioOutput=nullptr;
 #endif
 }
 
 void StelAudioMgr::loadSound(const QString& filename, const QString& id)
 {
+	if (!enabled)
+	{
+		qWarning() << "Not loading sound -- audio system disabled by configuration.";
+		return;
+	}
+
 	if (audioObjects.contains(id))
 	{
 		qWarning() << "Audio object with ID" << id << "already exists, dropping it";
@@ -69,9 +76,12 @@ void StelAudioMgr::loadSound(const QString& filename, const QString& id)
 
 void StelAudioMgr::playSound(const QString& id)
 {
+	if (!enabled)
+		return;
+
 	if (audioObjects.contains(id))
 	{
-		if (audioObjects[id]!=Q_NULLPTR)
+		if (audioObjects[id]!=nullptr)
 		{
 			// if already playing, stop and play from the start
 			#if (QT_VERSION>=QT_VERSION_CHECK(6,0,0))
@@ -94,9 +104,12 @@ void StelAudioMgr::playSound(const QString& id)
 
 void StelAudioMgr::pauseSound(const QString& id)
 {
+	if (!enabled)
+		return;
+
 	if (audioObjects.contains(id))
 	{
-		if (audioObjects[id]!=Q_NULLPTR)
+		if (audioObjects[id]!=nullptr)
 			audioObjects[id]->pause();
 		else
 			qDebug() << "StelAudioMgr: Cannot pause sound, " << id << "not correctly loaded.";
@@ -107,9 +120,12 @@ void StelAudioMgr::pauseSound(const QString& id)
 
 void StelAudioMgr::stopSound(const QString& id)
 {
+	if (!enabled)
+		return;
+
 	if (audioObjects.contains(id))
 	{
-		if (audioObjects[id]!=Q_NULLPTR)
+		if (audioObjects[id]!=nullptr)
 			audioObjects[id]->stop();
 		else
 			qDebug() << "StelAudioMgr: Cannot stop sound, " << id << "not correctly loaded.";
@@ -120,12 +136,15 @@ void StelAudioMgr::stopSound(const QString& id)
 
 void StelAudioMgr::dropSound(const QString& id)
 {
+	if (!enabled)
+		return;
+
 	if (!audioObjects.contains(id))
 	{
 		qDebug() << "StelAudioMgr: Cannot drop sound, " << id << "not loaded.";
 		return;
 	}
-	if (audioObjects[id]!=Q_NULLPTR)
+	if (audioObjects[id]!=nullptr)
 	{
 		audioObjects[id]->stop();
 		delete audioObjects[id];
@@ -136,12 +155,15 @@ void StelAudioMgr::dropSound(const QString& id)
 
 qint64 StelAudioMgr::position(const QString& id)
 {
+	if (!enabled)
+		return -1;
+
 	if (!audioObjects.contains(id))
 	{
 		qDebug() << "StelAudioMgr: Cannot report position for sound, " << id << "not loaded.";
 		return(-1);
 	}
-	if (audioObjects[id]!=Q_NULLPTR)
+	if (audioObjects[id]!=nullptr)
 	{
 		return audioObjects[id]->position();
 	}
@@ -150,12 +172,15 @@ qint64 StelAudioMgr::position(const QString& id)
 
 qint64 StelAudioMgr::duration(const QString& id)
 {
+	if (!enabled)
+		return -1;
+
 	if (!audioObjects.contains(id))
 	{
 		qDebug() << "StelAudioMgr: Cannot report duration for sound, " << id << "not loaded.";
 		return(-1);
 	}
-	if (audioObjects[id]!=Q_NULLPTR)
+	if (audioObjects[id]!=nullptr)
 	{
 		return audioObjects[id]->duration();
 	}

--- a/src/core/StelAudioMgr.hpp
+++ b/src/core/StelAudioMgr.hpp
@@ -33,7 +33,7 @@ class StelAudioMgr : public QObject
 	Q_OBJECT
 
 public:
-	StelAudioMgr();
+	StelAudioMgr(bool enable);
 	~StelAudioMgr() override;
 
 public slots:
@@ -56,6 +56,7 @@ public slots:
 	qint64 duration(const QString& id);
 
 private:
+	bool enabled; // global switch configured by constructor
 	QMap<QString, QMediaPlayer*> audioObjects;
 #if (QT_VERSION>=QT_VERSION_CHECK(6,0,0)) && defined(ENABLE_MEDIA)
 	QAudioOutput *audioOutput;

--- a/src/core/StelVideoMgr.cpp
+++ b/src/core/StelVideoMgr.cpp
@@ -104,6 +104,8 @@ void StelVideoMgr::loadVideo(const QString& filename, const QString& id, const f
 #else
 	videoObjects[id]->player = new QMediaPlayer(nullptr, QMediaPlayer::VideoSurface);
 	videoObjects[id]->player->setAudioRole(audioEnabled ? QAudio::VideoRole : QAudio::UnknownRole);
+	if (!audioEnabled)
+		videoObjects[id]->player->setMuted(true);
 	videoObjects[id]->resolution=QSize(); // initialize with "invalid" empty resolution, we must detect this when player is starting!
 	videoObjects[id]->targetFrameSize=QSizeF(); // start with invalid, depends on parameters given in playVideo(), playPopoutVideo() and resolution detected only after playing started.
 #endif

--- a/src/core/StelVideoMgr.cpp
+++ b/src/core/StelVideoMgr.cpp
@@ -36,19 +36,21 @@
 #endif
 
 
-StelVideoMgr::StelVideoMgr() : StelModule()
+StelVideoMgr::StelVideoMgr(bool withAudio) : StelModule()
 {
 	setObjectName("StelVideoMgr");
+	audioEnabled = withAudio;
 #ifdef ENABLE_MEDIA
 	// in case the property has not been set, getProperty() returns invalid.
 	verbose= (qApp->property("verbose") == true);
 	#if (QT_VERSION>=QT_VERSION_CHECK(6,0,0))
-	QMediaFormat fmt=QMediaFormat();
 	if (verbose)
 	{
+		QMediaFormat fmt=QMediaFormat();
 		qDebug() << "StelVideoMgr: Supported file formats: " << fmt.supportedFileFormats(QMediaFormat::Decode);
 		qDebug() << "StelVideoMgr: Supported video codecs: " << fmt.supportedVideoCodecs(QMediaFormat::Decode);
-		qDebug() << "StelVideoMgr: Supported audio codecs: " << fmt.supportedAudioCodecs(QMediaFormat::Decode);
+		if (audioEnabled)
+			qDebug() << "StelVideoMgr: Supported audio codecs: " << fmt.supportedAudioCodecs(QMediaFormat::Decode);
 	}
 	#endif
 #endif
@@ -61,7 +63,7 @@ StelVideoMgr::~StelVideoMgr()
 	while (it.hasNext())
 	{
 		it.next();
-		if (it.value()!=Q_NULLPTR)
+		if (it.value()!=nullptr)
 		{
 			it.value()->player->stop();
 			StelMainView::getInstance().scene()->removeItem(it.value()->videoItem);
@@ -89,14 +91,20 @@ void StelVideoMgr::loadVideo(const QString& filename, const QString& id, const f
 	videoObjects[id]->videoItem->setSize(QSizeF(1,1));
 
 #if (QT_VERSION>=QT_VERSION_CHECK(6,0,0))
-	videoObjects[id]->player = new QMediaPlayer(Q_NULLPTR);
-	videoObjects[id]->audioOutput = new QAudioOutput();
-	videoObjects[id]->player->setAudioOutput(videoObjects[id]->audioOutput);
+	videoObjects[id]->player = new QMediaPlayer(nullptr);
+	if (audioEnabled)
+	{
+		videoObjects[id]->audioOutput = new QAudioOutput();
+		videoObjects[id]->player->setAudioOutput(videoObjects[id]->audioOutput);
+	}
+	else
+		videoObjects[id]->audioOutput = nullptr;
+
 	videoObjects[id]->resolution=QSize(200,200); // We must initialize with "valid" resolution, maybe resize when player is starting!
 	videoObjects[id]->targetFrameSize=QSizeF(100, 200); // depends on parameters given in playVideo(), playPopoutVideo() and resolution detected only after playing started.
 #else
-	videoObjects[id]->player = new QMediaPlayer(Q_NULLPTR, QMediaPlayer::VideoSurface);
-	videoObjects[id]->player->setAudioRole(QAudio::VideoRole);
+	videoObjects[id]->player = new QMediaPlayer(nullptr, QMediaPlayer::VideoSurface);
+	videoObjects[id]->player->setAudioRole(audioEnabled ? QAudio::VideoRole : QAudio::UnknownRole);
 	videoObjects[id]->resolution=QSize(); // initialize with "invalid" empty resolution, we must detect this when player is starting!
 	videoObjects[id]->targetFrameSize=QSizeF(); // start with invalid, depends on parameters given in playVideo(), playPopoutVideo() and resolution detected only after playing started.
 #endif
@@ -213,7 +221,7 @@ void StelVideoMgr::playVideo(const QString& id, const bool keepVisibleAtEnd)
 	if (videoObjects.contains(id))
 	{
 		videoObjects[id]->keepVisible=keepVisibleAtEnd;
-		if (videoObjects[id]->player!=Q_NULLPTR)
+		if (videoObjects[id]->player!=nullptr)
 		{
 			// if already playing, stop and play from the start
 #if (QT_VERSION>=QT_VERSION_CHECK(6,0,0))
@@ -273,7 +281,7 @@ void StelVideoMgr::playVideoPopout(const QString& id, float fromX, float fromY, 
 	if (videoObjects.contains(id))
 	{
 		videoObjects[id]->keepVisible=frozenInTransition;
-		if (videoObjects[id]->player!=Q_NULLPTR)
+		if (videoObjects[id]->player!=nullptr)
 		{
 			// if already playing, stop and play from the start
 #if (QT_VERSION>=QT_VERSION_CHECK(6,0,0))
@@ -376,7 +384,7 @@ void StelVideoMgr::pauseVideo(const QString& id)
 {
 	if (videoObjects.contains(id))
 	{
-		if (videoObjects[id]->player!=Q_NULLPTR)
+		if (videoObjects[id]->player!=nullptr)
 		{
 			// Maybe we can only pause while already playing?
 #if (QT_VERSION>=QT_VERSION_CHECK(6,0,0))
@@ -398,7 +406,7 @@ void StelVideoMgr::stopVideo(const QString& id)
 {
 	if (videoObjects.contains(id))
 	{
-		if (videoObjects[id]->player!=Q_NULLPTR)
+		if (videoObjects[id]->player!=nullptr)
 		{
 			videoObjects[id]->player->stop();
 		}
@@ -412,7 +420,7 @@ void StelVideoMgr::seekVideo(const QString& id, const qint64 ms, bool pause)
 		qDebug() << "StelVideoMgr::seekVideo: " << id << " to:" << ms <<  (pause ? " (pausing)" : " (playing)");
 	if (videoObjects.contains(id))
 	{
-		if (videoObjects[id]->player!=Q_NULLPTR)
+		if (videoObjects[id]->player!=nullptr)
 		{
 			if (videoObjects[id]->player->isSeekable())
 			{
@@ -436,7 +444,7 @@ void StelVideoMgr::dropVideo(const QString& id)
 {
 	if (!videoObjects.contains(id))
 		return;
-	if (videoObjects[id]->player!=Q_NULLPTR)
+	if (videoObjects[id]->player!=nullptr)
 	{
 		if (verbose)
 			qDebug() << "About to drop (unload) video " << id << "(" << videoObjects[id]->player->mediaStatus() << ")";
@@ -462,7 +470,7 @@ void StelVideoMgr::setVideoXY(const QString& id, const float x, const float y, c
 {
 	if (videoObjects.contains(id))
 	{
-		if (videoObjects[id]->videoItem!=Q_NULLPTR)
+		if (videoObjects[id]->videoItem!=nullptr)
 		{
 			// if w or h < 1 we scale proportional to mainview!
 			int viewportWidth=StelMainView::getInstance().size().width();
@@ -491,7 +499,7 @@ void StelVideoMgr::setVideoAlpha(const QString& id, const float alpha)
 {
 	if (videoObjects.contains(id))
 	{
-		if (videoObjects[id]->videoItem!=Q_NULLPTR)
+		if (videoObjects[id]->videoItem!=nullptr)
 		{
 			videoObjects[id]->videoItem->setOpacity(alpha);
 		}
@@ -503,7 +511,7 @@ void StelVideoMgr::resizeVideo(const QString& id, float w, float h)
 {
 	if (videoObjects.contains(id))
 	{
-		if (videoObjects[id]->videoItem!=Q_NULLPTR)
+		if (videoObjects[id]->videoItem!=nullptr)
 		{
 			// if w or h <= 1 we scale proportional to mainview!
 			// Note that w or h thus cannot be set to 1.0, i.e. single-pixel rows/columns!
@@ -561,7 +569,7 @@ void StelVideoMgr::showVideo(const QString& id, const bool show)
 {
 	if (videoObjects.contains(id))
 	{
-		if (videoObjects[id]->videoItem!=Q_NULLPTR)
+		if (videoObjects[id]->videoItem!=nullptr)
 		{
 			videoObjects[id]->videoItem->setVisible(show);
 		}
@@ -629,9 +637,11 @@ int StelVideoMgr::getVideoHeight(const QString& id) const
 
 void StelVideoMgr::muteVideo(const QString& id, bool mute)
 {
+	if (!audioEnabled)
+		return;
 	if (videoObjects.contains(id))
 	{
-		if (videoObjects[id]->player!=Q_NULLPTR)
+		if (videoObjects[id]->player!=nullptr)
 		{
 #if (QT_VERSION>=QT_VERSION_CHECK(6,0,0))
 			videoObjects[id]->player->audioOutput()->setMuted(mute);
@@ -645,9 +655,11 @@ void StelVideoMgr::muteVideo(const QString& id, bool mute)
 
 void StelVideoMgr::setVideoVolume(const QString& id, int newVolume)
 {
+	if (!audioEnabled)
+		return;
 	if (videoObjects.contains(id))
 	{
-		if (videoObjects[id]->player!=Q_NULLPTR)
+		if (videoObjects[id]->player!=nullptr)
 		{
 #if (QT_VERSION>=QT_VERSION_CHECK(6,0,0))
 			videoObjects[id]->player->audioOutput()->setVolume(qBound(0,newVolume,100)/100.);
@@ -661,10 +673,13 @@ void StelVideoMgr::setVideoVolume(const QString& id, int newVolume)
 
 int StelVideoMgr::getVideoVolume(const QString& id) const
 {
+	if (!audioEnabled)
+		return 0;
+
 	int volume=-1;
 	if (videoObjects.contains(id))
 	{
-		if (videoObjects[id]->player!=Q_NULLPTR)
+		if (videoObjects[id]->player!=nullptr)
 		{
 #if (QT_VERSION>=QT_VERSION_CHECK(6,0,0))
 			volume=int(videoObjects[id]->player->audioOutput()->volume()*100.);
@@ -682,7 +697,7 @@ bool StelVideoMgr::isVideoPlaying(const QString& id) const
 	bool playing=false;
 	if (videoObjects.contains(id))
 	{
-		if (videoObjects[id]->player!=Q_NULLPTR)
+		if (videoObjects[id]->player!=nullptr)
 		{
 #if (QT_VERSION>=QT_VERSION_CHECK(6,0,0))
 			playing= (videoObjects[id]->player->playbackState() == QMediaPlayer::PlayingState );

--- a/src/core/StelVideoMgr.cpp
+++ b/src/core/StelVideoMgr.cpp
@@ -36,10 +36,9 @@
 #endif
 
 
-StelVideoMgr::StelVideoMgr(bool withAudio) : StelModule()
+StelVideoMgr::StelVideoMgr(bool withAudio) : StelModule(), audioEnabled(withAudio)
 {
 	setObjectName("StelVideoMgr");
-	audioEnabled = withAudio;
 #ifdef ENABLE_MEDIA
 	// in case the property has not been set, getProperty() returns invalid.
 	verbose= (qApp->property("verbose") == true);

--- a/src/core/StelVideoMgr.hpp
+++ b/src/core/StelVideoMgr.hpp
@@ -114,7 +114,9 @@ class StelVideoMgr : public StelModule
 	Q_OBJECT
 
 public:
-	StelVideoMgr();
+	//! Constructor.
+	//! @param withAudio usually true to allow audio output.
+	StelVideoMgr(bool withAudio);
 	~StelVideoMgr() override;
 
 public slots:
@@ -281,6 +283,7 @@ private:
 		int lastPos;               //!< This should not be required: We must track a bug in QtMultimedia where the QMediaPlayer is in playing state but does not progress the video position. In update() we try to let it run again.
 	} VideoPlayer;
 	QMap<QString, VideoPlayer*> videoObjects;
+	bool audioEnabled;                 //!< Allow audio output. May be disabled by command line or config arguments.
 	bool verbose;                      //!< true to write many more log entries (useful for script debugging) Activate with command-line option "--verbose"
 #endif
 };

--- a/src/core/StelVideoMgr.hpp
+++ b/src/core/StelVideoMgr.hpp
@@ -283,9 +283,9 @@ private:
 		int lastPos;               //!< This should not be required: We must track a bug in QtMultimedia where the QMediaPlayer is in playing state but does not progress the video position. In update() we try to let it run again.
 	} VideoPlayer;
 	QMap<QString, VideoPlayer*> videoObjects;
-	bool audioEnabled;                 //!< Allow audio output. May be disabled by command line or config arguments.
 	bool verbose;                      //!< true to write many more log entries (useful for script debugging) Activate with command-line option "--verbose"
 #endif
+	bool audioEnabled;                 //!< Allow audio output. May be disabled by command line or config arguments.
 };
 
 #endif // STELVIDEOMGR_HPP


### PR DESCRIPTION
### Description
<!--- Please include a summary of the change and which issue is fixed. -->
<!--- Please also include relevant motivation and context. -->
<!--- List any dependencies that are required for this change. -->

We had a complaint (#3725) that Stellarium takes some extra (unspecified) time to initialize on a system without sound hardware (or disabled).  While sound hardware has been generally available on consumer systems of the past 25 years, there may be circumstances, e.g. on Virtual Machines. This branch brings in yet another configuration option to avoid initialisation. The simple alternative is to build Stellarium from source without media support.

Fixes #3725

### Screenshots (if appropriate):

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Running scripts/test/audiotest.ssc. When audio system is disabled, observe text output. 

I have not yet tested videos with sound output! And I cannot test a physical system without sound hardware.


**Test Configuration**:
* Operating system: Win10pro
* Graphics Card: irrelevant

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (header file)
- [x] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
