### PR TITLE
Simplify and fix kerning of curved text

### DIFF
--- a/src/core/StelPainter.cpp
+++ b/src/core/StelPainter.cpp
@@ -575,84 +575,52 @@ void StelPainter::sSphereMap(double radius, unsigned int slices, unsigned int st
 	}
 }
 
-void StelPainter::drawTextGravity180(float x, float y, const QString& ws, float xshift, float yshift)
+void StelPainter::drawTextGravity180(const float x, const float y, const QString& ws, const float xshift, const float yshift)
 {
 	const float dx = x - static_cast<float>(prj->viewportCenter[0]);
 	const float dy = y - static_cast<float>(prj->viewportCenter[1]);
-	const float d = std::sqrt(dx*dx + dy*dy);
-	const float limit = 120.;
+	float d = std::sqrt(dx*dx + dy*dy);
 
 	// If the text is too far away to be visible in the screen return
 	if (d>qMax(prj->viewportXywh[3], prj->viewportXywh[2])*2 || ws.isEmpty())
 		return;
 
+	const auto fm = getFontMetrics();
+	const bool rtl = StelApp::getInstance().getLocaleMgr().isSkyRTL();
+
 	const float ppx = static_cast<float>(prj->getDevicePixelsPerPixel());
-	const float cWidth = static_cast<float>(getFontMetrics().boundingRect(ws).width())/ws.length(); // average character width
-	const float stdWidth = static_cast<float>(getFontMetrics().boundingRect("n").width());
-	const float theta_o = M_PIf + std::atan2(dx, dy - 1);
+	float anglePerUnitWidth = ppx / d;
 	float theta = std::atan2(dy - 1, dx);
-	float psi = std::atan2(ppx*cWidth*1.2, d + 1) * M_180_PIf; // Factor 1.2 is empirical.
-	if (psi>5)
-		psi = 5;
 
-	const float xVc = static_cast<float>(prj->viewportCenter[0]) + xshift;
-	const float yVc = static_cast<float>(prj->viewportCenter[1]) + yshift;
-	const float cosr = std::cos(-theta_o * M_PI_180f);
-	const float sinr = std::sin(-theta_o * M_PI_180f);
-	float xom = x + xshift*cosr - yshift*sinr;
-	float yom = y + yshift*sinr + xshift*cosr;
-	float width;
-	QChar s;
+	float xVc = static_cast<float>(prj->viewportCenter[0]) + xshift;
+	float yVc = static_cast<float>(prj->viewportCenter[1]) + yshift;
 
-	if (!StelApp::getInstance().getLocaleMgr().isSkyRTL())
+	const float charWidth = fm.averageCharWidth();
+	constexpr float maxAnglePerChar = 10 * M_PI_180f;
+	if (charWidth * anglePerUnitWidth > maxAnglePerChar)
 	{
-		for (int i=0; i<ws.length(); ++i)
-		{
-			s = ws[i];
-			if (d<limit)
-			{
-				drawText(xom, yom, s, -theta_o*M_180_PIf+psi*static_cast<float>(i), 0., 0.);
-				xom += cWidth*std::cos(-theta_o+psi*static_cast<float>(i) * M_PI_180f);
-				yom += cWidth*std::sin(-theta_o+psi*static_cast<float>(i) * M_PI_180f);
-			}
-			else
-			{
-				x = d * std::cos(theta) + xVc ;
-				y = d * std::sin(theta) + yVc ;
-				drawText(x, y, s, 90.f + theta*M_180_PIf, 0., 0.);
-				// Compute how much the character contributes to the angle
-				if (s.isSpace())
-					width = stdWidth;
-				else
-					width = static_cast<float>(getFontMetrics().boundingRect(s).width());
-				theta += psi * M_PI_180f * (1 + (width - cWidth)/ cWidth);
-			}
-		}
+		// Too curvy text, limit its curvature by moving the center of curvature away
+		const float x0 = d * std::cos(theta) + xVc;
+		const float y0 = d * std::sin(theta) + yVc;
+
+		anglePerUnitWidth = maxAnglePerChar / charWidth;
+		d = ppx / anglePerUnitWidth;
+
+		xVc = x0 - d * std::cos(theta);
+		yVc = y0 - d * std::sin(theta);
 	}
-	else
+
+	const int slen = ws.length();
+	const int startI = rtl ? slen - 1 : 0;
+	const int endI = rtl ? -1 : slen;
+	const int inc = rtl ? -1 : 1;
+	for (int i = startI; i != endI; i += inc)
 	{
-		int slen = ws.length();
-		for (int i=0;i<slen;i++)
-		{
-			s = ws[slen-1-i];
-			if (d<limit)
-			{
-				drawText(xom, yom, s, -theta_o*M_180_PIf+psi*static_cast<float>(i), 0., 0.);
-				xom += cWidth*std::cos(-theta_o+psi*static_cast<float>(i) * M_PI_180f);
-				yom += cWidth*std::sin(-theta_o+psi*static_cast<float>(i) * M_PI_180f);
-			}
-			else
-			{
-				x = d * std::cos(theta) + xVc;
-				y = d * std::sin(theta) + yVc;
-				drawText(x, y, s, 90.f + theta*M_180_PIf, 0., 0.);
-				if (s.isSpace())
-					width = stdWidth;
-				else
-					width = static_cast<float>(getFontMetrics().boundingRect(s).width());
-				theta += psi * M_PI_180f * (1 + (width - cWidth)/ cWidth);
-			}
-		}
+		const QChar c = ws[i];
+		const float x = d * std::cos(theta) + xVc;
+		const float y = d * std::sin(theta) + yVc;
+		drawText(x, y, c, 90.f + theta*M_180_PIf, 0., 0.);
+		theta += fm.horizontalAdvance(c) * anglePerUnitWidth;
 	}
 }
 


### PR DESCRIPTION
### Description

While reading the discussion of Oxford-13 I saw an example of very bad kerning of the so called "gravity labels". Additionally, baseline was uneven from character to character in a word, but this I've fixed and pushed already.

This PR is now only concerned with the kerning itself. Instead of using bounding rectangles of the characters the new code employs the proper horizontal advances. Also, now the limit of curvature is done in a bit smoother way, without sudden jump of density in text when it approaches the center of the screen, and the char density is now kept constant.

### Screenshots

The code had two special branches for RTL and LTR texts, so the screenshots below take two different sky culture languages to compare.

#### English old

![stellarium-018](https://github.com/user-attachments/assets/77cd0ade-d320-4b22-afa6-c1ea989ec876)

#### English new

![stellarium-019](https://github.com/user-attachments/assets/76704bf9-3f56-47ae-a2f8-49f277f85639)

#### Arabic old

![stellarium-016](https://github.com/user-attachments/assets/6b5e2850-7eff-4bcd-92b3-7a4923c39691)

#### Arabic new

![stellarium-017](https://github.com/user-attachments/assets/693a886d-e2ec-4499-a730-db05324c2fa6)

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system: Ubuntu 20.04 LTS
* Graphics Card: Intel UHD Graphics 620

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
