### PR TITLE
Fix code scanning alert no. 21: DOM text reinterpreted as HTML

### DIFF
--- a/plugins/RemoteControl/webroot/js/ui/scripts.js
+++ b/plugins/RemoteControl/webroot/js/ui/scripts.js
@@ -54,7 +54,7 @@ define(["jquery", "api/scripts", "api/remotecontrol"], function($, scriptApi, rc
 		$scriptlist.change(function() {
 			var selection = $scriptlist.children("option").filter(":selected").val();
 
-			$scriptinfo.attr('src', "/api/scripts/info?html=true&id="+selection);
+			$scriptinfo.attr('src', "/api/scripts/info?html=true&id=" + encodeURIComponent(selection));
 
 
 			$bt_runscript.prop({


### PR DESCRIPTION
Fixes [https://github.com/Stellarium/stellarium/security/code-scanning/21](https://github.com/Stellarium/stellarium/security/code-scanning/21)

To fix the problem, we need to ensure that the `selection` variable is properly encoded before being used in the URL. This can be achieved by using a function that encodes the value to make it safe for inclusion in a URL. The best way to do this is to use the `encodeURIComponent` function, which encodes a URI component by replacing each instance of certain characters with one, two, or three escape sequences representing the UTF-8 encoding of the character.

- Modify the line where the `selection` variable is concatenated into the URL string to use `encodeURIComponent(selection)`.
- This change should be made in the `initControls` function, specifically on line 57.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
