### PR TITLE
Cache UTC offset

### DIFF
--- a/src/core/StelCore.cpp
+++ b/src/core/StelCore.cpp
@@ -1351,8 +1351,6 @@ void StelCore::moveObserverTo(const StelLocation& target, double duration, doubl
 	emit locationChanged(getCurrentLocation());
 }
 
-QCache<size_t, qint64> StelCore::utcOffsetCache;
-
 double StelCore::getUTCOffset(const double JD) const
 {
 	// This method takes a significant amount of time. Try to cache a few entries.

--- a/src/core/StelCore.cpp
+++ b/src/core/StelCore.cpp
@@ -1413,6 +1413,7 @@ double StelCore::getUTCOffset(const double JD) const
 	// Complete the cache object and hash it.
 	u.loc= & const_cast<StelLocation &>(loc);
 	u.tz = & const_cast<QTimeZone&>(tz);
+	// TODO FIXME ERROR: We must hash the contents, not the pointer!
 	size_t dateLocHash=qHash(&u);
 
 	qint64 shiftInSeconds;

--- a/src/core/StelCore.hpp
+++ b/src/core/StelCore.hpp
@@ -27,6 +27,7 @@
 #include "StelSkyDrawer.hpp"
 #include "StelPropertyMgr.hpp"
 #include "Dithering.hpp"
+#include <QCache>
 #include <QString>
 #include <QStringList>
 #include <QTime>
@@ -315,8 +316,13 @@ public:
 	const StelLocation& getCurrentLocation() const;
 	//! Get the UTC offset on the current location (in hours)
 	//! N.B. This is a rather costly operation. Re-use where possible!
+	//! In addition, this is now cached with 1-minute granularity.
 	double getUTCOffset(const double JD) const;
+private:
+	// Cache is over qHash(&UTCOffsetHashData).
+	static QCache<size_t, qint64> utcOffsetCache;
 
+public:
 	QString getCurrentTimeZone() const;
 	void setCurrentTimeZone(const QString& tz);
 

--- a/src/core/StelCore.hpp
+++ b/src/core/StelCore.hpp
@@ -319,8 +319,8 @@ public:
 	//! In addition, this is now cached with 1-minute granularity.
 	double getUTCOffset(const double JD) const;
 private:
-	// Cache is over qHash(&UTCOffsetHashData).
-	static QCache<size_t, qint64> utcOffsetCache;
+	// Cache is over size_t qHash(&UTCOffsetHashData).
+	mutable QCache<size_t, qint64> utcOffsetCache;
 
 public:
 	QString getCurrentTimeZone() const;


### PR DESCRIPTION
Finding UTC offset is surprisingly costly but is executed per-frame, shown in VTune. Caching the result per-minute saves at least part of it. 

This needs some testing. 

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Please include a summary of the change and which issue is fixed. -->
<!--- Please also include relevant motivation and context. -->
<!--- List any dependencies that are required for this change. -->

Fixes # (issue)

### Screenshots (if appropriate):
![2024-09-16d getCommonInfoString_UTCoffset](https://github.com/user-attachments/assets/41642d16-9744-4b72-8be0-cb422a547ef1)

With this caching: 
![2024-09-16e cachedUTCoffset](https://github.com/user-attachments/assets/ed5dff95-76e4-404c-9513-c875e945a462)



### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system: Win11
* Graphics Card: irrelevant

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
