### PR TITLE
Filter of showing named DSO only

### DIFF
--- a/guide/app_config_ini.tex
+++ b/guide/app_config_ini.tex
@@ -104,8 +104,7 @@ shadow\_enlargement\_danjon 	   & bool   & false & Earth shadow enlargement (see
 flag\_dso\_designation\_usage      & bool   & false & If \emph{true}, use designations of deep-sky objects on the sky instead of their common names.\\%\midrule
 flag\_dso\_outlines\_usage         & bool   & false & If \emph{true}, use outlines for big deep-sky objects on the sky instead of their hints.\\%\midrule
 flag\_dso\_additional\_names       & bool   & true  & Set \emph{true} to use additional names (also known as) for deep-sky objects.\\\midrule
-%
-flag\_show\_only\_named\_dso       & bool   & false & If \emph{true}, only show deep-sky objects with names, hiding those with only designations.\\\midrule
+flag\_dso\_show\_only\_named       & bool   & false & If \emph{true}, only show deep-sky objects with names, hiding those with only designations.\\\midrule
 %
 grs\_longitude                     & int    & 216   & Longitude (System II) of Great Red Spot on Jupiter in degrees.\\%\midrule
 grs\_drift                         & float  & 15.0  & Annual drift of Great Red Spot on Jupiter in degrees.\\%\midrule

--- a/guide/app_config_ini.tex
+++ b/guide/app_config_ini.tex
@@ -105,6 +105,8 @@ flag\_dso\_designation\_usage      & bool   & false & If \emph{true}, use design
 flag\_dso\_outlines\_usage         & bool   & false & If \emph{true}, use outlines for big deep-sky objects on the sky instead of their hints.\\%\midrule
 flag\_dso\_additional\_names       & bool   & true  & Set \emph{true} to use additional names (also known as) for deep-sky objects.\\\midrule
 %
+flag\_show\_only\_named\_dso       & bool   & false & If \emph{true}, only show deep-sky objects with names, hiding those with only designations.\\\midrule
+%
 grs\_longitude                     & int    & 216   & Longitude (System II) of Great Red Spot on Jupiter in degrees.\\%\midrule
 grs\_drift                         & float  & 15.0  & Annual drift of Great Red Spot on Jupiter in degrees.\\%\midrule
 grs\_jd                            & float  & 2456901.5 & Initial JD for calculation of position of Great Red Spot on Jupiter.\\%\midrule

--- a/src/core/modules/Nebula.cpp
+++ b/src/core/modules/Nebula.cpp
@@ -58,6 +58,7 @@ bool Nebula::flagUseArcsecSurfaceBrightness = false;
 bool Nebula::flagUseShortNotationSurfaceBrightness = true;
 bool Nebula::flagUseOutlines = false;
 bool Nebula::flagShowAdditionalNames = true;
+bool Nebula::flagShowOnlyNamedDSO = false;
 bool Nebula::flagUseSizeLimits = false;
 double Nebula::minSizeLimit = 1.0;
 double Nebula::maxSizeLimit = 600.0;

--- a/src/core/modules/Nebula.hpp
+++ b/src/core/modules/Nebula.hpp
@@ -369,6 +369,7 @@ private:
 	static bool flagUseShortNotationSurfaceBrightness;
 	static bool flagUseOutlines;
 	static bool flagShowAdditionalNames;
+	static bool flagShowOnlyNamedDSO;
 
 	static bool flagUseSizeLimits;
 	static double minSizeLimit;

--- a/src/core/modules/NebulaMgr.cpp
+++ b/src/core/modules/NebulaMgr.cpp
@@ -170,6 +170,17 @@ void NebulaMgr::setFlagOutlines(const bool flag)
 	}
 }
 
+bool NebulaMgr::getFlagShowOnlyNamedDSO(void) const {return Nebula::flagShowOnlyNamedDSO; }
+void NebulaMgr::setFlagShowOnlyNamedDSO(const bool flag)
+{
+	if(Nebula::flagShowOnlyNamedDSO!=flag)
+	{
+		Nebula::flagShowOnlyNamedDSO=flag;
+		StelApp::immediateSave("astro/flag_show_only_named_dso", flag);
+		emit flagShowOnlyNamedDSOChanged(flag);
+	}
+}
+
 NebulaMgr::NebulaMgr(void) : StelObjectModule()
 	, nebGrid(200)
 	, hintsAmount(0)
@@ -228,6 +239,7 @@ void NebulaMgr::init()
 	setFlagSurfaceBrightnessUsage(conf->value("astro/flag_surface_brightness_usage", false).toBool());
 	setFlagSurfaceBrightnessArcsecUsage(conf->value("gui/flag_surface_brightness_arcsec", false).toBool());
 	setFlagSurfaceBrightnessShortNotationUsage(conf->value("gui/flag_surface_brightness_short", false).toBool());
+	setFlagShowOnlyNamedDSO(conf->value("astro/flag_show_only_named_dso", false).toBool());
 
 	setFlagSizeLimitsUsage(conf->value("astro/flag_size_limits_usage", false).toBool());
 	setMinSizeLimit(conf->value("astro/size_limit_min", 1.0).toDouble());
@@ -566,6 +578,9 @@ struct DrawNebulaFuncObject
 			return;
 
 		if (!n->objectInDisplayedCatalog())
+			return;
+
+		if (n->flagShowOnlyNamedDSO && n->getEnglishName().isEmpty())
 			return;
 
 		if (!n->objectInAllowedSizeRangeLimits())

--- a/src/core/modules/NebulaMgr.cpp
+++ b/src/core/modules/NebulaMgr.cpp
@@ -176,7 +176,7 @@ void NebulaMgr::setFlagShowOnlyNamedDSO(const bool flag)
 	if(Nebula::flagShowOnlyNamedDSO!=flag)
 	{
 		Nebula::flagShowOnlyNamedDSO=flag;
-		StelApp::immediateSave("astro/flag_show_only_named_dso", flag);
+		StelApp::immediateSave("astro/flag_dso_show_only_named", flag);
 		emit flagShowOnlyNamedDSOChanged(flag);
 	}
 }
@@ -239,7 +239,7 @@ void NebulaMgr::init()
 	setFlagSurfaceBrightnessUsage(conf->value("astro/flag_surface_brightness_usage", false).toBool());
 	setFlagSurfaceBrightnessArcsecUsage(conf->value("gui/flag_surface_brightness_arcsec", false).toBool());
 	setFlagSurfaceBrightnessShortNotationUsage(conf->value("gui/flag_surface_brightness_short", false).toBool());
-	setFlagShowOnlyNamedDSO(conf->value("astro/flag_show_only_named_dso", false).toBool());
+	setFlagShowOnlyNamedDSO(conf->value("astro/flag_dso_show_only_named", false).toBool());
 
 	setFlagSizeLimitsUsage(conf->value("astro/flag_size_limits_usage", false).toBool());
 	setMinSizeLimit(conf->value("astro/size_limit_min", 1.0).toDouble());

--- a/src/core/modules/NebulaMgr.hpp
+++ b/src/core/modules/NebulaMgr.hpp
@@ -115,6 +115,11 @@ class NebulaMgr : public StelObjectModule
 		   WRITE setDesignationUsage
 		   NOTIFY designationUsageChanged
 		   )
+	Q_PROPERTY(bool flagShowOnlyNamedDSO
+		   READ getFlagShowOnlyNamedDSO
+		   WRITE setFlagShowOnlyNamedDSO
+		   NOTIFY flagShowOnlyNamedDSOChanged
+		   )
 	Q_PROPERTY(bool flagUseSizeLimits
 		   READ getFlagSizeLimitsUsage
 		   WRITE setFlagSizeLimitsUsage
@@ -825,6 +830,11 @@ public slots:
 	//! Get value of flag used to turn on and off DSO type filtering.
 	bool getFlagUseTypeFilters(void) const;
 
+	//! Set flag used to turn on and off Named DSO Only.
+	void setFlagShowOnlyNamedDSO(const bool b);
+	//! Get value of flag used to turn on and off Named DSO Only.
+	bool getFlagShowOnlyNamedDSO(void) const;
+
 	//! Set the limit for min. angular size of displayed DSO.
 	//! @param s the angular size between 1 and 600 arcminutes
 	void setMinSizeLimit(double s);
@@ -893,6 +903,7 @@ signals:
 	void flagOutlinesDisplayedChanged(bool b);
 	void flagAdditionalNamesDisplayedChanged(bool b);
 	void designationUsageChanged(bool b);
+	void flagShowOnlyNamedDSOChanged(bool b);
 	void flagSurfaceBrightnessUsageChanged(bool b);
 	void flagSurfaceBrightnessArcsecUsageChanged(bool b);
 	void flagSurfaceBrightnessShortNotationUsageChanged(bool b);

--- a/src/gui/ViewDialog.cpp
+++ b/src/gui/ViewDialog.cpp
@@ -326,6 +326,7 @@ void ViewDialog::createDialogContent()
 	connectBoolProperty(ui->checkBoxSurfaceBrightnessUsage, "NebulaMgr.flagSurfaceBrightnessUsage");
 	connectBoolProperty(ui->nebulaLimitMagnitudeCheckBox,"StelSkyDrawer.flagNebulaMagnitudeLimit");
 	connectBoolProperty(ui->checkBoxAdditionalNamesDSO, "NebulaMgr.flagAdditionalNamesDisplayed");
+	connectBoolProperty(ui->checkBoxShowOnlyNamedDSO, "NebulaMgr.flagShowOnlyNamedDSO");
 	connectDoubleProperty(ui->nebulaLimitMagnitudeDoubleSpinBox,"StelSkyDrawer.customNebulaMagLimit");
 	connectBoolProperty(ui->nebulaLimitSizeCheckBox, "NebulaMgr.flagUseSizeLimits");
 	connectDoubleProperty(ui->nebulaLimitSizeMinDoubleSpinBox, "NebulaMgr.minSizeLimit");

--- a/src/gui/viewDialog.ui
+++ b/src/gui/viewDialog.ui
@@ -2583,6 +2583,13 @@
                  </property>
                 </widget>
                </item>
+               <item row="8" column="0">
+                <widget class="QCheckBox" name="checkBoxShowOnlyNamedDSO">
+                 <property name="text">
+                  <string>Show only named DSO</string>
+                 </property>
+                </widget>
+               </item>
                <item row="4" column="0">
                 <widget class="QCheckBox" name="checkBoxOutlines">
                  <property name="text">
@@ -2686,14 +2693,14 @@
                  </property>
                 </widget>
                </item>
-               <item row="9" column="0">
+               <item row="10" column="0">
                 <widget class="QPushButton" name="pushButtonConfigureDSOColors">
                  <property name="text">
                   <string>Configure colors of markers</string>
                  </property>
                 </widget>
                </item>
-               <item row="8" column="0">
+               <item row="9" column="0">
                 <layout class="QGridLayout" name="gridLayout_17">
                  <item row="1" column="0">
                   <widget class="QCheckBox" name="nebulaLimitSizeCheckBox">


### PR DESCRIPTION
### Description

This PR adds a new option that allows users to filter and display only deep-sky objects with names. This is particularly helpful for improving navigation efficiency during observation planning, especially when using catalogs like NGC or Sharpless, as it avoids displaying numerous less notable or unnamed objects that may clutter the screen and hinder users who do not wish to view these objects.

### Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/0ce9e70c-8317-42e6-b091-dfed0bb3a9f2)

![image](https://github.com/user-attachments/assets/7a59b8c3-907a-4381-adf5-4f11288f77b2)


### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?
Open View Dialog, toggle checkbox of "Show only named DSO".

**Test Configuration**:
* Operating system: Window 11 x64, Ubuntu latest
* Graphics Card: GTX 1060

## Checklist:

- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (header file)
- [x] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
