### PR TITLE
Disable ASCOM on Qt6

### DIFF
--- a/guide/plg_atTheTelescope.tex
+++ b/guide/plg_atTheTelescope.tex
@@ -921,7 +921,7 @@ List of telescope types supported by INDI\footnote{\url{https://indilib.org/devi
 \item IOptron GotoNova Upgrade Kit 8400
 \end{itemize}
 
-\subsection{ASCOM (Windows and Qt5-based builds only)}
+\subsection{ASCOM (Windows, Qt5-based builds only)}
 \label{sec:plugins:TelescopeControl:ASCOM}
 
 \indexterm{ASCOM} \newFeature{0.19.3}is probably the most widely used
@@ -934,7 +934,7 @@ and most of the astronomy software and tools can communicate with
 ASCOM compatible devices.
 
 The ASCOM telescope support has been added to Stellarium's Telescope Control plugin by Gion Kunz in version 0.19.3.\footnote{%
-Unfortunately ASCOM seems to be incompatible with Qt6. 
+Unfortunately traditional ASCOM seems to be incompatible with Qt6. 
 Starting with version 24.3 ASCOM support is no longer available on Qt6-based builds.
 If you depend on ASCOM support, please use a Qt5-based build of the same version.}
 

--- a/guide/plg_atTheTelescope.tex
+++ b/guide/plg_atTheTelescope.tex
@@ -514,7 +514,7 @@ Some users are running Stellarium on little, low-power ``Telescope computers'' c
 their powerful indoor PCs via RemoteDesktop or similar setups. Keep in mind that Stellarium 
 is a graphics-heavy program that may challenge the outdoor computer's graphics subsystem or network.
 See framerate intent settings on page~\pageref{sec:gui:configuration:tools:fps} for optimizing your screen refresh rates. 
-Better, run Stellarium on your indoor system and use INDI or ASCOM protocols.
+Better, run Stellarium on your indoor system and use INDI or ASCOM network protocols.
 
 \subsection{Using this plug-in}
 \label{sec:plugins:TelescopeControl:using}
@@ -921,7 +921,7 @@ List of telescope types supported by INDI\footnote{\url{https://indilib.org/devi
 \item IOptron GotoNova Upgrade Kit 8400
 \end{itemize}
 
-\subsection{ASCOM (Windows only)}
+\subsection{ASCOM (Windows and Qt5-based builds only)}
 \label{sec:plugins:TelescopeControl:ASCOM}
 
 \indexterm{ASCOM} \newFeature{0.19.3}is probably the most widely used
@@ -933,7 +933,10 @@ applications. Almost every telescope mount comes with an ASCOM driver
 and most of the astronomy software and tools can communicate with
 ASCOM compatible devices.
 
-The ASCOM telescope support has been added to Stellarium's Telescope Control plugin by Gion Kunz in version 0.19.3.
+The ASCOM telescope support has been added to Stellarium's Telescope Control plugin by Gion Kunz in version 0.19.3.\footnote{%
+Unfortunately ASCOM seems to be incompatible with Qt6. 
+Starting with version 24.3 ASCOM support is no longer available on Qt6-based builds.
+If you depend on ASCOM support, please use a Qt5-based build of the same version.}
 
 Note that in order for Stellarium to communicate with your ASCOM
 compatible mount, you will need to have the ASCOM platform installed

--- a/plugins/TelescopeControl/src/ASCOM/CMakeLists.txt
+++ b/plugins/TelescopeControl/src/ASCOM/CMakeLists.txt
@@ -1,4 +1,7 @@
-if(WIN32)
+# Due to incomprehensible errors between ASCOM and Qt6OpenGL!QOpenGL2PaintEngineEx::setState(), we must disable ASCOM in QT6-based builds.
+# No other code change related to Qt6 has been done so far, only the ASCOM selector has been greyed out.
+# Rather sooner than later ASCOM must be replaced by Alpaca.
+if(WIN32 AND (${QT_VERSION_MAJOR} EQUAL "5"))
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
@@ -11,9 +14,9 @@ SET(TelescopeControl_ASCOM_UIS
 
 IF (${QT_VERSION_MAJOR} EQUAL "5")
      QT5_WRAP_UI(TelescopeControl_ASCOM_UIS_H ${TelescopeControl_ASCOM_UIS})
-ELSE()
+ELSE(${QT_VERSION_MAJOR} EQUAL "5")
      QT_WRAP_UI(TelescopeControl_ASCOM_UIS_H ${TelescopeControl_ASCOM_UIS})
-ENDIF()
+ENDIF(${QT_VERSION_MAJOR} EQUAL "5")
 
 add_library(TelescopeControl_ASCOM STATIC
     ASCOMDevice.hpp
@@ -40,4 +43,4 @@ ENDIF(ENABLE_TESTING)
 
 SET_TARGET_PROPERTIES(TelescopeControl_ASCOM PROPERTIES FOLDER "plugins/TelescopeControl")
 
-ENDIF(WIN32)
+ENDIF(WIN32 AND (${QT_VERSION_MAJOR} EQUAL "5"))

--- a/plugins/TelescopeControl/src/CMakeLists.txt
+++ b/plugins/TelescopeControl/src/CMakeLists.txt
@@ -6,9 +6,9 @@ add_subdirectory(Lx200)
 add_subdirectory(NexStar)
 add_subdirectory(Rts2)
 add_subdirectory(INDI)
-if(WIN32)
+if(WIN32 AND (${QT_VERSION_MAJOR} EQUAL "5"))
     add_subdirectory(ASCOM)
-endif(WIN32)
+endif(WIN32 AND (${QT_VERSION_MAJOR} EQUAL "5"))
 
 SET(TelescopeControl_RES ../resources/TelescopeControl.qrc)
 IF (${QT_VERSION_MAJOR} EQUAL "5")
@@ -49,10 +49,11 @@ TARGET_LINK_LIBRARIES(TelescopeControl-static
     Qt${QT_VERSION_MAJOR}::SerialPort
     )
 
-IF(WIN32)
-TARGET_LINK_LIBRARIES(TelescopeControl-static
-    TelescopeControl_ASCOM)
-ENDIF(WIN32)
+# Due to incomprehensible errors between ASCOM and Qt6OpenGL!QOpenGL2PaintEngineEx::setState(), we must disable in QT6-based builds.
+if(WIN32 AND (${QT_VERSION_MAJOR} EQUAL "5"))
+#TARGET_LINK_LIBRARIES(TelescopeControl-static
+#    TelescopeControl_ASCOM)
+ENDIF(WIN32 AND (${QT_VERSION_MAJOR} EQUAL "5"))
 
 SET_TARGET_PROPERTIES(TelescopeControl-static PROPERTIES COMPILE_FLAGS "-DQT_STATICPLUGIN")
 ADD_DEPENDENCIES(AllStaticPlugins TelescopeControl-static)

--- a/plugins/TelescopeControl/src/TelescopeClient.cpp
+++ b/plugins/TelescopeControl/src/TelescopeClient.cpp
@@ -44,8 +44,10 @@
 #include <QTextStream>
 #include <QMessageBox>
 
-#ifdef Q_OS_WIN
+#if defined(Q_OS_WIN)
+#if QT_VERSION<QT_VERSION_CHECK(6,0,0)
 	#include "ASCOM/TelescopeClientASCOM.hpp"
+#endif
 	#include <Windows.h> // GetSystemTimeAsFileTime()
 #else
 	#include <sys/time.h>
@@ -103,7 +105,7 @@ TelescopeClient *TelescopeClient::create(const QString &url)
 	{
 		newTelescope = new TelescopeClientINDI(name, params);
 	}
-	#ifdef Q_OS_WIN
+	#if defined(Q_OS_WIN) && QT_VERSION<QT_VERSION_CHECK(6,0,0)
 	else if (type == "ASCOM")
 	{
 		newTelescope = new TelescopeClientASCOM(name, params, eq);

--- a/plugins/TelescopeControl/src/common/CMakeLists.txt
+++ b/plugins/TelescopeControl/src/common/CMakeLists.txt
@@ -1,14 +1,14 @@
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 
-IF(WIN32)
+IF(WIN32 AND (${QT_VERSION_MAJOR} EQUAL "5"))
     SET(TelescopeControl_ASCOM_common_SRC
         ASCOMSupport.hpp
         ASCOMSupport.cpp
         OLE.hpp
         OLE.cpp
     )
-ENDIF()
+ENDIF(WIN32 AND (${QT_VERSION_MAJOR} EQUAL "5"))
 
 add_library(TelescopeControl_common STATIC
     LogFile.hpp

--- a/plugins/TelescopeControl/src/common/Socket.cpp
+++ b/plugins/TelescopeControl/src/common/Socket.cpp
@@ -40,7 +40,11 @@ long long int GetNow(void)
 		qint64 t;
 	} tmp;
 	GetSystemTimeAsFileTime(&tmp.file_time);
-	t = (tmp.t/10) - 86400000000LL*(369*365+89); // TODO: Explain this magic please!
+	// convert from NT/NTFS time epoch (1601-01-01 0:00:00 UTC) in μs to UNIX epoch (1970-01-01 0:00:00 UTC) in μs. The difference is:
+	// 24 hour/day × 3600 s/hour × ((369×365+89) day).
+	// Here 369=1970-1601, and 89 is the number of leap years in the interval.
+	// The division by 10 in the minuend is to convert from 100-nanosecond intervals to microseconds.
+	t = (tmp.t/10) - 86400000000LL*(369*365+89);
 #else
 	struct timeval tv;
 	gettimeofday(&tv, 0);

--- a/plugins/TelescopeControl/src/common/Socket.cpp
+++ b/plugins/TelescopeControl/src/common/Socket.cpp
@@ -41,7 +41,7 @@ long long int GetNow(void)
 	} tmp;
 	GetSystemTimeAsFileTime(&tmp.file_time);
 	// convert from NT/NTFS time epoch (1601-01-01 0:00:00 UTC) in μs to UNIX epoch (1970-01-01 0:00:00 UTC) in μs. The difference is:
-	// 24 hour/day × 3600 s/hour × ((369×365+89) day).
+	// 24 hour/day × 3600 s/hour × 10^6 μs/s × ((369×365+89) day).
 	// Here 369=1970-1601, and 89 is the number of leap years in the interval.
 	// The division by 10 in the minuend is to convert from 100-nanosecond intervals to microseconds.
 	t = (tmp.t/10) - 86400000000LL*(369*365+89);

--- a/plugins/TelescopeControl/src/common/Socket.hpp
+++ b/plugins/TelescopeControl/src/common/Socket.hpp
@@ -77,8 +77,7 @@ static inline int SetNonblocking(int s)
 
 #endif //Q_OS_WIN
 
-// retrieve system time in milliseconds
-// TODO: Specify epoch?
+//! retrieve system time in microseconds from the UNIX epoch (1970)
 long long int GetNow(void);
 
 class Server;

--- a/plugins/TelescopeControl/src/gui/CMakeLists.txt
+++ b/plugins/TelescopeControl/src/gui/CMakeLists.txt
@@ -34,10 +34,10 @@ target_link_libraries(TelescopeControl_gui
     TelescopeControl_INDI    
     )
 
-IF(WIN32)
+if(WIN32 AND (${QT_VERSION_MAJOR} EQUAL "5"))
 target_link_libraries(TelescopeControl_gui
     TelescopeControl_ASCOM
     )
-ENDIF(WIN32)
+ENDif(WIN32 AND (${QT_VERSION_MAJOR} EQUAL "5"))
 
 SET_TARGET_PROPERTIES(TelescopeControl_gui PROPERTIES FOLDER "plugins/TelescopeControl")

--- a/plugins/TelescopeControl/src/gui/TelescopeConfigurationDialog.cpp
+++ b/plugins/TelescopeControl/src/gui/TelescopeConfigurationDialog.cpp
@@ -156,7 +156,7 @@ void TelescopeConfigurationDialog::createDialogContent()
 	connect(ui->radioButtonTelescopeINDI, SIGNAL(toggled(bool)), this, SLOT(toggleTypeINDI(bool)));
 	#ifdef Q_OS_WIN
 	#if (QT_VERSION>=QT_VERSION_CHECK(6,0,0))
-		ui->radioButtonTelescopeASCOM->setToolTip(q_("Disabled due to apparent incompatibility. Please use Qt5-based build."));
+		ui->radioButtonTelescopeASCOM->setToolTip(q_("Disabled due to apparent incompatibility. Please use the Qt5-based build of Stellarium."));
 		ui->radioButtonTelescopeASCOM->setDisabled(true);
 	#else
 		connect(ui->radioButtonTelescopeASCOM, SIGNAL(toggled(bool)), this, SLOT(toggleTypeASCOM(bool)));

--- a/plugins/TelescopeControl/src/gui/TelescopeConfigurationDialog.cpp
+++ b/plugins/TelescopeControl/src/gui/TelescopeConfigurationDialog.cpp
@@ -26,7 +26,7 @@
 #include "TelescopeControl.hpp"
 #include "ui_telescopeConfigurationDialog.h"
 
-#ifdef Q_OS_WIN
+#if defined(Q_OS_WIN) && QT_VERSION<QT_VERSION_CHECK(6,0,0)
 	#include "../common/ASCOMSupport.hpp"
 #endif
 
@@ -132,7 +132,7 @@ void TelescopeConfigurationDialog::createDialogContent()
 	ui->setupUi(dialog);
 
 	// ASCOM Telescope client widget needs to be dynamically added in order to make use of preprocessors to exclude for non-windows
-	#ifdef Q_OS_WIN
+	#if defined(Q_OS_WIN) && QT_VERSION<QT_VERSION_CHECK(6,0,0)
 	ascomWidget = new TelescopeClientASCOMWidget(ui->scrollAreaWidgetContents);
 	ui->ASCOMLayout->addWidget(ascomWidget);
 
@@ -155,7 +155,12 @@ void TelescopeConfigurationDialog::createDialogContent()
 	connect(ui->radioButtonTelescopeRTS2, SIGNAL(toggled(bool)), this, SLOT(toggleTypeRTS2(bool)));
 	connect(ui->radioButtonTelescopeINDI, SIGNAL(toggled(bool)), this, SLOT(toggleTypeINDI(bool)));
 	#ifdef Q_OS_WIN
-	connect(ui->radioButtonTelescopeASCOM, SIGNAL(toggled(bool)), this, SLOT(toggleTypeASCOM(bool)));
+	#if (QT_VERSION>=QT_VERSION_CHECK(6,0,0))
+		ui->radioButtonTelescopeASCOM->setToolTip(q_("Disabled due to apparent incompatibility. Please use Qt5-based build."));
+		ui->radioButtonTelescopeASCOM->setDisabled(true);
+	#else
+		connect(ui->radioButtonTelescopeASCOM, SIGNAL(toggled(bool)), this, SLOT(toggleTypeASCOM(bool)));
+	#endif
 	#else
 	ui->radioButtonTelescopeASCOM->hide();
 	#endif
@@ -193,7 +198,7 @@ void TelescopeConfigurationDialog::initConfigurationDialog()
 	ui->groupBoxDeviceSettings->hide();
 	ui->groupBoxRTS2Settings->hide();
 	ui->INDIProperties->hide();
-	#ifdef Q_OS_WIN
+	#if defined(Q_OS_WIN) && QT_VERSION<QT_VERSION_CHECK(6,0,0)
 	ascomWidget->hide();
 	#endif
 
@@ -347,7 +352,7 @@ void TelescopeConfigurationDialog::initExistingTelescopeConfiguration(int slot)
 		ui->INDIProperties->setPort(portTCP);
 		ui->INDIProperties->setSelectedDevice(deviceModelName);
 	}
-	#ifdef Q_OS_WIN
+	#if defined(Q_OS_WIN) && QT_VERSION<QT_VERSION_CHECK(6,0,0)
 	else if (connectionType == TelescopeControl::ConnectionASCOM)
 	{
 		ui->radioButtonTelescopeASCOM->setChecked(true);
@@ -456,7 +461,7 @@ void TelescopeConfigurationDialog::toggleTypeINDI(bool enabled)
 	ui->INDIProperties->setVisible(enabled);
 }
 
-#ifdef Q_OS_WIN
+#if defined(Q_OS_WIN) && QT_VERSION<QT_VERSION_CHECK(6,0,0)
 void TelescopeConfigurationDialog::toggleTypeASCOM(bool enabled)
 {
 	ascomWidget->setVisible(enabled);	
@@ -545,7 +550,7 @@ void TelescopeConfigurationDialog::buttonSavePressed()
 		telescopeManager->addTelescopeAtSlot(configuredSlot, type, name, equinox, ui->INDIProperties->host(),
 		  ui->INDIProperties->port(), delay, connectAtStartup, circles, ui->INDIProperties->selectedDevice());
 	}
-	#ifdef Q_OS_WIN
+	#if defined(Q_OS_WIN) && QT_VERSION<QT_VERSION_CHECK(6,0,0)
 	else if (ui->radioButtonTelescopeASCOM->isChecked())
 	{
 		type = TelescopeControl::ConnectionASCOM;

--- a/plugins/TelescopeControl/src/gui/TelescopeConfigurationDialog.hpp
+++ b/plugins/TelescopeControl/src/gui/TelescopeConfigurationDialog.hpp
@@ -29,7 +29,7 @@
 #include "StelDialog.hpp"
 #include "TelescopeControl.hpp"
 
-#ifdef Q_OS_WIN
+#if defined(Q_OS_WIN) && QT_VERSION<QT_VERSION_CHECK(6,0,0)
 #include "../ASCOM/TelescopeClientASCOMWidget.hpp"
 #endif
 
@@ -68,7 +68,7 @@ private slots:
 	void toggleTypeVirtual(bool);
 	void toggleTypeRTS2(bool);
 	void toggleTypeINDI(bool enabled);
-	#ifdef Q_OS_WIN
+	#if defined(Q_OS_WIN) && QT_VERSION<QT_VERSION_CHECK(6,0,0)
 	void toggleTypeASCOM(bool enabled);
 	#endif
 	
@@ -87,7 +87,7 @@ private:
 	QRegularExpressionValidator * circleListValidator;
 	QRegularExpressionValidator * serialPortValidator;
 
-	#ifdef Q_OS_WIN
+	#if defined(Q_OS_WIN) && QT_VERSION<QT_VERSION_CHECK(6,0,0)
 	TelescopeClientASCOMWidget* ascomWidget;
 	#endif
 	


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Please include a summary of the change and which issue is fixed. -->
<!--- Please also include relevant motivation and context. -->
<!--- List any dependencies that are required for this change. -->

We had a lot of complaints about unexpected crashes while running ASCOM-controlled telescopes.
It seems to be a conflict between ASCOM and Qt6 which we probably cannot solve. 

This branch disables ASCOM builds on Qt6. The selector radio button is greyed out, and an explanation displayed..

Other people had 2 years to help. So, disable for now, if anybody still wants to help us, you are free to do so.

In a later phase, we may consider adding support for ASCOM Alpaca, a wrapper that avoids the COM-based stuff.

Fixes #2821, #2874, 

### Screenshots (if appropriate):

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system: Windows 11
* Graphics Card: (irrelevant)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (header file)
- [x] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
