### PR TITLE
Fix code scanning alert no. 1: Prototype-polluting function

### DIFF
--- a/plugins/RemoteControl/webroot/js/globalize.js
+++ b/plugins/RemoteControl/webroot/js/globalize.js
@@ -320,6 +320,10 @@ extend = function() {
 		if ( (options = arguments[ i ]) != null ) {
 			// Extend the base object
 			for ( name in options ) {
+				// Skip special properties to prevent prototype pollution
+				if (name === "__proto__" || name === "constructor") {
+					continue;
+				}
 				src = target[ name ];
 				copy = options[ name ];
 


### PR DESCRIPTION
Fixes [https://github.com/Stellarium/stellarium/security/code-scanning/1](https://github.com/Stellarium/stellarium/security/code-scanning/1)

To fix the prototype pollution vulnerability in the `extend` function, we need to add checks to prevent the merging of special properties like `__proto__` and `constructor`. This can be done by adding a condition to skip these properties during the merge process.

- **General Fix:** Add a condition to skip properties named `__proto__` and `constructor` during the merge process.
- **Detailed Fix:** Modify the `extend` function to include a check that skips the properties `__proto__` and `constructor` when copying properties from the source object to the target object.
- **Specific Changes:** Update the `extend` function in the file `plugins/RemoteControl/webroot/js/globalize.js` to include the necessary checks.
- **Requirements:** No additional methods or imports are needed. The changes will be made directly within the `extend` function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
