### PR TITLE
Apply font size settings to Oculars plugin

### DIFF
--- a/plugins/Oculars/src/Oculars.cpp
+++ b/plugins/Oculars/src/Oculars.cpp
@@ -54,6 +54,12 @@
 #include <cmath>
 #include <stdexcept>
 
+// When DEFAULT_FONT_SIZE is 13, GUI panel's font size was designed to be 12.
+// This factor preserves the ratio when the fonts are scaled.
+constexpr double GUI_PANEL_FONT_SIZE_FACTOR = 12.0 / 13.0;
+// Design font size is 14, based on default app fontsize 13.
+constexpr double FONT_SIZE_FACTOR = 14.0 / 13.0;
+
 extern void qt_set_sequence_auto_mnemonic(bool b);
 
 static QSettings *settings; //!< The settings as read in from the ini file.
@@ -151,7 +157,7 @@ Oculars::Oculars()
 	, actionOcularIncrement(Q_NULLPTR)
 	, actionOcularDecrement(Q_NULLPTR)
 	, guiPanel(Q_NULLPTR)
-	, guiPanelFontSize(12)
+	, guiPanelFontSize(StelApp::getInstance().getScreenFontSize() * GUI_PANEL_FONT_SIZE_FACTOR)
 	, textColor(0.)
 	, lineColor(0.)
 	, focuserColor(0.)
@@ -181,7 +187,6 @@ Oculars::Oculars()
 	, flagUseLargeFocuserOverlay(true)
 {
 	setObjectName("Oculars");
-	// Design font size is 14, based on default app fontsize 13.
 	setFontSizeFromApp(StelApp::getInstance().getScreenFontSize());
 	connect(&StelApp::getInstance(), SIGNAL(screenFontSizeChanged(int)), this, SLOT(setFontSizeFromApp(int)));
 
@@ -323,6 +328,21 @@ void Oculars::deinit()
 	protractorFlipVTexture.clear();
 	protractorFlipHTexture.clear();
 	protractorFlipHVTexture.clear();
+}
+
+void Oculars::setFontSize(const int fontSize, const int guiPanelFontSize)
+{
+	font.setPixelSize(fontSize);
+
+	this->guiPanelFontSize = guiPanelFontSize;
+	if (guiPanel)
+		guiPanel->setFontSize(guiPanelFontSize);
+}
+
+void Oculars::setFontSizeFromApp(const int size)
+{
+	setFontSize(size * FONT_SIZE_FACTOR,
+	            size * GUI_PANEL_FONT_SIZE_FACTOR);
 }
 
 //! Draw any parts on the screen which are for our module
@@ -588,7 +608,8 @@ void Oculars::init()
 		initializeActivationActions();
 		determineMaxEyepieceAngle();
 
-		guiPanelFontSize=settings->value("gui_panel_fontsize", 12).toInt();
+		const int defaultGuiPanelFontSize = StelApp::getInstance().getScreenFontSize() * GUI_PANEL_FONT_SIZE_FACTOR;
+		guiPanelFontSize=settings->value("gui_panel_fontsize", defaultGuiPanelFontSize).toInt();
 		enableGuiPanel(settings->value("enable_control_panel", true).toBool());
 		textColor=Vec3f(settings->value("text_color", "0.8,0.48,0.0").toString());
 		lineColor=Vec3f(settings->value("line_color", "0.77,0.14,0.16").toString());

--- a/plugins/Oculars/src/Oculars.hpp
+++ b/plugins/Oculars/src/Oculars.hpp
@@ -291,9 +291,9 @@ public slots:
 	void setFlagShowOcularsButton(bool b);
 	bool getFlagShowOcularsButton(void) { return flagShowOcularsButton; }
 
-	void setFontSize(int s){font.setPixelSize(s);}
+	void setFontSize(int fontSize, int guiPanelFontSize);
 	//! Connect this to StelApp font size.
-	void setFontSizeFromApp(int s){font.setPixelSize(s+1);}
+	void setFontSizeFromApp(int size);
 
 	void setFlagShowCcdCropOverlay(const bool b);
 	bool getFlagShowCcdCropOverlay(void) const;

--- a/plugins/Oculars/src/gui/OcularsGuiPanel.cpp
+++ b/plugins/Oculars/src/gui/OcularsGuiPanel.cpp
@@ -98,10 +98,6 @@ OcularsGuiPanel::OcularsGuiPanel(Oculars* plugin,
 					     true);
 	buttonConfiguration->setToolTip(ocularsPlugin->actionConfiguration->getText());
 
-	qreal buttonHeight = buttonOcular->boundingRect().height();
-	buttonBar->setMinimumHeight(buttonHeight);
-	buttonBar->setMaximumHeight(buttonHeight);
-
 	setLayout(mainLayout);
 
 	//Widgets with control and information fields
@@ -146,40 +142,9 @@ OcularsGuiPanel::OcularsGuiPanel(Oculars* plugin,
 	newFont.setPixelSize(plugin->getGuiPanelFontSize());
 	setControlsFont(newFont);
 
-	//Traditional field width from Ocular ;)
-	QFontMetrics fm(fieldOcularName->font());
-	int maxWidth = fm.boundingRect(QString("MMMMMMMMMMMMMMMMMMMMMM")).width();
-	int lineHeight = fm.height();
-
-	fieldOcularName->setTextWidth(maxWidth);
-	fieldOcularFl->setTextWidth(maxWidth);
-	fieldOcularAfov->setTextWidth(maxWidth);
-	fieldCcdName->setTextWidth(maxWidth);
-	fieldCcdDimensions->setTextWidth(maxWidth);
-	fieldCcdBinning->setTextWidth(maxWidth);
-	fieldCcdHScale->setTextWidth(maxWidth);
-	fieldCcdVScale->setTextWidth(maxWidth);
-	fieldCcdRotation->setTextWidth(maxWidth);
-	fieldPrismRotation->setTextWidth(maxWidth);
-	fieldTelescopeName->setTextWidth(maxWidth);
-	fieldMagnification->setTextWidth(maxWidth);
-	fieldExitPupil->setTextWidth(maxWidth);
-	fieldTwilightFactor->setTextWidth(maxWidth);
-	fieldRelativeBrightness->setTextWidth(maxWidth);
-	fieldAdlerIndex->setTextWidth(maxWidth);
-	fieldBishopIndex->setTextWidth(maxWidth);
-	fieldFov->setTextWidth(maxWidth);
-	fieldRayleighCriterion->setTextWidth(maxWidth);
-	fieldDawesCriterion->setTextWidth(maxWidth);
-	fieldAbbeyCriterion->setTextWidth(maxWidth);
-	fieldSparrowCriterion->setTextWidth(maxWidth);
-	fieldVisualResolution->setTextWidth(maxWidth);
-	fieldLensName->setTextWidth(maxWidth);
-	fieldLensMultipler->setTextWidth(maxWidth);
-
 	// Retrieve value from setting directly, because at this stage the plugin has not parsed it yet.
 	float scv = plugin->getSettings()->value("arrow_scale", 150.f).toFloat();
-	int scale=static_cast<int>(lineHeight*scv*0.01f);
+	const int scale=static_cast<int>(0.14f * scv);
 	// TODO: change this load-once to interactively editable value of scaling coefficient
 	QPixmap pa(":/graphicGui/btTimeRewind-on.png");
 	QPixmap prevArrow = pa.scaledToHeight(scale * StelButton::getInputPixmapsDevicePixelRatio(), Qt::SmoothTransformation);
@@ -207,24 +172,12 @@ OcularsGuiPanel::OcularsGuiPanel(Oculars* plugin,
 	nextTelescopeButton = new StelButton(telescopeControls, nextArrow, nextArrowOff, QPixmap(), "actionShow_Telescope_Increment");
 	nextTelescopeButton->setToolTip(q_("Select next telescope"));
 
-	createRotationButtons();
+	updateRotationButtons();
 
-	//Set the layout and update the size
-	qreal width = 2*prevOcularButton->boundingRect().width() + maxWidth;
-	qreal left, right, top, bottom;
-	mainLayout->getContentsMargins(&left, &top, &right, &bottom);
-	ocularControls->setMaximumWidth(width);
-	ccdControls->setMaximumWidth(width);
-	telescopeControls->setMaximumWidth(width);
-	lensControls->setMaximumWidth(width);
-	resize(width + left + right, 10);
-	buttonBar->resize(width, size().height());
-	updateMainButtonsPositions();
-
-	//Border/background for the widget
-	borderPath = new QGraphicsPathItem();
+	borderPath = new QGraphicsPathItem(parentWidget);
 	borderPath->setZValue(100);
-	borderPath->setParentItem(parentWidget);
+
+	updateLayout();
 
 	updatePosition();
 	connect (parentWidget, SIGNAL(geometryChanged()),	 this, SLOT(updatePosition()));
@@ -1221,7 +1174,7 @@ void OcularsGuiPanel::setColorScheme(const QString &schemeName)
 	setControlsColor(QColor::fromRgbF(0.9, 0.91, 0.95, 0.9));
 }
 
-void OcularsGuiPanel::createRotationButtons()
+void OcularsGuiPanel::updateRotationButtons()
 {
 	const auto font = fieldOcularName->font();
 	QFontMetrics fm(font);
@@ -1236,8 +1189,10 @@ void OcularsGuiPanel::createRotationButtons()
 	QPixmap pOn    = createPixmapFromText(degrees, degreesW, lineHeight, font, cOn);
 	QPixmap pOff   = createPixmapFromText(degrees, degreesW, lineHeight, font, cOff);
 	QPixmap pHover = createPixmapFromText(degrees, degreesW, lineHeight, font, cHover);
+	delete rotateCcdMinus90Button;
 	rotateCcdMinus90Button = new StelButton(ccdControls, pOn,  pOff, pHover, "actionToggle_Oculars_Rotate_Frame_90_Counterclockwise", true);
 	rotateCcdMinus90Button->setToolTip(q_("Rotate the sensor frame 90 degrees counterclockwise"));
+	delete rotatePrismMinus90Button;
 	rotatePrismMinus90Button = new StelButton(ccdControls, pOn, pOff, pHover, "actionToggle_Oculars_Rotate_Prism_90_Counterclockwise", true);
 	rotatePrismMinus90Button->setToolTip(q_("Rotate the prism 90 degrees counterclockwise"));
 
@@ -1246,8 +1201,10 @@ void OcularsGuiPanel::createRotationButtons()
 	pOn    = createPixmapFromText(degrees, degreesW, lineHeight, font, cOn);
 	pOff   = createPixmapFromText(degrees, degreesW, lineHeight, font, cOff);
 	pHover = createPixmapFromText(degrees, degreesW, lineHeight, font, cHover);
+	delete rotateCcdMinus15Button;
 	rotateCcdMinus15Button = new StelButton(ccdControls, pOn,  pOff, pHover, "actionToggle_Oculars_Rotate_Frame_15_Counterclockwise", true);
 	rotateCcdMinus15Button->setToolTip(q_("Rotate the sensor frame 15 degrees counterclockwise"));
+	delete rotatePrismMinus15Button;
 	rotatePrismMinus15Button = new StelButton(ccdControls, pOn, pOff, pHover, "actionToggle_Oculars_Rotate_Prism_15_Counterclockwise", true);
 	rotatePrismMinus15Button->setToolTip(q_("Rotate the prism 15 degrees counterclockwise"));
 
@@ -1256,8 +1213,10 @@ void OcularsGuiPanel::createRotationButtons()
 	pOn    = createPixmapFromText(degrees, degreesW, lineHeight, font, cOn);
 	pOff   = createPixmapFromText(degrees, degreesW, lineHeight, font, cOff);
 	pHover = createPixmapFromText(degrees, degreesW, lineHeight, font, cHover);
+	delete rotateCcdMinus5Button;
 	rotateCcdMinus5Button = new StelButton(ccdControls, pOn, pOff, pHover, "actionToggle_Oculars_Rotate_Frame_5_Counterclockwise", true);
 	rotateCcdMinus5Button->setToolTip(q_("Rotate the sensor frame 5 degrees counterclockwise"));
+	delete rotatePrismMinus5Button;
 	rotatePrismMinus5Button = new StelButton(ccdControls, pOn, pOff, pHover, "actionToggle_Oculars_Rotate_Prism_5_Counterclockwise", true);
 	rotatePrismMinus5Button->setToolTip(q_("Rotate the prism 5 degrees counterclockwise"));
 
@@ -1266,8 +1225,10 @@ void OcularsGuiPanel::createRotationButtons()
 	pOn    = createPixmapFromText(degrees, degreesW, lineHeight, font, cOn);
 	pOff   = createPixmapFromText(degrees, degreesW, lineHeight, font, cOff);
 	pHover = createPixmapFromText(degrees, degreesW, lineHeight, font, cHover);
+	delete rotateCcdMinus1Button;
 	rotateCcdMinus1Button = new StelButton(ccdControls, pOn, pOff, pHover, "actionToggle_Oculars_Rotate_Frame_1_Counterclockwise", true);
 	rotateCcdMinus1Button->setToolTip(q_("Rotate the sensor frame 1 degree counterclockwise"));
+	delete rotatePrismMinus1Button;
 	rotatePrismMinus1Button = new StelButton(ccdControls, pOn, pOff, pHover, "actionToggle_Oculars_Rotate_Prism_1_Counterclockwise", true);
 	rotatePrismMinus1Button->setToolTip(q_("Rotate the prism 1 degree counterclockwise"));
 
@@ -1276,8 +1237,10 @@ void OcularsGuiPanel::createRotationButtons()
 	pOn    = createPixmapFromText(degrees, degreesW, lineHeight, font, cOn);
 	pOff   = createPixmapFromText(degrees, degreesW, lineHeight, font, cOff);
 	pHover = createPixmapFromText(degrees, degreesW, lineHeight, font, cHover);
+	delete resetCcdRotationButton;
 	resetCcdRotationButton = new StelButton(ccdControls, pOn, pOff, pHover, "actionToggle_Oculars_Rotate_Frame_Reset", true);
 	resetCcdRotationButton->setToolTip(q_("Reset the sensor frame rotation"));
+	delete resetPrismRotationButton;
 	resetPrismRotationButton = new StelButton(ccdControls, pOn, pOff, pHover, "actionToggle_Oculars_Rotate_Prism_Reset", true);
 	resetPrismRotationButton->setToolTip(q_("Reset the prism rotation"));
 
@@ -1286,8 +1249,10 @@ void OcularsGuiPanel::createRotationButtons()
 	pOn    = createPixmapFromText(degrees, degreesW, lineHeight, font, cOn);
 	pOff   = createPixmapFromText(degrees, degreesW, lineHeight, font, cOff);
 	pHover = createPixmapFromText(degrees, degreesW, lineHeight, font, cHover);
+	delete rotateCcdPlus1Button;
 	rotateCcdPlus1Button = new StelButton(ccdControls, pOn, pOff, pHover, "actionToggle_Oculars_Rotate_Frame_1_Clockwise", true);
 	rotateCcdPlus1Button->setToolTip(q_("Rotate the sensor frame 1 degree clockwise"));
+	delete rotatePrismPlus1Button;
 	rotatePrismPlus1Button = new StelButton(ccdControls, pOn, pOff, pHover, "actionToggle_Oculars_Rotate_Prism_1_Clockwise", true);
 	rotatePrismPlus1Button->setToolTip(q_("Rotate the prism 1 degree clockwise"));
 
@@ -1296,8 +1261,10 @@ void OcularsGuiPanel::createRotationButtons()
 	pOn    = createPixmapFromText(degrees, degreesW, lineHeight, font, cOn);
 	pOff   = createPixmapFromText(degrees, degreesW, lineHeight, font, cOff);
 	pHover = createPixmapFromText(degrees, degreesW, lineHeight, font, cHover);
+	delete rotateCcdPlus5Button;
 	rotateCcdPlus5Button = new StelButton(ccdControls, pOn, pOff, pHover, "actionToggle_Oculars_Rotate_Frame_5_Clockwise", true);
 	rotateCcdPlus5Button->setToolTip(q_("Rotate the sensor frame 5 degrees clockwise"));
+	delete rotatePrismPlus5Button;
 	rotatePrismPlus5Button = new StelButton(ccdControls, pOn, pOff, pHover, "actionToggle_Oculars_Rotate_Prism_5_Clockwise", true);
 	rotatePrismPlus5Button->setToolTip(q_("Rotate the prism 5 degrees clockwise"));
 
@@ -1306,8 +1273,10 @@ void OcularsGuiPanel::createRotationButtons()
 	pOn    = createPixmapFromText(degrees, degreesW, lineHeight, font, cOn);
 	pOff   = createPixmapFromText(degrees, degreesW, lineHeight, font, cOff);
 	pHover = createPixmapFromText(degrees, degreesW, lineHeight, font, cHover);
+	delete rotateCcdPlus15Button;
 	rotateCcdPlus15Button = new StelButton(ccdControls, pOn, pOff, pHover, "actionToggle_Oculars_Rotate_Frame_15_Clockwise", true);
 	rotateCcdPlus15Button->setToolTip(q_("Rotate the sensor frame 15 degrees clockwise"));
+	delete rotatePrismPlus15Button;
 	rotatePrismPlus15Button = new StelButton(ccdControls, pOn, pOff, pHover, "actionToggle_Oculars_Rotate_Prism_15_Clockwise", true);
 	rotatePrismPlus15Button->setToolTip(q_("Rotate the prism 15 degrees clockwise"));
 
@@ -1316,10 +1285,96 @@ void OcularsGuiPanel::createRotationButtons()
 	pOn    = createPixmapFromText(degrees, degreesW, lineHeight, font, cOn);
 	pOff   = createPixmapFromText(degrees, degreesW, lineHeight, font, cOff);
 	pHover = createPixmapFromText(degrees, degreesW, lineHeight, font, cHover);
+	delete rotateCcdPlus90Button;
 	rotateCcdPlus90Button = new StelButton(ccdControls, pOn, pOff, pHover, "actionToggle_Oculars_Rotate_Frame_90_Clockwise", true);
 	rotateCcdPlus90Button->setToolTip(q_("Rotate the sensor frame 90 degrees clockwise"));
+	delete rotatePrismPlus90Button;
 	rotatePrismPlus90Button = new StelButton(ccdControls, pOn, pOff, pHover, "actionToggle_Oculars_Rotate_Prism_90_Clockwise", true);
 	rotatePrismPlus90Button->setToolTip(q_("Rotate the prism 90 degrees clockwise"));
+}
+
+void OcularsGuiPanel::updateLayout()
+{
+	const qreal buttonHeight = buttonOcular->boundingRect().height();
+	buttonBar->setMinimumHeight(buttonHeight);
+	buttonBar->setMaximumHeight(buttonHeight);
+
+	//Traditional field width from Ocular ;)
+	QFontMetrics fm(fieldOcularName->font());
+	int maxWidth = fm.boundingRect(QString("MMMMMMMMMMMMMMMMMMMMMM")).width();
+
+	fieldOcularName->setTextWidth(maxWidth);
+	fieldOcularFl->setTextWidth(maxWidth);
+	fieldOcularAfov->setTextWidth(maxWidth);
+	fieldCcdName->setTextWidth(maxWidth);
+	fieldCcdDimensions->setTextWidth(maxWidth);
+	fieldCcdBinning->setTextWidth(maxWidth);
+	fieldCcdHScale->setTextWidth(maxWidth);
+	fieldCcdVScale->setTextWidth(maxWidth);
+	fieldCcdRotation->setTextWidth(maxWidth);
+	fieldPrismRotation->setTextWidth(maxWidth);
+	fieldTelescopeName->setTextWidth(maxWidth);
+	fieldMagnification->setTextWidth(maxWidth);
+	fieldExitPupil->setTextWidth(maxWidth);
+	fieldTwilightFactor->setTextWidth(maxWidth);
+	fieldRelativeBrightness->setTextWidth(maxWidth);
+	fieldAdlerIndex->setTextWidth(maxWidth);
+	fieldBishopIndex->setTextWidth(maxWidth);
+	fieldFov->setTextWidth(maxWidth);
+	fieldRayleighCriterion->setTextWidth(maxWidth);
+	fieldDawesCriterion->setTextWidth(maxWidth);
+	fieldAbbeyCriterion->setTextWidth(maxWidth);
+	fieldSparrowCriterion->setTextWidth(maxWidth);
+	fieldVisualResolution->setTextWidth(maxWidth);
+	fieldLensName->setTextWidth(maxWidth);
+	fieldLensMultipler->setTextWidth(maxWidth);
+
+	//Set the layout and update the size
+	qreal width = 2*prevOcularButton->boundingRect().width() + maxWidth;
+	qreal left, right, top, bottom;
+	mainLayout->getContentsMargins(&left, &top, &right, &bottom);
+	ocularControls->setMaximumWidth(width);
+	ccdControls->setMaximumWidth(width);
+	telescopeControls->setMaximumWidth(width);
+	lensControls->setMaximumWidth(width);
+	resize(width + left + right, std::max(size().height(), 1.));
+	buttonBar->resize(width, size().height());
+	updateMainButtonsPositions();
+}
+
+void OcularsGuiPanel::setFontSize(const int size)
+{
+	QFont newFont = font();
+	newFont.setPixelSize(size);
+	setControlsFont(newFont);
+
+	for (const auto button : {buttonOcular,
+	                          buttonCrosshairs,
+	                          buttonCcd,
+	                          buttonTelrad,
+	                          buttonConfiguration,
+	                          prevOcularButton,
+	                          nextOcularButton,
+	                          prevLensButton,
+	                          nextLensButton,
+	                          prevCcdButton,
+	                          nextCcdButton,
+	                          prevTelescopeButton,
+	                          nextTelescopeButton})
+	{
+		button->updateIcon();
+	}
+
+	const bool ocularsVisible = ocularControls->isVisible();
+	const bool ccdVisible = ccdControls->isVisible();
+	foldGui(); // This will force reshaping of mainLayout
+	updateRotationButtons();
+	updateLayout();
+	if (ocularsVisible)
+		updateOcularControls();
+	if (ccdVisible)
+		updateCcdControls();
+	updatePosition();
 }
 
 QPixmap OcularsGuiPanel::createPixmapFromText(const QString& text,

--- a/plugins/Oculars/src/gui/OcularsGuiPanel.hpp
+++ b/plugins/Oculars/src/gui/OcularsGuiPanel.hpp
@@ -50,6 +50,8 @@ public slots:
 	//! Hide the controls, leaving only the button bar.
 	void foldGui();
 
+	void setFontSize(int size);
+
 private slots:
 	//! Update the position of the widget within the parent.
 	//! Tied to the parent's geometryChanged() signal.
@@ -68,7 +70,8 @@ private slots:
 	//! Sets the color scheme (day/night mode)
 	void setColorScheme(const QString& schemeName);
 
-	void createRotationButtons();
+	void updateLayout();
+	void updateRotationButtons();
 
 private:
 	Oculars* ocularsPlugin;
@@ -131,24 +134,24 @@ private:
 	QGraphicsTextItem* fieldLimitMagnitude;
 
 	//Sensor frame rotation controls
-	StelButton* rotateCcdMinus90Button;
-	StelButton* rotateCcdMinus15Button;
-	StelButton* rotateCcdMinus5Button;
-	StelButton* rotateCcdMinus1Button;
-	StelButton* resetCcdRotationButton;
-	StelButton* rotateCcdPlus1Button;
-	StelButton* rotateCcdPlus5Button;
-	StelButton* rotateCcdPlus15Button;
-	StelButton* rotateCcdPlus90Button;
-	StelButton* rotatePrismMinus90Button;
-	StelButton* rotatePrismMinus15Button;
-	StelButton* rotatePrismMinus5Button;
-	StelButton* rotatePrismMinus1Button;
-	StelButton* resetPrismRotationButton;
-	StelButton* rotatePrismPlus1Button;
-	StelButton* rotatePrismPlus5Button;
-	StelButton* rotatePrismPlus15Button;
-	StelButton* rotatePrismPlus90Button;
+	StelButton* rotateCcdMinus90Button = nullptr;
+	StelButton* rotateCcdMinus15Button = nullptr;
+	StelButton* rotateCcdMinus5Button = nullptr;
+	StelButton* rotateCcdMinus1Button = nullptr;
+	StelButton* resetCcdRotationButton = nullptr;
+	StelButton* rotateCcdPlus1Button = nullptr;
+	StelButton* rotateCcdPlus5Button = nullptr;
+	StelButton* rotateCcdPlus15Button = nullptr;
+	StelButton* rotateCcdPlus90Button = nullptr;
+	StelButton* rotatePrismMinus90Button = nullptr;
+	StelButton* rotatePrismMinus15Button = nullptr;
+	StelButton* rotatePrismMinus5Button = nullptr;
+	StelButton* rotatePrismMinus1Button = nullptr;
+	StelButton* resetPrismRotationButton = nullptr;
+	StelButton* rotatePrismPlus1Button = nullptr;
+	StelButton* rotatePrismPlus5Button = nullptr;
+	StelButton* rotatePrismPlus15Button = nullptr;
+	StelButton* rotatePrismPlus90Button = nullptr;
 
 	//! Sets the visibility of the ocular name label and the associated buttons.
 	void setOcularControlsVisible(bool show);

--- a/src/gui/StelGuiItems.hpp
+++ b/src/gui/StelGuiItems.hpp
@@ -154,6 +154,7 @@ public slots:
 	//! set whether the button is checked
 	void setChecked(int b);
 	void setChecked(bool b) { setChecked(static_cast<int>(b)); }
+	void updateIcon();
 
 protected:
 	void hoverEnterEvent(QGraphicsSceneHoverEvent* event) override;
@@ -163,7 +164,6 @@ protected:
 	void paint(QPainter*, const QStyleOptionGraphicsItem*, QWidget*) override;
 private slots:
 	void animValueChanged(qreal value);
-	void updateIcon();
 private:
 	void initCtor(const QPixmap& apixOn,
                   const QPixmap& apixOff,


### PR DESCRIPTION
### Description
This is the continuation of the scaling of the GUI panels. Now the remaining panel—the Oculars one—is also scaled with increasing fonts sizes, applying these sizes on the fly.

### Screenshots

![stellarium-011](https://github.com/user-attachments/assets/a8b7de12-75b5-4673-9e1d-0f5cb9d1e6bc)

![stellarium-012](https://github.com/user-attachments/assets/e306f7aa-cd9d-4b35-b868-3020695b9d58)

![stellarium-013](https://github.com/user-attachments/assets/f7f935f1-3016-43ca-8081-650bccf2a8c2)

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?

**Test Configuration**:
* Operating system: Ubuntu 20.04
* Graphics Card: Intel UHD Graphics 620

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
