### PR TITLE
Enabling std::execution::par for Clang 17+ and libc++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -366,6 +366,10 @@ IF("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
 	  SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-common -Wall -Wextra -Wno-unused-parameter -Wno-string-plus-int")
 	  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-common -Wall -Wextra -Wno-unknown-warning-option -Wno-string-plus-int")
      ENDIF()
+     # Parallel algorithms support for Clang 17+ and operating systems with libc++
+     IF((${CMAKE_CXX_COMPILER_VERSION} VERSION_GREATER 16.0) AND (APPLE OR ${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD"))
+          SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fexperimental-library")
+     ENDIF()
 ENDIF()
 
 # FreeBSD-specific compiler flags


### PR DESCRIPTION
Enabling support of parallel algorithms for Clang 17+ and libc++ (like FreeBSD) via adding `-fexperimental-library` option for compiler. Of course other way to use parallel algorithms is adding Intel's oneDPL (Intel's oneAPI) library.

See:
* https://oneapi-src.github.io/oneDPL/parallel_api/execution_policies.html
* https://forum.juce.com/t/c-support-for-execution-policies-on-ios/61261/3
* https://stackoverflow.com/questions/74722155/stdboyer-moore-searcher-and-stdexecutionpar-not-available-on-appleclang-14
* https://github.com/llvm/llvm-project/issues/57898

Our CI instance FreeBSD/Clang 18 is passed the test

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] Housekeeping

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
