### PR TITLE
Let system-installed fast_float be found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1053,13 +1053,13 @@ ENDIF()
 
 include("cmake/Check-from_chars.cmake")
 IF(NOT FROM_CHARS_WORKS)
-    CPMFindPackage(NAME fast_float
+    CPMFindPackage(NAME FastFloat
                    GIT_REPOSITORY https://github.com/fastfloat/fast_float
                    VERSION 6.1.0
                    EXCLUDE_FROM_ALL yes)
-    GET_TARGET_PROPERTY(fast_float_INCLUDE_DIRECTORIES
+    GET_TARGET_PROPERTY(FastFloat_INCLUDE_DIRECTORIES
                         FastFloat::fast_float INTERFACE_INCLUDE_DIRECTORIES)
-    INCLUDE_DIRECTORIES(${fast_float_INCLUDE_DIRECTORIES})
+    INCLUDE_DIRECTORIES(${FastFloat_INCLUDE_DIRECTORIES})
     ADD_DEFINITIONS(-DUSE_FAST_FLOAT)
 ENDIF()
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

The library installs `/usr/share/cmake/FastFloat/FastFloatConfig.cmake`, so `find_package(fast_float)` cannot find it - `find_package(FastFloat)` can.

Only the `CPMFindPackage` line is relevant here, the other 2 are just for consistency, can revert them

<!--- Please include a summary of the change and which issue is fixed. -->
<!--- Please also include relevant motivation and context. -->
<!--- List any dependencies that are required for this change. -->

Fixes # (issue)

### Screenshots (if appropriate):

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] Housekeeping

### How Has This Been Tested?
By checking build log with libc++
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system: Gentoo
* Graphics Card: n/a

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
