### PR TITLE
fix the name in find query

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1048,9 +1048,9 @@ ENDIF()
 
 include("cmake/Check-from_chars.cmake")
 IF(NOT FROM_CHARS_WORKS)
-    CPMFindPackage(NAME fast_float
+    CPMFindPackage(NAME FastFloat
                    GIT_REPOSITORY https://github.com/fastfloat/fast_float
-                   VERSION 6.1.0
+                   VERSION 6.1.3
                    EXCLUDE_FROM_ALL yes)
     GET_TARGET_PROPERTY(fast_float_INCLUDE_DIRECTORIES
                         FastFloat::fast_float INTERFACE_INCLUDE_DIRECTORIES)


### PR DESCRIPTION
The .config installed by github's fast_float, makes the library to be exposed as FastFloat, not fast_float.

So current situation is that no matter if the library exist or not, it pulls from github remote anyways.

Also updated the version to be 6.1.3 as it's the newest release.

### Description

Fixes # (issue)

The current CMakeLists would pull fast_float from github anyways irrespective if the library is installed or not.

I changed the NAME field to FastFloat so it would pick up if previously has been installed.

### Type of change
- [x] Housekeeping

### How Has This Been Tested?
Tested with a clean install of fast_float library, then build stellarium. When change the NAME, cmake won't pull from remote.

**Test Configuration**:
* Operating system: 
*  - OS: Gentoo Linux x86_64 
*  - Kernel: 6.10.0-gentoo-x86_64 
* Graphics Card: Intel Raptor Lake-P [Iris Xe Graphics], 13th Gen Intel i9-13900H (20) @ 5.200GHz 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
