### PR TITLE
Fix code scanning alert no. 4: Incomplete string escaping or encoding

### DIFF
--- a/plugins/RemoteControl/webroot/js/jquery-ui.js
+++ b/plugins/RemoteControl/webroot/js/jquery-ui.js
@@ -17942,7 +17942,7 @@ $.widget( "ui.tabs", {
 	},
 
 	_sanitizeSelector: function( hash ) {
-		return hash ? hash.replace( /[!"$%&'()*+,.\/:;<=>?@\[\]\^`{|}~]/g, "\\$&" ) : "";
+		return hash ? hash.replace( /[\\!"$%&'()*+,.\/:;<=>?@\[\]\^`{|}~]/g, "\\$&" ) : "";
 	},
 
 	refresh: function() {


### PR DESCRIPTION
Fixes [https://github.com/Stellarium/stellarium/security/code-scanning/4](https://github.com/Stellarium/stellarium/security/code-scanning/4)

To fix the problem, we need to ensure that backslashes are also escaped in the `_sanitizeSelector` function. This can be done by modifying the regular expression to include backslashes. The best way to fix this without changing existing functionality is to update the `replace` method to handle backslashes correctly.

- Modify the `_sanitizeSelector` function to include backslashes in the regular expression.
- Ensure that all occurrences of the specified characters, including backslashes, are replaced.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
