### PR TITLE
Use commonNameMap instead of iterating over dsoArray

### DIFF
--- a/src/core/modules/NebulaMgr.cpp
+++ b/src/core/modules/NebulaMgr.cpp
@@ -870,15 +870,12 @@ void NebulaMgr::drawPointer(const StelCore* core, StelPainter& sPainter)
 }
 
 // Search by name
-NebulaP NebulaMgr::search(const QString& name)
+NebulaP NebulaMgr::searchForCommonName(const QString& name)
 {
 	QString uname = name.toUpper();
 
-	for (const auto& n : std::as_const(dsoArray))
-	{
-		QString testName = n->getEnglishName().toUpper();
-		if (testName==uname) return n;
-	}
+	if (const auto it = commonNameMap.find(uname); it != commonNameMap.end())
+		return *it;
 
 	return searchByDesignation(uname);
 }
@@ -1752,7 +1749,7 @@ bool NebulaMgr::loadDSODiscoveryData(const QString &filename)
 		dYear	= list.at(1).trimmed();
 		dName	= list.at(2).trimmed();
 
-		e = search(dso);
+		e = searchForCommonName(dso);
 		if (e.isNull()) // maybe this is inner number of DSO
 			e = searchDSO(dso.toUInt());
 
@@ -1816,7 +1813,7 @@ bool NebulaMgr::loadDSOOutlines(const QString &filename)
 		if (command.contains("start", Qt::CaseInsensitive))
 		{
 			outline.clear();
-			e = search(dso);
+			e = searchForCommonName(dso);
 			if (e.isNull()) // maybe this is inner number of DSO
 				e = searchDSO(dso.toUInt());
 

--- a/src/core/modules/NebulaMgr.hpp
+++ b/src/core/modules/NebulaMgr.hpp
@@ -971,7 +971,7 @@ private slots:
 
 private:
 	//! Search for a nebula object by name, e.g. M83, NGC 1123, IC 1234.
-	NebulaP search(const QString& name);
+	NebulaP searchForCommonName(const QString& name);
 
 	//! Search the Nebulae by position
 	NebulaP search(const Vec3d& pos);


### PR DESCRIPTION
The `search()` function is used when loading DSO outlines and discovery information. Its search for English names actually doesn't work, because it's called before any sky culture is loaded, which is when Nebula's English name is set. This doesn't appear to be a problem, because all the data we have are properly handled by a search by designation.

Now it's renamed to `searchForCommonName()`, and it uses `commonNameMap` instead of iterating over all the array of ~95k DSOs. This makes loading of outlines and discovery information almost instant, while before this patch it took about half a second to a second for each.

A small change in functionality is that now all the common names are searched, not only the first one per DSO, but it seems to be a useful change.


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
