### PR TITLE
Scale lines according to screen font size

### DIFF
--- a/src/core/StelProjector.cpp
+++ b/src/core/StelProjector.cpp
@@ -21,6 +21,7 @@
 #include "StelTranslator.hpp"
 
 #include "StelProjector.hpp"
+#include "StelApp.hpp"
 
 #include <QDebug>
 #include <QString>
@@ -307,6 +308,13 @@ const SphericalCap& StelProjector::getBoundingCap() const
 float StelProjector::getPixelPerRadAtCenter() const
 {
 	return pixelPerRad;
+}
+
+float StelProjector::getScreenScale() const
+{
+	const float dppRatio = getDevicePixelsPerPixel();
+	const float fontRatio = StelApp::getInstance().screenFontSizeRatio();
+	return dppRatio * fontRatio;
 }
 
 //! Get the current FOV diameter in degrees

--- a/src/core/StelProjector.hpp
+++ b/src/core/StelProjector.hpp
@@ -222,6 +222,10 @@ public:
 	//! Get size of a radian in pixels at the center of the viewport disk
 	float getPixelPerRadAtCenter() const;
 
+	//! Get the scale factor for objects drawn on screen. This takes into account
+	//! font size and the OS-given high-DPI scaling setting (see #getDevicePixelsPerPixel).
+	float getScreenScale() const;
+
 	//! Get the current FOV diameter in degrees
 	float getFov() const;
 

--- a/src/core/modules/ConstellationMgr.cpp
+++ b/src/core/modules/ConstellationMgr.cpp
@@ -711,10 +711,11 @@ void ConstellationMgr::drawArt(StelPainter& sPainter, const Vec3d &obsVelocity) 
 // Draw constellations lines
 void ConstellationMgr::drawLines(StelPainter& sPainter, const StelCore* core) const
 {
-	const float ppx = static_cast<float>(sPainter.getProjector()->getDevicePixelsPerPixel());
+	const float scale = sPainter.getProjector()->getScreenScale();
+
 	sPainter.setBlending(true);
-	if (constellationLineThickness>1 || ppx>1.f)
-		sPainter.setLineWidth(constellationLineThickness*ppx); // set line thickness
+	if (constellationLineThickness>1 || scale>1.f)
+		sPainter.setLineWidth(constellationLineThickness*scale); // set line thickness
 	sPainter.setLineSmooth(true);
 
 	const SphericalCap& viewportHalfspace = sPainter.getProjector()->getBoundingCap();
@@ -722,7 +723,7 @@ void ConstellationMgr::drawLines(StelPainter& sPainter, const StelCore* core) co
 	{
 		constellation->drawOptim(sPainter, core, viewportHalfspace);
 	}
-	if (constellationLineThickness>1 || ppx>1.f)
+	if (constellationLineThickness>1 || scale>1.f)
 		sPainter.setLineWidth(1); // restore line thickness
 	sPainter.setLineSmooth(false);
 }
@@ -1442,16 +1443,17 @@ bool ConstellationMgr::loadBoundaries(const QString& boundaryFile)
 
 void ConstellationMgr::drawBoundaries(StelPainter& sPainter, const Vec3d &obsVelocity) const
 {
-	const float ppx = static_cast<float>(sPainter.getProjector()->getDevicePixelsPerPixel());
+	const float scale = sPainter.getProjector()->getScreenScale();
+
 	sPainter.setBlending(false);
-	if (constellationBoundariesThickness>1 || ppx>1.f)
-		sPainter.setLineWidth(constellationBoundariesThickness*ppx); // set line thickness
+	if (constellationBoundariesThickness>1 || scale>1.f)
+		sPainter.setLineWidth(constellationBoundariesThickness*scale); // set line thickness
 	sPainter.setLineSmooth(true);
 	for (auto* constellation : constellations)
 	{
 		constellation->drawBoundaryOptim(sPainter, obsVelocity);
 	}
-	if (constellationBoundariesThickness>1 || ppx>1.f)
+	if (constellationBoundariesThickness>1 || scale>1.f)
 		sPainter.setLineWidth(1); // restore line thickness
 	sPainter.setLineSmooth(false);
 }

--- a/src/core/modules/Nebula.cpp
+++ b/src/core/modules/Nebula.cpp
@@ -712,6 +712,7 @@ void Nebula::drawOutlines(StelPainter &sPainter, float maxMagHints) const
 	float oLim = getVisibilityLevelByMagnitude() - 3.f;
 
 	sPainter.setColor(getHintColor(nType), hintsBrightness);
+	sPainter.setLineWidth(1.f * sPainter.getProjector()->getScreenScale());
 
 	StelCore *core=StelApp::getInstance().getCore();
 	Vec3d vel=core->getCurrentPlanet()->getHeliocentricEclipticVelocity();

--- a/src/core/modules/Planet.cpp
+++ b/src/core/modules/Planet.cpp
@@ -4886,7 +4886,7 @@ void Planet::drawOrbit(const StelCore* core)
 	const StelProjectorP prj = core->getProjection(StelCore::FrameHeliocentricEclipticJ2000);
 	KeplerOrbit *keplerOrbit=static_cast<KeplerOrbit*>(orbitPtr);
 	StelPainter sPainter(prj);
-	const float ppx = static_cast<float>(sPainter.getProjector()->getDevicePixelsPerPixel());
+	const float scale = sPainter.getProjector()->getScreenScale();
 
 	// Normal transparency mode
 	sPainter.setBlending(true);
@@ -4938,8 +4938,8 @@ void Planet::drawOrbit(const StelCore* core)
 	QVarLengthArray<float, 1024> vertexArray;
 
 	sPainter.enableClientStates(true, false, false);
-	if (orbitsThickness>1 || ppx>1.f)
-		sPainter.setLineWidth(orbitsThickness*ppx);
+	if (orbitsThickness>1 || scale>1.f)
+		sPainter.setLineWidth(orbitsThickness*scale);
 
 	sPainter.setLineSmooth(true);
 
@@ -4964,7 +4964,7 @@ void Planet::drawOrbit(const StelCore* core)
 		sPainter.drawFromArray(StelPainter::LineStrip, vertexArray.size()/2, 0, false);
 	}
 	sPainter.enableClientStates(false);
-	if (orbitsThickness>1 || ppx>1.f)
+	if (orbitsThickness>1 || scale>1.f)
 		sPainter.setLineWidth(1);
 
 	sPainter.setLineSmooth(false);


### PR DESCRIPTION
### Description

Currently lines (constellations, DSO markers etc.) are scaled in thickness according to device pixel ratio. I'm continuing the work on basing this on font scale instead.

This PR uses a product of device pixel ratio and font size ratio to yield the final scaling coefficient of the lines (and dotted DSO markers). For this, a function called `screenScale` is introduced in both `ConstellationMgr.cpp` and `Nebula.cpp`. It's rather simple, but I'd rather not repeat its implementation everywhere, so I have a question: where is the best place for it? `StelApp`, or maybe `StelSkyDrawer`, or `StelPainter` or `StelProjector`? It seems `StelApp` is too general a place for an OpenGL-rendering-specific coefficient, but OTOH, after we get rid of the Qt scaling kludge, this function will be simplified to just `StelApp::screenFontSizeRatio()`. And `StelSkyDrawer` doesn't appear to have getters for such low-level factors. Not sure about `StelPainter` or `StelProjector` either.

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system: Ubuntu 20.04
* Graphics Card: Intel UHD Graphics 620

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
