### PR TITLE
Densely sampling orbit of parent planet if on its moon

### DIFF
--- a/src/core/modules/Planet.cpp
+++ b/src/core/modules/Planet.cpp
@@ -4918,14 +4918,16 @@ void Planet::drawOrbit(const StelCore* core)
 			orbit[d] = getEclipticPos(calc_date);
 		}
 	}
-	else {
+	else 
+	{
 		// Update the orbit positions to the current planet date.
 		computeOrbit();
 	}
 	const Vec3d savePos = orbit[ORBIT_SEGMENTS/2];
 	if (closeOrbit)
 	{
-		if ((!keplerOrbit || keplerOrbit->getEccentricity()<=0.3) && !fromMoonPerspective) {
+		if ((!keplerOrbit || keplerOrbit->getEccentricity()<=0.3) && !fromMoonPerspective) 
+		{
 			// special case - use current Planet position as center vertex so that draws
 			// on its orbit all the time (since orbit is shown as segmented rather than smooth curve)
 			orbit[ORBIT_SEGMENTS/2]=getHeliocentricEclipticPos()+aberrationPush;

--- a/src/core/modules/Planet.cpp
+++ b/src/core/modules/Planet.cpp
@@ -4909,10 +4909,9 @@ void Planet::drawOrbit(const StelCore* core)
 		// we should concentrate on this theta when sampling orbit
 		double theta = (atan2((myparentPos ^ myPosProjected).dot(orbitalNormal), myparentPos.dot(myPosProjected)))  / M_PI;
 
-		double f;
 		for(int d = 0; d < ORBIT_SEGMENTS; d++)
 		{
-			f = (d - ORBIT_SEGMENTS/2.) / (ORBIT_SEGMENTS/2.);
+			const double f = (d - ORBIT_SEGMENTS/2.) / (ORBIT_SEGMENTS/2.);
 			// make sure only sample half of the orbit forward and half backward
 			// the sampling spacing is trial and error, but power of 13 seems to be good (i.e., densely sample around the current date)
 			calc_date = dateJDE + pow(f, 13)*deltaOrbitJDE*ORBIT_SEGMENTS/2. + theta*deltaOrbitJDE*ORBIT_SEGMENTS/2;
@@ -4922,7 +4921,7 @@ void Planet::drawOrbit(const StelCore* core)
 	else {
 		// Update the orbit positions to the current planet date.
 		computeOrbit();
-		}
+	}
 	const Vec3d savePos = orbit[ORBIT_SEGMENTS/2];
 	if (closeOrbit)
 	{
@@ -4930,7 +4929,7 @@ void Planet::drawOrbit(const StelCore* core)
 			// special case - use current Planet position as center vertex so that draws
 			// on its orbit all the time (since orbit is shown as segmented rather than smooth curve)
 			orbit[ORBIT_SEGMENTS/2]=getHeliocentricEclipticPos()+aberrationPush;
-			}
+		}
 		orbit[ORBIT_SEGMENTS]=orbit[0];
 	}
 	int nbIter = closeOrbit ? ORBIT_SEGMENTS : ORBIT_SEGMENTS-1;

--- a/src/core/modules/Planet.cpp
+++ b/src/core/modules/Planet.cpp
@@ -4904,12 +4904,10 @@ void Planet::drawOrbit(const StelCore* core)
 
 		Vec3d myPos = core->getCurrentPlanet()->getHeliocentricEclipticPos(lastJDE);
 		Vec3d myparentPos = core->getCurrentPlanet()->getParent()->getHeliocentricEclipticPos(dateJDE);
-		Vec3d parentPos = parent->getHeliocentricEclipticPos(dateJDE)+ parent->getAberrationPush(); // aberrationPush is not strictly correct, but helps a lot...
 
 		// pretend they are on x-y plane
 		myPos[2] = 0;
 		myparentPos[2] = 0;
-		parentPos[2] = 0;
 
 		// angle between me and parent
 		double theta = atan2(myPos[1], myPos[0]) - atan2(myparentPos[1], myparentPos[0]);
@@ -4919,13 +4917,10 @@ void Planet::drawOrbit(const StelCore* core)
 		for(int d = 0; d < ORBIT_SEGMENTS; d++)
 		{
 			f = static_cast<double>(d - ORBIT_SEGMENTS/2.) / (ORBIT_SEGMENTS/2.);
+			// make sure only sample half of the orbit forward and half backward
+			// the sampling spacing is trial and error, but power of 13 seems to be good (i.e., densely sample around the current date)
 			calc_date = dateJDE + pow(f, 13)*deltaOrbitJDE*ORBIT_SEGMENTS/2. + theta/180.*deltaOrbitJDE*ORBIT_SEGMENTS/2;
-			orbit[d] = getEclipticPos(calc_date) + parentPos;
-		}
-		Vec3d offsetPos = (getEclipticPos(dateJDE) + parentPos) - (getHeliocentricEclipticPos()+aberrationPush);
-		for(int d = 0; d < ORBIT_SEGMENTS; d++)
-		{
-			orbit[d] -= offsetPos;
+			orbit[d] = getEclipticPos(calc_date);
 		}
 	}
 	const Vec3d savePos = orbit[ORBIT_SEGMENTS/2];

--- a/src/core/modules/Planet.cpp
+++ b/src/core/modules/Planet.cpp
@@ -4877,10 +4877,10 @@ void Planet::drawOrbit(const StelCore* core)
 			return;
 	}
 	bool fromMoonPerspective = false;
-	if (core->getCurrentPlanet()->pType == 2)  // if I am a moon
+	if (core->getCurrentPlanet()->pType == isMoon || core->getCurrentPlanet()->pType == isObserver)  // if I am a moon or observer of a planet
 	{
 		// only if we are also drawing my parent
-		fromMoonPerspective = core->getCurrentPlanet()->getParent()->getID() == getID();
+		fromMoonPerspective = core->getCurrentPlanet()->getParent() == this;
 	}
 
 	const StelProjectorP prj = core->getProjection(StelCore::FrameHeliocentricEclipticJ2000);
@@ -4894,42 +4894,43 @@ void Planet::drawOrbit(const StelCore* core)
 	sPainter.setColor(getCurrentOrbitColor(), orbitFader.getInterstate());
 	Vec3d onscreen;
 
-	if (!fromMoonPerspective) {
-		// Update the orbit positions to the current planet date.
-		computeOrbit();
-	}
-	else {
+	if (fromMoonPerspective) {
 		double dateJDE = lastJDE;
 		double calc_date;
 
-		Vec3d myPos = core->getCurrentPlanet()->getHeliocentricEclipticPos(lastJDE);
-		Vec3d myparentPos = core->getCurrentPlanet()->getParent()->getHeliocentricEclipticPos(dateJDE);
-
-		// pretend they are on x-y plane
-		myPos[2] = 0;
-		myparentPos[2] = 0;
-
-		// angle between me and parent
-		double theta = atan2(myPos[1], myPos[0]) - atan2(myparentPos[1], myparentPos[0]);
-		theta = theta / M_PI * 180.;  // should concentrate on this theta when sampling orbit
+		Vec3d myPos = core->getCurrentPlanet()->getHeliocentricEclipticPos(dateJDE);
+		Vec3d myparentPos = getHeliocentricEclipticPos(dateJDE);
+		// orbital plane normal of parent planet, computed with the pos ~quarter of the orbit later
+		Vec3d orbitalNormal = myparentPos ^ getHeliocentricEclipticPos(dateJDE + deltaOrbitJDE*ORBIT_SEGMENTS/4);
+		orbitalNormal.normalize();
+		// project myPos into the orbital plane of parent planet using the normal of orbital plane
+		Vec3d myPosProjected = myPos - myPos.dot(orbitalNormal) * orbitalNormal;
+		// angle between myPos already projected onto the orbital plane of parent planet and the plane
+		// we should concentrate on this theta when sampling orbit
+		double theta = (atan2((myparentPos ^ myPosProjected).dot(orbitalNormal), myparentPos.dot(myPosProjected)))  / M_PI;
 
 		double f;
 		for(int d = 0; d < ORBIT_SEGMENTS; d++)
 		{
-			f = static_cast<double>(d - ORBIT_SEGMENTS/2.) / (ORBIT_SEGMENTS/2.);
+			f = (d - ORBIT_SEGMENTS/2.) / (ORBIT_SEGMENTS/2.);
 			// make sure only sample half of the orbit forward and half backward
 			// the sampling spacing is trial and error, but power of 13 seems to be good (i.e., densely sample around the current date)
-			calc_date = dateJDE + pow(f, 13)*deltaOrbitJDE*ORBIT_SEGMENTS/2. + theta/180.*deltaOrbitJDE*ORBIT_SEGMENTS/2;
+			calc_date = dateJDE + pow(f, 13)*deltaOrbitJDE*ORBIT_SEGMENTS/2. + theta*deltaOrbitJDE*ORBIT_SEGMENTS/2;
 			orbit[d] = getEclipticPos(calc_date);
 		}
 	}
+	else {
+		// Update the orbit positions to the current planet date.
+		computeOrbit();
+		}
 	const Vec3d savePos = orbit[ORBIT_SEGMENTS/2];
 	if (closeOrbit)
 	{
-		if ((!keplerOrbit || keplerOrbit->getEccentricity()<=0.3) && !fromMoonPerspective)
+		if ((!keplerOrbit || keplerOrbit->getEccentricity()<=0.3) && !fromMoonPerspective) {
 			// special case - use current Planet position as center vertex so that draws
 			// on its orbit all the time (since orbit is shown as segmented rather than smooth curve)
 			orbit[ORBIT_SEGMENTS/2]=getHeliocentricEclipticPos()+aberrationPush;
+			}
 		orbit[ORBIT_SEGMENTS]=orbit[0];
 	}
 	int nbIter = closeOrbit ? ORBIT_SEGMENTS : ORBIT_SEGMENTS-1;


### PR DESCRIPTION
This PR add the ability to densely sample orbit of parent planet if my current location is on its moon. To densely sample at the point where parent planet's orbit is at the closest to the present location of the moon.

**NO** additional line segments on top of the existing 360 segments are drawn to smooth the orbit and minimal additional calculation is required so should not affect performances. Moreover, this new code only activated if you are on a moon and drawing orbital line for your parent planet, so by default on Earth should not be affected by this PR.

Fixes #83 (issue)

### Screenshots (if appropriate):

Pluto's orbit from Charon
<img width="1512" alt="Screenshot 2024-12-20 at 11 43 11 PM" src="https://github.com/user-attachments/assets/31d7fabd-d0da-4b2e-9449-164aa3fdfe69" />
![Untitled](https://github.com/user-attachments/assets/f2767d1a-72e3-494b-8b22-bd81597b6e13)

Neptune's orbit from Naiad
<img width="1512" alt="Screenshot 2024-12-20 at 11 43 56 PM" src="https://github.com/user-attachments/assets/73116192-4a5d-4b09-8e36-8c9aa4b93e0b" />

Jupiter's orbit from Io
<img width="1512" alt="Screenshot 2024-12-20 at 11 45 04 PM" src="https://github.com/user-attachments/assets/19f996cd-ca97-457b-b2fd-f2ccabbe9e63" />

Earth's orbit from the Moon at different time in a month
<img width="1512" alt="Screenshot 2024-12-20 at 11 45 41 PM" src="https://github.com/user-attachments/assets/74200730-c831-4a1a-acdf-7f7af7507ef4" />
<img width="1512" alt="Screenshot 2024-12-20 at 11 45 54 PM" src="https://github.com/user-attachments/assets/a14ad58c-719c-41d0-ae7f-518d89abb55f" />
<img width="1512" alt="Screenshot 2024-12-20 at 11 46 06 PM" src="https://github.com/user-attachments/assets/06bce616-c8e7-4845-820d-d2271fc826b9" />
<img width="1512" alt="Screenshot 2024-12-20 at 11 46 20 PM" src="https://github.com/user-attachments/assets/ca48064b-a13c-4103-93c1-7714fbfa2dff" />


### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Visually

**Test Configuration**:
* Operating system: MacOS 15
* Graphics Card: Apple M3

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
