### PR TITLE
Fix proper motion equation in Star1/2 and Pulsar

### DIFF
--- a/plugins/Pulsars/src/Pulsar.cpp
+++ b/plugins/Pulsars/src/Pulsar.cpp
@@ -457,10 +457,11 @@ void Pulsar::draw(StelCore* core, StelPainter *painter)
 Vec3d Pulsar::getJ2000EquatorialPos(const StelCore* core) const
 {
 	static const double d2000 = 2451545.0;
-	const double movementFactor = (M_PI/180.)*(0.0001/3600.) * (core->getJDE()-d2000)/365.25;
+	static const double MAS2RAD = 1 / 3600000.0 * M_PI / 180.0;
+	const double dyr = (core->getJDE()-d2000)/365.25;
 	Vec3d v;
-	const double cRA = RA + movementFactor*pmRA;
-	const double cDE = DE + movementFactor*pmDE;
+	const double cRA = RA + MAS2RAD*dyr*pmRA / cos(DE);
+	const double cDE = DE + MAS2RAD*dyr*pmDE;
 	StelUtils::spheToRect(cRA, cDE, v);
 
 	if ((core) && (core->getUseAberration()) && (core->getCurrentPlanet()))

--- a/src/core/modules/Star.hpp
+++ b/src/core/modules/Star.hpp
@@ -21,9 +21,11 @@
 
 #ifndef STAR_HPP
 #define STAR_HPP
+#define MAS2RAD 1 / 3600000.0 * M_PI / 180.0
 
 #include "ZoneData.hpp"
 #include "StelObjectType.hpp"
+#include "StelUtils.hpp"
 #include <QString>
 #include <QtEndian>
 
@@ -112,12 +114,19 @@ private:
 public:
 	enum {MaxPosVal=0x7FFFFFFF};
 	StelObjectP createStelObject(const SpecialZoneArray<Star1> *a, const SpecialZoneData<Star1> *z) const;
-	void getJ2000Pos(const ZoneData *z,float movementFactor, Vec3f& pos) const
+	void getJ2000Pos(const ZoneData *z,float dyr, Vec3f& pos) const
 	{
 		pos = z->axis0;
-		pos*=(static_cast<float>(getX0())+movementFactor*getDx0());
-		pos+=(static_cast<float>(getX1())+movementFactor*getDx1())*z->axis1;
+		pos*=static_cast<float>(getX0());
 		pos+=z->center;
+		pos+=static_cast<float>(getX1())*z->axis1;
+
+		double RA;
+		double DE;
+		StelUtils::rectToSphe(&RA, &DE, pos);
+		const double cRA = RA + (static_cast<float>(getDx0())/10.f*dyr*MAS2RAD) / cos(DE);
+		const double cDE = DE +  static_cast<float>(getDx1())/10.f*dyr*MAS2RAD;
+		StelUtils::spheToRect(cRA, cDE, pos);
 	}
 	inline int getBVIndex() const {return d.b_v;}
 	inline int getMag() const {return d.vmag;}
@@ -207,12 +216,19 @@ public:
 
 	enum {MaxPosVal=((1<<19)-1)};
 	StelObjectP createStelObject(const SpecialZoneArray<Star2> *a, const SpecialZoneData<Star2> *z) const;
-	void getJ2000Pos(const ZoneData *z,float movementFactor, Vec3f& pos) const
+	void getJ2000Pos(const ZoneData *z,float dyr, Vec3f& pos) const
 	{
 		pos = z->axis0;
-		pos*=(static_cast<float>(getX0())+movementFactor*getDx0());
-		pos+=(static_cast<float>(getX1())+movementFactor*getDx1())*z->axis1;
+		pos*=static_cast<float>(getX0());
 		pos+=z->center;
+		pos+=static_cast<float>(getX1())*z->axis1;
+
+		double RA;
+		double DE;
+		StelUtils::rectToSphe(&RA, &DE, pos);
+		const double cRA = RA + (static_cast<float>(getDx0())/10.f*dyr*MAS2RAD) / cos(DE);
+		const double cDE = DE +  static_cast<float>(getDx1())/10.f*dyr*MAS2RAD;
+		StelUtils::spheToRect(cRA, cDE, pos);
 	}
 	float getBV(void) const {return IndexToBV(getBVIndex());}
 	QString getNameI18n(void) const {return QString();}

--- a/src/core/modules/StarMgr.cpp
+++ b/src/core/modules/StarMgr.cpp
@@ -717,9 +717,8 @@ void StarMgr::populateHipparcosLists()
 				doubleHipStars.push_back(sd);
 			}
 			// use separate variables for avoid the overflow (esp. for Barnard's star)
-			PMData properMotion = getProperMotion(s->getHip());
-			float pmX = properMotion.first;
-			float pmY = properMotion.second;
+			float pmX = 0.1f*s->getDx0();
+			float pmY = 0.1f*s->getDx0();
 			float pm = 0.001f * std::sqrt((pmX*pmX) + (pmY*pmY));
 			if (qAbs(pm)>=pmLimit)
 			{

--- a/src/core/modules/StarWrapper.cpp
+++ b/src/core/modules/StarWrapper.cpp
@@ -160,7 +160,6 @@ QString StarWrapper1::getInfoString(const StelCore *core, const InfoStringGroup&
 	const double vPeriod = StarMgr::getGcvsPeriod(s->getHip());
 	const int vMm = StarMgr::getGcvsMM(s->getHip());
 	const float plxErr = StarMgr::getPlxError(s->getHip());
-	const PMData properMotion = StarMgr::getProperMotion(s->getHip());
 	if (s->getHip())
 	{
 		if ((flags&Name) || (flags&CatalogNumber))
@@ -325,10 +324,10 @@ QString StarWrapper1::getInfoString(const StelCore *core, const InfoStringGroup&
 		oss << getExtraInfoStrings(Distance).join("");
 	}
 
-	if (flags&ProperMotion && (!isNan(properMotion.first) && !isNan(properMotion.second)))
+	if (flags)
 	{
-		float dx = properMotion.first;
-		float dy = properMotion.second;
+		float dx = 0.1f*s->getDx0();
+		float dy = 0.1f*s->getDx1();
 		float pa = std::atan2(dx, dy)*M_180_PIf;
 		if (pa<0)
 			pa += 360.f;

--- a/src/core/modules/StarWrapper.hpp
+++ b/src/core/modules/StarWrapper.hpp
@@ -79,7 +79,7 @@ protected:
 	{
 		static const double d2000 = 2451545.0;
 		Vec3f v;
-		s->getJ2000Pos(z, (M_PI/180.)*(0.0001/3600.) * ((core->getJDE()-d2000)/365.25) / a->star_position_scale, v);
+		s->getJ2000Pos(z, ((core->getJDE()-d2000)/365.25), v);
 
 		// Aberration: Explanatory Supplement 2013, (7.38). We must get the observer planet speed vector in Equatorial J2000 coordinates.
 		if (core->getUseAberration())

--- a/src/core/modules/ZoneArray.cpp
+++ b/src/core/modules/ZoneArray.cpp
@@ -413,7 +413,7 @@ void SpecialZoneArray<Star>::draw(StelPainter* sPainter, int index, bool isInsid
 	StelSkyDrawer* drawer = core->getSkyDrawer();
 	Vec3f vf;
 	static const double d2000 = 2451545.0;
-	const float movementFactor = static_cast<float>((M_PI/180.)*(0.0001/3600.) * ((core->getJDE()-d2000)/365.25) / static_cast<double>(star_position_scale));
+	const float dyr = (core->getJDE()-d2000)/365.25;
 
 	const Extinction& extinction=core->getSkyDrawer()->getExtinction();
 	const bool withExtinction=drawer->getFlagHasAtmosphere() && extinction.getExtinctionCoefficient()>=0.01f;
@@ -445,7 +445,7 @@ void SpecialZoneArray<Star>::draw(StelPainter* sPainter, int index, bool isInsid
 		const RCMag* tmpRcmag = &rcmag_table[s->getMag()];
 		
 		// Get the star position from the array
-		s->getJ2000Pos(zoneToDraw, movementFactor, vf);
+		s->getJ2000Pos(zoneToDraw, dyr, vf);
 
 		// Aberration: vf contains Equatorial J2000 position.
 		if (withAberration)
@@ -505,13 +505,13 @@ void SpecialZoneArray<Star>::searchAround(const StelCore* core, int index, const
 					  QList<StelObjectP > &result)
 {
 	static const double d2000 = 2451545.0;
-	const double movementFactor = (M_PI/180.)*(0.0001/3600.) * ((core->getJDE()-d2000)/365.25)/ static_cast<double>(star_position_scale);
+	const float dyr = (core->getJDE()-d2000)/365.25;
 	const SpecialZoneData<Star> *const z = getZones()+index;
 	Vec3f tmp;
 	Vec3f vf = v.toVec3f();
 	for (const Star* s=z->getStars();s<z->getStars()+z->size;++s)
 	{
-		s->getJ2000Pos(z,static_cast<float>(movementFactor), tmp);
+		s->getJ2000Pos(z, dyr, tmp);
 		tmp.normalize();
 		if (tmp*vf >= static_cast<float>(cosLimFov))
 		{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
This PR fixes the issue of reading proper motion for the main catalog and issue of errorous calculation of RA/DEC with proper motion (equation is wrong).

My understanding of the past issue regarding proper motion is that the pmra/pmdec values in the catalog can not be decoded properly(?). But it seems to me the catalog proper motion are simply pmra and pmdec in the unit of 0.1 mas/yr. I've picked a few HIP stars and seem to check out.

Now this PR simply read the pmra/pmdec from the catalog and use it to calculate RA/DEC at any date. IMO this is a good temporary solution until new catalog arrives.

I kept the extra proper motion data in the repository but they are not used to display nor calculation.

Fixes #85 (issue), #1061 (partially)


### Screenshots (if appropriate):

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Nutation, Abberation and atmosphere are turned off!!

Compared to SIMBAD on high proper motion stars Proxima Centauri and Barnard's star.

On the issue of Proxima Centauri from #1061, here are the comparison

On 1 Jan 2000
|Source (1 Jan 2000)|RA|DEC|Diff|
|---|---|---|---|
|Gaia DR3|14h29m42.94|-62d40m46.16| 0.00s / 0.00s|
|Stellarium 24.3 & PR|14h29m47.59|-62d40m52.50| 4.64s / 6.34s|

so Proxima Centauri is off by RA/DEC +4.64s/+6.34s to begin with between Stellarium catalog and Gaia DR3 regardless if proper motion is done correctly.

on 22 Apr 2020
|Source (22 Apr 2020)|RA|DEC|Diff|
|---|---|---|---|
|Gaia DR3|14h29m31.74|-62d40m30.48| 0.00s / 0.00s|
|Stellarium This PR (corrected with offset manually)|14h29m31.68|-62d40m30.66|-0.06 / 0.16s|
|Stellarium This PR|14h29m36.32|-62d40m37.00|5.84s / 6.52s|
|Stellarium 24.3 (corrected with offset manually)|14h29m32.33|-62d40m17.76|1.85s / -12.72s|
|Stellarium 24.3|14h29m36.97|-62d40m24.10|5.23s / -6.38s|

<!--- Gaia J2000 RA/DEC on 2000-Jan-1 are 14h29m42.94, -62d40m46.16 with pmra/pmdec are -3781.741/769.465 mas/yr. So on 2020-Apr-22, Proxima Centauri should be at 14h29m31.74, -62d40m30.48. In Stellarium, Proxima Centauri on 2000-Jan-1 is at 14h29m47.59, -62d40m52.50, so Proxima Centauri is off by RA/DEC +4.64s/+6.34s to begin with. On 2020-Apr-22, Proxima Centauri with this PR is at 14h29m36.32, -62d40m37.00 in stellarium. Considering the offset at 2000-Jan-1 to begin with, the corrected coordinates are 14h29m31.68, -62d40m30.66, which is really close to what Gaia implies. Stellarium 24.3 gives 14h29m36.97, -62d40m24.1, it is off even with correction calculated at 2000-Jan-1. --->

Another case: Barnard's star. Its J2000 RA/DEC on 2000-Jan-1 are very accurate already in stellarium.
On 19 Nov 2024
|Source (19 Nov 2024)|RA|DEC|Diff|
|---|---|---|---|
|Gaia DR3|17h57m47.16|+4d45m54.31| 0.00s / 0.00s|
|Stellarium This PR|17h57m47.06|+4d45m54.20| -0.10s / 0.11s|
|Stellarium 24.3|17h57m47.28|+4d45m52.40| 0.12s / -1.91s|

<!--- Gaia implies it should be at RA/DEC 17h57m47.16, +4d45m54.31 on 19 Nov 2024. Stellarium 24.3 gives 17h57m47.28, +4d45m52.40 while this PR gives 17h57m47.06, +4d45m54.20. --->

The display of proper motions seems fine, just a bit off due to using old ata compared to precise Gaia.

<img width="1257" alt="image" src="https://github.com/user-attachments/assets/c7399452-267f-45db-b307-e1558165d9c2">

**Test Configuration**:
* Operating system: MacOS 15
* Graphics Card: Apple M3

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
