### PR TITLE
add Direction of Crosshairs in Oculars

### DIFF
--- a/plugins/Oculars/src/Oculars.cpp
+++ b/plugins/Oculars/src/Oculars.cpp
@@ -2080,6 +2080,25 @@ void Oculars::paintCrosshairs()
 	a = ch_transform.map(QPoint(-hw, 0));
 	b = ch_transform.map(QPoint(hw, 0));
 	painter.drawLine2d(a.x(), a.y(), b.x(), b.y());
+
+   if (getFlagAlignCrosshair())
+   {
+      bool flipH = core->getFlipHorz();
+      bool flipV = core->getFlipVert();
+      painter.setColor(1.0, 1.0, 1.0);
+
+      QPoint nDirection = ch_transform.map(QPoint(0, hw + 20));
+      painter.drawText(nDirection.x(), nDirection.y(), q_("N"));
+
+      QPoint sDirection = ch_transform.map(QPoint(0, -hw - 20));
+      painter.drawText(sDirection.x(), sDirection.y(), q_("S"));
+
+      QPoint eDirection = ch_transform.map(QPoint(-hw - 20, 0));
+      painter.drawText(eDirection.x(), eDirection.y(), flipH == flipV ? q_("E") : q_("W"));
+
+      QPoint wDirection = ch_transform.map(QPoint(hw + 20, 0));
+      painter.drawText(wDirection.x(), wDirection.y(), flipH == flipV ? q_("W") : q_("E"));
+   }
 }
 
 void Oculars::paintTelrad()


### PR DESCRIPTION

### Description

Add directional indicators to the eyepiece view when the crosshairs are enabled and aligned with the equatorial coordinate system. This will help observers quickly identify the directional angles of celestial objects in the eyepiece. Such indicators are also widely used in sketches of deep-sky objects.


### Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/fc834882-fbb2-438b-a8aa-19309b0409d7)

![image](https://github.com/user-attachments/assets/9ecdaae6-6507-4c74-b616-4e95927b0bb3)



### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?
Enable oculars, enable crosshairs, check align crosshairs.

Switch flip options.

**Test Configuration**:
* Operating system: Windows 11 21H2
* Graphics Card: GTX 1060

