### PR TITLE
Rewrite spheric mirror to make it more efficient

### DIFF
--- a/src/core/StelViewportEffect.hpp
+++ b/src/core/StelViewportEffect.hpp
@@ -20,8 +20,12 @@
 #ifndef STELVIEWPORTEFFECT_HPP
 #define STELVIEWPORTEFFECT_HPP
 
+#include <memory>
 #include "VecMath.hpp"
 #include "StelProjector.hpp"
+#include <QOpenGLBuffer>
+#include <QOpenGLShaderProgram>
+#include <QOpenGLVertexArrayObject>
 
 class QOpenGLFramebufferObject;
 
@@ -54,6 +58,14 @@ public:
 	QString getName() const override {return "sphericMirrorDistorter";}
 	void paintViewportBuffer(const QOpenGLFramebufferObject* buf) const override;
 	void distortXY(qreal& x, qreal& y) const override;
+
+private:
+	void setupShaders();
+	void setupBuffers();
+	void bindVAO() const;
+	void releaseVAO() const;
+	void setupCurrentVAO() const;
+
 private:
 	const int screen_w;
 	const int screen_h;
@@ -68,6 +80,18 @@ private:
 	QVector<Vec2f> displayVertexList;
 	QVector<Vec4f> displayColorList;
 	QVector<Vec2f> displayTexCoordList;
+	std::unique_ptr<QOpenGLVertexArrayObject> vao;
+	std::unique_ptr<QOpenGLBuffer> verticesVBO;
+	std::unique_ptr<QOpenGLShaderProgram> shaderProgram;
+	int vboVertexDataOffset;
+	int vboTexCoordDataOffset;
+	int vboColorDataOffset;
+	struct ShaderVars
+	{
+		int projectionMatrix;
+		int texture;
+	};
+	ShaderVars shaderVars;
 };
 
 #endif // STELVIEWPORTEFFECT_HPP


### PR DESCRIPTION
The old version rewrote VBO about 150×3 times per frame, which is very inefficient, especially given that the data written never change. This version writes these constant data once in the constructor of the distorter and uses them on rendering.

Fixes #3535

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?

* Enabled spheric mirror distortion, checked performance, noted improvement in frame rate.
* Disabled distortion, checked that no errors are reported in the log.
* Enabled again, exited Stellarium, checked that no errors are reported.
* Run with `--opengl-compat` and with `MESA_GL_VERSION_OVERRIDE=2.1` with distortion on, checked that the render looks as expected.
* Build against GLES2-using Qt6, check that in this mode distortion works as expected.

NOTE: I didn't try different parameters of the distortion, nor did I check the support for a custom distortion file. I don't expect that these would be affected, but this might be worth checking.

**Test Configuration**:
* Operating system: Ubuntu 20.04 LTS
* Graphics Card: Intel UHD Graphics 620

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
