### PR TITLE
Fix code scanning alert no. 20: Unsafe jQuery plugin

### DIFF
--- a/plugins/RemoteControl/webroot/js/jquery-ui.js
+++ b/plugins/RemoteControl/webroot/js/jquery-ui.js
@@ -907,9 +907,7 @@ $.fn.position = function( options ) {
 	var atOffset, targetWidth, targetHeight, targetOffset, basePosition, dimensions,
 
 		// Make sure string options are treated as CSS selectors
-		target = typeof options.of === "string" ?
-			$( document ).find( options.of ) :
-			$( options.of ),
+		target = $( document ).find( options.of ),
 
 		within = $.position.getWithinInfo( options.within ),
 		scrollInfo = $.position.getScrollInfo( within ),


### PR DESCRIPTION
Fixes [https://github.com/Stellarium/stellarium/security/code-scanning/20](https://github.com/Stellarium/stellarium/security/code-scanning/20)

To fix the problem, we need to ensure that the `options.of` input is always treated as a CSS selector and not as HTML. This can be achieved by using the `jQuery.find` method, which interprets the input strictly as a CSS selector. This change will prevent any potential XSS vulnerabilities arising from interpreting the input as HTML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
