### PR TITLE
Keep FOV search radius on hiDPI screen consistent from user perspective

### DIFF
--- a/src/core/StelObjectMgr.cpp
+++ b/src/core/StelObjectMgr.cpp
@@ -461,8 +461,8 @@ StelObjectP StelObjectMgr::cleverFind(const StelCore* core, const Vec3d& v) cons
 {
 	const StelProjectorP prj = core->getProjection(StelCore::FrameJ2000);
 
-	// Field of view for a searchRadiusPixel pixel diameter circle on screen
-	const double fov_around = core->getMovementMgr()->getCurrentFov()/qMin(prj->getViewportWidth(), prj->getViewportHeight()) * searchRadiusPixel;
+	// Field of view for a searchRadiusPixel pixel diameter circle on User's screen (which may not be the same on scaled display)
+	const double fov_around = core->getMovementMgr()->getCurrentFov()/qMin(prj->getViewportWidth(), prj->getViewportHeight()) * searchRadiusPixel * core->getCurrentStelProjectorParams().devicePixelsPerPixel;
 
 	// Collect the objects inside the range
 	// TODO: normalize v here, and just Q_ASSERT normalized state in the submodules' searchAround() calls.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

I briefly looked into the issue #3733 because the issue of selecting the wrong star/ not selecting any stars even clicked near a star somewhat are becoming more problematic when some sky regions can have stars densely packed together with future star catalogs with Gaia. Although this PR does not fix anything, but a minor logical improvement until someone takes a deep dive into the issue after the new star catalogs are done because things can still be changed around.

I've found that the FOV to search around are penalized for user with a scaled high DPI screen by the display scaling factor. So hiDPI screen users are expected to click closer to a star in order for it to be searched. Now the FOV to search should be independent of display scaling (N pixels from user perspective around the mouse click will be searched)

Fixes # (issue)

None

### Screenshots (if appropriate):

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system: MacOS 13
* Graphics Card: Apple M3

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
