### PR TITLE
improved size of small asteroids

### DIFF
--- a/plugins/SolarSystemEditor/src/SolarSystemEditor.cpp
+++ b/plugins/SolarSystemEditor/src/SolarSystemEditor.cpp
@@ -1195,7 +1195,7 @@ SsoElements SolarSystemEditor::readMpcOneLineMinorPlanetElements(const QString &
 	if (q > 30 && semiMajorAxis > 250)
 		objectType = "sednoid";
 
-	// don't save estimated albedo and radius
+	// Loader will estimate albedo and radius
 
 	DiscoveryCircumstances dc = numberedMinorPlanets.value(minorPlanetNumber, DiscoveryCircumstances("",""));
 	if (!dc.first.isEmpty())

--- a/plugins/SolarSystemEditor/src/SolarSystemEditor.cpp
+++ b/plugins/SolarSystemEditor/src/SolarSystemEditor.cpp
@@ -1195,13 +1195,7 @@ SsoElements SolarSystemEditor::readMpcOneLineMinorPlanetElements(const QString &
 	if (q > 30 && semiMajorAxis > 250)
 		objectType = "sednoid";
 
-	//Radius and albedo
-	//Assume albedo of 0.15 and calculate a radius based on the absolute magnitude
-	//as described here: http://www.physics.sfasu.edu/astro/asteroids/sizemagnitude.html
-	double albedo = 0.15; //Assumed
-	double radius = std::ceil(0.5*(1329 / std::sqrt(albedo)) * std::pow(10., -0.2 * absoluteMagnitude)); // Original formula is for diameter!
-	result.insert("albedo", albedo);
-	result.insert("radius", radius);
+	// don't save estimated albedo and radius
 
 	DiscoveryCircumstances dc = numberedMinorPlanets.value(minorPlanetNumber, DiscoveryCircumstances("",""));
 	if (!dc.first.isEmpty())

--- a/src/core/modules/MinorPlanet.cpp
+++ b/src/core/modules/MinorPlanet.cpp
@@ -127,6 +127,24 @@ void MinorPlanet::setAbsoluteMagnitudeAndSlope(const float magnitude, const floa
 	slopeParameter = slope;
 }
 
+void MinorPlanet::updateEquatorialRadius(void)
+{
+	if (absoluteMagnitude <= -99.f)
+	{
+		qWarning() << "MinorPlanet::updateEquatorialRadius():" <<
+				"invalid absoluteMagnitude for" << getEnglishName();
+		return;
+	}
+	if (equatorialRadius <= 0.)
+	{
+		if (albedo <= 0.0f)
+			albedo = 0.15f; // assumed
+		// Estimate as described at http://www.physics.sfasu.edu/astro/asteroids/sizemagnitude.html
+		float diameterKm = 1329.f / std::sqrt(albedo) * std::pow(10.f, -0.2f * absoluteMagnitude);
+		equatorialRadius = 0.5 * diameterKm / AU;
+	}
+}
+
 void MinorPlanet::setIAUDesignation(const QString &designation)
 {
 	//TODO: This feature has to be implemented better, anyway.

--- a/src/core/modules/MinorPlanet.cpp
+++ b/src/core/modules/MinorPlanet.cpp
@@ -138,7 +138,11 @@ void MinorPlanet::updateEquatorialRadius(void)
 	if (equatorialRadius <= 0.)
 	{
 		if (albedo <= 0.0f)
-			albedo = 0.15f; // assumed
+		{
+			// ESA NEOCC and NASA CNEOS assume albedo between 0.05 and 0.25
+			// https://neo.ssa.esa.int/definitions-assumptions
+			albedo = 0.15f;
+		}
 		// Estimate as described at http://www.physics.sfasu.edu/astro/asteroids/sizemagnitude.html
 		float diameterKm = 1329.f / std::sqrt(albedo) * std::pow(10.f, -0.2f * absoluteMagnitude);
 		equatorialRadius = 0.5 * diameterKm / AU;

--- a/src/core/modules/MinorPlanet.hpp
+++ b/src/core/modules/MinorPlanet.hpp
@@ -93,6 +93,9 @@ public:
 	//! @param slope Slope parameter G. This is usually [0..1], sometimes slightly outside. Allowed here [-1..2].
 	void setAbsoluteMagnitudeAndSlope(const float magnitude, const float slope);
 
+	//! sets radius based on absolute magnitude.
+	void updateEquatorialRadius(void);
+
 	//! renders the subscript in a minor planet IAU provisional designation with HTML.
 	static QString renderIAUDesignationinHtml(const QString& plainText);
 

--- a/src/core/modules/MinorPlanet.hpp
+++ b/src/core/modules/MinorPlanet.hpp
@@ -93,7 +93,7 @@ public:
 	//! @param slope Slope parameter G. This is usually [0..1], sometimes slightly outside. Allowed here [-1..2].
 	void setAbsoluteMagnitudeAndSlope(const float magnitude, const float slope);
 
-	//! sets radius based on absolute magnitude.
+	//! sets radius based on absolute magnitude and albedo.
 	void updateEquatorialRadius(void);
 
 	//! renders the subscript in a minor planet IAU provisional designation with HTML.

--- a/src/core/modules/SolarSystem.cpp
+++ b/src/core/modules/SolarSystem.cpp
@@ -1266,10 +1266,10 @@ bool SolarSystem::loadPlanets(const QString& filePath)
 			const QString horizonMapName = ( hidden ? "" : englishName.toLower().append("_normals.png")); // no normal maps for invisible objects!
 
 			newP = PlanetP(new MinorPlanet(englishName,
-						    pd.value(secname+"/radius", 1.0).toDouble()/AU,
+						    pd.value(secname+"/radius", 0.0).toDouble()/AU,
 						    pd.value(secname+"/oblateness", 0.0).toDouble(),
 						    color, // halo color
-						    pd.value(secname+"/albedo", 0.25f).toFloat(),
+						    pd.value(secname+"/albedo", 0.15f).toFloat(),
 						    pd.value(secname+"/roughness",0.9f).toFloat(),
 						    pd.value(secname+"/tex_map", "nomap.png").toString(),
 						    pd.value(secname+"/normals_map", normalMapName).toString(),
@@ -1292,6 +1292,7 @@ bool SolarSystem::loadPlanets(const QString& filePath)
 			if (magnitude > -99.f)
 			{
 				mp->setAbsoluteMagnitudeAndSlope(magnitude, qBound(0.0f, slope, 1.0f));
+				mp->updateEquatorialRadius();
 			}
 
 			mp->setColorIndexBV(static_cast<float>(bV));

--- a/src/core/modules/SolarSystem.cpp
+++ b/src/core/modules/SolarSystem.cpp
@@ -1269,7 +1269,7 @@ bool SolarSystem::loadPlanets(const QString& filePath)
 						    pd.value(secname+"/radius", 0.0).toDouble()/AU,
 						    pd.value(secname+"/oblateness", 0.0).toDouble(),
 						    color, // halo color
-						    pd.value(secname+"/albedo", 0.15f).toFloat(),
+						    pd.value(secname+"/albedo", 0.0f).toFloat(),
 						    pd.value(secname+"/roughness",0.9f).toFloat(),
 						    pd.value(secname+"/tex_map", "nomap.png").toString(),
 						    pd.value(secname+"/normals_map", normalMapName).toString(),


### PR DESCRIPTION
### Description
Most asteroids' sizes are unknown and estimated from their absolute magnitude.
Previous versions would round a small asteroid up to a radius of 1 km and save that in ssystem_minor.ini.
This caused small asteroids' Info to show an incorrect "Diameter: 2 km."

MPC elements do not provide albedo or radius, so in this revision,
SolarSystemEditor::readMpcOneLineMinorPlanetElements no longer sets them.
SolarSystem::loadPlanets calls new method MinorPlanet::updateEquatorialRadius,
which estimates radius using the same formula as before but does not round up.
To fix a bad radius already in ssystem_minor.ini, delete that line manually.
If an asteroid's size is known and different from the usual estimate, a radius may be added manually.

Fixes # (issue)

### Screenshots (if appropriate):

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?
With Size enabled in Info:

* Newly imported asteroid with H>18 shows reasonable diameter, e.g. 2024 ON with H=20.5 shows 0.3 km
* Asteroid imported using older release shows reasonable diameter if radius is deleted from ssystem_minor.ini
* Asteroid with radius specified in ssystem_minor.ini shows 2x that diameter
* Newly imported comet still shows 10 km diameter, e.g. C/2024 S1

**Test Configuration**:
* Operating system: Linux Ubuntu 22.04
* Graphics Card: NVidia GeForce GT 750M, driver 390

## Checklist:
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
