### PR TITLE
Make it possible to scale screen buttons independently

### DIFF
--- a/plugins/Oculars/src/Oculars.cpp
+++ b/plugins/Oculars/src/Oculars.cpp
@@ -189,6 +189,10 @@ Oculars::Oculars()
 	setObjectName("Oculars");
 	setFontSizeFromApp(StelApp::getInstance().getScreenFontSize());
 	connect(&StelApp::getInstance(), SIGNAL(screenFontSizeChanged(int)), this, SLOT(setFontSizeFromApp(int)));
+	connect(&StelApp::getInstance(), &StelApp::screenButtonScaleChanged, this,
+	        [this]{const int size = StelApp::getInstance().getScreenFontSize();
+	               setFontSizeFromApp(size); /* and repeat to apply all the geometry changes */
+	               setFontSizeFromApp(size);});
 
 	ccds = QList<CCD *>();
 	oculars = QList<Ocular *>();

--- a/src/core/StelApp.cpp
+++ b/src/core/StelApp.cpp
@@ -450,6 +450,7 @@ void StelApp::init(QSettings* conf)
 
 	setScreenFontSize(confSettings->value("gui/screen_font_size", getDefaultGuiFontSize()).toInt());
 	setGuiFontSize(confSettings->value("gui/gui_font_size", getDefaultGuiFontSize()).toInt());
+	setScreenButtonScale(confSettings->value("gui/screen_button_scale", 100).toDouble());
 
 	SplashScreen::present(guiFontSizeRatio());
 
@@ -1461,6 +1462,16 @@ void StelApp::setScreenFontSize(int s)
 		screenFontSize=s;
 		StelApp::immediateSave("gui/screen_font_size", s);
 		emit screenFontSizeChanged(s);
+	}
+}
+
+void StelApp::setScreenButtonScale(const double s)
+{
+	if (screenButtonScale!=s)
+	{
+		screenButtonScale = s;
+		StelApp::immediateSave("gui/screen_button_scale", s);
+		emit screenButtonScaleChanged(s);
 	}
 }
 

--- a/src/core/StelApp.hpp
+++ b/src/core/StelApp.hpp
@@ -88,6 +88,7 @@ class StelApp : public QObject
 	Q_PROPERTY(Vec3f daylightInfoColor	READ getDaylightInfoColor	WRITE setDaylightInfoColor	 NOTIFY daylightInfoColorChanged)
 	Q_PROPERTY(int  screenFontSize          READ getScreenFontSize          WRITE setScreenFontSize          NOTIFY screenFontSizeChanged)
 	Q_PROPERTY(int  guiFontSize             READ getGuiFontSize             WRITE setGuiFontSize             NOTIFY guiFontSizeChanged)
+	Q_PROPERTY(double screenButtonScale     READ getScreenButtonScale       WRITE setScreenButtonScale       NOTIFY screenButtonScaleChanged)
 	Q_PROPERTY(bool flagImmediateSave       READ getFlagImmediateSave       WRITE setFlagImmediateSave       NOTIFY flagImmediateSaveChanged)
 
 	Q_PROPERTY(QString version READ getVersion CONSTANT)
@@ -224,6 +225,11 @@ public:
 	int getGuiFontSize() const;
 	//! change GUI font size.
 	void setGuiFontSize(int s);
+
+	//! Get the ratio (in percent) of screen button size to the default screen scale-dependent one
+	double getScreenButtonScale() const { return screenButtonScale; }
+	//! Set the ratio (in percent) of screen button size to the default screen scale-dependent one
+	void setScreenButtonScale(double s);
 
 	//! Combines #getDevicePixelsPerPixel and #getScreenFontSize
 	float getScreenScale() const;
@@ -374,6 +380,7 @@ signals:
 	void languageChanged();
 	void screenFontSizeChanged(int);
 	void guiFontSizeChanged(int);
+	void screenButtonScaleChanged(double);
 	void fontChanged(const QFont&);
 	void overwriteInfoColorChanged(const Vec3f & color);
 	void daylightInfoColorChanged(const Vec3f & color);
@@ -505,6 +512,7 @@ private:
 
 	QList<StelProgressController*> progressControllers;
 
+	double screenButtonScale = 100; // in percent
 	int screenFontSize;
 	int numMultiSamples = 1;
 

--- a/src/gui/ConfigurationDialog.cpp
+++ b/src/gui/ConfigurationDialog.cpp
@@ -354,6 +354,7 @@ void ConfigurationDialog::createDialogContent()
 	// Font selection. We use a hidden, but documented entry in config.ini to optionally show a font selection option.
 	connectIntProperty(ui->screenFontSizeSpinBox, "StelApp.screenFontSize");
 	connectIntProperty(ui->guiFontSizeSpinBox, "StelApp.guiFontSize");
+	connectDoubleProperty(ui->screenButtonScaleSpinBox, "StelApp.screenButtonScale");
 	if (StelApp::getInstance().getSettings()->value("gui/flag_font_selection", true).toBool())
 	{
 		populateFontWritingSystemCombo();
@@ -1235,6 +1236,7 @@ void ConfigurationDialog::saveAllSettings()
 	//conf->setValue("gui/screen_font_size",						propMgr->getStelPropertyValue("StelApp.screenFontSize").toInt());
 	//conf->setValue("gui/gui_font_size",							propMgr->getStelPropertyValue("StelApp.guiFontSize").toInt());
 	storeFontSettings();
+	conf->setValue("gui/screen_button_scale",					propMgr->getStelPropertyValue("StelApp.screenButtonScale").toDouble());
 
 	conf->setValue("video/minimum_fps",						propMgr->getStelPropertyValue("MainView.minFps").toInt());
 	conf->setValue("video/maximum_fps",						propMgr->getStelPropertyValue("MainView.maxFps").toInt());

--- a/src/gui/StelGuiItems.cpp
+++ b/src/gui/StelGuiItems.cpp
@@ -234,6 +234,12 @@ int StelButton::toggleChecked(int checked)
 	return checked;
 }
 
+double StelButton::buttonSizeRatio()
+{
+	const auto& app = StelApp::getInstance();
+	return app.screenFontSizeRatio() * app.getScreenButtonScale()/100;
+}
+
 void StelButton::hoverEnterEvent(QGraphicsSceneHoverEvent*)
 {
 	timeLine->setDirection(QTimeLine::Forward);
@@ -356,12 +362,12 @@ QRectF StelButton::boundingRect() const
 
 int StelButton::getButtonPixmapWidth() const
 {
-	const double baseWidth = pixOn.width() / pixmapsScale * StelApp::getInstance().screenFontSizeRatio();
+	const double baseWidth = pixOn.width() / pixmapsScale * buttonSizeRatio();
 	return std::lround(baseWidth);
 }
 int StelButton::getButtonPixmapHeight() const
 {
-	const double baseHeight = pixOn.height() / pixmapsScale * StelApp::getInstance().screenFontSizeRatio();
+	const double baseHeight = pixOn.height() / pixmapsScale * buttonSizeRatio();
 	return std::lround(baseHeight);
 }
 
@@ -404,6 +410,10 @@ LeftStelBar::LeftStelBar(QGraphicsItem* parent)
 
 	setFontSizeFromApp(StelApp::getInstance().getScreenFontSize());
 	connect(&StelApp::getInstance(), &StelApp::screenFontSizeChanged, this, &LeftStelBar::setFontSizeFromApp);
+	connect(&StelApp::getInstance(), &StelApp::screenButtonScaleChanged, this,
+	        [this]{const int size = StelApp::getInstance().getScreenFontSize();
+	               setFontSizeFromApp(size); /* and repeat to apply all the geometry changes */
+	               setFontSizeFromApp(size);});
 	connect(&StelApp::getInstance(), &StelApp::fontChanged, this, &LeftStelBar::setFont);
 }
 
@@ -423,7 +433,7 @@ void LeftStelBar::addButton(StelButton* button)
 	button->setParentItem(this);
 	button->setFocusOnSky(false);
 	//button->prepareGeometryChange(); // could possibly be removed when qt 4.6 become stable
-	button->setPos(0., qRound(posY + 9.5 * StelApp::getInstance().screenFontSizeRatio()));
+	button->setPos(0., qRound(posY + 9.5 * StelButton::buttonSizeRatio()));
 
 	connect(button, SIGNAL(hoverChanged(bool)), this, SLOT(buttonHoverChanged(bool)));
 }
@@ -436,7 +446,7 @@ void LeftStelBar::updateButtonPositions()
 		if (const auto b = dynamic_cast<StelButton*>(button))
 			b->animValueChanged(0.); // update button pixmap
 		button->setPos(0., posY);
-		posY += std::round(button->boundingRect().height() + 9.5 * StelApp::getInstance().screenFontSizeRatio());
+		posY += std::round(button->boundingRect().height() + 9.5 * StelButton::buttonSizeRatio());
 	}
 }
 
@@ -566,6 +576,10 @@ BottomStelBar::BottomStelBar(QGraphicsItem* parent,
 
 	setFontSizeFromApp(StelApp::getInstance().getScreenFontSize());
 	connect(&StelApp::getInstance(), &StelApp::screenFontSizeChanged, this, [=](int fontsize){setFontSizeFromApp(fontsize); setFontSizeFromApp(fontsize);}); // We must call that twice to force all geom. updates
+	connect(&StelApp::getInstance(), &StelApp::screenButtonScaleChanged, this,
+	        [this]{const int size = StelApp::getInstance().getScreenFontSize();
+	               setFontSizeFromApp(size); /* and repeat to apply all the geometry changes */
+	               setFontSizeFromApp(size);});
 	connect(&StelApp::getInstance(), &StelApp::fontChanged, this, &BottomStelBar::setFont);
 	connect(StelApp::getInstance().getCore(), &StelCore::flagUseTopocentricCoordinatesChanged, this, [=](bool){updateText(false, true);});
 

--- a/src/gui/StelGuiItems.hpp
+++ b/src/gui/StelGuiItems.hpp
@@ -173,6 +173,7 @@ private:
 		  bool noBackground,
 		  bool isTristate);
 	int toggleChecked(int);
+	static double buttonSizeRatio();
 
 	QPixmap pixOn;
 	QPixmap pixOff;

--- a/src/gui/configurationDialog.ui
+++ b/src/gui/configurationDialog.ui
@@ -1749,20 +1749,6 @@
              <property name="bottomMargin">
               <number>0</number>
              </property>
-             <item row="7" column="3">
-              <layout class="QHBoxLayout" name="horizontalLayout_dither">
-               <item>
-                <widget class="QLabel" name="dithering_label">
-                 <property name="text">
-                  <string>Dithering</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QComboBox" name="ditheringComboBox"/>
-               </item>
-              </layout>
-             </item>
              <item row="7" column="1">
               <layout class="QHBoxLayout" name="mouseTimeoutLayout">
                <item>
@@ -1812,27 +1798,6 @@
                </item>
               </layout>
              </item>
-             <item row="9" column="1">
-              <layout class="QHBoxLayout" name="horizontalLayout_15">
-               <item>
-                <widget class="ColorButton" name="overwriteTextColorButton">
-                 <property name="toolTip">
-                  <string>Info text color for overwrite</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="overwriteTextColorCheckBox">
-                 <property name="toolTip">
-                  <string>Set one color for text in info panel for all objects</string>
-                 </property>
-                 <property name="text">
-                  <string>Overwrite text color</string>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </item>
              <item row="1" column="1">
               <widget class="QCheckBox" name="diskViewportCheckbox">
                <property name="toolTip">
@@ -1842,183 +1807,6 @@
                 <string>Disc viewport</string>
                </property>
               </widget>
-             </item>
-             <item row="3" column="1">
-              <widget class="QCheckBox" name="autoZoomResetsDirectionCheckbox">
-               <property name="toolTip">
-                <string>When enabled, the &quot;auto zoom out&quot; key will also set the initial viewing direction</string>
-               </property>
-               <property name="text">
-                <string>Auto-direction at zoom out</string>
-               </property>
-              </widget>
-             </item>
-             <item row="5" column="1">
-              <widget class="QCheckBox" name="enableMouseNavigationCheckBox">
-               <property name="toolTip">
-                <string>Allow mouse to pan (drag)</string>
-               </property>
-               <property name="text">
-                <string>Enable mouse navigation</string>
-               </property>
-              </widget>
-             </item>
-             <item row="3" column="3">
-              <layout class="QHBoxLayout" name="horizontalLayout_fps">
-               <item>
-                <widget class="QLabel" name="label_fpsIntent">
-                 <property name="text">
-                  <string>Framerate intent:</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <spacer name="horizontalSpacer_6">
-                 <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>40</width>
-                   <height>20</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
-               <item>
-                <widget class="QLabel" name="label_min">
-                 <property name="text">
-                  <string>min:</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QSpinBox" name="minFpsSpinBox">
-                 <property name="toolTip">
-                  <string>Minimum intended FPS between user interaction. Set very low to conserve energy or save CPU use.</string>
-                 </property>
-                 <property name="alignment">
-                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                 </property>
-                 <property name="keyboardTracking">
-                  <bool>false</bool>
-                 </property>
-                 <property name="minimum">
-                  <number>1</number>
-                 </property>
-                 <property name="maximum">
-                  <number>1000</number>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QLabel" name="label_max">
-                 <property name="text">
-                  <string>max:</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QSpinBox" name="maxFpsSpinBox">
-                 <property name="toolTip">
-                  <string>Maximum allowed FPS. 1000 just means &quot;as fast as possible&quot;. </string>
-                 </property>
-                 <property name="alignment">
-                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                 </property>
-                 <property name="keyboardTracking">
-                  <bool>false</bool>
-                 </property>
-                 <property name="minimum">
-                  <number>5</number>
-                 </property>
-                 <property name="maximum">
-                  <number>1000</number>
-                 </property>
-                 <property name="value">
-                  <number>1000</number>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </item>
-             <item row="5" column="3">
-              <widget class="QCheckBox" name="focusOnDaySpinnerCheckBox">
-               <property name="toolTip">
-                <string>Force date/time tab and focus on day input when activating date panel</string>
-               </property>
-               <property name="text">
-                <string>Set keyboard focus to day input</string>
-               </property>
-              </widget>
-             </item>
-             <item row="6" column="1">
-              <widget class="QCheckBox" name="enableMouseZoomingCheckBox">
-               <property name="toolTip">
-                <string>Allow mouse to zoom (mousewheel)</string>
-               </property>
-               <property name="text">
-                <string>Enable mouse zooming</string>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="1">
-              <widget class="QCheckBox" name="sphericMirrorCheckbox">
-               <property name="toolTip">
-                <string>Spheric mirror distortion is used when projecting Stellarium onto a spheric mirror for low-cost planetarium systems.</string>
-               </property>
-               <property name="text">
-                <string>Spheric mirror distortion</string>
-               </property>
-               <property name="checkable">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-             <item row="4" column="1">
-              <layout class="QHBoxLayout" name="horizontalLayout_keyboardNavigation">
-               <item>
-                <widget class="QCheckBox" name="enableKeysNavigationCheckBox">
-                 <property name="toolTip">
-                  <string>Allow keyboard to pan and zoom</string>
-                 </property>
-                 <property name="text">
-                  <string>Enable keyboard navigation</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <spacer name="horizontalSpacer_3">
-                 <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>40</width>
-                   <height>20</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
-               <item>
-                <widget class="QPushButton" name="editShortcutsPushButton">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="toolTip">
-                  <string>Edit keyboard shortcuts...</string>
-                 </property>
-                 <property name="icon">
-                  <iconset resource="../../data/gui/guiRes.qrc">
-                   <normaloff>:/graphicGui/uibtSettings.png</normaloff>
-                   <disabledoff>:/graphicGui/uibtSettings-disabled.png</disabledoff>:/graphicGui/uibtSettings.png</iconset>
-                 </property>
-                </widget>
-               </item>
-              </layout>
              </item>
              <item row="6" column="3">
               <widget class="QCheckBox" name="kineticScrollingCheckBox">
@@ -2030,159 +1818,33 @@
                </property>
               </widget>
              </item>
-             <item row="4" column="3">
-              <layout class="QHBoxLayout" name="horizontalLayout_threads">
+             <item row="9" column="3">
+              <layout class="QHBoxLayout" name="horizontalLayout_14">
                <item>
-                <widget class="QLabel" name="label_threads">
-                 <property name="text">
-                  <string>Additional threads for solar system</string>
+                <widget class="ColorButton" name="daylightTextColorButton">
+                 <property name="toolTip">
+                  <string>Info text color at daylight</string>
                  </property>
                 </widget>
                </item>
                <item>
-                <spacer name="horizontalSpacer_12">
-                 <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>40</width>
-                   <height>20</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
-               <item>
-                <widget class="QSpinBox" name="solarSystemThreadNumberSpinBox">
-                 <property name="toolTip">
-                  <string>A few additional threads may improve speed with many solar system objects. Observe what works best on your multicore system.</string>
-                 </property>
-                 <property name="alignment">
-                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                 </property>
-                 <property name="maximum">
-                  <number>31</number>
+                <widget class="QLabel" name="label_2">
+                 <property name="text">
+                  <string>Info text color at daylight</string>
                  </property>
                 </widget>
                </item>
               </layout>
              </item>
-             <item row="2" column="1">
-              <widget class="QCheckBox" name="gravityLabelCheckbox">
+             <item row="5" column="1">
+              <widget class="QCheckBox" name="enableMouseNavigationCheckBox">
                <property name="toolTip">
-                <string>Align labels with the screen center</string>
+                <string>Allow mouse to pan (drag)</string>
                </property>
                <property name="text">
-                <string>Gravity labels</string>
+                <string>Enable mouse navigation</string>
                </property>
               </widget>
-             </item>
-             <item row="11" column="1" colspan="3">
-              <layout class="QHBoxLayout" name="fontHorizontalLayout">
-               <item>
-                <widget class="QLabel" name="fontSizeLabel">
-                 <property name="text">
-                  <string>Font size: Screen</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QSpinBox" name="screenFontSizeSpinBox">
-                 <property name="toolTip">
-                  <string>Base font size for on-screen text</string>
-                 </property>
-                 <property name="alignment">
-                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                 </property>
-                 <property name="minimum">
-                  <number>5</number>
-                 </property>
-                 <property name="maximum">
-                  <number>50</number>
-                 </property>
-                 <property name="value">
-                  <number>13</number>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QLabel" name="guiFontSizeLabel">
-                 <property name="toolTip">
-                  <string>Graphical user interface</string>
-                 </property>
-                 <property name="text">
-                  <string comment="abbreviation">GUI</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QSpinBox" name="guiFontSizeSpinBox">
-                 <property name="toolTip">
-                  <string>Base font size for dialogs</string>
-                 </property>
-                 <property name="alignment">
-                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                 </property>
-                 <property name="minimum">
-                  <number>7</number>
-                 </property>
-                 <property name="maximum">
-                  <number>50</number>
-                 </property>
-                 <property name="value">
-                  <number>13</number>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <spacer name="horizontalSpacer_7">
-                 <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>40</width>
-                   <height>20</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
-               <item>
-                <widget class="QComboBox" name="fontWritingSystemComboBox">
-                 <property name="toolTip">
-                  <string>Pre-select fonts for a particular writing system</string>
-                 </property>
-                 <property name="editable">
-                  <bool>true</bool>
-                 </property>
-                 <property name="insertPolicy">
-                  <enum>QComboBox::NoInsert</enum>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QFontComboBox" name="fontComboBox">
-                 <property name="toolTip">
-                  <string>Application font</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QToolButton" name="fontSaveToolButton">
-                 <property name="toolTip">
-                  <string>Store font settings</string>
-                 </property>
-                 <property name="text">
-                  <string>Save</string>
-                 </property>
-                 <property name="icon">
-                  <iconset resource="../../data/gui/guiRes.qrc">
-                   <normaloff>:/graphicGui/uibtSave.png</normaloff>
-                   <disabledoff>:/graphicGui/uibtSave-disabled.png</disabledoff>:/graphicGui/uibtSave.png</iconset>
-                 </property>
-                </widget>
-               </item>
-              </layout>
              </item>
              <item row="0" column="3" rowspan="2">
               <layout class="QGridLayout" name="gridLayoutInclude">
@@ -2302,6 +1964,197 @@
                </item>
               </layout>
              </item>
+             <item row="3" column="3">
+              <layout class="QHBoxLayout" name="horizontalLayout_fps">
+               <item>
+                <widget class="QLabel" name="label_fpsIntent">
+                 <property name="text">
+                  <string>Framerate intent:</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <spacer name="horizontalSpacer_6">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               <item>
+                <widget class="QLabel" name="label_min">
+                 <property name="text">
+                  <string>min:</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QSpinBox" name="minFpsSpinBox">
+                 <property name="toolTip">
+                  <string>Minimum intended FPS between user interaction. Set very low to conserve energy or save CPU use.</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                 <property name="keyboardTracking">
+                  <bool>false</bool>
+                 </property>
+                 <property name="minimum">
+                  <number>1</number>
+                 </property>
+                 <property name="maximum">
+                  <number>1000</number>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLabel" name="label_max">
+                 <property name="text">
+                  <string>max:</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QSpinBox" name="maxFpsSpinBox">
+                 <property name="toolTip">
+                  <string>Maximum allowed FPS. 1000 just means &quot;as fast as possible&quot;. </string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                 <property name="keyboardTracking">
+                  <bool>false</bool>
+                 </property>
+                 <property name="minimum">
+                  <number>5</number>
+                 </property>
+                 <property name="maximum">
+                  <number>1000</number>
+                 </property>
+                 <property name="value">
+                  <number>1000</number>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+             <item row="4" column="1">
+              <layout class="QHBoxLayout" name="horizontalLayout_keyboardNavigation">
+               <item>
+                <widget class="QCheckBox" name="enableKeysNavigationCheckBox">
+                 <property name="toolTip">
+                  <string>Allow keyboard to pan and zoom</string>
+                 </property>
+                 <property name="text">
+                  <string>Enable keyboard navigation</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <spacer name="horizontalSpacer_3">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               <item>
+                <widget class="QPushButton" name="editShortcutsPushButton">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="toolTip">
+                  <string>Edit keyboard shortcuts...</string>
+                 </property>
+                 <property name="icon">
+                  <iconset resource="../../data/gui/guiRes.qrc">
+                   <normaloff>:/graphicGui/uibtSettings.png</normaloff>
+                   <disabledoff>:/graphicGui/uibtSettings-disabled.png</disabledoff>:/graphicGui/uibtSettings.png</iconset>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+             <item row="7" column="3">
+              <layout class="QHBoxLayout" name="horizontalLayout_dither">
+               <item>
+                <widget class="QLabel" name="dithering_label">
+                 <property name="text">
+                  <string>Dithering</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QComboBox" name="ditheringComboBox"/>
+               </item>
+              </layout>
+             </item>
+             <item row="2" column="1">
+              <widget class="QCheckBox" name="gravityLabelCheckbox">
+               <property name="toolTip">
+                <string>Align labels with the screen center</string>
+               </property>
+               <property name="text">
+                <string>Gravity labels</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="1">
+              <widget class="QCheckBox" name="sphericMirrorCheckbox">
+               <property name="toolTip">
+                <string>Spheric mirror distortion is used when projecting Stellarium onto a spheric mirror for low-cost planetarium systems.</string>
+               </property>
+               <property name="text">
+                <string>Spheric mirror distortion</string>
+               </property>
+               <property name="checkable">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+             <item row="3" column="1">
+              <widget class="QCheckBox" name="autoZoomResetsDirectionCheckbox">
+               <property name="toolTip">
+                <string>When enabled, the &quot;auto zoom out&quot; key will also set the initial viewing direction</string>
+               </property>
+               <property name="text">
+                <string>Auto-direction at zoom out</string>
+               </property>
+              </widget>
+             </item>
+             <item row="5" column="3">
+              <widget class="QCheckBox" name="focusOnDaySpinnerCheckBox">
+               <property name="toolTip">
+                <string>Force date/time tab and focus on day input when activating date panel</string>
+               </property>
+               <property name="text">
+                <string>Set keyboard focus to day input</string>
+               </property>
+              </widget>
+             </item>
+             <item row="6" column="1">
+              <widget class="QCheckBox" name="enableMouseZoomingCheckBox">
+               <property name="toolTip">
+                <string>Allow mouse to zoom (mousewheel)</string>
+               </property>
+               <property name="text">
+                <string>Enable mouse zooming</string>
+               </property>
+              </widget>
+             </item>
              <item row="2" column="3">
               <widget class="QCheckBox" name="indicationMountModeCheckBox">
                <property name="toolTip">
@@ -2312,19 +2165,209 @@
                </property>
               </widget>
              </item>
-             <item row="9" column="3">
-              <layout class="QHBoxLayout" name="horizontalLayout_14">
+             <item row="9" column="1">
+              <layout class="QHBoxLayout" name="horizontalLayout_15">
                <item>
-                <widget class="ColorButton" name="daylightTextColorButton">
+                <widget class="ColorButton" name="overwriteTextColorButton">
                  <property name="toolTip">
-                  <string>Info text color at daylight</string>
+                  <string>Info text color for overwrite</string>
                  </property>
                 </widget>
                </item>
                <item>
-                <widget class="QLabel" name="label_2">
+                <widget class="QCheckBox" name="overwriteTextColorCheckBox">
+                 <property name="toolTip">
+                  <string>Set one color for text in info panel for all objects</string>
+                 </property>
                  <property name="text">
-                  <string>Info text color at daylight</string>
+                  <string>Overwrite text color</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+             <item row="4" column="3">
+              <layout class="QHBoxLayout" name="horizontalLayout_threads">
+               <item>
+                <widget class="QLabel" name="label_threads">
+                 <property name="text">
+                  <string>Additional threads for solar system</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <spacer name="horizontalSpacer_12">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               <item>
+                <widget class="QSpinBox" name="solarSystemThreadNumberSpinBox">
+                 <property name="toolTip">
+                  <string>A few additional threads may improve speed with many solar system objects. Observe what works best on your multicore system.</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                 <property name="maximum">
+                  <number>31</number>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+             <item row="10" column="1" colspan="3">
+              <layout class="QHBoxLayout" name="fontHorizontalLayout">
+               <item>
+                <widget class="QLabel" name="fontSizeLabel">
+                 <property name="text">
+                  <string>Font size: Screen</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QSpinBox" name="screenFontSizeSpinBox">
+                 <property name="toolTip">
+                  <string>Base font size for on-screen text</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                 <property name="minimum">
+                  <number>5</number>
+                 </property>
+                 <property name="maximum">
+                  <number>50</number>
+                 </property>
+                 <property name="value">
+                  <number>13</number>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLabel" name="guiFontSizeLabel">
+                 <property name="toolTip">
+                  <string>Graphical user interface</string>
+                 </property>
+                 <property name="text">
+                  <string comment="abbreviation">GUI</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QSpinBox" name="guiFontSizeSpinBox">
+                 <property name="toolTip">
+                  <string>Base font size for dialogs</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                 <property name="minimum">
+                  <number>7</number>
+                 </property>
+                 <property name="maximum">
+                  <number>50</number>
+                 </property>
+                 <property name="value">
+                  <number>13</number>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <spacer name="horizontalSpacer_7">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               <item>
+                <widget class="QComboBox" name="fontWritingSystemComboBox">
+                 <property name="toolTip">
+                  <string>Pre-select fonts for a particular writing system</string>
+                 </property>
+                 <property name="editable">
+                  <bool>true</bool>
+                 </property>
+                 <property name="insertPolicy">
+                  <enum>QComboBox::NoInsert</enum>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QFontComboBox" name="fontComboBox">
+                 <property name="toolTip">
+                  <string>Application font</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QToolButton" name="fontSaveToolButton">
+                 <property name="toolTip">
+                  <string>Store font settings</string>
+                 </property>
+                 <property name="text">
+                  <string>Save</string>
+                 </property>
+                 <property name="icon">
+                  <iconset resource="../../data/gui/guiRes.qrc">
+                   <normaloff>:/graphicGui/uibtSave.png</normaloff>
+                   <disabledoff>:/graphicGui/uibtSave-disabled.png</disabledoff>:/graphicGui/uibtSave.png</iconset>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+             <item row="11" column="1">
+              <layout class="QHBoxLayout" name="horizontalLayout_11">
+               <item>
+                <widget class="QLabel" name="label_4">
+                 <property name="text">
+                  <string>Screen button scale:</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <spacer name="horizontalSpacer_4">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               <item>
+                <widget class="QDoubleSpinBox" name="screenButtonScaleSpinBox">
+                 <property name="suffix">
+                  <string notr="true">%</string>
+                 </property>
+                 <property name="decimals">
+                  <number>0</number>
+                 </property>
+                 <property name="minimum">
+                  <double>10.000000000000000</double>
+                 </property>
+                 <property name="maximum">
+                  <double>500.000000000000000</double>
+                 </property>
+                 <property name="value">
+                  <double>100.000000000000000</double>
                  </property>
                 </widget>
                </item>


### PR DESCRIPTION
### Description

This adds an option in the Configuration dialog to apply a scale to screen (panel) buttons as requested in #4073.

Fixes #4073

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules