### PR TITLE
Enable sorting in Observing Lists; correctly sort by RA/dec/mag

### DIFF
--- a/src/gui/ObsListDialog.hpp
+++ b/src/gui/ObsListDialog.hpp
@@ -22,6 +22,7 @@
 
 #include <QObject>
 #include <QStandardItemModel>
+#include <QSortFilterProxyModel>
 
 #include "StelDialog.hpp"
 #include "StelCore.hpp"
@@ -427,6 +428,12 @@ private:
 	static const QString CUSTOM_OBJECT;
 
 	static const QString DASH;
+};
+
+class ObsListDialogSortFilterProxyModel : public QSortFilterProxyModel
+{
+protected:
+    bool lessThan(const QModelIndex &left, const QModelIndex &right) const override;
 };
 
 #endif // OBSLISTDIALOG_H


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Please include a summary of the change and which issue is fixed. -->
<!--- Please also include relevant motivation and context. -->
<!--- List any dependencies that are required for this change. -->

This enables sorting in observing lists, which previously seems to have relied on the default Qt behavior.  In particular, there was some sorting code in there already, but it wasn't doing anything.  So I've hooked it in, and added a little extra code to sort the RA, dec, and mag columns as numbers, instead of as strings.

Fixes #3893

Note that there was nothing in the existing code that would enable a double-click to reverse the sort order.  I'm not sure how you would want to handle that, as it seems like either doubling the number of `ObsListDialog::SORTING_BY_`* variables, or adding a `bool` to indicate the direction.  But either one seems like it could break existing lists, so I think it should be left for another PR.  (Another option would be to not store it, but just do it locally.  That one seems not too hard.)

### Screenshots (if appropriate):

Sorting by RA:

<img width="975" alt="Sorted_by_RA" src="https://github.com/user-attachments/assets/c232bc58-2a58-4c6a-b515-1aeca2947442" />

Sorting by dec:

<img width="973" alt="Sorted_by_Dec" src="https://github.com/user-attachments/assets/fe1f8bb2-a585-4af7-9384-f61cee305eca" />

Sorting by mag:

<img width="972" alt="Sorted_by_Mag" src="https://github.com/user-attachments/assets/2e5e7543-fc97-4d43-95d0-aadbecbbf230" />



### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

I think this is kind of a combination of bug fix and new feature, because there was code that was evidently intended to be used, but wasn't.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I've built the code, run it, and tested on my own observing list.

**Test Configuration**:
* Operating system: macOS 14.6.1 
* Graphics Card: Apple M2 Max (Metal 3)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules

The tests all pass *except for* `testAstrometry`, which segfaults — but I checked that it does that on master for me as well, and I don't suppose I did anything that should affect that test...