### PR TITLE
Make it possible to filter surveys by name

### DIFF
--- a/src/gui/ViewDialog.cpp
+++ b/src/gui/ViewDialog.cpp
@@ -576,6 +576,7 @@ void ViewDialog::createDialogContent()
 	connect(ui->stackListWidget, SIGNAL(currentItemChanged(QListWidgetItem *, QListWidgetItem *)), this, SLOT(updateHips()));
 	connect(ui->surveysListWidget, SIGNAL(currentRowChanged(int)), this, SLOT(updateHips()), Qt::QueuedConnection);
 	connect(ui->surveysListWidget, SIGNAL(itemChanged(QListWidgetItem*)), this, SLOT(hipsListItemChanged(QListWidgetItem*)));
+	connect(ui->surveysFilter, &QLineEdit::textChanged, this, &ViewDialog::filterSurveys);
 	updateHips();
 
 	updateTabBarListWidgetWidth();
@@ -732,6 +733,7 @@ void ViewDialog::updateHips()
 			ui->surveysTextBrowser->document()->setDefaultStyleSheet(QString(gui->getStelStyle().htmlStyleSheet));
 		ui->surveysTextBrowser->setHtml(html);
 	}
+	filterSurveys();
 }
 
 void ViewDialog::populateHipsGroups()
@@ -747,6 +749,19 @@ void ViewDialog::populateHipsGroups()
 	typeComboBox->addItem(q_("Solar System"), "sol");
 	index = typeComboBox->findData(selectedType, Qt::UserRole, Qt::MatchCaseSensitive);
 	typeComboBox->setCurrentIndex(index);
+}
+
+void ViewDialog::filterSurveys()
+{
+	const QString pattern = ui->surveysFilter->text().simplified();
+	const auto& list = *ui->surveysListWidget;
+	for (int row = 0; row < list.count(); ++row)
+	{
+		auto& item = *list.item(row);
+		const QString text = item.text().simplified();
+		const bool show = pattern.isEmpty() || text.contains(pattern, Qt::CaseInsensitive);
+		item.setHidden(!show);
+	}
 }
 
 void ViewDialog::hipsListItemChanged(QListWidgetItem* item)

--- a/src/gui/ViewDialog.hpp
+++ b/src/gui/ViewDialog.hpp
@@ -93,6 +93,7 @@ private slots:
 	void updateSelectedTypesCheckBoxes();
 
 	void updateHips();
+	void filterSurveys();
 	void hipsListItemChanged(QListWidgetItem* item);
 	void populateHipsGroups();
 

--- a/src/gui/viewDialog.ui
+++ b/src/gui/viewDialog.ui
@@ -5317,19 +5317,29 @@
           <property name="spacing">
            <number>3</number>
           </property>
-          <item row="1" column="0">
-           <widget class="QListWidget" name="surveysListWidget">
-            <property name="horizontalScrollBarPolicy">
-             <enum>Qt::ScrollBarAlwaysOff</enum>
+          <item row="0" column="1" rowspan="3">
+           <widget class="QTextBrowser" name="surveysTextBrowser">
+            <property name="openExternalLinks">
+             <bool>true</bool>
             </property>
            </widget>
           </item>
           <item row="0" column="0">
            <widget class="QComboBox" name="surveyTypeComboBox"/>
           </item>
-          <item row="0" column="1" rowspan="2">
-           <widget class="QTextBrowser" name="surveysTextBrowser">
-            <property name="openExternalLinks">
+          <item row="2" column="0">
+           <widget class="QListWidget" name="surveysListWidget">
+            <property name="horizontalScrollBarPolicy">
+             <enum>Qt::ScrollBarAlwaysOff</enum>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLineEdit" name="surveysFilter">
+            <property name="placeholderText">
+             <string>Filter</string>
+            </property>
+            <property name="clearButtonEnabled">
              <bool>true</bool>
             </property>
            </widget>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

This patch adds an ability to filter surveys similarly to how it's done in Qt Designer's list of widgets, by entering some text that is expected to be present in the name of a survey.

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system: Ubuntu 20.04
* Graphics Card: Intel UHD Graphics 620

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
