### PR TITLE
Attempt to resolve HIP first in search via SIMBAD

### DIFF
--- a/src/core/SimbadSearcher.cpp
+++ b/src/core/SimbadSearcher.cpp
@@ -149,12 +149,17 @@ void SimbadLookupReply::httpQueryFinished()
 					Vec3d v;
 					StelUtils::spheToRect(ra, dec, v);
 					line = reply->readLine();
-					line.chop(1); // Remove a line break at the end
+					while (line.simplified().isEmpty())
+					{   // for example SDSS J140312.52+542056.2 (i.e. M101) does not have HIP so an empty lines, need to check
+						line = reply->readLine();
+						line.chop(1); // Remove a line break at the end
+					}
 					line.replace("NAME " ,"");
 					resultPositions[line.simplified()]=v; // Remove an extra spaces
 				}
 				line = reply->readLine();
 				line.chop(1); // Remove a line break at the end
+				break;  // there might be more than one result of names for the same object
 			}
 			currentStatus = SimbadLookupFinished;
 		}
@@ -189,7 +194,7 @@ SimbadLookupReply* SimbadSearcher::lookup(const QString& serverUrl, const QStrin
 {
 	// Create the Simbad query
 	QString url(serverUrl);
-	QString query = "format object \"%COO(d;A D)\\n%IDLIST(1)\"\n";
+	QString query = "format object \"%COO(d;A D)\\n%IDLIST(HIP)\\n%IDLIST(1)\"\n";
 	query += QString("set epoch J2000\nset limit %1\n query id ").arg(maxNbResult);
 	query += objectName;
 	QByteArray ba = QUrl::toPercentEncoding(query, "", "");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
In the search functionality via SIMBAD, stellarium should at least attempt to resolve the HIP number before trying the main identification `IDLIST(1)` from SIMBAD.

Because there can be scenario where one searches `TIC 211277570` and stellarium points to a custom object `* tet01 Sgr` near `HIP 98412` (`TIC 211277570` is `HIP 98412`).

Fixes # (issue)

### Screenshots (if appropriate):

<img width="1006" alt="image" src="https://github.com/user-attachments/assets/8f93e3fb-6081-479f-af81-77d5257b89ec">


### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Compiled and ran.

Tried to search `TIC 211277570` which point to the right star. Tried to search `SDSS J140312.52+542056.2` which correctly point to M101 who does not have a HIP id.

**Test Configuration**:
* Operating system: MacOS 15
* Graphics Card: Apple M3

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
