### PR TITLE
Add timestamp and message type to the log

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -159,6 +159,11 @@ void clearCache()
 // Main stellarium procedure
 int main(int argc, char **argv)
 {
+	qSetMessagePattern("[%{time process}][%{if-debug}DBG %{endif}"
+	                                     "%{if-info}INFO%{endif}"
+	                                     "%{if-warning}WARN%{endif}"
+	                                     "%{if-critical}CRIT%{endif}"
+	                                     "%{if-fatal}FATAL%{endif}] %{message}");
 	Q_INIT_RESOURCE(mainRes);
 	Q_INIT_RESOURCE(guiRes);
 


### PR DESCRIPTION
This PR adds a timestamp and message type tag to the log output, so that it's easier to find what takes excessive time (e.g. at loading state), as well as to filter by message type (e.g. highlight all warnings, delete all debug messages). After this change the log will look like this:

```
[    13.921][DBG ] [TelescopeControl] Adding device model: "Meade AutoStar compatible" "Any telescope or telescope mount compatible with Meade's AutoStar controller." "TelescopeServerLx200" 500000
[    13.921][DBG ] [TelescopeControl] Adding device model: "Meade LX200 (compatible)" "Any telescope or telescope mount compatible with Meade LX200." "TelescopeServerLx200" 500000
[    13.921][DBG ] [TelescopeControl] Adding device model: "Meade ETX70 (#494 Autostar, #506 CCS)" "Meade's ETX70 with the #494 Autostar controller and the #506 Connector Cable Set." "TelescopeServerLx200" 1500000
[    13.921][DBG ] [TelescopeControl] Adding device model: "Losmandy G-11" "Losmandy's G-11 telescope mount." "TelescopeServerLx200" 500000
[    13.921][DBG ] [TelescopeControl] Adding device model: "Wildcard Innovations Argo Navis (Meade mode)" "Wildcard Innovations' Argo Navis DTC in Meade LX200 emulation mode." "TelescopeServerLx200" 500000
[    13.921][DBG ] [TelescopeControl] Adding device model: "Celestron NexStar (compatible)" "Any telescope or telescope mount compatible with Celestron NexStar." "TelescopeServerNexStar" 500000
[    13.921][DBG ] [TelescopeControl] Adding device model: "Sky-Watcher SynScan (version 3 or later)" "Any Sky-Watcher mount that uses version 3 or later of the SynScan hand controller." "TelescopeServerNexStar" 500000
[    13.921][DBG ] [TelescopeControl] Adding device model: "Sky-Watcher SynScan AZ GOTO" "The Sky-Watcher SynScan AZ GOTO mount used in a number of telescope models." "TelescopeServerNexStar" 500000
[    13.921][WARN] [TelescopeControl] loadTelescopes(): No telescopes loaded. File is missing: /home/ruslan/.stellarium/modules/TelescopeControl/telescopes.json
[    13.945][DBG ] Loaded plugin "TextUserInterface"
[    14.138][WARN] Dubious result: Landscape  "Guereins"  not calibrated. Opacity test represents mathematical horizon only.
[    14.138][DBG ] OpenGL viewport size: 1920 x 1044
[    14.138][DBG ] Creating scene FBO with size 1920x1044
```