### PR TITLE
Add Export Map button for local solar eclipses too

### DIFF
--- a/src/gui/AstroCalcDialog.hpp
+++ b/src/gui/AstroCalcDialog.hpp
@@ -341,7 +341,7 @@ private slots:
 	void selectCurrentSolarEclipseContact(const QModelIndex &modelIndex);
 	void saveSolarEclipses();
 	void saveSolarEclipseCircumstances();
-	void saveSolarEclipseMap();
+	void saveSolarEclipseMap(bool local);
 
 	//! Calculating local solar eclipses to fill the list.
 	//! Algorithm taken from calculating the rises, transits and sets.
@@ -581,6 +581,7 @@ private:
 	void enableSolarEclipsesButtons(bool enable);
 	void enableSolarEclipsesCircumstancesButtons(bool enable);
 	void enableSolarEclipsesLocalButtons(bool enable);
+	void enableSolarEclipsesLocalSingleEclipseButtons(bool enable);
 	void enableLunarEclipsesButtons(bool enable);
 	void enableLunarEclipsesCircumstancesButtons(bool enable);
 	void enableTransitsButtons(bool enable);

--- a/src/gui/astroCalcDialog.ui
+++ b/src/gui/astroCalcDialog.ui
@@ -2666,6 +2666,16 @@
                  </widget>
                 </item>
                 <item>
+                 <widget class="QPushButton" name="solareclipseslocalMapSaveButton">
+                  <property name="toolTip">
+                   <string>Export a visibility map of the selected eclipse</string>
+                  </property>
+                  <property name="text">
+                   <string>Export map...</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
                  <widget class="QPushButton" name="solareclipseslocalCalculateButton">
                   <property name="text">
                    <string>Calculate eclipses</string>


### PR DESCRIPTION

### Description
Currently it's only possible to save an eclipse map from the general solar eclipses tab, but not from the local eclipses one. This seems unfair, so this PR adds a similar button in the local solar eclipses tab.

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
