### PR TITLE
Fix StelMovementMgr Zoomout

### DIFF
--- a/src/core/StelMovementMgr.cpp
+++ b/src/core/StelMovementMgr.cpp
@@ -79,27 +79,28 @@ bool Smoother::finished() const
 }
 
 StelMovementMgr::StelMovementMgr(StelCore* acore)
-	: currentFov(60.)
-	, initFov(60.)
-	, minFov(0.001389)
+	: core(acore)
+	, conf(StelApp::getInstance().getSettings())
+	, objectMgr(GETSTELMODULE(StelObjectMgr))
+	, initFov(conf->value("navigation/init_fov",60.0).toDouble())
+	, currentFov(initFov)
+	, minFov(conf->value("navigation/min_fov",0.001389).toDouble()) // default: minimal FOV = 5"
 	, maxFov(100.)
-	, userMaxFov(360.)
+	, userMaxFov(conf->value("navigation/max_fov",360.).toDouble()) // default: 360°=no real limit. maxFov then depends on projection only.
 	, deltaFov(0.0)
-	, core(acore)
-	, objectMgr(Q_NULLPTR)
 	, flagLockEquPos(false)
 	, flagTracking(false)
 	, flagInhibitAllAutomoves(false)
 	, isMouseMovingHoriz(false)
 	, isMouseMovingVert(false)
-	, flagEnableMoveAtScreenEdge(false)
-	, flagEnableMouseNavigation(true)
-	, flagEnableMouseZooming(true)
-	, mouseZoomSpeed(30)
-	, flagEnableZoomKeys(true)
-	, flagEnableMoveKeys(true)
-	, keyMoveSpeed(0.00025)
-	, keyZoomSpeed(0.00025)
+	, flagEnableMoveAtScreenEdge(conf->value("navigation/flag_enable_move_at_screen_edge",false).toBool())
+	, flagEnableMouseNavigation(conf->value("navigation/flag_enable_mouse_navigation",true).toBool())
+	, flagEnableMouseZooming(conf->value("navigation/flag_enable_mouse_zooming",true).toBool())
+	, mouseZoomSpeed(conf->value("navigation/mouse_zoom",30).toInt())
+	, flagEnableZoomKeys(conf->value("navigation/flag_enable_zoom_keys", true).toBool())
+	, flagEnableMoveKeys(conf->value("navigation/flag_enable_move_keys", true).toBool())
+	, keyMoveSpeed(conf->value("navigation/move_speed",0.0004).toDouble())
+	, keyZoomSpeed(conf->value("navigation/zoom_speed", 0.0004).toDouble())
 	, flagMoveSlow(false)
 	, flagCustomPan(false)
 	, rateX(0.0)
@@ -110,17 +111,18 @@ StelMovementMgr::StelMovementMgr(StelCore* acore)
 	, zoomingMode(ZoomNone)
 	, deltaAlt(0.0)
 	, deltaAz(0.0)
-	, flagManualZoom(false)
-	, autoMoveDuration(1.5)
+	, flagManualZoom(conf->value("navigation/flag_manual_zoom", false).toBool())
+	, autoMoveDuration(conf->value ("navigation/auto_move_duration",1.5f).toFloat())
 	, isDragging(false)
 	, hasDragged(false)
 	, previousX(0)
 	, previousY(0)
+	, timeDragHistory()
 	, beforeTimeDragTimeRate(0.0)
 	, dragTimeMode(false)
 	, zoomMove()
 	, flagAutoZoom(false)
-	, flagAutoZoomOutResetsDirection(false)
+	, flagAutoZoomOutResetsDirection(conf->value("navigation/auto_zoom_out_resets_direction", true).toBool())
 	, mountMode(MountAltAzimuthal)
 	, initViewPos(1., 0., 0.)
 	, initViewUp(0., 0., 1.)
@@ -128,13 +130,14 @@ StelMovementMgr::StelMovementMgr(StelCore* acore)
 	, viewDirectionMountFrame(0., 1., 0.)
 	, upVectorMountFrame(0.,0.,1.)
 	, dragTriggerDistance(4.f)
-	, viewportOffsetTimeline(Q_NULLPTR)
+	, viewportOffsetTimeline(new QTimeLine(1000, this))
 	, oldViewportOffset(0.0, 0.0)
 	, targetViewportOffset(0.0, 0.0)
-	, flagIndicationMountMode(false)
+	, flagIndicationMountMode(conf->value("gui/flag_indication_mount_mode", false).toBool())
 	, lastMessageID(0)
 {
 	setObjectName("StelMovementMgr");
+	Q_ASSERT(objectMgr);
 }
 
 StelMovementMgr::~StelMovementMgr()
@@ -148,31 +151,9 @@ StelMovementMgr::~StelMovementMgr()
 
 void StelMovementMgr::init()
 {
-	conf = StelApp::getInstance().getSettings();
-	objectMgr = GETSTELMODULE(StelObjectMgr);
-	Q_ASSERT(conf);
-	Q_ASSERT(objectMgr);
 	connect(objectMgr, SIGNAL(selectedObjectChanged(StelModule::StelModuleSelectAction)),
 		this, SLOT(selectedObjectChange(StelModule::StelModuleSelectAction)));
 	connect(&StelApp::getInstance(), SIGNAL(languageChanged()), this, SLOT(bindingFOVActions()));
-
-	flagEnableMoveAtScreenEdge = conf->value("navigation/flag_enable_move_at_screen_edge",false).toBool();
-	mouseZoomSpeed = conf->value("navigation/mouse_zoom",30).toInt();
-	flagEnableZoomKeys = conf->value("navigation/flag_enable_zoom_keys", true).toBool();
-	flagEnableMoveKeys = conf->value("navigation/flag_enable_move_keys", true).toBool();
-	keyMoveSpeed = conf->value("navigation/move_speed",0.0004).toDouble();
-	keyZoomSpeed = conf->value("navigation/zoom_speed", 0.0004).toDouble();
-	autoMoveDuration = conf->value ("navigation/auto_move_duration",1.5f).toFloat();
-	flagManualZoom = conf->value("navigation/flag_manual_zoom").toBool();
-	flagAutoZoomOutResetsDirection = conf->value("navigation/auto_zoom_out_resets_direction", true).toBool();
-	flagEnableMouseNavigation = conf->value("navigation/flag_enable_mouse_navigation",true).toBool();
-	flagEnableMouseZooming = conf->value("navigation/flag_enable_mouse_zooming",true).toBool();
-	flagIndicationMountMode = conf->value("gui/flag_indication_mount_mode", false).toBool();
-
-	minFov = conf->value("navigation/min_fov",0.001389).toDouble(); // default: minimal FOV = 5"
-	userMaxFov = conf->value("navigation/max_fov",360.).toDouble(); // default: 360°=no real limit. maxFov then depends on projection only.
-	initFov = conf->value("navigation/init_fov",60.0).toDouble();
-	currentFov = initFov;
 
 	// we must set mount mode before potentially loading zenith views etc.
 	QString tmpstr = conf->value("navigation/viewing_mode", "horizon").toString();
@@ -212,7 +193,6 @@ void StelMovementMgr::init()
 	// The feature was moved from FOV plugin	
 	bindingFOVActions();
 
-	viewportOffsetTimeline=new QTimeLine(1000, this);
 	viewportOffsetTimeline->setFrameRange(0, 100);
 	connect(viewportOffsetTimeline, SIGNAL(valueChanged(qreal)), this, SLOT(handleViewportOffsetMovement(qreal)));
 	targetViewportOffset.set(core->getViewportHorizontalOffset(), core->getViewportVerticalOffset());

--- a/src/core/StelMovementMgr.cpp
+++ b/src/core/StelMovementMgr.cpp
@@ -24,6 +24,7 @@
 */
 
 #include "StelMovementMgr.hpp"
+#include "StelMainView.hpp"
 #include "StelObjectMgr.hpp"
 #include "StelModuleMgr.hpp"
 #include "StelApp.hpp"
@@ -323,8 +324,8 @@ Vec3d StelMovementMgr::getViewUpVectorJ2000() const
 
 bool StelMovementMgr::handleMouseMoves(int x, int y, Qt::MouseButtons)
 {
-	// Turn if the mouse is at the edge of the screen unless config asks otherwise
-	if (flagEnableMoveAtScreenEdge)
+	// Turn if the mouse is at the edge of the screen unless config asks otherwise (this is too awkward in windowed mode)
+	if (flagEnableMoveAtScreenEdge && StelMainView::getInstance().isFullScreen())
 	{
 		if (x <= 1)
 		{

--- a/src/core/StelMovementMgr.cpp
+++ b/src/core/StelMovementMgr.cpp
@@ -124,6 +124,7 @@ StelMovementMgr::StelMovementMgr(StelCore* acore)
 	, flagAutoZoom(false)
 	, flagAutoZoomOutResetsDirection(conf->value("navigation/auto_zoom_out_resets_direction", true).toBool())
 	, mountMode(MountAltAzimuthal)
+	, flagIndicationMountMode(conf->value("gui/flag_indication_mount_mode", false).toBool())
 	, initViewPos(1., 0., 0.)
 	, initViewUp(0., 0., 1.)
 	, viewDirectionJ2000(0., 1., 0.)
@@ -133,7 +134,6 @@ StelMovementMgr::StelMovementMgr(StelCore* acore)
 	, viewportOffsetTimeline(new QTimeLine(1000, this))
 	, oldViewportOffset(0.0, 0.0)
 	, targetViewportOffset(0.0, 0.0)
-	, flagIndicationMountMode(conf->value("gui/flag_indication_mount_mode", false).toBool())
 	, lastMessageID(0)
 {
 	setObjectName("StelMovementMgr");
@@ -1760,6 +1760,16 @@ void StelMovementMgr::setUserMaxFov(double max)
 	}
 	StelApp::immediateSave("navigation/max_fov", userMaxFov);
 	emit userMaxFovChanged(userMaxFov);
+}
+
+void StelMovementMgr::setFov(double f)
+{
+	if (core->getCurrentProjectionType()==StelCore::ProjectionCylinderFill)
+		currentFov=180.0;
+	else
+		currentFov=qBound(minFov, f, maxFov);
+
+	emit currentFovChanged(currentFov);
 }
 
 void StelMovementMgr::moveViewport(double offsetX, double offsetY, const float duration)

--- a/src/core/StelMovementMgr.hpp
+++ b/src/core/StelMovementMgr.hpp
@@ -502,15 +502,15 @@ private slots:
 	void bindingFOVActions();
 
 private:
-	double currentFov; // The current FOV in degrees
+	StelCore* core;          // The core on which the movement are applied
+	QSettings* conf;
+	class StelObjectMgr* objectMgr;
 	double initFov;    // The FOV at startup
+	double currentFov; // The current FOV in degrees
 	double minFov;     // Minimum FOV in degrees
 	double maxFov;     // Maximum FOV in degrees. Depends on projection.
 	double userMaxFov; // Custom setting. Can be useful in a planetarium context.
 	double deltaFov;   // requested change of FOV (degrees) used during zooming.
-	StelCore* core;          // The core on which the movement are applied
-	QSettings* conf;
-	class StelObjectMgr* objectMgr;
 
 	// immediately add deltaFov argument to FOV - does not change private var.
 	void changeFov(double deltaFov);

--- a/src/core/StelMovementMgr.hpp
+++ b/src/core/StelMovementMgr.hpp
@@ -55,59 +55,20 @@ private:
 class StelMovementMgr : public StelModule
 {
 	Q_OBJECT
-	Q_PROPERTY(bool equatorialMount
-		   READ getEquatorialMount
-		   WRITE setEquatorialMount
-		   NOTIFY equatorialMountChanged)
-	Q_PROPERTY(bool tracking
-		   READ getFlagTracking
-		   WRITE setFlagTracking
-		   NOTIFY flagTrackingChanged)
-	Q_PROPERTY(bool flagIndicationMountMode
-		   READ getFlagIndicationMountMode
-		   WRITE setFlagIndicationMountMode
-		   NOTIFY flagIndicationMountModeChanged)
+	Q_PROPERTY(bool equatorialMount			 READ getEquatorialMount		 WRITE setEquatorialMount		 NOTIFY equatorialMountChanged)
+	Q_PROPERTY(bool tracking			 READ getFlagTracking			 WRITE setFlagTracking			 NOTIFY flagTrackingChanged)
+	Q_PROPERTY(bool flagIndicationMountMode		 READ getFlagIndicationMountMode	 WRITE setFlagIndicationMountMode	 NOTIFY flagIndicationMountModeChanged)
 	//The targets of viewport offset animation
-	Q_PROPERTY(double viewportHorizontalOffsetTarget
-		   READ getViewportHorizontalOffsetTarget
-		   WRITE setViewportHorizontalOffsetTarget
-		   NOTIFY viewportHorizontalOffsetTargetChanged)
-	Q_PROPERTY(double viewportVerticalOffsetTarget
-		   READ getViewportVerticalOffsetTarget
-		   WRITE setViewportVerticalOffsetTarget
-		   NOTIFY viewportVerticalOffsetTargetChanged)
-	Q_PROPERTY(bool flagAutoZoomOutResetsDirection
-		   READ getFlagAutoZoomOutResetsDirection
-		   WRITE setFlagAutoZoomOutResetsDirection
-		   NOTIFY flagAutoZoomOutResetsDirectionChanged)
-	Q_PROPERTY(bool flagEnableMouseNavigation
-		   READ getFlagEnableMouseNavigation
-		   WRITE setFlagEnableMouseNavigation
-		   NOTIFY flagEnableMouseNavigationChanged)
-	Q_PROPERTY(bool flagEnableMouseZooming
-		   READ getFlagEnableMouseZooming
-		   WRITE setFlagEnableMouseZooming
-		   NOTIFY flagEnableMouseZoomingChanged)
-	Q_PROPERTY(bool flagEnableMoveKeys
-		   READ getFlagEnableMoveKeys
-		   WRITE setFlagEnableMoveKeys
-		   NOTIFY flagEnableMoveKeysChanged)
-	Q_PROPERTY(bool flagEnableZoomKeys
-		   READ getFlagEnableZoomKeys
-		   WRITE setFlagEnableZoomKeys
-		   NOTIFY flagEnableZoomKeysChanged)
-	Q_PROPERTY(bool flagEnableMoveAtScreenEdge
-		   READ getFlagEnableMoveAtScreenEdge
-		   WRITE setFlagEnableMoveAtScreenEdge
-		   NOTIFY flagEnableMoveAtScreenEdgeChanged)
-	Q_PROPERTY(double userMaxFov
-		   READ getUserMaxFov
-		   WRITE setUserMaxFov
-		   NOTIFY userMaxFovChanged)
-	Q_PROPERTY(double currentFov
-		   READ getCurrentFov
-		   WRITE setFov
-		   NOTIFY currentFovChanged)
+	Q_PROPERTY(double viewportHorizontalOffsetTarget READ getViewportHorizontalOffsetTarget	 WRITE setViewportHorizontalOffsetTarget NOTIFY viewportHorizontalOffsetTargetChanged)
+	Q_PROPERTY(double viewportVerticalOffsetTarget	 READ getViewportVerticalOffsetTarget	 WRITE setViewportVerticalOffsetTarget	 NOTIFY viewportVerticalOffsetTargetChanged)
+	Q_PROPERTY(bool flagAutoZoomOutResetsDirection	 READ getFlagAutoZoomOutResetsDirection	 WRITE setFlagAutoZoomOutResetsDirection NOTIFY flagAutoZoomOutResetsDirectionChanged)
+	Q_PROPERTY(bool flagEnableMouseNavigation	 READ getFlagEnableMouseNavigation	 WRITE setFlagEnableMouseNavigation	 NOTIFY flagEnableMouseNavigationChanged)
+	Q_PROPERTY(bool flagEnableMouseZooming		 READ getFlagEnableMouseZooming		 WRITE setFlagEnableMouseZooming	 NOTIFY flagEnableMouseZoomingChanged)
+	Q_PROPERTY(bool flagEnableMoveKeys		 READ getFlagEnableMoveKeys		 WRITE setFlagEnableMoveKeys		 NOTIFY flagEnableMoveKeysChanged)
+	Q_PROPERTY(bool flagEnableZoomKeys		 READ getFlagEnableZoomKeys		 WRITE setFlagEnableZoomKeys		 NOTIFY flagEnableZoomKeysChanged)
+	Q_PROPERTY(bool flagEnableMoveAtScreenEdge	 READ getFlagEnableMoveAtScreenEdge	 WRITE setFlagEnableMoveAtScreenEdge	 NOTIFY flagEnableMoveAtScreenEdgeChanged)
+	Q_PROPERTY(double userMaxFov			 READ getUserMaxFov			 WRITE setUserMaxFov			 NOTIFY userMaxFovChanged)
+	Q_PROPERTY(double currentFov			 READ getCurrentFov			 WRITE setFov				 NOTIFY currentFovChanged)
 public:
 	//! Possible mount modes defining the reference frame in which head movements occur.
 	//! MountGalactic and MountSupergalactic is currently only available via scripting API: core.clear("galactic") and core.clear("supergalactic")
@@ -187,16 +148,89 @@ public slots:
 	//! load and process initial viewing position. Can be called later to restore original "default" view.
 	void resetInitViewPos();
 
-	// UNUSED, but scriptable
-	//! Toggle current mount mode between equatorial and altazimuthal
-	void toggleMountMode() {if (getMountMode()==MountAltAzimuthal) setMountMode(MountEquinoxEquatorial); else setMountMode(MountAltAzimuthal);}
+	//! Set current mount type defining the reference frame in which head movements occur.
+	void setMountMode(StelMovementMgr::MountMode m);
+	//! Get current mount type defining the reference frame in which head movements occur.
+	StelMovementMgr::MountMode getMountMode(void) const {return mountMode;}
+
+	//! PROPERTY GETTER/SETTER
+	bool getEquatorialMount(void) const {return mountMode == StelMovementMgr::MountEquinoxEquatorial;}
 	//! Define whether we should use equatorial mount or altazimuthal
 	void setEquatorialMount(bool b);
 
+	// UNUSED, but scriptable
+	//! Toggle current mount mode between equatorial and altazimuthal
+	Q_DECL_DEPRECATED_X("This function will be removed. Use setEquatorialMount(bool b) with a clear decision.")
+	void toggleMountMode() {if (getMountMode()==MountAltAzimuthal) setMountMode(MountEquinoxEquatorial); else setMountMode(MountAltAzimuthal);}
+
+	//! PROPERTY GETTER/SETTER
 	//! Set object tracking on/off and go to selected object
 	void setFlagTracking(bool b=true);
 	//! Get current object tracking status.
 	bool getFlagTracking(void) const {return flagTracking;}
+
+	//! PROPERTY GETTER/SETTER
+	//! Set flag for showing a temporary screen text message indicating mount mode
+	bool getFlagIndicationMountMode() const {return flagIndicationMountMode;}
+	//! Set flag for showing a temporary screen text message indicating mount mode
+	void setFlagIndicationMountMode(bool b) { if (flagIndicationMountMode!=b){flagIndicationMountMode=b; StelApp::immediateSave("gui/flag_indication_mount_mode", b); emit flagIndicationMountModeChanged(b);}}
+
+	//! Returns the targeted value of the viewport offset
+	Vec2d getViewportOffsetTarget() const { return targetViewportOffset; }
+	//! PROPERTY GETTERS/SETTERS
+	double getViewportHorizontalOffsetTarget() const { return targetViewportOffset[0]; }
+	double getViewportVerticalOffsetTarget() const { return targetViewportOffset[1]; }
+	void setViewportHorizontalOffsetTarget(double f) { moveViewport(f,getViewportVerticalOffsetTarget()); }
+	void setViewportVerticalOffsetTarget(double f) { moveViewport(getViewportHorizontalOffsetTarget(),f); }
+
+	//! PROPERTY GETTER/SETTER
+	//! Get whether auto zoom out will reset the viewing direction to the initial value
+	bool getFlagAutoZoomOutResetsDirection(void) const {return flagAutoZoomOutResetsDirection;}
+	//! Set whether auto zoom out will reset the viewing direction to the initial value
+	void setFlagAutoZoomOutResetsDirection(bool b) {if (flagAutoZoomOutResetsDirection != b) { flagAutoZoomOutResetsDirection = b; StelApp::immediateSave("navigation/auto_zoom_out_resets_direction", b); emit flagAutoZoomOutResetsDirectionChanged(b);}}
+
+	//! PROPERTY GETTER/SETTER
+	//! Get whether mouse can control movement
+	bool getFlagEnableMouseNavigation() const {return flagEnableMouseNavigation;}
+	//! Set whether mouse can control movement
+	void setFlagEnableMouseNavigation(bool b) {if (flagEnableMouseNavigation!=b){flagEnableMouseNavigation=b; StelApp::immediateSave("navigation/flag_enable_mouse_navigation", b); emit flagEnableMouseNavigationChanged(b);}}
+
+	//! PROPERTY GETTER/SETTER
+	//! Get whether mouse can control zooming
+	bool getFlagEnableMouseZooming() const {return flagEnableMouseZooming;}
+	//! Set whether mouse can control zooming
+	void setFlagEnableMouseZooming(bool b) {if (flagEnableMouseZooming!=b) {flagEnableMouseZooming=b; StelApp::immediateSave("navigation/flag_enable_mouse_zooming", b); emit flagEnableMouseZoomingChanged(b);}}
+
+	//! PROPERTY GETTER/SETTER
+	//! Get whether keys can control zoom
+	bool getFlagEnableZoomKeys() const {return flagEnableZoomKeys;}
+	//! Set whether keys can control zoom
+	void setFlagEnableZoomKeys(bool b) {if (flagEnableZoomKeys!=b) {flagEnableZoomKeys=b; StelApp::immediateSave("navigation/flag_enable_zoom_keys", b); emit flagEnableZoomKeysChanged(b);}}
+
+	//! PROPERTY GETTER/SETTER
+	//! Get whether keys can control movement
+	bool getFlagEnableMoveKeys() const {return flagEnableMoveKeys;}
+	//! Set whether keys can control movement
+	void setFlagEnableMoveKeys(bool b) {if (flagEnableMoveKeys!=b) {flagEnableMoveKeys=b; StelApp::immediateSave("navigation/flag_enable_move_keys", b); emit flagEnableMoveKeysChanged(b);}}
+
+	//! PROPERTY GETTER/SETTER
+	//! Get whether being at the edge of the screen activates movement
+	bool getFlagEnableMoveAtScreenEdge() const {return flagEnableMoveAtScreenEdge;}
+	//! Set whether being at the edge of the screen activates movement
+	void setFlagEnableMoveAtScreenEdge(bool b) {if (flagEnableMoveAtScreenEdge!=b){flagEnableMoveAtScreenEdge=b; StelApp::immediateSave("navigation/flag_enable_move_at_screen_edge", b); emit flagEnableMoveAtScreenEdgeChanged(b);}}
+
+	//! PROPERTY GETTER/SETTER
+	//! Set a hard limit for any fov change. Useful in the context of a planetarium with dome
+	//! where a presenter never ever wants to set more than 180° even if the projection would allow it.
+	void setUserMaxFov(double max);
+	double getUserMaxFov() const {return userMaxFov; }
+
+	//! PROPERTY GETTER/SETTER
+	//! Get the current Field Of View in degrees
+	double getCurrentFov() const {return currentFov;}
+	//! Set the current vertical Field Of View in degrees
+	void setFov(double f);
+
 
 	//! Set whether sky position is to be locked.
 	void setFlagLockEquPos(bool b);
@@ -216,40 +250,6 @@ public slots:
 	//! @return the number of seconds it takes for an auto-move operation to complete.
 	float getAutoMoveDuration(void) const {return autoMoveDuration;}
 
-	//! Set whether auto zoom out will reset the viewing direction to the initial value
-	void setFlagAutoZoomOutResetsDirection(bool b) {if (flagAutoZoomOutResetsDirection != b) { flagAutoZoomOutResetsDirection = b; StelApp::immediateSave("navigation/auto_zoom_out_resets_direction", b); emit flagAutoZoomOutResetsDirectionChanged(b);}}
-	//! Get whether auto zoom out will reset the viewing direction to the initial value
-	bool getFlagAutoZoomOutResetsDirection(void) const {return flagAutoZoomOutResetsDirection;}
-
-	//! Get whether keys can control zoom
-	bool getFlagEnableZoomKeys() const {return flagEnableZoomKeys;}
-	//! Set whether keys can control zoom
-	void setFlagEnableZoomKeys(bool b) {if (flagEnableZoomKeys!=b) {flagEnableZoomKeys=b; StelApp::immediateSave("navigation/flag_enable_zoom_keys", b); emit flagEnableZoomKeysChanged(b);}}
-
-	//! Get whether keys can control movement
-	bool getFlagEnableMoveKeys() const {return flagEnableMoveKeys;}
-	//! Set whether keys can control movement
-	void setFlagEnableMoveKeys(bool b) {if (flagEnableMoveKeys!=b) {flagEnableMoveKeys=b; StelApp::immediateSave("navigation/flag_enable_move_keys", b); emit flagEnableMoveKeysChanged(b);}}
-
-	//! Get whether being at the edge of the screen activates movement
-	bool getFlagEnableMoveAtScreenEdge() const {return flagEnableMoveAtScreenEdge;}
-	//! Set whether being at the edge of the screen activates movement
-	void setFlagEnableMoveAtScreenEdge(bool b) {flagEnableMoveAtScreenEdge=b; emit flagEnableMoveAtScreenEdgeChanged(b);}
-
-	//! Get whether mouse can control movement
-	bool getFlagEnableMouseNavigation() const {return flagEnableMouseNavigation;}
-	//! Set whether mouse can control movement
-	void setFlagEnableMouseNavigation(bool b) {if (flagEnableMouseNavigation!=b){flagEnableMouseNavigation=b; StelApp::immediateSave("navigation/flag_enable_mouse_navigation", b); emit flagEnableMouseNavigationChanged(b);}}
-
-	//! Get whether mouse can control zooming
-	bool getFlagEnableMouseZooming() const {return flagEnableMouseZooming;}
-	//! Set whether mouse can control zooming
-	void setFlagEnableMouseZooming(bool b) {if (flagEnableMouseZooming!=b) {flagEnableMouseZooming=b; StelApp::immediateSave("navigation/flag_enable_mouse_zooming", b); emit flagEnableMouseZoomingChanged(b);}}
-
-	//! Get the state of flag for indication of mount mode
-	bool getFlagIndicationMountMode() const {return flagIndicationMountMode;}
-	//! Set the state of flag for indication of mount mode
-	void setFlagIndicationMountMode(bool b) { if (flagIndicationMountMode!=b){flagIndicationMountMode=b; StelApp::immediateSave("gui/flag_indication_mount_mode", b); emit flagIndicationMountModeChanged(b);}}
 
 	//! Move the view to a specified J2000 position.
 	//! @param aim The position to move to expressed as a vector.
@@ -293,8 +293,6 @@ public slots:
 	//! @param aimFov The desired field of view in degrees.
 	//! @param zoomDuration The time that the operation should take to complete. [seconds]
 	void zoomTo(double aimFov, float zoomDuration = 1.f);
-	//! Get the current Field Of View in degrees
-	double getCurrentFov() const {return currentFov;}
 
 	//! Return the initial default FOV in degree.
 	double getInitFov() const {return initFov;}
@@ -384,6 +382,7 @@ public slots:
 	//! @note Use StelMovementMgr.panView for precise control of view movements.
 	void turnDown(bool s);
 	
+	//! Modal switch used for user keyboard interaction, linked to shift key press/release.
 	void moveSlow(bool b) {flagMoveSlow=b;}
 
 	//! With true, starts zooming in, with an unspecified ratio of degrees per second, either until zooming
@@ -440,39 +439,9 @@ public slots:
 	//! @note Only vertical viewport is really meaningful.
 	void moveViewport(double offsetX, double offsetY, const float duration=0.f);
 
-	//! Set current mount type defining the reference frame in which head movements occur.
-	void setMountMode(StelMovementMgr::MountMode m);
-	//! Get current mount type defining the reference frame in which head movements occur.
-	StelMovementMgr::MountMode getMountMode(void) const {return mountMode;}
-	bool getEquatorialMount(void) const {return mountMode == StelMovementMgr::MountEquinoxEquatorial;}
-
 	//! Function designed only for scripting context. Put the function into the startup.ssc of your planetarium setup,
 	//! this will avoid any unwanted tracking.
 	void setInhibitAllAutomoves(bool inhibit) { flagInhibitAllAutomoves=inhibit;}
-
-	//! Returns the targeted value of the viewport offset
-	Vec2d getViewportOffsetTarget() const { return targetViewportOffset; }
-	double getViewportHorizontalOffsetTarget() const { return targetViewportOffset[0]; }
-	double getViewportVerticalOffsetTarget() const { return targetViewportOffset[1]; }
-
-	void setViewportHorizontalOffsetTarget(double f) { moveViewport(f,getViewportVerticalOffsetTarget()); }
-	void setViewportVerticalOffsetTarget(double f) { moveViewport(getViewportHorizontalOffsetTarget(),f); }
-
-	//! Set a hard limit for any fov change. Useful in the context of a planetarium with dome
-	//! where a presenter never ever wants to set more than 180° even if the projection would allow it.
-	void setUserMaxFov(double max);
-	double getUserMaxFov() const {return userMaxFov; }
-
-	void setFov(double f)
-	{
-		if (core->getCurrentProjectionType()==StelCore::ProjectionCylinderFill)
-			currentFov=180.0;
-		else
-			currentFov=qBound(minFov, f, maxFov);
-
-		core->setClearSkyOnce();
-		emit currentFovChanged(currentFov);
-	}
 
 signals:
 	//! Emitted when the tracking property changes
@@ -538,9 +507,9 @@ private:
 
 	bool flagEnableZoomKeys;
 	bool flagEnableMoveKeys;
-	double keyMoveSpeed;              // Speed of keys movement
-	double keyZoomSpeed;              // Speed of keys zoom
-	bool flagMoveSlow;
+	double keyMoveSpeed;            // Speed of keys movement
+	double keyZoomSpeed;            // Speed of keys zoom
+	bool flagMoveSlow;		// Modal switch used during user keyboard interaction, linked to shift key press/release.
 
 	//flag to enable panning a predetermined amount
 	bool flagCustomPan;
@@ -608,6 +577,7 @@ private:
 
 	// defines if view corrects for horizon, or uses equatorial coordinates
 	MountMode mountMode;
+	bool flagIndicationMountMode; // set true to show a screen text message indicating state of mount mode
 
 	Vec3d initViewPos;        // Default viewing direction
 	Vec3d initViewUp;         // original up vector. Usually 0/0/1, but maybe something else in rare setups (e.g. Planetarium dome upwards fisheye projection).
@@ -630,7 +600,6 @@ private:
 	Vec2d oldViewportOffset;
 	Vec2d targetViewportOffset;
 
-	bool flagIndicationMountMode; // state of mount mode
 
 	//! @name Screen message infrastructure
 	//@{

--- a/src/core/StelMovementMgr.hpp
+++ b/src/core/StelMovementMgr.hpp
@@ -96,6 +96,10 @@ class StelMovementMgr : public StelModule
 		   READ getFlagEnableZoomKeys
 		   WRITE setFlagEnableZoomKeys
 		   NOTIFY flagEnableZoomKeysChanged)
+	Q_PROPERTY(bool flagEnableMoveAtScreenEdge
+		   READ getFlagEnableMoveAtScreenEdge
+		   WRITE setFlagEnableMoveAtScreenEdge
+		   NOTIFY flagEnableMoveAtScreenEdgeChanged)
 	Q_PROPERTY(double userMaxFov
 		   READ getUserMaxFov
 		   WRITE setUserMaxFov
@@ -230,7 +234,7 @@ public slots:
 	//! Get whether being at the edge of the screen activates movement
 	bool getFlagEnableMoveAtScreenEdge() const {return flagEnableMoveAtScreenEdge;}
 	//! Set whether being at the edge of the screen activates movement
-	void setFlagEnableMoveAtScreenEdge(bool b) {flagEnableMoveAtScreenEdge=b;}
+	void setFlagEnableMoveAtScreenEdge(bool b) {flagEnableMoveAtScreenEdge=b; emit flagEnableMoveAtScreenEdgeChanged(b);}
 
 	//! Get whether mouse can control movement
 	bool getFlagEnableMouseNavigation() const {return flagEnableMouseNavigation;}
@@ -482,6 +486,7 @@ signals:
 	void flagEnableMouseZoomingChanged(bool b);
 	void flagEnableMoveKeysChanged(bool b);
 	void flagEnableZoomKeysChanged(bool b);
+	void flagEnableMoveAtScreenEdgeChanged(bool b);
 	void userMaxFovChanged(double fov);
 	void currentFovChanged(double fov);
 	void currentDirectionChanged();

--- a/src/gui/ConfigurationDialog.cpp
+++ b/src/gui/ConfigurationDialog.cpp
@@ -351,6 +351,7 @@ void ConfigurationDialog::createDialogContent()
 	connectBoolProperty(ui->useButtonsBackgroundCheckBox,        "StelGui.flagUseButtonsBackground");
 	connectBoolProperty(ui->indicationMountModeCheckBox,         "StelMovementMgr.flagIndicationMountMode");
 	connectBoolProperty(ui->kineticScrollingCheckBox,            "StelGui.flagUseKineticScrolling");
+	connectBoolProperty(ui->pushScreenEdgeCheckBox,	             "StelMovementMgr.flagEnableMoveAtScreenEdge");
 	connectBoolProperty(ui->focusOnDaySpinnerCheckBox,           "StelGui.flagEnableFocusOnDaySpinner");
 	ui->overwriteTextColorButton->setup("StelApp.overwriteInfoColor", "color/info_text_color");
 	ui->daylightTextColorButton ->setup("StelApp.daylightInfoColor",  "color/daylight_text_color");
@@ -1424,6 +1425,7 @@ void ConfigurationDialog::saveAllSettings()
         conf->setValue("gui/flag_indication_mount_mode",                mvmgr->getFlagIndicationMountMode());
 
 	// configuration dialog / navigation tab
+	conf->setValue("navigation/flag_enable_move_at_screen_edge",		mvmgr->getFlagEnableMoveAtScreenEdge());
         conf->setValue("navigation/flag_enable_zoom_keys",              mvmgr->getFlagEnableZoomKeys());
         conf->setValue("navigation/flag_enable_mouse_navigation",       mvmgr->getFlagEnableMouseNavigation());
         conf->setValue("navigation/flag_enable_mouse_zooming",          mvmgr->getFlagEnableMouseZooming());

--- a/src/gui/configurationDialog.ui
+++ b/src/gui/configurationDialog.ui
@@ -2132,6 +2132,7 @@
              <property name="bottomMargin">
               <number>0</number>
              </property>
+	     
              <item row="7" column="1">
               <layout class="QHBoxLayout" name="mouseTimeoutLayout">
                <item>
@@ -2181,6 +2182,7 @@
                </item>
               </layout>
              </item>
+	     
              <item row="1" column="1">
               <widget class="QCheckBox" name="diskViewportCheckbox">
                <property name="toolTip">
@@ -2191,6 +2193,7 @@
                </property>
               </widget>
              </item>
+	     
              <item row="6" column="3">
               <widget class="QCheckBox" name="kineticScrollingCheckBox">
                <property name="toolTip">
@@ -2201,6 +2204,7 @@
                </property>
               </widget>
              </item>
+	     
              <item row="9" column="3">
               <layout class="QHBoxLayout" name="horizontalLayout_14">
                <item>
@@ -2219,16 +2223,8 @@
                </item>
               </layout>
              </item>
-             <item row="5" column="1">
-              <widget class="QCheckBox" name="enableMouseNavigationCheckBox">
-               <property name="toolTip">
-                <string>Allow mouse to pan (drag)</string>
-               </property>
-               <property name="text">
-                <string>Enable mouse navigation</string>
-               </property>
-              </widget>
-             </item>
+	     
+	     
              <item row="0" column="3" rowspan="2">
               <layout class="QGridLayout" name="gridLayoutInclude">
                <item row="2" column="1">
@@ -2347,6 +2343,7 @@
                </item>
               </layout>
              </item>
+	     
              <item row="3" column="3">
               <layout class="QHBoxLayout" name="horizontalLayout_fps">
                <item>
@@ -2528,16 +2525,8 @@
                </property>
               </widget>
              </item>
-             <item row="6" column="1">
-              <widget class="QCheckBox" name="enableMouseZoomingCheckBox">
-               <property name="toolTip">
-                <string>Allow mouse to zoom (mousewheel)</string>
-               </property>
-               <property name="text">
-                <string>Enable mouse zooming</string>
-               </property>
-              </widget>
-             </item>
+	     
+	     
              <item row="2" column="3">
               <widget class="QCheckBox" name="indicationMountModeCheckBox">
                <property name="toolTip">
@@ -2756,6 +2745,112 @@
                </item>
               </layout>
              </item>
+	     
+             <item row="5" column="1">
+			  <layout class="QHBoxLayout" name="horizontalLayout_mouseNav">
+			  <item>
+              <widget class="QCheckBox" name="enableMouseNavigationCheckBox">
+               <property name="toolTip">
+                <string>Allow mouse to pan (drag)</string>
+               </property>
+               <property name="text">
+                <string>Mouse navigation</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QCheckBox" name="enableMouseZoomingCheckBox">
+               <property name="toolTip">
+                <string>Allow mouse to zoom (mousewheel)</string>
+               </property>
+               <property name="text">
+                <string>Mouse zooming</string>
+               </property>
+              </widget>
+             </item>
+			 </layout>
+			 </item>
+			 
+			 
+             <item row="6" column="1">
+              <widget class="QCheckBox" name="pushScreenEdgeCheckBox">
+               <property name="toolTip">
+                <string>Allow mouse to move view when at screen edge</string>
+               </property>
+               <property name="text">
+                <string>Mouse push screen edge</string>
+               </property>
+              </widget>
+             </item>
+	     
+             <item row="0" column="3" rowspan="2">
+              <layout class="QGridLayout" name="gridLayoutInclude">
+               <property name="spacing">
+                <number>0</number>
+               </property>
+               <item row="1" column="2">
+                <layout class="QHBoxLayout" name="horizontalLayout_IncludeNutAberr">
+                 <item>
+                  <widget class="QCheckBox" name="aberrationCheckBox">
+                   <property name="toolTip">
+                    <string>Annual aberration is an annual wobble in positions, amounting to max. about 20 arcseconds for observers on Earth.</string>
+                   </property>
+                   <property name="text">
+                    <string>Aberration</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QDoubleSpinBox" name="aberrationSpinBox">
+                   <property name="toolTip">
+                    <string>Exaggerate aberration (for didactic explanations)</string>
+                   </property>
+                   <property name="decimals">
+                    <number>1</number>
+                   </property>
+                   <property name="maximum">
+                    <double>5.000000000000000</double>
+                   </property>
+                   <property name="singleStep">
+                    <double>0.100000000000000</double>
+                   </property>
+                   <property name="value">
+                    <double>1.000000000000000</double>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </item>
+               <item row="0" column="1" colspan="2">
+                <widget class="QCheckBox" name="topocentricCheckBox">
+                 <property name="toolTip">
+                  <string>Activate to view as seen from surface of the planet (recommended). If switched off, display planetocentric view.</string>
+                 </property>
+                 <property name="text">
+                  <string>Topocentric coordinates</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="1">
+                <widget class="QCheckBox" name="nutationCheckBox">
+                 <property name="toolTip">
+                  <string>Nutation is a small wobble of Earth's axis, amounting to a few arcseconds.</string>
+                 </property>
+                 <property name="text">
+                  <string>Nutation</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="0">
+                <widget class="QLabel" name="label_Include">
+                 <property name="text">
+                  <string>Include </string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+	     
             </layout>
            </widget>
           </item>

--- a/src/gui/configurationDialog.ui
+++ b/src/gui/configurationDialog.ui
@@ -2775,7 +2775,7 @@
              <item row="6" column="1">
               <widget class="QCheckBox" name="pushScreenEdgeCheckBox">
                <property name="toolTip">
-                <string>Allow mouse to move view when at screen edge</string>
+                <string>Allow mouse to move view when at screen edge (Fullscreen only)</string>
                </property>
                <property name="text">
                 <string>Mouse push screen edge</string>

--- a/src/gui/configurationDialog.ui
+++ b/src/gui/configurationDialog.ui
@@ -2321,6 +2321,7 @@
                  </property>
                 </widget>
                </item>
+	       
                <item row="1" column="2">
                 <widget class="QCheckBox" name="nutationCheckBox">
                  <property name="toolTip">
@@ -2331,6 +2332,7 @@
                  </property>
                 </widget>
                </item>
+	       
                <item row="1" column="1">
                 <widget class="QCheckBox" name="topocentricCheckBox">
                  <property name="toolTip">
@@ -2782,75 +2784,7 @@
                </property>
               </widget>
              </item>
-	     
-             <item row="0" column="3" rowspan="2">
-              <layout class="QGridLayout" name="gridLayoutInclude">
-               <property name="spacing">
-                <number>0</number>
-               </property>
-               <item row="1" column="2">
-                <layout class="QHBoxLayout" name="horizontalLayout_IncludeNutAberr">
-                 <item>
-                  <widget class="QCheckBox" name="aberrationCheckBox">
-                   <property name="toolTip">
-                    <string>Annual aberration is an annual wobble in positions, amounting to max. about 20 arcseconds for observers on Earth.</string>
-                   </property>
-                   <property name="text">
-                    <string>Aberration</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QDoubleSpinBox" name="aberrationSpinBox">
-                   <property name="toolTip">
-                    <string>Exaggerate aberration (for didactic explanations)</string>
-                   </property>
-                   <property name="decimals">
-                    <number>1</number>
-                   </property>
-                   <property name="maximum">
-                    <double>5.000000000000000</double>
-                   </property>
-                   <property name="singleStep">
-                    <double>0.100000000000000</double>
-                   </property>
-                   <property name="value">
-                    <double>1.000000000000000</double>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </item>
-               <item row="0" column="1" colspan="2">
-                <widget class="QCheckBox" name="topocentricCheckBox">
-                 <property name="toolTip">
-                  <string>Activate to view as seen from surface of the planet (recommended). If switched off, display planetocentric view.</string>
-                 </property>
-                 <property name="text">
-                  <string>Topocentric coordinates</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="1">
-                <widget class="QCheckBox" name="nutationCheckBox">
-                 <property name="toolTip">
-                  <string>Nutation is a small wobble of Earth's axis, amounting to a few arcseconds.</string>
-                 </property>
-                 <property name="text">
-                  <string>Nutation</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="0">
-                <widget class="QLabel" name="label_Include">
-                 <property name="text">
-                  <string>Include </string>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </item>
-	     
+	     	     
             </layout>
            </widget>
           </item>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Please include a summary of the change and which issue is fixed. -->
<!--- Please also include relevant motivation and context. -->
<!--- List any dependencies that are required for this change. -->

This should finally repair some mess around zoom-to-object, zoom in a bit more, zoom out a bit and zoom out to base view.
I had never seen this in operation given its default keyboard bindings that never worked on non-US keyboards, and some changes deemed relevant in 2022 may have broken the behaviour known and probably seen essential to others. 
After explanations it becomes clear this is something of actual importance in a planetarium.

There are a few settings that are already involved in the whole workflow. However, maybe a LIFO stack of zoom states will be required for stepping in and out (with even more steps), with a master command to "zoom all the way to normal" scrubbing the stack. 

This also makes another so-far hidden flag finally fully accessible: Pushing the view with the mouse cursor touching screen edge.

Fixes #3553

### Screenshots (if appropriate):

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system: Windows 11
* Graphics Card: Geforce 3070Ti (but irrelevant)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
