### PR TITLE
Fix aberration factor not taken into account for milkyway texture

### DIFF
--- a/src/core/StelCore.cpp
+++ b/src/core/StelCore.cpp
@@ -3173,14 +3173,10 @@ vec3 applyAberrationToViewDir(vec3 viewDir)
 
 void StelCore::setAberrationUniforms(QOpenGLShaderProgram& program) const
 {
-	Vec3d velocity;
+	Vec3d velocity(0.);
 	if(getUseAberration())
 	{
-		velocity = cachedAberrationVec;
-	}
-	else
-	{
-		velocity = Vec3d(0,0,0);
+		velocity = getAberrationFactor() * cachedAberrationVec;
 	}
 	program.setUniformValue("STELCORE_currentPlanetBarycentricEclipticVelocity", velocity.toQVector());
 }


### PR DESCRIPTION
Fix aberration factor not taken into account for milkyway texture.

Fixes #4099 

### Screenshots (if appropriate):

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?

Visually, go to Mercury and set aberration to x5.0 and then toggle on and off to check how the milkyway texture move compared to stars.

**Test Configuration**:
* Operating system: MacOS 15.2
* Graphics Card: Apple M3

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
