### PR TITLE
Fix code scanning alert no. 2: Prototype-polluting function

### DIFF
--- a/plugins/RemoteControl/webroot/js/require.js
+++ b/plugins/RemoteControl/webroot/js/require.js
@@ -109,6 +109,9 @@ var requirejs, require, define;
     function mixin(target, source, force, deepStringMixin) {
         if (source) {
             eachProp(source, function (value, prop) {
+                if (prop === '__proto__' || prop === 'constructor') {
+                    return;
+                }
                 if (force || !hasProp(target, prop)) {
                     if (deepStringMixin && typeof value === 'object' && value &&
                         !isArray(value) && !isFunction(value) &&


### PR DESCRIPTION
Fixes [https://github.com/Stellarium/stellarium/security/code-scanning/2](https://github.com/Stellarium/stellarium/security/code-scanning/2)

To fix the prototype pollution vulnerability in the `mixin` function, we need to add checks to block the special properties `__proto__` and `constructor`. This will prevent these properties from being copied from the source object to the target object, thereby mitigating the risk of prototype pollution.

- Modify the `mixin` function to include checks for `__proto__` and `constructor` properties.
- Ensure these checks are applied before any properties are copied from the source to the target object.
- The changes will be made in the file `plugins/RemoteControl/webroot/js/require.js` within the `mixin` function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
