### PR TITLE
Pre-trim DSO string catalog numbers

### DIFF
--- a/src/core/modules/Nebula.cpp
+++ b/src/core/modules/Nebula.cpp
@@ -1200,6 +1200,15 @@ void Nebula::readDSO(QDataStream &in)
 		>> Mel_nb >> PGC_nb >> UGC_nb >> Ced_nb >> Arp_nb >> VV_nb >> PK_nb >> PNG_nb >> SNRG_nb >> ACO_nb
 		>> HCG_nb >> ESO_nb >> VdBH_nb >> DWB_nb >> Tr_nb >> St_nb >> Ru_nb >> VdBHa_nb;
 
+	Ced_nb = Ced_nb.trimmed();
+	PK_nb = PK_nb.trimmed();
+	PNG_nb = PNG_nb.trimmed();
+	SNRG_nb = SNRG_nb.trimmed();
+	ACO_nb = ACO_nb.trimmed();
+	HCG_nb = HCG_nb.trimmed();
+	ESO_nb = ESO_nb.trimmed();
+	VdBH_nb = VdBH_nb.trimmed();
+
 	const unsigned int f = NGC_nb + IC_nb + M_nb + C_nb + B_nb + Sh2_nb + VdB_nb + RCW_nb + LDN_nb + LBN_nb + Cr_nb + Mel_nb + PGC_nb + UGC_nb + Arp_nb + VV_nb + DWB_nb + Tr_nb + St_nb + Ru_nb + VdBHa_nb;
 	if (f==0 && Ced_nb.isEmpty() && PK_nb.isEmpty() && PNG_nb.isEmpty() && SNRG_nb.isEmpty() && ACO_nb.isEmpty() && HCG_nb.isEmpty() && ESO_nb.isEmpty() && VdBH_nb.isEmpty())
 		withoutID = true;

--- a/src/core/modules/NebulaMgr.cpp
+++ b/src/core/modules/NebulaMgr.cpp
@@ -1105,7 +1105,7 @@ NebulaP NebulaMgr::searchCed(QString Ced) const
 {
 	Ced = Ced.trimmed().toUpper();
 	for (const auto& n : dsoArray)
-		if (n->Ced_nb.trimmed().toUpper() == Ced)
+		if (n->Ced_nb.toUpper() == Ced)
 			return n;
 	return NebulaP();
 }
@@ -1130,7 +1130,7 @@ NebulaP NebulaMgr::searchPK(QString PK) const
 {
 	PK = PK.trimmed().toUpper();
 	for (const auto& n : dsoArray)
-		if (n->PK_nb.trimmed().toUpper() == PK)
+		if (n->PK_nb.toUpper() == PK)
 			return n;
 	return NebulaP();
 }
@@ -1139,7 +1139,7 @@ NebulaP NebulaMgr::searchPNG(QString PNG) const
 {
 	PNG = PNG.trimmed().toUpper();
 	for (const auto& n : dsoArray)
-		if (n->PNG_nb.trimmed().toUpper() == PNG)
+		if (n->PNG_nb.toUpper() == PNG)
 			return n;
 	return NebulaP();
 }
@@ -1148,7 +1148,7 @@ NebulaP NebulaMgr::searchSNRG(QString SNRG) const
 {
 	SNRG = SNRG.trimmed().toUpper();
 	for (const auto& n : dsoArray)
-		if (n->SNRG_nb.trimmed().toUpper() == SNRG)
+		if (n->SNRG_nb.toUpper() == SNRG)
 			return n;
 	return NebulaP();
 }
@@ -1157,7 +1157,7 @@ NebulaP NebulaMgr::searchACO(QString ACO) const
 {
 	ACO = ACO.trimmed().toUpper();
 	for (const auto& n : dsoArray)
-		if (n->ACO_nb.trimmed().toUpper() == ACO)
+		if (n->ACO_nb.toUpper() == ACO)
 			return n;
 	return NebulaP();
 }
@@ -1166,7 +1166,7 @@ NebulaP NebulaMgr::searchHCG(QString HCG) const
 {
 	HCG = HCG.trimmed().toUpper();
 	for (const auto& n : dsoArray)
-		if (n->HCG_nb.trimmed().toUpper() == HCG)
+		if (n->HCG_nb.toUpper() == HCG)
 			return n;
 	return NebulaP();
 }
@@ -1175,7 +1175,7 @@ NebulaP NebulaMgr::searchESO(QString ESO) const
 {
 	ESO = ESO.trimmed().toUpper();
 	for (const auto& n : dsoArray)
-		if (n->ESO_nb.trimmed().toUpper() == ESO)
+		if (n->ESO_nb.toUpper() == ESO)
 			return n;
 	return NebulaP();
 }
@@ -1184,7 +1184,7 @@ NebulaP NebulaMgr::searchVdBH(QString VdBH) const
 {
 	VdBH = VdBH.trimmed().toUpper();
 	for (const auto& n : dsoArray)
-		if (n->VdBH_nb.trimmed().toUpper() == VdBH)
+		if (n->VdBH_nb.toUpper() == VdBH)
 			return n;
 	return NebulaP();
 }
@@ -2268,14 +2268,14 @@ QStringList NebulaMgr::listMatchingObjects(const QString& objPrefix, int maxNbIt
 		for (const auto& n : dsoArray)
 		{
 			if (n->Ced_nb.isEmpty()) continue;
-			QString constw = QString("Ced%1").arg(n->Ced_nb.trimmed());
+			QString constw = QString("Ced%1").arg(n->Ced_nb);
 			QString constws = constw.mid(0, objw.size());
 			if (constws.toUpper()==objw)
 			{
 				result << constws;
 				continue;	// Prevent adding both forms for name
 			}
-			constw = QString("Ced %1").arg(n->Ced_nb.trimmed());
+			constw = QString("Ced %1").arg(n->Ced_nb);
 			constws = constw.mid(0, objw.size());
 			if (constws.toUpper()==objw)
 				result << constw;
@@ -2448,14 +2448,14 @@ QStringList NebulaMgr::listMatchingObjects(const QString& objPrefix, int maxNbIt
 		for (const auto& n : dsoArray)
 		{
 			if (n->PK_nb.isEmpty()) continue;
-			QString constw = QString("PK%1").arg(n->PK_nb.trimmed());
+			QString constw = QString("PK%1").arg(n->PK_nb);
 			QString constws = constw.mid(0, objw.size());
 			if (constws.toUpper()==objw)
 			{
 				result << constws;
 				continue;	// Prevent adding both forms for name
 			}
-			constw = QString("PK %1").arg(n->PK_nb.trimmed());
+			constw = QString("PK %1").arg(n->PK_nb);
 			constws = constw.mid(0, objw.size());
 			if (constws.toUpper()==objw)
 				result << constw;
@@ -2468,14 +2468,14 @@ QStringList NebulaMgr::listMatchingObjects(const QString& objPrefix, int maxNbIt
 		for (const auto& n : dsoArray)
 		{
 			if (n->PNG_nb.isEmpty()) continue;
-			QString constw = QString("PNG%1").arg(n->PNG_nb.trimmed());
+			QString constw = QString("PNG%1").arg(n->PNG_nb);
 			QString constws = constw.mid(0, objw.size());
 			if (constws.toUpper()==objw)
 			{
 				result << constws;
 				continue;	// Prevent adding both forms for name
 			}
-			constw = QString("PN G%1").arg(n->PNG_nb.trimmed());
+			constw = QString("PN G%1").arg(n->PNG_nb);
 			constws = constw.mid(0, objw.size());
 			if (constws.toUpper()==objw)
 				result << constw;
@@ -2488,14 +2488,14 @@ QStringList NebulaMgr::listMatchingObjects(const QString& objPrefix, int maxNbIt
 		for (const auto& n : dsoArray)
 		{
 			if (n->SNRG_nb.isEmpty()) continue;
-			QString constw = QString("SNRG%1").arg(n->SNRG_nb.trimmed());
+			QString constw = QString("SNRG%1").arg(n->SNRG_nb);
 			QString constws = constw.mid(0, objw.size());
 			if (constws.toUpper()==objw)
 			{
 				result << constws;
 				continue;	// Prevent adding both forms for name
 			}
-			constw = QString("SNR G%1").arg(n->SNRG_nb.trimmed());
+			constw = QString("SNR G%1").arg(n->SNRG_nb);
 			constws = constw.mid(0, objw.size());
 			if (constws.toUpper()==objw)
 				result << constw;
@@ -2508,17 +2508,17 @@ QStringList NebulaMgr::listMatchingObjects(const QString& objPrefix, int maxNbIt
 		for (const auto& n : dsoArray)
 		{
 			if (n->ACO_nb.isEmpty()) continue;
-			QString constw = QString("Abell%1").arg(n->ACO_nb.trimmed());
+			QString constw = QString("Abell%1").arg(n->ACO_nb);
 			QString constws = constw.mid(0, objw.size());
-			QString constws2 = QString("ACO%1").arg(n->ACO_nb.trimmed()).mid(0, objw.size());
+			QString constws2 = QString("ACO%1").arg(n->ACO_nb).mid(0, objw.size());
 			if (constws.toUpper()==objw || constws2.toUpper()==objw)
 			{
 				result << constws;
 				continue;	// Prevent adding both forms for name
 			}
-			constw = QString("Abell %1").arg(n->ACO_nb.trimmed());
+			constw = QString("Abell %1").arg(n->ACO_nb);
 			constws = constw.mid(0, objw.size());
-			constws2 = QString("ACO %1").arg(n->ACO_nb.trimmed()).mid(0, objw.size());
+			constws2 = QString("ACO %1").arg(n->ACO_nb).mid(0, objw.size());
 			if (constws.toUpper()==objw || constws2.toUpper()==objw)
 				result << constw;
 		}
@@ -2530,14 +2530,14 @@ QStringList NebulaMgr::listMatchingObjects(const QString& objPrefix, int maxNbIt
 		for (const auto& n : dsoArray)
 		{
 			if (n->HCG_nb.isEmpty()) continue;
-			QString constw = QString("HCG%1").arg(n->HCG_nb.trimmed());
+			QString constw = QString("HCG%1").arg(n->HCG_nb);
 			QString constws = constw.mid(0, objw.size());
 			if (constws.toUpper()==objw)
 			{
 				result << constws;
 				continue;	// Prevent adding both forms for name
 			}
-			constw = QString("HCG %1").arg(n->HCG_nb.trimmed());
+			constw = QString("HCG %1").arg(n->HCG_nb);
 			constws = constw.mid(0, objw.size());
 			if (constws.toUpper()==objw)
 				result << constw;
@@ -2550,14 +2550,14 @@ QStringList NebulaMgr::listMatchingObjects(const QString& objPrefix, int maxNbIt
 		for (const auto& n : dsoArray)
 		{
 			if (n->ESO_nb.isEmpty()) continue;
-			QString constw = QString("ESO%1").arg(n->ESO_nb.trimmed());
+			QString constw = QString("ESO%1").arg(n->ESO_nb);
 			QString constws = constw.mid(0, objw.size());
 			if (constws.toUpper()==objw)
 			{
 				result << constws;
 				continue;	// Prevent adding both forms for name
 			}
-			constw = QString("ESO %1").arg(n->ESO_nb.trimmed());
+			constw = QString("ESO %1").arg(n->ESO_nb);
 			constws = constw.mid(0, objw.size());
 			if (constws.toUpper()==objw)
 				result << constw;
@@ -2570,14 +2570,14 @@ QStringList NebulaMgr::listMatchingObjects(const QString& objPrefix, int maxNbIt
 		for (const auto& n : dsoArray)
 		{
 			if (n->VdBH_nb.isEmpty()) continue;
-			QString constw = QString("vdBH%1").arg(n->VdBH_nb.trimmed());
+			QString constw = QString("vdBH%1").arg(n->VdBH_nb);
 			QString constws = constw.mid(0, objw.size());
 			if (constws.toUpper()==objw)
 			{
 				result << constws;
 				continue;	// Prevent adding both forms for name
 			}
-			constw = QString("vdBH %1").arg(n->VdBH_nb.trimmed());
+			constw = QString("vdBH %1").arg(n->VdBH_nb);
 			constws = constw.mid(0, objw.size());
 			if (constws.toUpper()==objw)
 				result << constw;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

Currently DSO catalog numbers that are not actually numbers but strings are constantly re-trimmed on use. This PR trims them on reading.

The patch seems trivial, but maybe I'm missing some reason not to trim them?

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] Housekeeping

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system: Ubuntu 20.04
* Graphics Card: Intel UHD Graphics 620

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
