### PR TITLE
Added ability to use a wider range of dates for AstroCalc/Ephemeris tool

### DIFF
--- a/src/gui/AstroCalcDialog.cpp
+++ b/src/gui/AstroCalcDialog.cpp
@@ -1936,7 +1936,6 @@ void AstroCalcDialog::generateEphemeris()
 	StelUtils::getJDFromDate(&firstJD, ui->dateFromYearSpinBox->value(), ui->dateFromMonthSpinBox->value(), ui->dateFromDaySpinBox->value(), ui->dateFromHourSpinBox->value(), ui->dateFromMinuteSpinBox->value(), 0.0);
 	firstJD -= core->getUTCOffset(firstJD) / 24.;
 	double secondJD = firstJD + ui->dateToDurationSpinBox->value()*getEphemerisTimeDuration();
-	secondJD -= core->getUTCOffset(secondJD) / 24.;
 
 	const int elements = static_cast<int>((secondJD - firstJD) / currentStep);
 	EphemerisList.clear();

--- a/src/gui/AstroCalcDialog.hpp
+++ b/src/gui/AstroCalcDialog.hpp
@@ -360,9 +360,10 @@ private slots:
 	void saveEphemerisCelestialBody(int index);
 	void saveEphemerisSecondaryCelestialBody(int index);
 	void saveEphemerisTimeStep(int index);
+	void saveEphemerisTimeUnit(int index);
 	void initEphemerisFlagNakedEyePlanets(void);
 	void saveEphemerisFlagNakedEyePlanets(bool flag);
-	void saveEphemerisFlagWideRangeDates(bool flag);
+	void setMonthDuration();
 
 	//! Calculating phenomena for selected celestial body and fill the list.
 	void calculatePhenomena();
@@ -547,6 +548,8 @@ private:
 	void populateCelestialBodyList();	
 	//! Populates the drop-down list of time steps.
 	void populateEphemerisTimeStepsList();
+	//! Populates the drop-down list of time units for Ephemeris tool.
+	void populateEphemerisTimeUnitsList();
 	//! Populates the drop-down list of planets.
 	void populatePlanetList();
 	//! Prepare graph settings
@@ -576,8 +579,7 @@ private:
 	void enableTransitsButtons(bool enable);
 
 	void enableCustomEphemerisTimeStepButton();
-	void enableEphemerisWideRangeGUI(bool enable);
-	double getCustomTimeStep();	
+	double getCustomTimeStep();
 	void reGenerateEphemeris(bool withSelection);
 
 	//! Finding and selecting an object by its name in specific JD
@@ -648,7 +650,6 @@ private:
 	bool plotAziVsTime = false;
 	bool computeRTS = false;
 	bool computeEphemeris = false;
-	bool usingWideRangeDates = false;
 	int altVsTimePositiveLimit = 0, monthlyElevationPositiveLimit = 0, graphsDuration = 1, graphsStep = 24;
 	QStringList ephemerisHeader, phenomenaHeader, positionsHeader, hecPositionsHeader, wutHeader, rtsHeader, lunareclipseHeader, lunareclipsecontactsHeader, solareclipseHeader, solareclipsecontactsHeader, solareclipselocalHeader, transitHeader;
 	static double brightLimit;

--- a/src/gui/AstroCalcDialog.hpp
+++ b/src/gui/AstroCalcDialog.hpp
@@ -362,6 +362,7 @@ private slots:
 	void saveEphemerisTimeStep(int index);
 	void initEphemerisFlagNakedEyePlanets(void);
 	void saveEphemerisFlagNakedEyePlanets(bool flag);
+	void saveEphemerisFlagWideRangeDates(bool flag);
 
 	//! Calculating phenomena for selected celestial body and fill the list.
 	void calculatePhenomena();
@@ -575,7 +576,8 @@ private:
 	void enableTransitsButtons(bool enable);
 
 	void enableCustomEphemerisTimeStepButton();
-	double getCustomTimeStep();
+	void enableEphemerisWideRangeGUI(bool enable);
+	double getCustomTimeStep();	
 	void reGenerateEphemeris(bool withSelection);
 
 	//! Finding and selecting an object by its name in specific JD
@@ -646,6 +648,7 @@ private:
 	bool plotAziVsTime = false;
 	bool computeRTS = false;
 	bool computeEphemeris = false;
+	bool usingWideRangeDates = false;
 	int altVsTimePositiveLimit = 0, monthlyElevationPositiveLimit = 0, graphsDuration = 1, graphsStep = 24;
 	QStringList ephemerisHeader, phenomenaHeader, positionsHeader, hecPositionsHeader, wutHeader, rtsHeader, lunareclipseHeader, lunareclipsecontactsHeader, solareclipseHeader, solareclipsecontactsHeader, solareclipselocalHeader, transitHeader;
 	static double brightLimit;

--- a/src/gui/AstroCalcDialog.hpp
+++ b/src/gui/AstroCalcDialog.hpp
@@ -550,6 +550,10 @@ private:
 	void populateEphemerisTimeStepsList();
 	//! Populates the drop-down list of time units for Ephemeris tool.
 	void populateEphemerisTimeUnitsList();
+	//! Get time step for Ephemeris tool
+	double getEphemerisTimeStep(const PlanetP& planet);
+	//! Get time limit at right side for Ephemeris tool
+	double getEphemerisTimeDuration();
 	//! Populates the drop-down list of planets.
 	void populatePlanetList();
 	//! Prepare graph settings

--- a/src/gui/astroCalcDialog.ui
+++ b/src/gui/astroCalcDialog.ui
@@ -819,31 +819,76 @@
                </widget>
               </item>
               <item>
-               <widget class="QDateTimeEdit" name="dateFromDateTimeEdit">
-                <property name="wrapping">
-                 <bool>true</bool>
+               <widget class="QSpinBox" name="dateFromYearSpinBox">
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                 </property>
-                <property name="displayFormat">
-                 <string notr="true">yyyy.MM.dd hh:mm:ss</string>
+                <property name="minimum">
+                 <number>-13000</number>
                 </property>
-                <property name="calendarPopup">
-                 <bool>true</bool>
+                <property name="maximum">
+                 <number>17000</number>
                 </property>
                </widget>
               </item>
               <item>
-               <widget class="QDoubleSpinBox" name="dateFromDoubleSpinBox">
+               <widget class="QSpinBox" name="dateFromMonthSpinBox">
+                <property name="toolTip">
+                 <string>Month</string>
+                </property>
                 <property name="alignment">
                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                 </property>
-                <property name="decimals">
-                 <number>5</number>
-                </property>
                 <property name="minimum">
-                 <double>-3027192.732689999975264</double>
+                 <number>1</number>
                 </property>
                 <property name="maximum">
-                 <double>7930547.208320000208914</double>
+                 <number>12</number>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QSpinBox" name="dateFromDaySpinBox">
+                <property name="toolTip">
+                 <string>Day</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+                <property name="minimum">
+                 <number>1</number>
+                </property>
+                <property name="maximum">
+                 <number>31</number>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QSpinBox" name="dateFromHourSpinBox">
+                <property name="toolTip">
+                 <string>Hours</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+                <property name="minimum">
+                 <number>0</number>
+                </property>
+                <property name="maximum">
+                 <number>23</number>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QSpinBox" name="dateFromMinuteSpinBox">
+                <property name="toolTip">
+                 <string>Minutes</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+                <property name="maximum">
+                 <number>59</number>
                 </property>
                </widget>
               </item>
@@ -869,50 +914,27 @@
               <item>
                <widget class="QLabel" name="dateToLabel">
                 <property name="text">
-                 <string>To:</string>
+                 <string>to the next</string>
                 </property>
                </widget>
               </item>
               <item>
-               <widget class="QDateTimeEdit" name="dateToDateTimeEdit">
-                <property name="wrapping">
-                 <bool>true</bool>
-                </property>
-                <property name="displayFormat">
-                 <string notr="true">yyyy.MM.dd hh:mm:ss</string>
-                </property>
-                <property name="calendarPopup">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QDoubleSpinBox" name="dateToDoubleSpinBox">
+               <widget class="QSpinBox" name="dateToDurationSpinBox">
                 <property name="alignment">
                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                 </property>
-                <property name="decimals">
-                 <number>5</number>
-                </property>
                 <property name="minimum">
-                 <double>-3027192.732689999975264</double>
+                 <number>1</number>
                 </property>
                 <property name="maximum">
-                 <double>7930547.208320000208914</double>
+                 <number>100</number>
                 </property>
                </widget>
               </item>
+              <item>
+               <widget class="QComboBox" name="dateToUnitsComboBox"/>
+              </item>
              </layout>
-            </item>
-            <item>
-             <widget class="QCheckBox" name="wrdCheckBox">
-              <property name="toolTip">
-               <string>Using a wide range of dates</string>
-              </property>
-              <property name="text">
-               <string extracomment="W.R.D. = wide range of dates">W.R.D.</string>
-              </property>
-             </widget>
             </item>
             <item>
              <spacer name="horizontalSpacer_8">

--- a/src/gui/astroCalcDialog.ui
+++ b/src/gui/astroCalcDialog.ui
@@ -832,6 +832,22 @@
                </widget>
               </item>
               <item>
+               <widget class="QDoubleSpinBox" name="dateFromDoubleSpinBox">
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+                <property name="decimals">
+                 <number>5</number>
+                </property>
+                <property name="minimum">
+                 <double>-3027192.732689999975264</double>
+                </property>
+                <property name="maximum">
+                 <double>7930547.208320000208914</double>
+                </property>
+               </widget>
+              </item>
+              <item>
                <widget class="QToolButton" name="pushButtonNow">
                 <property name="toolTip">
                  <string>Now</string>
@@ -870,7 +886,33 @@
                 </property>
                </widget>
               </item>
+              <item>
+               <widget class="QDoubleSpinBox" name="dateToDoubleSpinBox">
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+                <property name="decimals">
+                 <number>5</number>
+                </property>
+                <property name="minimum">
+                 <double>-3027192.732689999975264</double>
+                </property>
+                <property name="maximum">
+                 <double>7930547.208320000208914</double>
+                </property>
+               </widget>
+              </item>
              </layout>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="wrdCheckBox">
+              <property name="toolTip">
+               <string>Using a wide range of dates</string>
+              </property>
+              <property name="text">
+               <string extracomment="W.R.D. = wide range of dates">W.R.D.</string>
+              </property>
+             </widget>
             </item>
             <item>
              <spacer name="horizontalSpacer_8">


### PR DESCRIPTION
### Description
This patch adding ability to use a wider range of dates for AstroCalc/Ephemeris tool.

Fixes #3868 (issue)

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
