### PR TITLE
Orbit color and selection improvements

### DIFF
--- a/src/core/modules/Planet.cpp
+++ b/src/core/modules/Planet.cpp
@@ -4697,39 +4697,49 @@ Ring::Ring(float radiusMin, float radiusMax, const QString &texname)
 
 Vec3f Planet::getCurrentOrbitColor() const
 {
+	static const QMap<Planet::PlanetType, Vec3f> typeColorMap = {
+		{ isMoon,         orbitMoonsColor       },
+		{ isPlanet,       orbitMajorPlanetsColor},
+		{ isAsteroid,     orbitMinorPlanetsColor},
+		{ isDwarfPlanet,  orbitDwarfPlanetsColor},
+		{ isCubewano,     orbitCubewanosColor   },
+		{ isPlutino,      orbitPlutinosColor    },
+		{ isSDO,          orbitScatteredDiscObjectsColor},
+		{ isOCO,          orbitOortCloudObjectsColor},
+		{ isComet,        orbitCometsColor      },
+		{ isSednoid,      orbitSednoidsColor    },
+		{ isInterstellar, orbitInterstellarColor}};
+	static const QMap<QString, Vec3f>majorPlanetColorMap = {
+		{ "mercury", orbitMercuryColor},
+		{ "venus",   orbitVenusColor  },
+		{ "earth",   orbitEarthColor  },
+		{ "mars",    orbitMarsColor   },
+		{ "jupiter", orbitJupiterColor},
+		{ "saturn",  orbitSaturnColor },
+		{ "uranus",  orbitUranusColor },
+		{ "neptune", orbitNeptuneColor}};
+
 	Vec3f orbColor = orbitColor;
 	switch(orbitColorStyle)
 	{
 		case ocsGroups:
 		{
-			const QMap<Planet::PlanetType, Vec3f> typeColorMap = {
-				{ isMoon,         orbitMoonsColor       },
-				{ isPlanet,       orbitMajorPlanetsColor},
-				{ isAsteroid,     orbitMinorPlanetsColor},
-				{ isDwarfPlanet,  orbitDwarfPlanetsColor},
-				{ isCubewano,     orbitCubewanosColor   },
-				{ isPlutino,      orbitPlutinosColor    },
-				{ isSDO,          orbitScatteredDiscObjectsColor},
-				{ isOCO,          orbitOortCloudObjectsColor},
-				{ isComet,        orbitCometsColor      },
-				{ isSednoid,      orbitSednoidsColor    },
-				{ isInterstellar, orbitInterstellarColor}};
 			orbColor = typeColorMap.value(pType, orbitColor);
 			break;
 		}
 		case ocsMajorPlanets:
 		{
 			const QString pName = getEnglishName().toLower();
-			const QMap<QString, Vec3f>majorPlanetColorMap = {
-				{ "mercury", orbitMercuryColor},
-				{ "venus",   orbitVenusColor  },
-				{ "earth",   orbitEarthColor  },
-				{ "mars",    orbitMarsColor   },
-				{ "jupiter", orbitJupiterColor},
-				{ "saturn",  orbitSaturnColor },
-				{ "uranus",  orbitUranusColor },
-				{ "neptune", orbitNeptuneColor}};
 			orbColor=majorPlanetColorMap.value(pName, orbitColor);
+			break;
+		}
+		case ocsMajorPlanetsMinorTypes:
+		{
+			const QString pName = getEnglishName().toLower();
+			if (majorPlanetColorMap.contains(pName))
+				orbColor=majorPlanetColorMap.value(pName, orbitColor);
+			else
+				orbColor = typeColorMap.value(pType, orbitColor);
 			break;
 		}
 		case ocsOneColor:

--- a/src/core/modules/Planet.hpp
+++ b/src/core/modules/Planet.hpp
@@ -121,9 +121,10 @@ public:
 
 	enum PlanetOrbitColorStyle
 	{
-		ocsOneColor,            // One color for all orbits
-		ocsGroups,              // Separate colors for each group of Solar system bodies
-		ocsMajorPlanets         // Separate colors for each of major planets of Solar system
+		ocsOneColor,               // One color for all orbits
+		ocsGroups,                 // Separate colors for each group of Solar system bodies
+		ocsMajorPlanets,           // Separate colors for each of major planets of Solar system
+		ocsMajorPlanetsMinorTypes  // Separate colors for each of major planets of Solar system
 	};
 	Q_ENUM(PlanetOrbitColorStyle)
 

--- a/src/core/modules/SolarSystem.cpp
+++ b/src/core/modules/SolarSystem.cpp
@@ -2778,10 +2778,9 @@ void SolarSystem::reconfigureOrbits()
 	{
 		for (const auto& p : std::as_const(systemPlanets))
 			p->setFlagOrbits(false);
-		return;
 	}
 	// from here, flagOrbits is certainly on
-	if (!flagIsolatedOrbits)
+	else if (!flagIsolatedOrbits)
 	{
 		for (const auto& p : std::as_const(systemPlanets))
 			p->setFlagOrbits(!flagPlanetsOrbitsOnly || (p->getPlanetType()==Planet::isPlanet || (flagOrbitsWithMoons && p->parent && p->parent->getPlanetType()==Planet::isPlanet) ));
@@ -2794,7 +2793,7 @@ void SolarSystem::reconfigureOrbits()
 					 || (flagOrbitsWithMoons && p->getPlanetType()==Planet::isMoon && p->parent==selected ) );
 	}
 	// 24.3: With new flag, we can override to see the orbits of major planets together with that of a single selected minor body.
-	if (flagPlanetsOrbits && !flagPlanetsOrbitsOnly)
+	if (flagOrbits && flagPlanetsOrbits)
 	{
 		for (const auto& p : std::as_const(systemPlanets))
 			if ((p->getPlanetType()==Planet::isPlanet) || (flagOrbitsWithMoons && p->getPlanetType()==Planet::isMoon ))

--- a/src/core/modules/SolarSystem.hpp
+++ b/src/core/modules/SolarSystem.hpp
@@ -63,6 +63,7 @@ class SolarSystem : public StelObjectModule
 	Q_PROPERTY(bool flagNativePlanetNames		READ getFlagNativePlanetNames		WRITE setFlagNativePlanetNames		NOTIFY flagNativePlanetNamesChanged)
 	Q_PROPERTY(bool planetsDisplayed		READ getFlagPlanets			WRITE setFlagPlanets			NOTIFY flagPlanetsDisplayedChanged)
 	Q_PROPERTY(bool flagOrbits			READ getFlagOrbits			WRITE setFlagOrbits			NOTIFY flagOrbitsChanged)
+	Q_PROPERTY(bool flagPlanetsOrbits		READ getFlagPlanetsOrbits		WRITE setFlagPlanetsOrbits		NOTIFY flagPlanetsOrbitsChanged)
 	Q_PROPERTY(bool flagPlanetsOrbitsOnly		READ getFlagPlanetsOrbitsOnly		WRITE setFlagPlanetsOrbitsOnly		NOTIFY flagPlanetsOrbitsOnlyChanged)
 	Q_PROPERTY(bool flagPermanentOrbits		READ getFlagPermanentOrbits		WRITE setFlagPermanentOrbits		NOTIFY flagPermanentOrbitsChanged)
 	Q_PROPERTY(bool flagIsolatedOrbits		READ getFlagIsolatedOrbits		WRITE setFlagIsolatedOrbits		NOTIFY flagIsolatedOrbitsChanged)
@@ -663,6 +664,11 @@ public slots:
 	//! Get the current value of the flag which enables showing of isolated orbits for selected objects only or not.
 	bool getFlagIsolatedOrbits(void) const;
 
+	//! Set flag which enabled the showing of planets orbits, regardless of the other orbit settings
+	void setFlagPlanetsOrbits(bool b);
+	//! Get the current value of the flag which enables showing of planets orbits, regardless of the other orbit settings.
+	bool getFlagPlanetsOrbits(void) const;
+
 	//! Set flag which enabled the showing of planets orbits only or not
 	void setFlagPlanetsOrbitsOnly(bool b);
 	//! Get the current value of the flag which enables showing of planets orbits only or not.
@@ -755,6 +761,7 @@ signals:
 	void flagPointerChanged(bool b);
 	void flagNativePlanetNamesChanged(bool b);
 	void flagPlanetsDisplayedChanged(bool b);
+	void flagPlanetsOrbitsChanged(bool b);
 	void flagPlanetsOrbitsOnlyChanged(bool b);
 	void flagPermanentOrbitsChanged(bool b);
 	void flagIsolatedOrbitsChanged(bool b);
@@ -1115,8 +1122,9 @@ private:
 	int maxTrailTimeExtent;
 	int trailsThickness;
 	bool flagIsolatedOrbits;
-	bool flagPlanetsOrbitsOnly;
-	bool flagOrbitsWithMoons;
+	bool flagPlanetsOrbits;				// Show orbits of the major planets, regardless of other orbit settings
+	bool flagPlanetsOrbitsOnly;			// show orbits of the major planets only (no minor bodies in any case)
+	bool flagOrbitsWithMoons;			// Show moon systems if planet orbits are displayed
 	bool ephemerisMarkersDisplayed;
 	bool ephemerisDatesDisplayed;
 	bool ephemerisMagnitudesDisplayed;

--- a/src/gui/ConfigurationDialog.cpp
+++ b/src/gui/ConfigurationDialog.cpp
@@ -874,6 +874,7 @@ void ConfigurationDialog::saveAllSettings()
 	conf->setValue("viewing/max_trail_points",				propMgr->getStelPropertyValue("SolarSystem.maxTrailPoints").toInt());
 	conf->setValue("viewing/max_trail_time_extent",			propMgr->getStelPropertyValue("SolarSystem.maxTrailTimeExtent").toInt());
 	conf->setValue("viewing/flag_isolated_orbits",			propMgr->getStelPropertyValue("SolarSystem.flagIsolatedOrbits").toBool());
+	conf->setValue("viewing/flag_planets_orbits",			propMgr->getStelPropertyValue("SolarSystem.flagPlanetsOrbits").toBool());
 	conf->setValue("viewing/flag_planets_orbits_only",		propMgr->getStelPropertyValue("SolarSystem.flagPlanetsOrbitsOnly").toBool());
 	conf->setValue("viewing/flag_orbits_with_moons",		propMgr->getStelPropertyValue("SolarSystem.flagOrbitsWithMoons").toBool());
 	conf->setValue("astro/flag_light_travel_time",			propMgr->getStelPropertyValue("SolarSystem.flagLightTravelTime").toBool());

--- a/src/gui/ConfigureOrbitColorsDialog.cpp
+++ b/src/gui/ConfigureOrbitColorsDialog.cpp
@@ -17,12 +17,6 @@
 */
 
 #include "StelApp.hpp"
-#include "StelCore.hpp"
-#include "StelPropertyMgr.hpp"
-#include "StelLocaleMgr.hpp"
-#include "StelModuleMgr.hpp"
-#include "StelTranslator.hpp"
-#include "StelUtils.hpp"
 #include "ConfigureOrbitColorsDialog.hpp"
 #include "ui_orbitColorsDialog.h"
 
@@ -61,11 +55,14 @@ void ConfigureOrbitColorsDialog::createDialogContent()
 		ui->groupsRadioButton->setChecked(true);
 	else if (activeColorStyle=="major_planets")
 		ui->majorPlanetsRadioButton->setChecked(true);
+	else if (activeColorStyle=="major_planets_minor_types")
+		ui->majorPlanetsAndMinorTypeRadioButton->setChecked(true);
 	else
 		ui->oneColorRadioButton->setChecked(true);
 	connect(ui->oneColorRadioButton, SIGNAL(clicked(bool)), this, SLOT(setColorStyle()));
 	connect(ui->groupsRadioButton, SIGNAL(clicked(bool)), this, SLOT(setColorStyle()));
 	connect(ui->majorPlanetsRadioButton, SIGNAL(clicked(bool)), this, SLOT(setColorStyle()));
+	connect(ui->majorPlanetsAndMinorTypeRadioButton, SIGNAL(clicked(bool)), this, SLOT(setColorStyle()));
 
 	ui->colorGenericOrbits           ->setup("SolarSystem.orbitsColor",                     "color/sso_orbits_color");
 	ui->colorGroupsMajorPlanetsOrbits->setup("SolarSystem.majorPlanetsOrbitsColor",         "color/major_planet_orbits_color");
@@ -94,6 +91,8 @@ void ConfigureOrbitColorsDialog::setColorStyle()
 	QString colorStyle;
 	if (ui->majorPlanetsRadioButton->isChecked())
 		colorStyle = "major_planets";
+	else if (ui->majorPlanetsAndMinorTypeRadioButton->isChecked())
+		colorStyle = "major_planets_minor_types";
 	else if (ui->groupsRadioButton->isChecked())
 		colorStyle = "groups";
 	else

--- a/src/gui/ViewDialog.cpp
+++ b/src/gui/ViewDialog.cpp
@@ -594,6 +594,7 @@ void ViewDialog::setDisplayFormatForSpins(bool flagDecimalDegrees)
 void ViewDialog::populateOrbitsControls(bool flag)
 {
 	ui->planetIsolatedOrbitCheckBox->setEnabled(flag);
+	ui->planetOrbitMajorPlanetsCheckBox->setEnabled(flag);
 	ui->planetOrbitOnlyCheckBox->setEnabled(flag);
 	ui->planetOrbitsMoonCheckBox->setEnabled(flag);
 	ui->planetOrbitPermanentCheckBox->setEnabled(flag);

--- a/src/gui/ViewDialog.cpp
+++ b/src/gui/ViewDialog.cpp
@@ -217,6 +217,7 @@ void ViewDialog::createDialogContent()
 	connectCheckBox(ui->planetMarkerCheckBox, "actionShow_Planets_Hints");
 	connectCheckBox(ui->planetOrbitCheckBox, "actionShow_Planets_Orbits");
 	connectBoolProperty(ui->planetIsolatedOrbitCheckBox, "SolarSystem.flagIsolatedOrbits");
+	connectBoolProperty(ui->planetOrbitMajorPlanetsCheckBox, "SolarSystem.flagPlanetsOrbits");
 	connectBoolProperty(ui->planetOrbitOnlyCheckBox, "SolarSystem.flagPlanetsOrbitsOnly");
 	connectBoolProperty(ui->planetOrbitsMoonCheckBox, "SolarSystem.flagOrbitsWithMoons");
 	connectBoolProperty(ui->planetOrbitPermanentCheckBox, "SolarSystem.flagPermanentOrbits");

--- a/src/gui/orbitColorsDialog.ui
+++ b/src/gui/orbitColorsDialog.ui
@@ -69,6 +69,13 @@
         </property>
        </widget>
       </item>
+      <item>
+       <widget class="QRadioButton" name="majorPlanetsAndMinorTypeRadioButton">
+        <property name="text">
+         <string>Separate colors for orbits of major planets and by minor body object type</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/src/gui/viewDialog.ui
+++ b/src/gui/viewDialog.ui
@@ -1233,7 +1233,7 @@
                <item>
                 <widget class="QCheckBox" name="planetOrbitPermanentCheckBox">
                  <property name="sizePolicy">
-                  <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                  <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
                    <horstretch>0</horstretch>
                    <verstretch>0</verstretch>
                   </sizepolicy>
@@ -1243,6 +1243,22 @@
                  </property>
                  <property name="text">
                   <string>permanently</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QCheckBox" name="planetOrbitMajorPlanetsCheckBox">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="toolTip">
+                  <string>Show orbits of major planets</string>
+                 </property>
+                 <property name="text">
+                  <string>Major planets</string>
                  </property>
                 </widget>
                </item>
@@ -5286,12 +5302,12 @@
  </resources>
  <connections/>
  <buttongroups>
-  <buttongroup name="buttonGroupDisplayedDSOTypes">
+  <buttongroup name="buttonGroupDisplayedDSOCatalogs">
    <property name="exclusive">
     <bool>false</bool>
    </property>
   </buttongroup>
-  <buttongroup name="buttonGroupDisplayedDSOCatalogs">
+  <buttongroup name="buttonGroupDisplayedDSOTypes">
    <property name="exclusive">
     <bool>false</bool>
    </property>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Please include a summary of the change and which issue is fixed. -->
<!--- Please also include relevant motivation and context. -->
<!--- List any dependencies that are required for this change. -->

In light of other upcoming changes and a potentially interesting comet, I see need for two improvements: 

- In the orbit color selection, you can so far draw planet orbits in distinct colors, while all other objects are drawn in a single other color. Alternatively, you can draw orbits in color per planet subtype. This branch adds the option to draw planet orbits in distinct colors _and_ those of the minor bodies per planet subtype.

- Currently you can draw either all orbits, only major planet orbits, or only that of the selected object. This was result of a long development of added flags and settings, and TBH already on the brink of maintainability. Now, it was not possible to show e.g. a view from Solar System Observer where you can see the planet orbits combined with the orbit of a single selected comet.  I have added another checkbox for planet orbits. 

This may again not be the best interface when you can select "Major planets" and "Only major planets". etc., and there is a quirk as the default orbit display without selection is "all orbits". When you now select "Major Planets" but deselect "with moons", moon orbits are still seen.  Maybe the whole selection should be re-done, and e.g. allow Major planets plus 1...n last selected objects (like trails). This way you could enable e.g. 5 interesting comet orbits while having thousands loaded. Hmm, or even allow loading from a list of minor bodies, permanently, in a separate GUI list. 




Fixes #3849  (issue)

### Screenshots (if appropriate):

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system: Win11
* Graphics Card: Geforce 3070Ti (irrelevant)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
