### PR TITLE
Scale bottom and left panel buttons according to font size

### DIFF
--- a/src/gui/SkyGui.cpp
+++ b/src/gui/SkyGui.cpp
@@ -386,6 +386,7 @@ void SkyGui::updateBarsPos()
 	progressBarMgr->setZValue(400);	
 
 	// Update position of the auto-hide buttons
+	btHorizAutoHide->setPos(1,btVertAutoHide->getButtonPixmapHeight()-btHorizAutoHide->getButtonPixmapHeight()+1);
 	autoHidebts->setPos(0, hh-autoHidebts->childrenBoundingRect().height()+1);
 	double opacity = qMax(animLeftBarTimeLine->currentValue(), animBottomBarTimeLine->currentValue());
 	autoHidebts->setOpacity(qMax(0.01, opacity));	// Work around a qt bug

--- a/src/gui/StelGuiItems.cpp
+++ b/src/gui/StelGuiItems.cpp
@@ -55,6 +55,16 @@
 #include <QSettings>
 #include <QGuiApplication>
 
+namespace
+{
+
+constexpr double DEFAULT_FONT_SIZE = 13;
+
+double fontSizeRatio()
+{
+	return StelApp::getInstance().getScreenFontSize() / DEFAULT_FONT_SIZE;
+}
+
 void brightenImage(QImage &img, float factor)
 {
 	for (int y=0; y<img.height(); y++)
@@ -78,6 +88,7 @@ void brightenImage(QImage &img, float factor)
 		}
 }
 
+}
 
 void StelButton::initCtor(const QPixmap& apixOn,
 						  const QPixmap& apixOff,
@@ -349,6 +360,17 @@ QRectF StelButton::boundingRect() const
 	return QRectF(0,0, getButtonPixmapWidth(), getButtonPixmapHeight());
 }
 
+int StelButton::getButtonPixmapWidth() const
+{
+	const double baseWidth = pixOn.width() / pixmapsScale * fontSizeRatio();
+	return std::lround(baseWidth);
+}
+int StelButton::getButtonPixmapHeight() const
+{
+	const double baseHeight = pixOn.height() / pixmapsScale * fontSizeRatio();
+	return std::lround(baseHeight);
+}
+
 void StelButton::paint(QPainter* painter, const QStyleOptionGraphicsItem*, QWidget*)
 {
 	/* QPixmap::scaled has much better quality than that scaling via QPainter::drawPixmap, so let's
@@ -367,8 +389,8 @@ void StelButton::paint(QPainter* painter, const QStyleOptionGraphicsItem*, QWidg
 	const double ratio = QOpenGLContext::currentContext()->screen()->devicePixelRatio();
 	if(scaledCurrentPixmap.isNull() || ratio != scaledCurrentPixmap.devicePixelRatioF())
 	{
-		const auto scale = ratio / pixmapsScale;
-		scaledCurrentPixmap = pixmap().scaled(pixOn.size()*scale, Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
+		const auto size = boundingRect().size() * ratio;
+		scaledCurrentPixmap = pixmap().scaled(size.toSize(), Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
 		scaledCurrentPixmap.setDevicePixelRatio(ratio);
 	}
 	// Align the pixmap to pixel grid, otherwise we'll get artifacts at some scaling factors.
@@ -402,14 +424,26 @@ void LeftStelBar::addButton(StelButton* button)
 	if (QGraphicsItem::childItems().size()!=0)
 	{
 		const QRectF& r = childrenBoundingRect();
-		posY += r.bottom()-1;
+		posY += r.bottom();
 	}
 	button->setParentItem(this);
 	button->setFocusOnSky(false);
 	//button->prepareGeometryChange(); // could possibly be removed when qt 4.6 become stable
-	button->setPos(0., qRound(posY+10.5));
+	button->setPos(0., qRound(posY + 9.5 * fontSizeRatio()));
 
 	connect(button, SIGNAL(hoverChanged(bool)), this, SLOT(buttonHoverChanged(bool)));
+}
+
+void LeftStelBar::updateButtonPositions()
+{
+	double posY = 0;
+	for (const auto button : childItems())
+	{
+		if (const auto b = dynamic_cast<StelButton*>(button))
+			b->animValueChanged(0.); // update button pixmap
+		button->setPos(0., posY);
+		posY += std::round(button->boundingRect().height() + 9.5 * fontSizeRatio());
+	}
 }
 
 void LeftStelBar::paint(QPainter*, const QStyleOptionGraphicsItem*, QWidget*)
@@ -476,6 +510,7 @@ void LeftStelBar::setColor(const QColor& c)
 //! connect from StelApp to resize fonts on the fly.
 void LeftStelBar::setFontSizeFromApp(int size)
 {
+	prepareGeometryChange();
 	// Font size was developed based on base font size 13, i.e. 12
 	int screenFontSize = size-1;
 	QFont font=QGuiApplication::font();
@@ -487,7 +522,10 @@ void LeftStelBar::setFontSizeFromApp(int size)
 		// to avoid crash
 		SkyGui* skyGui=gui->getSkyGui();
 		if (skyGui)
+		{
 			skyGui->updateBarsPos();
+			updateButtonPositions();
+		}
 	}
 }
 

--- a/src/gui/StelGuiItems.hpp
+++ b/src/gui/StelGuiItems.hpp
@@ -116,8 +116,8 @@ public:
 
 	//! Get the width of the button image.
 	//! The width is based on pixOn.
-	int getButtonPixmapWidth() const {return pixOn.width() / pixmapsScale;}
-	int getButtonPixmapHeight() const {return pixOn.height() / pixmapsScale;}
+	int getButtonPixmapWidth() const;
+	int getButtonPixmapHeight() const;
 
 	//! Set the button opacity
 	void setOpacity(double v) {opacity=v; updateIcon();}
@@ -220,6 +220,7 @@ private slots:
 	void setFontSizeFromApp(int size);
 	//! connect from StelApp to set font on the fly.
 	void setFont(const QFont &cfont);
+	void updateButtonPositions();
 private:
 	QTimeLine* hideTimeLine;
 	QGraphicsSimpleTextItem* helpLabel;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

This is a continuation of the scalable GUI series. Currently the dialogs are scaled according to font size, but not the panels. This PR makes the panels, namely bottom and left one also scale. The Oculars plugin's panel (are there others?) remains unaffected, this will be fixed in a subsequent PR.

### Screenshots:

#### 13px font, old

![stellarium-011](https://github.com/user-attachments/assets/436c33d4-ab87-4530-a14f-28120b15b3a7)

#### 13px font, new

![stellarium-014](https://github.com/user-attachments/assets/8c43fc1f-b84b-48dc-8cc3-96308c4bd844)

#### 19px font, old

![stellarium-012](https://github.com/user-attachments/assets/c62c5261-8df3-4abd-9d13-c2e29a89a5ed)

#### 19px font, new

![stellarium-015](https://github.com/user-attachments/assets/9e260dcb-8ee3-44ea-bc61-3f040ad14f93)

#### 40px font, old

![stellarium-013](https://github.com/user-attachments/assets/9440542e-87bc-4f23-b845-b4e731d05734)

#### 40px font, new

![stellarium-016](https://github.com/user-attachments/assets/bbfbb096-b047-4c85-afac-d50d52a6f405)

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?

**Test Configuration**:
* Operating system: Ubuntu 20.04
* Graphics Card: Intel UHD Graphics 620

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules