### PR TITLE
Base star and planet scaling on screen scale

### DIFF
--- a/src/StelMainView.cpp
+++ b/src/StelMainView.cpp
@@ -623,7 +623,6 @@ StelMainView::StelMainView(QSettings* settings)
 	  customScreenshotWidth(1024),
 	  customScreenshotHeight(768),
 	  screenshotDpi(72),
-	  customScreenshotMagnification(1.0f),
 	  screenShotPrefix("stellarium-"),
 	  screenShotFormat("png"),
 	  screenShotFileMask("yyyyMMdd-hhmmssz"),
@@ -1764,8 +1763,6 @@ void StelMainView::doScreenshot(void)
 	sParams.viewportXywh[2] = virtImgWidth;
 	sParams.viewportXywh[3] = virtImgHeight;
 
-	// Configure a helper value to allow some modules to tweak their output sizes. Currently used by StarMgr, maybe solve font issues?
-	customScreenshotMagnification=static_cast<float>(virtImgHeight)/static_cast<float>(screen->geometry().height());
 	sParams.viewportCenter.set(0.0+(0.5+pParams.viewportCenterOffset.v[0])*virtImgWidth,
 							   0.0+(0.5+pParams.viewportCenterOffset.v[1])*virtImgHeight);
 	sParams.viewportFovDiameter = qMin(virtImgWidth,virtImgHeight);
@@ -1801,7 +1798,6 @@ void StelMainView::doScreenshot(void)
 	delete fbObj;
 	// reset viewport and GUI
 	core->setCurrentStelProjectorParams(pParams);
-	customScreenshotMagnification=1.0f;
 	nightModeEffect->setEnabled(nightModeWasEnabled);
 	stelScene->setSceneRect(0, 0, pParams.viewportXywh[2], pParams.viewportXywh[3]);
 	rootItem->setSize(QSize(pParams.viewportXywh[2], pParams.viewportXywh[3]));

--- a/src/StelMainView.hpp
+++ b/src/StelMainView.hpp
@@ -189,9 +189,6 @@ public slots:
 	int getScreenshotDpi() const {return screenshotDpi;}
 	//! Set screenshot DPI. This is only an entry in the screenshot image metadata. The raster content is not influenced.
 	void setScreenshotDpi(int dpi);
-	//! Get screenshot magnification. This should be used by StarMgr, text drawing and other elements which may
-	//! want to enlarge their output in screenshots to keep them visible.
-	float getCustomScreenshotMagnification() const {return customScreenshotMagnification;}
 	//! Get the state of the mouse cursor timeout flag
 	bool getFlagCursorTimeout() const {return flagCursorTimeout;}
 	//! Set the state of the mouse cursor timeout flag
@@ -334,7 +331,6 @@ private:
 	int customScreenshotWidth;            //! used when flagCustomResolutionScreenshots==true
 	int customScreenshotHeight;           //! used when flagCustomResolutionScreenshots==true
 	int screenshotDpi;                //! Image metadata entry for DPI. This does not influence the screenshot raster image content in any way, but some workflows like to have a configurable entry.
-	float customScreenshotMagnification;  //! tracks the magnification factor customScreenshotHeight/NormalWindowHeight
 	QString screenShotPrefix;
 	QString screenShotFormat; //! file type like "png" or "jpg".
 	QString screenShotFileMask;

--- a/src/core/StelSkyDrawer.cpp
+++ b/src/core/StelSkyDrawer.cpp
@@ -482,11 +482,13 @@ bool StelSkyDrawer::drawPointSource(StelPainter* sPainter, const Vec3d& v, const
 	// Random coef for star twinkling. twinkleFactor can introduce height-dependent twinkling.
 	const float tw = ((flagStarTwinkle && (flagHasAtmosphere || flagForcedTwinkle))) ? (1.f-twinkleFactor*static_cast<float>(twinkleAmount)*frand)*rcMag.luminance : rcMag.luminance;
 
+	const float scale = StelApp::getInstance().getScreenScale();
 	// If the rmag is big, draw a big halo
-	if (flagDrawBigStarHalo && radius>MAX_LINEAR_RADIUS+5.f)
+	const float bigHaloThresholdRadius = (MAX_LINEAR_RADIUS+5)*scale;
+	if (flagDrawBigStarHalo && radius > bigHaloThresholdRadius)
 	{
-		float cmag = qMin(1.0f, qMin(rcMag.luminance, (radius-(MAX_LINEAR_RADIUS+5.f))/30.f));
-		float rmag = 150.f;
+		const float cmag = qMin(1.0f, qMin(rcMag.luminance, (radius-bigHaloThresholdRadius)/30.f/scale));
+		const float rmag = 150.f * scale;
 
 		texBigHalo->bind();
 		sPainter->setBlending(true, GL_ONE, GL_ONE);

--- a/src/core/StelSkyDrawer.cpp
+++ b/src/core/StelSkyDrawer.cpp
@@ -544,7 +544,7 @@ void StelSkyDrawer::postDrawSky3dModel(StelPainter* painter, const Vec3d& v, flo
 	const float pixPerRad = painter->getProjector()->getPixelPerRadAtCenter();
 	// Assume a disk shape
 	float pixRadius = std::sqrt(illuminatedArea/(60.f*60.f)*M_PI_180f*M_PI_180f*(pixPerRad*pixPerRad))/M_PIf;
-	float pxRd = pixRadius*3.f+100.f;
+	float pxRd = pixRadius*3.f+100.f*scale;
 	bool noStarHalo = false;
 
 	if (isSun)
@@ -554,8 +554,8 @@ void StelSkyDrawer::postDrawSky3dModel(StelPainter* painter, const Vec3d& v, flo
 		texSunHalo->bind();
 		painter->setBlending(true, GL_ONE, GL_ONE);
 
-		float rmag = big3dModelHaloRadius*(mag+15.f)/-11.f;
-		float cmag = (rmag>=pxRd) ? 1.f : qMax(0.15f, 1.f-(pxRd-rmag)/100); // was qMax(0, .), but this would remove the halo when sun is dim.
+		const float rmag = big3dModelHaloRadius*scale*(mag+15.f)/-11.f;
+		const float cmag = (rmag>=pxRd) ? 1.f : qMax(0.15f, 1.f-(pxRd-rmag)/100/scale); // was qMax(0, .), but this would remove the halo when sun is dim.
 		Vec3f win;
 		painter->getProjector()->project(v, win);
 		painter->setColor(color*cmag);

--- a/src/core/StelSkyDrawer.cpp
+++ b/src/core/StelSkyDrawer.cpp
@@ -389,7 +389,6 @@ bool StelSkyDrawer::computeRCMag(float mag, RCMag* rcMag) const
 {
 	rcMag->radius = eye->adaptLuminanceScaledLn(pointSourceMagToLnLuminance(mag), static_cast<float>(starRelativeScale)*1.40f*0.5f);
 	rcMag->radius *=starLinearScale;
-	rcMag->radius *=StelMainView::getInstance().getCustomScreenshotMagnification();
 	// Use now statically min_rmag = 0.5, because higher and too small values look bad
 	if (rcMag->radius < 0.3f)
 	{
@@ -419,6 +418,7 @@ bool StelSkyDrawer::computeRCMag(float mag, RCMag* rcMag) const
 			rcMag->radius=MAX_LINEAR_RADIUS+std::sqrt(1.f+rcMag->radius-MAX_LINEAR_RADIUS)-1.f;
 		}
 	}
+	rcMag->radius *= StelApp::getInstance().getScreenScale();
 	return true;
 }
 
@@ -476,7 +476,7 @@ bool StelSkyDrawer::drawPointSource(StelPainter* sPainter, const Vec3d& v, const
 	if (!(checkInScreen ? sPainter->getProjector()->projectCheck(v, win) : sPainter->getProjector()->project(v, win)))
 		return false;
 
-	const float radius = rcMag.radius * static_cast<float>(sPainter->getProjector()->getDevicePixelsPerPixel());
+	const float radius = rcMag.radius;
 	const float frand=StelApp::getInstance().getRandF();
 
 	// Random coef for star twinkling. twinkleFactor can introduce height-dependent twinkling.

--- a/src/core/StelSkyDrawer.cpp
+++ b/src/core/StelSkyDrawer.cpp
@@ -540,6 +540,7 @@ void StelSkyDrawer::drawSunCorona(StelPainter* painter, const Vec3f& v, float ra
 // Terminate drawing of a 3D model, draw the halo
 void StelSkyDrawer::postDrawSky3dModel(StelPainter* painter, const Vec3d& v, float illuminatedArea, float mag, const Vec3f& color, const bool isSun)
 {
+	const float scale = StelApp::getInstance().getScreenScale();
 	const float pixPerRad = painter->getProjector()->getPixelPerRadAtCenter();
 	// Assume a disk shape
 	float pixRadius = std::sqrt(illuminatedArea/(60.f*60.f)*M_PI_180f*M_PI_180f*(pixPerRad*pixPerRad))/M_PIf;
@@ -581,15 +582,16 @@ void StelSkyDrawer::postDrawSky3dModel(StelPainter* painter, const Vec3d& v, flo
 	// so that the radius of the halo is small enough to be not visible (so that we see the disk)
 
 	// TODO: Change drawing halo to more realistic view of stars and planets
-	float tStart = 3.f; // Was 2.f: planet's halo is too dim. Atque 2020-11-12: No need to change these anymore. It appears that this has to do with halo size vs FOV (?).
-	float tStop = 6.f;
+	float tStart = 3.f*scale; // Was 2.f: planet's halo is too dim. Atque 2020-11-12: No need to change these anymore. It appears that this has to do with halo size vs FOV (?).
+	float tStop = 6.f*scale;
 	bool truncated=false;
 
 	float maxHaloRadius = qMax(tStart*6.f, pixRadius*3.f); //Atque 2020-11-12: Careful, if tStart*6.f is too big (tStart*10.f or something), the Moon gets a ridiculously big halo.
 	if (rcm.radius>maxHaloRadius)
 	{
 		truncated = true;
-		rcm.radius=maxHaloRadius+std::sqrt(rcm.radius-maxHaloRadius);
+		// One more factor of scale here is needed to compensate for taking a square root of the already included factor
+		rcm.radius=maxHaloRadius+std::sqrt((rcm.radius-maxHaloRadius)*scale);
 	}
 
 	// Fade the halo away when the disk is too big

--- a/src/core/modules/Planet.cpp
+++ b/src/core/modules/Planet.cpp
@@ -4828,9 +4828,10 @@ void Planet::drawHints(const StelCore* core, StelPainter &sPainter, const QFont&
 	//StelPainter sPainter(prj);
 	sPainter.setFont(planetNameFont);
 	// Draw nameI18 + scaling if it's not == 1.
+	const float scale = StelApp::getInstance().getScreenScale();
 	const float pixPerRad = sPainter.getProjector()->getPixelPerRadAtCenter();
 	const float angularRadius = getAngularRadius(core)*M_PI/180.;
-	float tmp = (hintFader.getInterstate()<=0.f ? 7.f : 10.f) + angularRadius*pixPerRad/1.44f; // Shift for nameI18 printing
+	float tmp = (hintFader.getInterstate()<=0.f ? 7.f : 10.f) * scale + angularRadius*pixPerRad/1.44f; // Shift for nameI18 printing
 	sPainter.setColor(labelColor,labelsFader.getInterstate());
 	const QString label = sphereScale != 1. ? QString(u8"%1 (\u00d7%2)").arg(getPlanetLabel(), QString::number(sphereScale, 'f', 2))
 	                                        : getPlanetLabel();


### PR DESCRIPTION
### Description

Currently most of screen objects are scaled according to the screen scale—based on Qt/OS scaling factor, or on font size. This PR makes stars and planets follow this too. This removes the old `customScreenshotMagnification` that didn't even work properly, and makes creation of screenshots at different resolutions preserving thickness of lines and points much easier.

### Screenshots

Here's a couple of screenshots made with different settings (to see how good the scaling is, open them in separate tabs small enough to squeeze the smaller image, and switch between them back and forth):

##### 1024×1024, 13px screen font

![stellarium-012](https://github.com/user-attachments/assets/959c17c3-17de-42f3-9986-553a15066632)

##### 2048×2048, 26px screen font

![stellarium-013](https://github.com/user-attachments/assets/205e955d-510b-47ea-8efd-a2dddeae2134)

And here's a couple of windowed-mode screenshots at different Qt scaling factors:

##### 100%, 19px screen font

![stellarium-014](https://github.com/user-attachments/assets/effa375d-e7e8-41bc-9d43-c43a6eb5fc4d)

##### 150%, 13px screen font

![stellarium-015](https://github.com/user-attachments/assets/6232f9a0-b671-4486-a22a-a78cb56d16fc)


### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system: Ubuntu 20.04
* Graphics Card: Intel UHD Graphics 620

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
