### PR TITLE
Using English terms for English names of constellations

### DIFF
--- a/skycultures/modern/index.json
+++ b/skycultures/modern/index.json
@@ -438,7 +438,7 @@
           {"pos": [397, 397], "hip": 93805}
         ]
       },
-      "common_name": {"english": "Aquila", "native": "Aquila"}
+      "common_name": {"english": "Eagle", "native": "Aquila"}
     },
     {
       "id": "CON modern And",
@@ -452,7 +452,7 @@
           {"pos": [224, 428], "hip": 9640}
         ]
       },
-      "common_name": {"english": "Andromeda", "native": "Andromeda"}
+      "common_name": {"english": "Chained Maiden", "native": "Andromeda"}
     },
     {
       "id": "CON modern Scl",
@@ -480,7 +480,7 @@
           {"pos": [107, 249], "hip": 88714}
         ]
       },
-      "common_name": {"english": "Ara", "native": "Ara"}
+      "common_name": {"english": "Altar", "native": "Ara"}
     },
     {
       "id": "CON modern Lib",
@@ -494,7 +494,7 @@
           {"pos": [224, 107], "hip": 73714}
         ]
       },
-      "common_name": {"english": "Libra", "native": "Libra"}
+      "common_name": {"english": "Scales", "native": "Libra"}
     },
     {
       "id": "CON modern Cet",
@@ -508,7 +508,7 @@
           {"pos": [412, 440], "hip": 1562}
         ]
       },
-      "common_name": {"english": "Cetus", "native": "Cetus"}
+      "common_name": {"english": "Sea Monster", "native": "Cetus"}
     },
     {
       "id": "CON modern Ari",
@@ -522,7 +522,7 @@
           {"pos": [210, 47], "hip": 8832}
         ]
       },
-      "common_name": {"english": "Aries", "native": "Aries"}
+      "common_name": {"english": "Ram", "native": "Aries"}
     },
     {
       "id": "CON modern Sct",
@@ -536,7 +536,7 @@
           {"pos": [139, 206], "hip": 92814}
         ]
       },
-      "common_name": {"english": "Scutum", "native": "Scutum"}
+      "common_name": {"english": "Shield", "native": "Scutum"}
     },
     {
       "id": "CON modern Pyx",
@@ -550,7 +550,7 @@
           {"pos": [44, 202], "hip": 42515}
         ]
       },
-      "common_name": {"english": "Pyxis", "native": "Pyxis"}
+      "common_name": {"english": "Mariner Compass", "native": "Pyxis"}
     },
     {
       "id": "CON modern Boo",
@@ -564,7 +564,7 @@
           {"pos": [207, 401], "hip": 67927}
         ]
       },
-      "common_name": {"english": "Bootes", "native": "Bootes"}
+      "common_name": {"english": "Herdsman", "native": "Boötes"}
     },
     {
       "id": "CON modern Cae",
@@ -578,7 +578,7 @@
           {"pos": [199, 75], "hip": 21861}
         ]
       },
-      "common_name": {"english": "Caelum", "native": "Caelum"}
+      "common_name": {"english": "Engraving Tool", "native": "Caelum"}
     },
     {
       "id": "CON modern Cha",
@@ -592,7 +592,7 @@
           {"pos": [184, 33], "hip": 40702}
         ]
       },
-      "common_name": {"english": "Chamaeleon", "native": "Chamaeleon"}
+      "common_name": {"english": "Chameleon", "native": "Chamaeleon"}
     },
     {
       "id": "CON modern Cnc",
@@ -606,7 +606,7 @@
           {"pos": [206, 91], "hip": 40843}
         ]
       },
-      "common_name": {"english": "Cancer", "native": "Cancer"}
+      "common_name": {"english": "Crab", "native": "Cancer"}
     },
     {
       "id": "CON modern Cap",
@@ -620,7 +620,7 @@
           {"pos": [460, 438], "hip": 102978}
         ]
       },
-      "common_name": {"english": "Capricornus", "native": "Capricornus"}
+      "common_name": {"english": "Sea Goat", "native": "Capricornus"}
     },
     {
       "id": "CON modern Car",
@@ -634,7 +634,7 @@
           {"pos": [298, 22], "hip": 39757}
         ]
       },
-      "common_name": {"english": "Carina", "native": "Carina"}
+      "common_name": {"english": "Keel", "native": "Carina"}
     },
     {
       "id": "CON modern Cas",
@@ -648,7 +648,7 @@
           {"pos": [73, 243], "hip": 746}
         ]
       },
-      "common_name": {"english": "Cassiopeia", "native": "Cassiopeia"}
+      "common_name": {"english": "Seated Queen", "native": "Cassiopeia"}
     },
     {
       "id": "CON modern Cen",
@@ -662,7 +662,7 @@
           {"pos": [463, 412], "hip": 56561}
         ]
       },
-      "common_name": {"english": "Centaurus", "native": "Centaurus"}
+      "common_name": {"english": "Centaur", "native": "Centaurus"}
     },
     {
       "id": "CON modern Cep",
@@ -676,7 +676,7 @@
           {"pos": [335, 147], "hip": 109492}
         ]
       },
-      "common_name": {"english": "Cepheus", "native": "Cepheus"}
+      "common_name": {"english": "King", "native": "Cepheus"}
     },
     {
       "id": "CON modern Com",
@@ -690,7 +690,7 @@
           {"pos": [172, 64], "hip": 60742}
         ]
       },
-      "common_name": {"english": "Coma Berenices", "native": "Coma Berenices"}
+      "common_name": {"english": "Bernice's Hair", "native": "Coma Berenices"}
     },
     {
       "id": "CON modern CVn",
@@ -704,7 +704,7 @@
           {"pos": [207, 152], "hip": 61309}
         ]
       },
-      "common_name": {"english": "Canes Venatici", "native": "Canes Venatici"}
+      "common_name": {"english": "Hunting Dogs", "native": "Canes Venatici"}
     },
     {
       "id": "CON modern Aur",
@@ -718,7 +718,7 @@
           {"pos": [290, 423], "hip": 23015}
         ]
       },
-      "common_name": {"english": "Auriga", "native": "Auriga"}
+      "common_name": {"english": "Charioteer", "native": "Auriga"}
     },
     {
       "id": "CON modern Col",
@@ -732,7 +732,7 @@
           {"pos": [204, 211], "hip": 25859}
         ]
       },
-      "common_name": {"english": "Columba", "native": "Columba"}
+      "common_name": {"english": "Dove", "native": "Columba"}
     },
     {
       "id": "CON modern Cir",
@@ -746,7 +746,7 @@
           {"pos": [235, 239], "hip": 71908}
         ]
       },
-      "common_name": {"english": "Circinus", "native": "Circinus"}
+      "common_name": {"english": "Drawing Compass", "native": "Circinus"}
     },
     {
       "id": "CON modern Crt",
@@ -760,7 +760,7 @@
           {"pos": [55, 242], "hip": 54682}
         ]
       },
-      "common_name": {"english": "Crater", "native": "Crater"}
+      "common_name": {"english": "Cup", "native": "Crater"}
     },
     {
       "id": "CON modern CrA",
@@ -774,7 +774,7 @@
           {"pos": [195, 208], "hip": 92953}
         ]
       },
-      "common_name": {"english": "Corona Australis", "native": "Corona Australis"}
+      "common_name": {"english": "Southern Crown", "native": "Corona Australis"}
     },
     {
       "id": "CON modern CrB",
@@ -788,7 +788,7 @@
           {"pos": [157, 20], "hip": 76127}
         ]
       },
-      "common_name": {"english": "Corona Borealis", "native": "Corona Borealis"}
+      "common_name": {"english": "Northern Crown", "native": "Corona Borealis"}
     },
     {
       "id": "CON modern Crv",
@@ -802,7 +802,7 @@
           {"pos": [213, 187], "hip": 59316}
         ]
       },
-      "common_name": {"english": "Corvus", "native": "Corvus"}
+      "common_name": {"english": "Crow", "native": "Corvus"}
     },
     {
       "id": "CON modern Cru",
@@ -816,7 +816,7 @@
           {"pos": [21, 106], "hip": 60718}
         ]
       },
-      "common_name": {"english": "Crux", "native": "Crux"}
+      "common_name": {"english": "Southern Cross", "native": "Crux"}
     },
     {
       "id": "CON modern Cyg",
@@ -830,7 +830,7 @@
           {"pos": [467, 453], "hip": 95947}
         ]
       },
-      "common_name": {"english": "Cygnus", "native": "Cygnus"}
+      "common_name": {"english": "Swan", "native": "Cygnus"}
     },
     {
       "id": "CON modern Del",
@@ -844,7 +844,7 @@
           {"pos": [211, 143], "hip": 101421}
         ]
       },
-      "common_name": {"english": "Delphinus", "native": "Delphinus"}
+      "common_name": {"english": "Dolphin", "native": "Delphinus"}
     },
     {
       "id": "CON modern Dor",
@@ -858,7 +858,7 @@
           {"pos": [219, 46], "hip": 19893}
         ]
       },
-      "common_name": {"english": "Dorado", "native": "Dorado"}
+      "common_name": {"english": "Swordfish", "native": "Dorado"}
     },
     {
       "id": "CON modern Dra",
@@ -872,7 +872,7 @@
           {"pos": [449, 429], "hip": 97433}
         ]
       },
-      "common_name": {"english": "Draco", "native": "Draco"}
+      "common_name": {"english": "Dragon", "native": "Draco"}
     },
     {
       "id": "CON modern Nor",
@@ -886,7 +886,7 @@
           {"pos": [16, 112], "hip": 80582}
         ]
       },
-      "common_name": {"english": "Norma", "native": "Norma"}
+      "common_name": {"english": "Carpenter's Square", "native": "Norma"}
     },
     {
       "id": "CON modern Eri",
@@ -900,7 +900,7 @@
           {"pos": [493, 490], "hip": 7588}
         ]
       },
-      "common_name": {"english": "Eridanus", "native": "Eridanus"}
+      "common_name": {"english": "River", "native": "Eridanus"}
     },
     {
       "id": "CON modern Sge",
@@ -914,7 +914,7 @@
           {"pos": [218, 243], "hip": 96837}
         ]
       },
-      "common_name": {"english": "Sagitta", "native": "Sagitta"}
+      "common_name": {"english": "Arrow", "native": "Sagitta"}
     },
     {
       "id": "CON modern For",
@@ -928,7 +928,7 @@
           {"pos": [190, 129], "hip": 13147}
         ]
       },
-      "common_name": {"english": "Fornax", "native": "Fornax"}
+      "common_name": {"english": "Furnace", "native": "Fornax"}
     },
     {
       "id": "CON modern Gem",
@@ -942,7 +942,7 @@
           {"pos": [249, 165], "hip": 28734}
         ]
       },
-      "common_name": {"english": "Gemini", "native": "Gemini"}
+      "common_name": {"english": "Twins", "native": "Gemini"}
     },
     {
       "id": "CON modern Cam",
@@ -956,7 +956,7 @@
           {"pos": [219, 136], "hip": 16228}
         ]
       },
-      "common_name": {"english": "Camelopardalis", "native": "Camelopardalis"}
+      "common_name": {"english": "Giraffe", "native": "Camelopardalis"}
     },
     {
       "id": "CON modern CMa",
@@ -970,7 +970,7 @@
           {"pos": [318, 492], "hip": 30122}
         ]
       },
-      "common_name": {"english": "Canis Major", "native": "Canis Major"}
+      "common_name": {"english": "Great Dog", "native": "Canis Major"}
     },
     {
       "id": "CON modern UMa",
@@ -984,7 +984,7 @@
           {"pos": [258, 394], "hip": 50372}
         ]
       },
-      "common_name": {"english": "Ursa Major", "native": "Ursa Major"}
+      "common_name": {"english": "Great Bear", "native": "Ursa Major"}
     },
     {
       "id": "CON modern Gru",
@@ -998,7 +998,7 @@
           {"pos": [220, 45], "hip": 108085}
         ]
       },
-      "common_name": {"english": "Grus", "native": "Grus"}
+      "common_name": {"english": "Crane", "native": "Grus"}
     },
     {
       "id": "CON modern Her",
@@ -1026,7 +1026,7 @@
           {"pos": [235, 119], "hip": 14240}
         ]
       },
-      "common_name": {"english": "Horologium", "native": "Horologium"}
+      "common_name": {"english": "Clock", "native": "Horologium"}
     },
     {
       "id": "CON modern Hya",
@@ -1040,7 +1040,7 @@
           {"pos": [401, 33], "hip": 43813}
         ]
       },
-      "common_name": {"english": "Hydra", "native": "Hydra"}
+      "common_name": {"english": "Female Water Snake", "native": "Hydra"}
     },
     {
       "id": "CON modern Hyi",
@@ -1054,7 +1054,7 @@
           {"pos": [241, 215], "hip": 17678}
         ]
       },
-      "common_name": {"english": "Hydrus", "native": "Hydrus"}
+      "common_name": {"english": "Male Water Snake", "native": "Hydrus"}
     },
     {
       "id": "CON modern Ind",
@@ -1068,7 +1068,7 @@
           {"pos": [175, 98], "hip": 105319}
         ]
       },
-      "common_name": {"english": "Indus", "native": "Indus"}
+      "common_name": {"english": "Indian", "native": "Indus"}
     },
     {
       "id": "CON modern Lac",
@@ -1082,7 +1082,7 @@
           {"pos": [67, 215], "hip": 109937}
         ]
       },
-      "common_name": {"english": "Lacerta", "native": "Lacerta"}
+      "common_name": {"english": "Lizard", "native": "Lacerta"}
     },
     {
       "id": "CON modern Mon",
@@ -1096,7 +1096,7 @@
           {"pos": [509, 359], "hip": 29651}
         ]
       },
-      "common_name": {"english": "Monoceros", "native": "Monoceros"}
+      "common_name": {"english": "Unicorn", "native": "Monoceros"}
     },
     {
       "id": "CON modern Lep",
@@ -1110,7 +1110,7 @@
           {"pos": [213, 235], "hip": 23685}
         ]
       },
-      "common_name": {"english": "Lepus", "native": "Lepus"}
+      "common_name": {"english": "Hare", "native": "Lepus"}
     },
     {
       "id": "CON modern Leo",
@@ -1124,7 +1124,7 @@
           {"pos": [321, 32], "hip": 47908}
         ]
       },
-      "common_name": {"english": "Leo", "native": "Leo"}
+      "common_name": {"english": "Lion", "native": "Leo"}
     },
     {
       "id": "CON modern Lup",
@@ -1138,7 +1138,7 @@
           {"pos": [425, 239], "hip": 75177}
         ]
       },
-      "common_name": {"english": "Lupus", "native": "Lupus"}
+      "common_name": {"english": "Wolf", "native": "Lupus"}
     },
     {
       "id": "CON modern Lyn",
@@ -1166,7 +1166,7 @@
           {"pos": [139, 162], "hip": 92420}
         ]
       },
-      "common_name": {"english": "Lyra", "native": "Lyra"}
+      "common_name": {"english": "Lyre", "native": "Lyra"}
     },
     {
       "id": "CON modern Ant",
@@ -1180,7 +1180,7 @@
           {"pos": [42, 120], "hip": 48926}
         ]
       },
-      "common_name": {"english": "Antlia", "native": "Antlia"}
+      "common_name": {"english": "Air Pump", "native": "Antlia"}
     },
     {
       "id": "CON modern Mic",
@@ -1194,7 +1194,7 @@
           {"pos": [234, 115], "hip": 102831}
         ]
       },
-      "common_name": {"english": "Microscopium", "native": "Microscopium"}
+      "common_name": {"english": "Microscope", "native": "Microscopium"}
     },
     {
       "id": "CON modern Mus",
@@ -1208,7 +1208,7 @@
           {"pos": [129, 236], "hip": 57363}
         ]
       },
-      "common_name": {"english": "Musca", "native": "Musca"}
+      "common_name": {"english": "Fly", "native": "Musca"}
     },
     {
       "id": "CON modern Oct",
@@ -1222,7 +1222,7 @@
           {"pos": [247, 140], "hip": 112405}
         ]
       },
-      "common_name": {"english": "Octans", "native": "Octans"}
+      "common_name": {"english": "Octant", "native": "Octans"}
     },
     {
       "id": "CON modern Aps",
@@ -1236,7 +1236,7 @@
           {"pos": [163, 110], "hip": 72370}
         ]
       },
-      "common_name": {"english": "Apus", "native": "Apus"}
+      "common_name": {"english": "Bird of Paradise", "native": "Apus"}
     },
     {
       "id": "CON modern Oph",
@@ -1250,7 +1250,7 @@
           {"pos": [238, 453], "hip": 85755}
         ]
       },
-      "common_name": {"english": "Ophiuchus", "native": "Ophiuchus"}
+      "common_name": {"english": "Serpent Bearer", "native": "Ophiuchus"}
     },
     {
       "id": "CON modern Ori",
@@ -1264,7 +1264,7 @@
           {"pos": [421, 91], "hip": 22449}
         ]
       },
-      "common_name": {"english": "Orion", "native": "Orion"}
+      "common_name": {"english": "Hunter", "native": "Orion"}
     },
     {
       "id": "CON modern Pav",
@@ -1278,7 +1278,7 @@
           {"pos": [235, 146], "hip": 86929}
         ]
       },
-      "common_name": {"english": "Pavo", "native": "Pavo"}
+      "common_name": {"english": "Peacock", "native": "Pavo"}
     },
     {
       "id": "CON modern Peg",
@@ -1292,7 +1292,7 @@
           {"pos": [409, 349], "hip": 1067}
         ]
       },
-      "common_name": {"english": "Pegasus", "native": "Pegasus"}
+      "common_name": {"english": "Winged Horse", "native": "Pegasus"}
     },
     {
       "id": "CON modern Pic",
@@ -1306,7 +1306,7 @@
           {"pos": [167, 38], "hip": 27321}
         ]
       },
-      "common_name": {"english": "Pictor", "native": "Pictor"}
+      "common_name": {"english": "Painter's Easel", "native": "Pictor"}
     },
     {
       "id": "CON modern Per",
@@ -1320,7 +1320,7 @@
           {"pos": [385, 386], "hip": 13254}
         ]
       },
-      "common_name": {"english": "Perseus", "native": "Perseus"}
+      "common_name": {"english": "Hero", "native": "Perseus"}
     },
     {
       "id": "CON modern Equ",
@@ -1334,7 +1334,7 @@
           {"pos": [160, 160], "hip": 105570}
         ]
       },
-      "common_name": {"english": "Equuleus", "native": "Equuleus"}
+      "common_name": {"english": "Little Horse", "native": "Equuleus"}
     },
     {
       "id": "CON modern CMi",
@@ -1348,7 +1348,7 @@
           {"pos": [184, 124], "hip": 36188}
         ]
       },
-      "common_name": {"english": "Canis Minor", "native": "Canis Minor"}
+      "common_name": {"english": "Lesser Dog", "native": "Canis Minor"}
     },
     {
       "id": "CON modern LMi",
@@ -1362,7 +1362,7 @@
           {"pos": [61, 155], "hip": 50303}
         ]
       },
-      "common_name": {"english": "Leo Minor", "native": "Leo Minor"}
+      "common_name": {"english": "Lesser Lion", "native": "Leo Minor"}
     },
     {
       "id": "CON modern Vul",
@@ -1376,7 +1376,7 @@
           {"pos": [242, 135], "hip": 94703}
         ]
       },
-      "common_name": {"english": "Vulpecula", "native": "Vulpecula"}
+      "common_name": {"english": "Fox", "native": "Vulpecula"}
     },
     {
       "id": "CON modern UMi",
@@ -1390,7 +1390,7 @@
           {"pos": [93, 209], "hip": 79822}
         ]
       },
-      "common_name": {"english": "Ursa Minor", "native": "Ursa Minor"}
+      "common_name": {"english": "Little Bear", "native": "Ursa Minor"}
     },
     {
       "id": "CON modern Phe",
@@ -1418,7 +1418,7 @@
           {"pos": [481, 155], "hip": 114971}
         ]
       },
-      "common_name": {"english": "Pisces", "native": "Pisces"}
+      "common_name": {"english": "Fishes", "native": "Pisces"}
     },
     {
       "id": "CON modern PsA",
@@ -1432,7 +1432,7 @@
           {"pos": [236, 92], "hip": 111954}
         ]
       },
-      "common_name": {"english": "Piscis Austrinus", "native": "Piscis Austrinus"}
+      "common_name": {"english": "Southern Fish", "native": "Piscis Austrinus"}
     },
     {
       "id": "CON modern Vol",
@@ -1446,12 +1446,12 @@
           {"pos": [207, 163], "hip": 34481}
         ]
       },
-      "common_name": {"english": "Volans", "native": "Volans"}
+      "common_name": {"english": "Flying Fish", "native": "Volans"}
     },
     {
       "id": "CON modern Pup",
       "lines": [[39757, 38146, 35264, 31685, 32768, 36377, 39429, 39757]],
-      "common_name": {"english": "Puppis", "native": "Puppis"}
+      "common_name": {"english": "Stern", "native": "Puppis"}
     },
     {
       "id": "CON modern Ret",
@@ -1465,7 +1465,7 @@
           {"pos": [16, 111], "hip": 19921}
         ]
       },
-      "common_name": {"english": "Reticulum", "native": "Reticulum"}
+      "common_name": {"english": "Reticle", "native": "Reticulum"}
     },
     {
       "id": "CON modern Sgr",
@@ -1479,7 +1479,7 @@
           {"pos": [506, 100], "hip": 87072}
         ]
       },
-      "common_name": {"english": "Sagittarius", "native": "Sagittarius"}
+      "common_name": {"english": "Archer", "native": "Sagittarius"}
     },
     {
       "id": "CON modern Sco",
@@ -1493,12 +1493,12 @@
           {"pos": [217, 462], "hip": 82729}
         ]
       },
-      "common_name": {"english": "Scorpius", "native": "Scorpius"}
+      "common_name": {"english": "Scorpion", "native": "Scorpius"}
     },
     {
       "id": "CON modern Ser",
       "lines": [[77516, 77622, 77070, 76276, 77233, 78072, 77450, 77233], [92946, 89962, 86565, 86263, 84880]],
-      "common_name": {"english": "Serpens", "native": "Serpens"}
+      "common_name": {"english": "Serpent", "native": "Serpens"}
     },
     {
       "id": "CON modern Sex",
@@ -1512,7 +1512,7 @@
           {"pos": [118, 84], "hip": 48437}
         ]
       },
-      "common_name": {"english": "Sextans", "native": "Sextans"}
+      "common_name": {"english": "Sextant", "native": "Sextans"}
     },
     {
       "id": "CON modern Men",
@@ -1526,7 +1526,7 @@
           {"pos": [54, 183], "hip": 29134}
         ]
       },
-      "common_name": {"english": "Mensa", "native": "Mensa"}
+      "common_name": {"english": "Table Mountain", "native": "Mensa"}
     },
     {
       "id": "CON modern Tau",
@@ -1540,7 +1540,7 @@
           {"pos": [382, 192], "hip": 17999}
         ]
       },
-      "common_name": {"english": "Taurus", "native": "Taurus"}
+      "common_name": {"english": "Bull", "native": "Taurus"}
     },
     {
       "id": "CON modern Tel",
@@ -1554,7 +1554,7 @@
           {"pos": [106, 92], "hip": 90568}
         ]
       },
-      "common_name": {"english": "Telescopium", "native": "Telescopium"}
+      "common_name": {"english": "Telescope", "native": "Telescopium"}
     },
     {
       "id": "CON modern Tuc",
@@ -1568,7 +1568,7 @@
           {"pos": [224, 141], "hip": 110130}
         ]
       },
-      "common_name": {"english": "Tucana", "native": "Tucana"}
+      "common_name": {"english": "Toucan", "native": "Tucana"}
     },
     {
       "id": "CON modern Tri",
@@ -1582,7 +1582,7 @@
           {"pos": [97, 78], "hip": 8796}
         ]
       },
-      "common_name": {"english": "Triangulum", "native": "Triangulum"}
+      "common_name": {"english": "Triangle", "native": "Triangulum"}
     },
     {
       "id": "CON modern TrA",
@@ -1596,7 +1596,7 @@
           {"pos": [60, 106], "hip": 82273}
         ]
       },
-      "common_name": {"english": "Triangulum Australe", "native": "Triangulum Australe"}
+      "common_name": {"english": "Southern Triangle", "native": "Triangulum Australe"}
     },
     {
       "id": "CON modern Aqr",
@@ -1610,7 +1610,7 @@
           {"pos": [465, 49], "hip": 102618}
         ]
       },
-      "common_name": {"english": "Aquarius", "native": "Aquarius"}
+      "common_name": {"english": "Water Bearer", "native": "Aquarius"}
     },
     {
       "id": "CON modern Vir",
@@ -1624,12 +1624,12 @@
           {"pos": [338, 382], "hip": 65474}
         ]
       },
-      "common_name": {"english": "Virgo", "native": "Virgo"}
+      "common_name": {"english": "Maiden", "native": "Virgo"}
     },
     {
       "id": "CON modern Vel",
       "lines": [[39953, 42536, 42913, 45941, 48774, 52727, 51986, 50191, 46651, 44816, 39953]],
-      "common_name": {"english": "Vela", "native": "Vela"}
+      "common_name": {"english": "Sails", "native": "Vela"}
     }
   ],
   "edges_type": "iau",

--- a/skycultures/modern/index.json
+++ b/skycultures/modern/index.json
@@ -438,7 +438,7 @@
           {"pos": [397, 397], "hip": 93805}
         ]
       },
-      "common_name": {"english": "Eagle", "native": "Aquila"}
+      "common_name": {"english": "Eagle", "native": "Aquila", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern And",
@@ -452,7 +452,7 @@
           {"pos": [224, 428], "hip": 9640}
         ]
       },
-      "common_name": {"english": "Chained Maiden", "native": "Andromeda"}
+      "common_name": {"english": "Chained Maiden", "native": "Andromeda", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Scl",
@@ -466,7 +466,7 @@
           {"pos": [32, 174], "hip": 4577}
         ]
       },
-      "common_name": {"english": "Sculptor", "native": "Sculptor"}
+      "common_name": {"english": "Sculptor", "native": "Sculptor", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Ara",
@@ -480,7 +480,7 @@
           {"pos": [107, 249], "hip": 88714}
         ]
       },
-      "common_name": {"english": "Altar", "native": "Ara"}
+      "common_name": {"english": "Altar", "native": "Ara", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Lib",
@@ -494,7 +494,7 @@
           {"pos": [224, 107], "hip": 73714}
         ]
       },
-      "common_name": {"english": "Scales", "native": "Libra"}
+      "common_name": {"english": "Scales", "native": "Libra", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Cet",
@@ -508,7 +508,7 @@
           {"pos": [412, 440], "hip": 1562}
         ]
       },
-      "common_name": {"english": "Sea Monster", "native": "Cetus"}
+      "common_name": {"english": "Sea Monster", "native": "Cetus", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Ari",
@@ -522,7 +522,7 @@
           {"pos": [210, 47], "hip": 8832}
         ]
       },
-      "common_name": {"english": "Ram", "native": "Aries"}
+      "common_name": {"english": "Ram", "native": "Aries", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Sct",
@@ -536,7 +536,7 @@
           {"pos": [139, 206], "hip": 92814}
         ]
       },
-      "common_name": {"english": "Shield", "native": "Scutum"}
+      "common_name": {"english": "Shield", "native": "Scutum", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Pyx",
@@ -550,7 +550,7 @@
           {"pos": [44, 202], "hip": 42515}
         ]
       },
-      "common_name": {"english": "Mariner Compass", "native": "Pyxis"}
+      "common_name": {"english": "Mariner Compass", "native": "Pyxis", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Boo",
@@ -564,7 +564,7 @@
           {"pos": [207, 401], "hip": 67927}
         ]
       },
-      "common_name": {"english": "Herdsman", "native": "Boötes"}
+      "common_name": {"english": "Herdsman", "native": "Boötes", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Cae",
@@ -578,7 +578,7 @@
           {"pos": [199, 75], "hip": 21861}
         ]
       },
-      "common_name": {"english": "Engraving Tool", "native": "Caelum"}
+      "common_name": {"english": "Engraving Tool", "native": "Caelum", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Cha",
@@ -592,7 +592,7 @@
           {"pos": [184, 33], "hip": 40702}
         ]
       },
-      "common_name": {"english": "Chameleon", "native": "Chamaeleon"}
+      "common_name": {"english": "Chameleon", "native": "Chamaeleon", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Cnc",
@@ -606,7 +606,7 @@
           {"pos": [206, 91], "hip": 40843}
         ]
       },
-      "common_name": {"english": "Crab", "native": "Cancer"}
+      "common_name": {"english": "Crab", "native": "Cancer", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Cap",
@@ -620,7 +620,7 @@
           {"pos": [460, 438], "hip": 102978}
         ]
       },
-      "common_name": {"english": "Sea Goat", "native": "Capricornus"}
+      "common_name": {"english": "Sea Goat", "native": "Capricornus", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Car",
@@ -634,7 +634,7 @@
           {"pos": [298, 22], "hip": 39757}
         ]
       },
-      "common_name": {"english": "Keel", "native": "Carina"}
+      "common_name": {"english": "Keel", "native": "Carina", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Cas",
@@ -648,7 +648,7 @@
           {"pos": [73, 243], "hip": 746}
         ]
       },
-      "common_name": {"english": "Seated Queen", "native": "Cassiopeia"}
+      "common_name": {"english": "Seated Queen", "native": "Cassiopeia", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Cen",
@@ -662,7 +662,7 @@
           {"pos": [463, 412], "hip": 56561}
         ]
       },
-      "common_name": {"english": "Centaur", "native": "Centaurus"}
+      "common_name": {"english": "Centaur", "native": "Centaurus", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Cep",
@@ -676,7 +676,7 @@
           {"pos": [335, 147], "hip": 109492}
         ]
       },
-      "common_name": {"english": "King", "native": "Cepheus"}
+      "common_name": {"english": "King", "native": "Cepheus", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Com",
@@ -690,7 +690,7 @@
           {"pos": [172, 64], "hip": 60742}
         ]
       },
-      "common_name": {"english": "Bernice's Hair", "native": "Coma Berenices"}
+      "common_name": {"english": "Bernice's Hair", "native": "Coma Berenices", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern CVn",
@@ -704,7 +704,7 @@
           {"pos": [207, 152], "hip": 61309}
         ]
       },
-      "common_name": {"english": "Hunting Dogs", "native": "Canes Venatici"}
+      "common_name": {"english": "Hunting Dogs", "native": "Canes Venatici", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Aur",
@@ -718,7 +718,7 @@
           {"pos": [290, 423], "hip": 23015}
         ]
       },
-      "common_name": {"english": "Charioteer", "native": "Auriga"}
+      "common_name": {"english": "Charioteer", "native": "Auriga", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Col",
@@ -732,7 +732,7 @@
           {"pos": [204, 211], "hip": 25859}
         ]
       },
-      "common_name": {"english": "Dove", "native": "Columba"}
+      "common_name": {"english": "Dove", "native": "Columba", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Cir",
@@ -746,7 +746,7 @@
           {"pos": [235, 239], "hip": 71908}
         ]
       },
-      "common_name": {"english": "Drawing Compass", "native": "Circinus"}
+      "common_name": {"english": "Drawing Compass", "native": "Circinus", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Crt",
@@ -760,7 +760,7 @@
           {"pos": [55, 242], "hip": 54682}
         ]
       },
-      "common_name": {"english": "Cup", "native": "Crater"}
+      "common_name": {"english": "Cup", "native": "Crater", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern CrA",
@@ -774,7 +774,7 @@
           {"pos": [195, 208], "hip": 92953}
         ]
       },
-      "common_name": {"english": "Southern Crown", "native": "Corona Australis"}
+      "common_name": {"english": "Southern Crown", "native": "Corona Australis", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern CrB",
@@ -788,7 +788,7 @@
           {"pos": [157, 20], "hip": 76127}
         ]
       },
-      "common_name": {"english": "Northern Crown", "native": "Corona Borealis"}
+      "common_name": {"english": "Northern Crown", "native": "Corona Borealis", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Crv",
@@ -802,7 +802,7 @@
           {"pos": [213, 187], "hip": 59316}
         ]
       },
-      "common_name": {"english": "Crow", "native": "Corvus"}
+      "common_name": {"english": "Crow", "native": "Corvus", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Cru",
@@ -816,7 +816,7 @@
           {"pos": [21, 106], "hip": 60718}
         ]
       },
-      "common_name": {"english": "Southern Cross", "native": "Crux"}
+      "common_name": {"english": "Southern Cross", "native": "Crux", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Cyg",
@@ -830,7 +830,7 @@
           {"pos": [467, 453], "hip": 95947}
         ]
       },
-      "common_name": {"english": "Swan", "native": "Cygnus"}
+      "common_name": {"english": "Swan", "native": "Cygnus", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Del",
@@ -844,7 +844,7 @@
           {"pos": [211, 143], "hip": 101421}
         ]
       },
-      "common_name": {"english": "Dolphin", "native": "Delphinus"}
+      "common_name": {"english": "Dolphin", "native": "Delphinus", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Dor",
@@ -858,7 +858,7 @@
           {"pos": [219, 46], "hip": 19893}
         ]
       },
-      "common_name": {"english": "Swordfish", "native": "Dorado"}
+      "common_name": {"english": "Swordfish", "native": "Dorado", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Dra",
@@ -872,7 +872,7 @@
           {"pos": [449, 429], "hip": 97433}
         ]
       },
-      "common_name": {"english": "Dragon", "native": "Draco"}
+      "common_name": {"english": "Dragon", "native": "Draco", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Nor",
@@ -886,7 +886,7 @@
           {"pos": [16, 112], "hip": 80582}
         ]
       },
-      "common_name": {"english": "Carpenter's Square", "native": "Norma"}
+      "common_name": {"english": "Carpenter's Square", "native": "Norma", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Eri",
@@ -900,7 +900,7 @@
           {"pos": [493, 490], "hip": 7588}
         ]
       },
-      "common_name": {"english": "River", "native": "Eridanus"}
+      "common_name": {"english": "River", "native": "Eridanus", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Sge",
@@ -914,7 +914,7 @@
           {"pos": [218, 243], "hip": 96837}
         ]
       },
-      "common_name": {"english": "Arrow", "native": "Sagitta"}
+      "common_name": {"english": "Arrow", "native": "Sagitta", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern For",
@@ -928,7 +928,7 @@
           {"pos": [190, 129], "hip": 13147}
         ]
       },
-      "common_name": {"english": "Furnace", "native": "Fornax"}
+      "common_name": {"english": "Furnace", "native": "Fornax", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Gem",
@@ -942,7 +942,7 @@
           {"pos": [249, 165], "hip": 28734}
         ]
       },
-      "common_name": {"english": "Twins", "native": "Gemini"}
+      "common_name": {"english": "Twins", "native": "Gemini", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Cam",
@@ -956,7 +956,7 @@
           {"pos": [219, 136], "hip": 16228}
         ]
       },
-      "common_name": {"english": "Giraffe", "native": "Camelopardalis"}
+      "common_name": {"english": "Giraffe", "native": "Camelopardalis", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern CMa",
@@ -970,7 +970,7 @@
           {"pos": [318, 492], "hip": 30122}
         ]
       },
-      "common_name": {"english": "Great Dog", "native": "Canis Major"}
+      "common_name": {"english": "Great Dog", "native": "Canis Major", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern UMa",
@@ -984,7 +984,7 @@
           {"pos": [258, 394], "hip": 50372}
         ]
       },
-      "common_name": {"english": "Great Bear", "native": "Ursa Major"}
+      "common_name": {"english": "Great Bear", "native": "Ursa Major", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Gru",
@@ -998,7 +998,7 @@
           {"pos": [220, 45], "hip": 108085}
         ]
       },
-      "common_name": {"english": "Crane", "native": "Grus"}
+      "common_name": {"english": "Crane", "native": "Grus", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Her",
@@ -1012,7 +1012,7 @@
           {"pos": [441, 102], "hip": 88794}
         ]
       },
-      "common_name": {"english": "Hercules", "native": "Hercules"}
+      "common_name": {"english": "Hercules", "native": "Hercules", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Hor",
@@ -1026,7 +1026,7 @@
           {"pos": [235, 119], "hip": 14240}
         ]
       },
-      "common_name": {"english": "Clock", "native": "Horologium"}
+      "common_name": {"english": "Clock", "native": "Horologium", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Hya",
@@ -1040,7 +1040,7 @@
           {"pos": [401, 33], "hip": 43813}
         ]
       },
-      "common_name": {"english": "Female Water Snake", "native": "Hydra"}
+      "common_name": {"english": "Female Water Snake", "native": "Hydra", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Hyi",
@@ -1054,7 +1054,7 @@
           {"pos": [241, 215], "hip": 17678}
         ]
       },
-      "common_name": {"english": "Male Water Snake", "native": "Hydrus"}
+      "common_name": {"english": "Male Water Snake", "native": "Hydrus", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Ind",
@@ -1068,7 +1068,7 @@
           {"pos": [175, 98], "hip": 105319}
         ]
       },
-      "common_name": {"english": "Indian", "native": "Indus"}
+      "common_name": {"english": "Indian", "native": "Indus", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Lac",
@@ -1082,7 +1082,7 @@
           {"pos": [67, 215], "hip": 109937}
         ]
       },
-      "common_name": {"english": "Lizard", "native": "Lacerta"}
+      "common_name": {"english": "Lizard", "native": "Lacerta", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Mon",
@@ -1096,7 +1096,7 @@
           {"pos": [509, 359], "hip": 29651}
         ]
       },
-      "common_name": {"english": "Unicorn", "native": "Monoceros"}
+      "common_name": {"english": "Unicorn", "native": "Monoceros", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Lep",
@@ -1110,7 +1110,7 @@
           {"pos": [213, 235], "hip": 23685}
         ]
       },
-      "common_name": {"english": "Hare", "native": "Lepus"}
+      "common_name": {"english": "Hare", "native": "Lepus", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Leo",
@@ -1124,7 +1124,7 @@
           {"pos": [321, 32], "hip": 47908}
         ]
       },
-      "common_name": {"english": "Lion", "native": "Leo"}
+      "common_name": {"english": "Lion", "native": "Leo", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Lup",
@@ -1138,7 +1138,7 @@
           {"pos": [425, 239], "hip": 75177}
         ]
       },
-      "common_name": {"english": "Wolf", "native": "Lupus"}
+      "common_name": {"english": "Wolf", "native": "Lupus", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Lyn",
@@ -1152,7 +1152,7 @@
           {"pos": [472, 119], "hip": 30060}
         ]
       },
-      "common_name": {"english": "Lynx", "native": "Lynx"}
+      "common_name": {"english": "Lynx", "native": "Lynx", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Lyr",
@@ -1166,7 +1166,7 @@
           {"pos": [139, 162], "hip": 92420}
         ]
       },
-      "common_name": {"english": "Lyre", "native": "Lyra"}
+      "common_name": {"english": "Lyre", "native": "Lyra", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Ant",
@@ -1180,7 +1180,7 @@
           {"pos": [42, 120], "hip": 48926}
         ]
       },
-      "common_name": {"english": "Air Pump", "native": "Antlia"}
+      "common_name": {"english": "Air Pump", "native": "Antlia", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Mic",
@@ -1194,7 +1194,7 @@
           {"pos": [234, 115], "hip": 102831}
         ]
       },
-      "common_name": {"english": "Microscope", "native": "Microscopium"}
+      "common_name": {"english": "Microscope", "native": "Microscopium", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Mus",
@@ -1208,7 +1208,7 @@
           {"pos": [129, 236], "hip": 57363}
         ]
       },
-      "common_name": {"english": "Fly", "native": "Musca"}
+      "common_name": {"english": "Fly", "native": "Musca", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Oct",
@@ -1222,7 +1222,7 @@
           {"pos": [247, 140], "hip": 112405}
         ]
       },
-      "common_name": {"english": "Octant", "native": "Octans"}
+      "common_name": {"english": "Octant", "native": "Octans", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Aps",
@@ -1236,7 +1236,7 @@
           {"pos": [163, 110], "hip": 72370}
         ]
       },
-      "common_name": {"english": "Bird of Paradise", "native": "Apus"}
+      "common_name": {"english": "Bird of Paradise", "native": "Apus", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Oph",
@@ -1250,7 +1250,7 @@
           {"pos": [238, 453], "hip": 85755}
         ]
       },
-      "common_name": {"english": "Serpent Bearer", "native": "Ophiuchus"}
+      "common_name": {"english": "Serpent Bearer", "native": "Ophiuchus", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Ori",
@@ -1264,7 +1264,7 @@
           {"pos": [421, 91], "hip": 22449}
         ]
       },
-      "common_name": {"english": "Hunter", "native": "Orion"}
+      "common_name": {"english": "Hunter", "native": "Orion", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Pav",
@@ -1278,7 +1278,7 @@
           {"pos": [235, 146], "hip": 86929}
         ]
       },
-      "common_name": {"english": "Peacock", "native": "Pavo"}
+      "common_name": {"english": "Peacock", "native": "Pavo", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Peg",
@@ -1292,7 +1292,7 @@
           {"pos": [409, 349], "hip": 1067}
         ]
       },
-      "common_name": {"english": "Winged Horse", "native": "Pegasus"}
+      "common_name": {"english": "Winged Horse", "native": "Pegasus", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Pic",
@@ -1306,7 +1306,7 @@
           {"pos": [167, 38], "hip": 27321}
         ]
       },
-      "common_name": {"english": "Painter's Easel", "native": "Pictor"}
+      "common_name": {"english": "Painter's Easel", "native": "Pictor", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Per",
@@ -1320,7 +1320,7 @@
           {"pos": [385, 386], "hip": 13254}
         ]
       },
-      "common_name": {"english": "Hero", "native": "Perseus"}
+      "common_name": {"english": "Hero", "native": "Perseus", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Equ",
@@ -1334,7 +1334,7 @@
           {"pos": [160, 160], "hip": 105570}
         ]
       },
-      "common_name": {"english": "Little Horse", "native": "Equuleus"}
+      "common_name": {"english": "Little Horse", "native": "Equuleus", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern CMi",
@@ -1348,7 +1348,7 @@
           {"pos": [184, 124], "hip": 36188}
         ]
       },
-      "common_name": {"english": "Lesser Dog", "native": "Canis Minor"}
+      "common_name": {"english": "Lesser Dog", "native": "Canis Minor", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern LMi",
@@ -1362,7 +1362,7 @@
           {"pos": [61, 155], "hip": 50303}
         ]
       },
-      "common_name": {"english": "Lesser Lion", "native": "Leo Minor"}
+      "common_name": {"english": "Lesser Lion", "native": "Leo Minor", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Vul",
@@ -1376,7 +1376,7 @@
           {"pos": [242, 135], "hip": 94703}
         ]
       },
-      "common_name": {"english": "Fox", "native": "Vulpecula"}
+      "common_name": {"english": "Fox", "native": "Vulpecula", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern UMi",
@@ -1390,7 +1390,7 @@
           {"pos": [93, 209], "hip": 79822}
         ]
       },
-      "common_name": {"english": "Little Bear", "native": "Ursa Minor"}
+      "common_name": {"english": "Little Bear", "native": "Ursa Minor", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Phe",
@@ -1404,7 +1404,7 @@
           {"pos": [229, 214], "hip": 5348}
         ]
       },
-      "common_name": {"english": "Phoenix", "native": "Phoenix"}
+      "common_name": {"english": "Phoenix", "native": "Phoenix", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Psc",
@@ -1418,7 +1418,7 @@
           {"pos": [481, 155], "hip": 114971}
         ]
       },
-      "common_name": {"english": "Fishes", "native": "Pisces"}
+      "common_name": {"english": "Fishes", "native": "Pisces", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern PsA",
@@ -1432,7 +1432,7 @@
           {"pos": [236, 92], "hip": 111954}
         ]
       },
-      "common_name": {"english": "Southern Fish", "native": "Piscis Austrinus"}
+      "common_name": {"english": "Southern Fish", "native": "Piscis Austrinus", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Vol",
@@ -1446,12 +1446,12 @@
           {"pos": [207, 163], "hip": 34481}
         ]
       },
-      "common_name": {"english": "Flying Fish", "native": "Volans"}
+      "common_name": {"english": "Flying Fish", "native": "Volans", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Pup",
       "lines": [[39757, 38146, 35264, 31685, 32768, 36377, 39429, 39757]],
-      "common_name": {"english": "Stern", "native": "Puppis"}
+      "common_name": {"english": "Stern", "native": "Puppis", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Ret",
@@ -1465,7 +1465,7 @@
           {"pos": [16, 111], "hip": 19921}
         ]
       },
-      "common_name": {"english": "Reticle", "native": "Reticulum"}
+      "common_name": {"english": "Reticle", "native": "Reticulum", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Sgr",
@@ -1479,7 +1479,7 @@
           {"pos": [506, 100], "hip": 87072}
         ]
       },
-      "common_name": {"english": "Archer", "native": "Sagittarius"}
+      "common_name": {"english": "Archer", "native": "Sagittarius", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Sco",
@@ -1493,7 +1493,7 @@
           {"pos": [217, 462], "hip": 82729}
         ]
       },
-      "common_name": {"english": "Scorpion", "native": "Scorpius"}
+      "common_name": {"english": "Scorpion", "native": "Scorpius", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Ser",
@@ -1512,7 +1512,7 @@
           {"pos": [118, 84], "hip": 48437}
         ]
       },
-      "common_name": {"english": "Sextant", "native": "Sextans"}
+      "common_name": {"english": "Sextant", "native": "Sextans", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Men",
@@ -1526,7 +1526,7 @@
           {"pos": [54, 183], "hip": 29134}
         ]
       },
-      "common_name": {"english": "Table Mountain", "native": "Mensa"}
+      "common_name": {"english": "Table Mountain", "native": "Mensa", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Tau",
@@ -1540,7 +1540,7 @@
           {"pos": [382, 192], "hip": 17999}
         ]
       },
-      "common_name": {"english": "Bull", "native": "Taurus"}
+      "common_name": {"english": "Bull", "native": "Taurus", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Tel",
@@ -1554,7 +1554,7 @@
           {"pos": [106, 92], "hip": 90568}
         ]
       },
-      "common_name": {"english": "Telescope", "native": "Telescopium"}
+      "common_name": {"english": "Telescope", "native": "Telescopium", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Tuc",
@@ -1568,7 +1568,7 @@
           {"pos": [224, 141], "hip": 110130}
         ]
       },
-      "common_name": {"english": "Toucan", "native": "Tucana"}
+      "common_name": {"english": "Toucan", "native": "Tucana", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Tri",
@@ -1582,7 +1582,7 @@
           {"pos": [97, 78], "hip": 8796}
         ]
       },
-      "common_name": {"english": "Triangle", "native": "Triangulum"}
+      "common_name": {"english": "Triangle", "native": "Triangulum", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern TrA",
@@ -1596,7 +1596,7 @@
           {"pos": [60, 106], "hip": 82273}
         ]
       },
-      "common_name": {"english": "Southern Triangle", "native": "Triangulum Australe"}
+      "common_name": {"english": "Southern Triangle", "native": "Triangulum Australe", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Aqr",
@@ -1610,7 +1610,7 @@
           {"pos": [465, 49], "hip": 102618}
         ]
       },
-      "common_name": {"english": "Water Bearer", "native": "Aquarius"}
+      "common_name": {"english": "Water Bearer", "native": "Aquarius", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Vir",
@@ -1624,7 +1624,7 @@
           {"pos": [338, 382], "hip": 65474}
         ]
       },
-      "common_name": {"english": "Maiden", "native": "Virgo"}
+      "common_name": {"english": "Maiden", "native": "Virgo", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern Vel",

--- a/skycultures/modern_iau/index.json
+++ b/skycultures/modern_iau/index.json
@@ -7,442 +7,442 @@
     {
       "id": "CON modern_iau And",
       "lines": [[677, 3092, 5447, 9640], [113726, 116631, 116805, 116584], [116631, 2912, 3092], [2912, 5447, 4436, 3881, 5434, 7607], [3092, 3031, 3693, 4463]],
-      "common_name": {"english": "Chained Maiden", "native": "Andromeda"}
+      "common_name": {"english": "Chained Maiden", "native": "Andromeda", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Ant",
       "lines": [[53502, 51172, 46515]],
-      "common_name": {"english": "Air Pump", "native": "Antlia"}
+      "common_name": {"english": "Air Pump", "native": "Antlia", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Aps",
       "lines": [[72370, 81065], [80047, 81852, 81065]],
-      "common_name": {"english": "Bird of Paradise", "native": "Apus"}
+      "common_name": {"english": "Bird of Paradise", "native": "Apus", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Aql",
       "lines": [[98036, 97649, 97278, 95501, 93805, 95501, 93747, 95501, 97804, 99473], [93244, 93747], [93805, 93429], [99473, 96468, 93805, 93747]],
-      "common_name": {"english": "Eagle", "native": "Aquila"}
+      "common_name": {"english": "Eagle", "native": "Aquila", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Aqr",
       "lines": [[102618, 106278, 109074, 110395, 110960, 111497, 110960, 110672, 109074], [109139, 106278, 109074, 110003, 112961, 114724, 115033, 115438, 115033, 114341, 115033, 113136, 112716, 112961]],
-      "common_name": {"english": "Water Bearer", "native": "Aquarius"}
+      "common_name": {"english": "Water Bearer", "native": "Aquarius", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Ara",
       "lines": [[85267, 85727, 82363, 83081, 83153, 85792, 88714, 85792, 85258]],
-      "common_name": {"english": "Altar", "native": "Ara"}
+      "common_name": {"english": "Altar", "native": "Ara", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Ari",
       "lines": [[8832, 8903, 9884, 13209]],
-      "common_name": {"english": "Ram", "native": "Aries"}
+      "common_name": {"english": "Ram", "native": "Aries", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Aur",
       "lines": [[25428, 23015, 23767, 24608, 28360, 28380, 25428], [23767, 23453, 23416, 24608, 28358, 28360]],
-      "common_name": {"english": "Charioteer", "native": "Auriga"}
+      "common_name": {"english": "Charioteer", "native": "Auriga", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Boo",
       "lines": [[69673, 72105, 74666, 73555, 71075, 71053, 69673, 67927, 67275], [69673, 71795], [71075, 69732, 70497, 69483, 69732]],
-      "common_name": {"english": "Herdsman", "native": "Boötes"}
+      "common_name": {"english": "Herdsman", "native": "Boötes", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau CMa",
       "lines": [[30324, 32349, 34444, 33579, 34444, 35904], [30324, 31592, 33152, 33579], [32349, 33347, 34045, 33160, 33347]],
-      "common_name": {"english": "Great Dog", "native": "Canis Major"}
+      "common_name": {"english": "Great Dog", "native": "Canis Major", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau CMi",
       "lines": [[37279, 36188]],
-      "common_name": {"english": "Lesser Dog", "native": "Canis Minor"}
+      "common_name": {"english": "Lesser Dog", "native": "Canis Minor", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau CVn",
       "lines": [[63125, 61317]],
-      "common_name": {"english": "Hunting Dogs", "native": "Canes Venatici"}
+      "common_name": {"english": "Hunting Dogs", "native": "Canes Venatici", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Cae",
       "lines": [[23595, 21861, 21770, 21060]],
-      "common_name": {"english": "Engraving Tool", "native": "Caelum"}
+      "common_name": {"english": "Engraving Tool", "native": "Caelum", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Cam",
       "lines": [[23040, 23522, 22783, 29997, 33694, 29997, 22783, 17959, 17884, 16228]],
-      "common_name": {"english": "Giraffe", "native": "Camelopardalis"}
+      "common_name": {"english": "Giraffe", "native": "Camelopardalis", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Cap",
       "lines": [[100064, 100345, 102485, 102978, 105881, 106723, 107556, 106985, 104139, 100064]],
-      "common_name": {"english": "Sea Goat", "native": "Capricornus"}
+      "common_name": {"english": "Sea Goat", "native": "Capricornus", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Car",
       "lines": [[30438, 45238, 50099, 52419, 51576, 50371, 45556, 42913], [51576, 53253], [52419, 54301, 54751, 54463, 53253], [45556, 41037, 38827, 39953]],
-      "common_name": {"english": "Keel", "native": "Carina"}
+      "common_name": {"english": "Keel", "native": "Carina", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Cas",
       "lines": [[746, 3179, 4427, 6686, 8886]],
-      "common_name": {"english": "Seated Queen", "native": "Cassiopeia"}
+      "common_name": {"english": "Seated Queen", "native": "Cassiopeia", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Cen",
       "lines": [[61932, 66657, 68702, 71683, 68702, 66657, 68002, 61932, 68002, 68282, 68245, 71352, 68245, 68862, 70090, 68933, 67464, 68002], [55425, 59196, 60823, 61932, 60823, 59449, 56243], [67464, 65936, 65109, 61789], [71352, 73334]],
-      "common_name": {"english": "Centaur", "native": "Centaurus"}
+      "common_name": {"english": "Centaur", "native": "Centaurus", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Cep",
       "lines": [[102422, 105199, 106032, 112724, 106032, 116727, 112724, 110991, 109492, 109857, 107259, 105199], [101093, 102422]],
-      "common_name": {"english": "King", "native": "Cepheus"}
+      "common_name": {"english": "King", "native": "Cepheus", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Cet",
       "lines": [[12706, 14135, 13954, 12828, 11484, 12706, 12387, 10826, 8645, 8102, 3419, 1562, 5364, 6537, 8645]],
-      "common_name": {"english": "Sea Monster", "native": "Cetus"}
+      "common_name": {"english": "Sea Monster", "native": "Cetus", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Cha",
       "lines": [[40702, 51839, 52633, 60000, 58484, 51839]],
-      "common_name": {"english": "Chameleon", "native": "Chamaeleon"}
+      "common_name": {"english": "Chameleon", "native": "Chamaeleon", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Cir",
       "lines": [[74824, 71908, 75323]],
-      "common_name": {"english": "Drawing Compass", "native": "Circinus"}
+      "common_name": {"english": "Drawing Compass", "native": "Circinus", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Cnc",
       "lines": [[44066, 42911, 40526, 42911, 42806, 43103]],
-      "common_name": {"english": "Crab", "native": "Cancer"}
+      "common_name": {"english": "Crab", "native": "Cancer", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Col",
       "lines": [[26634, 27628], [25859, 26634], [28328, 27628, 28199, 30277]],
-      "common_name": {"english": "Dove", "native": "Columba"}
+      "common_name": {"english": "Dove", "native": "Columba", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Com",
       "lines": [[64241, 64241, 64394, 60742]],
-      "common_name": {"english": "Bernice's Hair", "native": "Coma Berenices"}
+      "common_name": {"english": "Bernice's Hair", "native": "Coma Berenices", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau CrA",
       "lines": [[93825, 94114, 94160, 94005, 90982]],
-      "common_name": {"english": "Southern Crown", "native": "Corona Australis"}
+      "common_name": {"english": "Southern Crown", "native": "Corona Australis", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau CrB",
       "lines": [[76127, 75695, 76267, 76952, 77512, 78159, 78493]],
-      "common_name": {"english": "Northern Crown", "native": "Corona Borealis"}
+      "common_name": {"english": "Northern Crown", "native": "Corona Borealis", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Crt",
       "lines": [[53740, 54682, 55705, 57283, 58188, 57283, 55705, 55282, 55687, 56633, 55687, 55282, 53740]],
-      "common_name": {"english": "Cup", "native": "Crater"}
+      "common_name": {"english": "Cup", "native": "Crater", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Cru",
       "lines": [[60718, 61084], [62434, 59747], [62434, 59747]],
-      "common_name": {"english": "Southern Cross", "native": "Crux"}
+      "common_name": {"english": "Southern Cross", "native": "Crux", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Crv",
       "lines": [[60965, 59803, 59316, 61359, 60965], [59316, 59199]],
-      "common_name": {"english": "Crow", "native": "Corvus"}
+      "common_name": {"english": "Crow", "native": "Corvus", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Cyg",
       "lines": [[102098, 100453, 102488, 100453, 95947, 100453, 97165, 95853, 94779, 95853, 99848, 102098, 103413, 104732, 102488]],
-      "common_name": {"english": "Swan", "native": "Cygnus"}
+      "common_name": {"english": "Swan", "native": "Cygnus", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Del",
       "lines": [[101421, 101769, 101958, 102532, 102281, 101769]],
-      "common_name": {"english": "Dolphin", "native": "Delphinus"}
+      "common_name": {"english": "Dolphin", "native": "Delphinus", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Dor",
       "lines": [[19893, 21281, 23693, 26069, 21281, 26069, 27100, 27890, 26069]],
-      "common_name": {"english": "Swordfish", "native": "Dorado"}
+      "common_name": {"english": "Swordfish", "native": "Dorado", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Dra",
       "lines": [[56211, 61281, 68756, 75458, 78527, 80331, 83895, 89908, 89937, 89908, 94376, 97433, 94376, 87585, 85829, 85670, 87833, 87585, 94376]],
-      "common_name": {"english": "Dragon", "native": "Draco"}
+      "common_name": {"english": "Dragon", "native": "Draco", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Equ",
       "lines": [[104987, 104858, 104521]],
-      "common_name": {"english": "Little Horse", "native": "Equuleus"}
+      "common_name": {"english": "Little Horse", "native": "Equuleus", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Eri",
       "lines": [[23875, 22109, 21444, 19587, 18543, 17593, 17378, 16537, 13701, 12770, 12770, 12843, 14146, 15474, 16611, 17651, 18216, 18673, 21248, 21393, 20535, 20042, 17874, 17874, 16870, 15510, 13847, 12486, 12413, 11407, 9007, 7588]],
-      "common_name": {"english": "River", "native": "Eridanus"}
+      "common_name": {"english": "River", "native": "Eridanus", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau For",
       "lines": [[14879, 13147, 9677]],
-      "common_name": {"english": "Furnace", "native": "Fornax"}
+      "common_name": {"english": "Furnace", "native": "Fornax", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Gem",
       "lines": [[32362, 35350, 35550, 34088, 31681, 34088, 35550, 36962, 37740, 36962, 37826, 36962, 36046, 34693, 36850, 34693, 33018, 34693, 32246, 30883, 32246, 30343, 29655, 28734]],
-      "common_name": {"english": "Twins", "native": "Gemini"}
+      "common_name": {"english": "Twins", "native": "Gemini", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Gru",
       "lines": [[108085, 109111, 110997, 109268, 112122, 110997, 112122, 112623, 113638]],
-      "common_name": {"english": "Crane", "native": "Grus"}
+      "common_name": {"english": "Crane", "native": "Grus", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Her",
       "lines": [[84379, 84345, 80816, 80170, 80816, 81693, 83207, 81693, 81833, 81126, 79992, 81126, 81833, 84380, 85112, 87808, 86414, 87808, 85112, 84380, 83207, 84379, 85693, 86974, 87933, 88794], [77760, 79101, 79992], [80170, 80463, 81008]],
-      "common_name": {"english": "Hercules", "native": "Hercules"}
+      "common_name": {"english": "Hercules", "native": "Hercules", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Hor",
       "lines": [[19747, 12653, 12225, 12484, 14240, 13884]],
-      "common_name": {"english": "Clock", "native": "Horologium"}
+      "common_name": {"english": "Clock", "native": "Horologium", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Hya",
       "lines": [[43234, 42799, 42402, 42313, 43109, 43813, 45336, 47431, 46390, 48356, 49402, 49841, 51069, 52943, 53740], [54682, 56343, 57936, 64962, 68895, 72571]],
-      "common_name": {"english": "Female Water Snake", "native": "Hydra"}
+      "common_name": {"english": "Female Water Snake", "native": "Hydra", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Hyi",
       "lines": [[2021, 17678, 11001, 9236, 2021]],
-      "common_name": {"english": "Male Water Snake", "native": "Hydrus"}
+      "common_name": {"english": "Male Water Snake", "native": "Hydrus", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Ind",
       "lines": [[103227, 102333, 101772, 105319, 108431, 103227]],
-      "common_name": {"english": "Indian", "native": "Indus"}
+      "common_name": {"english": "Indian", "native": "Indus", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau LMi",
       "lines": [[46952, 49593, 51233, 53229, 51056, 49593]],
-      "common_name": {"english": "Lesser Lion", "native": "Leo Minor"}
+      "common_name": {"english": "Lesser Lion", "native": "Leo Minor", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Lac",
       "lines": [[111022, 111169, 110538, 110609, 111022, 110351, 111104, 111944, 111104, 111944, 111022, 111944, 111104, 109754, 109937]],
-      "common_name": {"english": "Lizard", "native": "Lacerta"}
+      "common_name": {"english": "Lizard", "native": "Lacerta", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Leo",
       "lines": [[49669, 49583, 50583, 50335, 48455, 47908], [50583, 54872, 57632, 54879, 54872, 54879, 49583], [48455, 46146, 46750, 47908, 49583], [54879, 55642, 55434]],
-      "common_name": {"english": "Lion", "native": "Leo"}
+      "common_name": {"english": "Lion", "native": "Leo", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Lep",
       "lines": [[23685, 24305, 25985, 25606, 23685], [24845, 24305, 24327], [25606, 27072, 27654, 28910, 28103, 27288, 25985]],
-      "common_name": {"english": "Hare", "native": "Lepus"}
+      "common_name": {"english": "Hare", "native": "Lepus", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Lib",
       "lines": [[72622, 74785], [72622, 73714], [74785, 76333, 72622, 76333, 76470, 76600]],
-      "common_name": {"english": "Scales", "native": "Libra"}
+      "common_name": {"english": "Scales", "native": "Libra", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Lup",
       "lines": [[71860, 74395, 75264, 76297, 75141, 73273, 75141, 76297, 78384, 75177, 77634, 78384, 74395]],
-      "common_name": {"english": "Wolf", "native": "Lupus"}
+      "common_name": {"english": "Wolf", "native": "Lupus", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Lyn",
       "lines": [[45860, 45688, 44700, 44248, 41075, 36145, 33449, 30060]],
-      "common_name": {"english": "Lynx", "native": "Lynx"}
+      "common_name": {"english": "Lynx", "native": "Lynx", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Lyr",
       "lines": [[91262, 91919, 91971, 91262, 91971, 92791, 93194, 92420, 91971]],
-      "common_name": {"english": "Lyre", "native": "Lyra"}
+      "common_name": {"english": "Lyre", "native": "Lyra", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Men",
       "lines": [[29271, 23467]],
-      "common_name": {"english": "Table Mountain", "native": "Mensa"}
+      "common_name": {"english": "Table Mountain", "native": "Mensa", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Mic",
       "lines": [[102831, 102989]],
-      "common_name": {"english": "Microscope", "native": "Microscopium"}
+      "common_name": {"english": "Microscope", "native": "Microscopium", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Mon",
       "lines": [[31978, 31216, 30419, 30419, 32578, 31216, 32578, 34769, 30867, 29651, 30867, 34769, 39863, 37447]],
-      "common_name": {"english": "Unicorn", "native": "Monoceros"}
+      "common_name": {"english": "Unicorn", "native": "Monoceros", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Mus",
       "lines": [[57363, 59929, 61585, 62322, 63613, 61199, 61585]],
-      "common_name": {"english": "Fly", "native": "Musca"}
+      "common_name": {"english": "Fly", "native": "Musca", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Nor",
       "lines": [[78639, 80000, 80582, 78914, 78639]],
-      "common_name": {"english": "Carpenter's Square", "native": "Norma"}
+      "common_name": {"english": "Carpenter's Square", "native": "Norma", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Oct",
       "lines": [[70638, 107089, 112405, 70638]],
-      "common_name": {"english": "Octant", "native": "Octans"}
+      "common_name": {"english": "Octant", "native": "Octans", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Oph",
       "lines": [[86032, 83000, 80883, 79593, 79882, 80628, 81377, 80628, 79882, 79593, 80883, 83000, 81377, 84012, 86742, 87108, 88048, 87108, 86742, 86032], [84012, 84970, 85423], [81377, 80894, 80569, 80343, 80473]],
-      "common_name": {"english": "Serpent Bearer", "native": "Ophiuchus"}
+      "common_name": {"english": "Serpent Bearer", "native": "Ophiuchus", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Ori",
       "lines": [[27989, 26727, 27366, 26727, 26311, 25930, 25336, 25930, 25281, 24436], [27989, 25336, 26207, 26207, 27989], [23607, 22957, 22845, 22509, 22449, 25336, 22449, 22549, 22797, 23123], [27989, 28614, 29038], [29426, 28716, 27913, 29038]],
-      "common_name": {"english": "Hunter", "native": "Orion"}
+      "common_name": {"english": "Hunter", "native": "Orion", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Pav",
       "lines": [[100751, 99240, 102395], [100751, 105858, 102395], [91792, 99240, 98495, 99240, 93015, 88866, 86929, 88866, 90098, 92609, 99240]],
-      "common_name": {"english": "Peacock", "native": "Pavo"}
+      "common_name": {"english": "Peacock", "native": "Pavo", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Peg",
       "lines": [[109410, 112158, 113881, 112748, 112440, 109176, 107354], [677, 113881, 113963, 1067, 677], [107315, 109427, 112029, 113963]],
-      "common_name": {"english": "Winged Horse", "native": "Pegasus"}
+      "common_name": {"english": "Winged Horse", "native": "Pegasus", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Per",
       "lines": [[17448, 18246, 18614, 18532, 17358, 15863, 14328, 13268, 13531, 14328, 13531, 14632, 15863, 14632, 14668, 14576, 18532, 14576, 14354], [17358, 19343, 19812, 20070, 19167], [14632, 12777, 8068]],
-      "common_name": {"english": "Hero", "native": "Perseus"}
+      "common_name": {"english": "Hero", "native": "Perseus", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Phe",
       "lines": [[2081, 5165, 6867], [2081, 765, 5165, 5348, 7083, 6867]],
-      "common_name": {"english": "Phoenix", "native": "Phoenix"}
+      "common_name": {"english": "Phoenix", "native": "Phoenix", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Pic",
       "lines": [[32607, 27530, 27321]],
-      "common_name": {"english": "Painter's Easel", "native": "Pictor"}
+      "common_name": {"english": "Painter's Easel", "native": "Pictor", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau PsA",
       "lines": [[113368, 113246, 112948, 111188, 109285, 107380, 107608, 109285, 111954, 113368]],
-      "common_name": {"english": "Southern Fish", "native": "Piscis Austrinus"}
+      "common_name": {"english": "Southern Fish", "native": "Piscis Austrinus", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Psc",
       "lines": [[5742, 6193, 5586, 5742, 7097, 8198, 9487, 7884, 4906, 3786, 118268, 116771, 115830, 114971, 115738, 116928, 116771]],
-      "common_name": {"english": "Fishes", "native": "Pisces"}
+      "common_name": {"english": "Fishes", "native": "Pisces", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Pup",
       "lines": [[39953, 39429, 39757, 38170, 37229, 36917, 35264, 31685, 30438], [36917, 37677, 38070, 38170]],
-      "common_name": {"english": "Stern", "native": "Puppis"}
+      "common_name": {"english": "Stern", "native": "Puppis", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Pyx",
       "lines": [[39429, 42515, 42828, 43409]],
-      "common_name": {"english": "Mariner Compass", "native": "Pyxis"}
+      "common_name": {"english": "Mariner Compass", "native": "Pyxis", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Ret",
       "lines": [[19780, 17440, 18597, 19921, 19780]],
-      "common_name": {"english": "Reticle", "native": "Reticulum"}
+      "common_name": {"english": "Reticle", "native": "Reticulum", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Scl",
       "lines": [[4577, 117452, 115102, 116231]],
-      "common_name": {"english": "Sculptor", "native": "Sculptor"}
+      "common_name": {"english": "Sculptor", "native": "Sculptor", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Sco",
       "lines": [[78820, 78401, 78265, 78401, 80112, 80763, 81266, 82396, 82514, 82729, 84143, 86228, 87073, 86670, 85696, 85927, 87261], [78820, 79374], [78265, 78104]],
-      "common_name": {"english": "Scorpion", "native": "Scorpius"}
+      "common_name": {"english": "Scorpion", "native": "Scorpius", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Sct",
       "lines": [[92175, 91117, 90595, 91726, 92175]],
-      "common_name": {"english": "Shield", "native": "Scutum"}
+      "common_name": {"english": "Shield", "native": "Scutum", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Ser",
       "lines": [[77233, 78072, 77450, 76852, 77233, 76276, 77070, 77622, 77516, 79593], [84012, 86263, 88048, 89962, 92946]],
-      "common_name": {"english": "Serpent", "native": "Serpens"}
+      "common_name": {"english": "Serpent", "native": "Serpens", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Sex",
       "lines": [[48437, 49641, 51437, 51362]],
-      "common_name": {"english": "Sextant", "native": "Sextans"}
+      "common_name": {"english": "Sextant", "native": "Sextans", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Sge",
       "lines": [[98337, 97365, 96757, 97365, 96837]],
-      "common_name": {"english": "Arrow", "native": "Sagitta"}
+      "common_name": {"english": "Arrow", "native": "Sagitta", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Sgr",
       "lines": [[90185, 88635, 89931, 90185, 89931, 90496, 92041, 89931, 92041, 92855, 93864, 93506, 92041, 93506, 90185, 89642], [90496, 89341], [95168, 94141, 93683, 93085, 94141]],
-      "common_name": {"english": "Archer", "native": "Sagittarius"}
+      "common_name": {"english": "Archer", "native": "Sagittarius", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Tau",
       "lines": [[26451, 21421, 20894, 20205, 20455, 20889, 25428], [16083, 18907], [15900, 16852], [20205, 18724, 16083]],
-      "common_name": {"english": "Bull", "native": "Taurus"}
+      "common_name": {"english": "Bull", "native": "Taurus", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Tel",
       "lines": [[89112, 90422, 90568]],
-      "common_name": {"english": "Telescope", "native": "Telescopium"}
+      "common_name": {"english": "Telescope", "native": "Telescopium", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau TrA",
       "lines": [[82273, 77952, 76440, 74946, 82273]],
-      "common_name": {"english": "Southern Triangle", "native": "Triangulum Australe"}
+      "common_name": {"english": "Southern Triangle", "native": "Triangulum Australe", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Tri",
       "lines": [[8796, 10064, 10670, 8796]],
-      "common_name": {"english": "Triangle", "native": "Triangulum"}
+      "common_name": {"english": "Triangle", "native": "Triangulum", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Tuc",
       "lines": [[2484, 1599, 118322, 110838, 110130, 114996, 2484]],
-      "common_name": {"english": "Toucan", "native": "Tucana"}
+      "common_name": {"english": "Toucan", "native": "Tucana", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau UMa",
       "lines": [[58001, 57399, 54539, 50801, 50372, 50801, 54539, 57399, 55219, 55203], [59774, 54061, 53910, 58001, 59774, 62956, 65378, 67301], [54061, 46733, 48319, 46733, 41704, 48319, 53910, 48319, 46853, 44471, 44127]],
-      "common_name": {"english": "Great Bear", "native": "Ursa Major"}
+      "common_name": {"english": "Great Bear", "native": "Ursa Major", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau UMi",
       "lines": [[11767, 85822, 82080, 77055, 79822, 75097, 72607, 77055]],
-      "common_name": {"english": "Little Bear", "native": "Ursa Minor"}
+      "common_name": {"english": "Little Bear", "native": "Ursa Minor", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Vel",
       "lines": [[42913, 39953, 44816, 46651, 50191, 52727, 48774, 45941, 42913]],
-      "common_name": {"english": "Sails", "native": "Vela"}
+      "common_name": {"english": "Sails", "native": "Vela", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Vir",
       "lines": [[60129, 58948, 57380, 57757, 60129, 61941, 63090, 63608, 63090, 61941, 64238, 65474, 64238, 61941, 66249, 68520, 72220, 68520, 66249, 69701, 71957]],
-      "common_name": {"english": "Maiden", "native": "Virgo"}
+      "common_name": {"english": "Maiden", "native": "Virgo", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Vol",
       "lines": [[44382, 41312, 39794, 35228, 34481, 39794, 44382]],
-      "common_name": {"english": "Flying Fish", "native": "Volans"}
+      "common_name": {"english": "Flying Fish", "native": "Volans", "context": "IAU constellation name"}
     },
     {
       "id": "CON modern_iau Vul",
       "lines": [[95771, 97886]],
-      "common_name": {"english": "Fox", "native": "Vulpecula"}
+      "common_name": {"english": "Fox", "native": "Vulpecula", "context": "IAU constellation name"}
     }
   ],
   "edges_type": "iau",

--- a/skycultures/modern_iau/index.json
+++ b/skycultures/modern_iau/index.json
@@ -7,197 +7,197 @@
     {
       "id": "CON modern_iau And",
       "lines": [[677, 3092, 5447, 9640], [113726, 116631, 116805, 116584], [116631, 2912, 3092], [2912, 5447, 4436, 3881, 5434, 7607], [3092, 3031, 3693, 4463]],
-      "common_name": {"english": "Andromeda", "native": "Andromeda"}
+      "common_name": {"english": "Chained Maiden", "native": "Andromeda"}
     },
     {
       "id": "CON modern_iau Ant",
       "lines": [[53502, 51172, 46515]],
-      "common_name": {"english": "Antlia", "native": "Antlia"}
+      "common_name": {"english": "Air Pump", "native": "Antlia"}
     },
     {
       "id": "CON modern_iau Aps",
       "lines": [[72370, 81065], [80047, 81852, 81065]],
-      "common_name": {"english": "Apus", "native": "Apus"}
+      "common_name": {"english": "Bird of Paradise", "native": "Apus"}
     },
     {
       "id": "CON modern_iau Aql",
       "lines": [[98036, 97649, 97278, 95501, 93805, 95501, 93747, 95501, 97804, 99473], [93244, 93747], [93805, 93429], [99473, 96468, 93805, 93747]],
-      "common_name": {"english": "Aquila", "native": "Aquila"}
+      "common_name": {"english": "Eagle", "native": "Aquila"}
     },
     {
       "id": "CON modern_iau Aqr",
       "lines": [[102618, 106278, 109074, 110395, 110960, 111497, 110960, 110672, 109074], [109139, 106278, 109074, 110003, 112961, 114724, 115033, 115438, 115033, 114341, 115033, 113136, 112716, 112961]],
-      "common_name": {"english": "Aquarius", "native": "Aquarius"}
+      "common_name": {"english": "Water Bearer", "native": "Aquarius"}
     },
     {
       "id": "CON modern_iau Ara",
       "lines": [[85267, 85727, 82363, 83081, 83153, 85792, 88714, 85792, 85258]],
-      "common_name": {"english": "Ara", "native": "Ara"}
+      "common_name": {"english": "Altar", "native": "Ara"}
     },
     {
       "id": "CON modern_iau Ari",
       "lines": [[8832, 8903, 9884, 13209]],
-      "common_name": {"english": "Aries", "native": "Aries"}
+      "common_name": {"english": "Ram", "native": "Aries"}
     },
     {
       "id": "CON modern_iau Aur",
       "lines": [[25428, 23015, 23767, 24608, 28360, 28380, 25428], [23767, 23453, 23416, 24608, 28358, 28360]],
-      "common_name": {"english": "Auriga", "native": "Auriga"}
+      "common_name": {"english": "Charioteer", "native": "Auriga"}
     },
     {
       "id": "CON modern_iau Boo",
       "lines": [[69673, 72105, 74666, 73555, 71075, 71053, 69673, 67927, 67275], [69673, 71795], [71075, 69732, 70497, 69483, 69732]],
-      "common_name": {"english": "Bootes", "native": "Bootes"}
+      "common_name": {"english": "Herdsman", "native": "Boötes"}
     },
     {
       "id": "CON modern_iau CMa",
       "lines": [[30324, 32349, 34444, 33579, 34444, 35904], [30324, 31592, 33152, 33579], [32349, 33347, 34045, 33160, 33347]],
-      "common_name": {"english": "Canis Major", "native": "Canis Major"}
+      "common_name": {"english": "Great Dog", "native": "Canis Major"}
     },
     {
       "id": "CON modern_iau CMi",
       "lines": [[37279, 36188]],
-      "common_name": {"english": "Canis Minor", "native": "Canis Minor"}
+      "common_name": {"english": "Lesser Dog", "native": "Canis Minor"}
     },
     {
       "id": "CON modern_iau CVn",
       "lines": [[63125, 61317]],
-      "common_name": {"english": "Canes Venatici", "native": "Canes Venatici"}
+      "common_name": {"english": "Hunting Dogs", "native": "Canes Venatici"}
     },
     {
       "id": "CON modern_iau Cae",
       "lines": [[23595, 21861, 21770, 21060]],
-      "common_name": {"english": "Caelum", "native": "Caelum"}
+      "common_name": {"english": "Engraving Tool", "native": "Caelum"}
     },
     {
       "id": "CON modern_iau Cam",
       "lines": [[23040, 23522, 22783, 29997, 33694, 29997, 22783, 17959, 17884, 16228]],
-      "common_name": {"english": "Camelopardalis", "native": "Camelopardalis"}
+      "common_name": {"english": "Giraffe", "native": "Camelopardalis"}
     },
     {
       "id": "CON modern_iau Cap",
       "lines": [[100064, 100345, 102485, 102978, 105881, 106723, 107556, 106985, 104139, 100064]],
-      "common_name": {"english": "Capricornus", "native": "Capricornus"}
+      "common_name": {"english": "Sea Goat", "native": "Capricornus"}
     },
     {
       "id": "CON modern_iau Car",
       "lines": [[30438, 45238, 50099, 52419, 51576, 50371, 45556, 42913], [51576, 53253], [52419, 54301, 54751, 54463, 53253], [45556, 41037, 38827, 39953]],
-      "common_name": {"english": "Carina", "native": "Carina"}
+      "common_name": {"english": "Keel", "native": "Carina"}
     },
     {
       "id": "CON modern_iau Cas",
       "lines": [[746, 3179, 4427, 6686, 8886]],
-      "common_name": {"english": "Cassiopeia", "native": "Cassiopeia"}
+      "common_name": {"english": "Seated Queen", "native": "Cassiopeia"}
     },
     {
       "id": "CON modern_iau Cen",
       "lines": [[61932, 66657, 68702, 71683, 68702, 66657, 68002, 61932, 68002, 68282, 68245, 71352, 68245, 68862, 70090, 68933, 67464, 68002], [55425, 59196, 60823, 61932, 60823, 59449, 56243], [67464, 65936, 65109, 61789], [71352, 73334]],
-      "common_name": {"english": "Centaurus", "native": "Centaurus"}
+      "common_name": {"english": "Centaur", "native": "Centaurus"}
     },
     {
       "id": "CON modern_iau Cep",
       "lines": [[102422, 105199, 106032, 112724, 106032, 116727, 112724, 110991, 109492, 109857, 107259, 105199], [101093, 102422]],
-      "common_name": {"english": "Cepheus", "native": "Cepheus"}
+      "common_name": {"english": "King", "native": "Cepheus"}
     },
     {
       "id": "CON modern_iau Cet",
       "lines": [[12706, 14135, 13954, 12828, 11484, 12706, 12387, 10826, 8645, 8102, 3419, 1562, 5364, 6537, 8645]],
-      "common_name": {"english": "Cetus", "native": "Cetus"}
+      "common_name": {"english": "Sea Monster", "native": "Cetus"}
     },
     {
       "id": "CON modern_iau Cha",
       "lines": [[40702, 51839, 52633, 60000, 58484, 51839]],
-      "common_name": {"english": "Chamaeleon", "native": "Chamaeleon"}
+      "common_name": {"english": "Chameleon", "native": "Chamaeleon"}
     },
     {
       "id": "CON modern_iau Cir",
       "lines": [[74824, 71908, 75323]],
-      "common_name": {"english": "Circinus", "native": "Circinus"}
+      "common_name": {"english": "Drawing Compass", "native": "Circinus"}
     },
     {
       "id": "CON modern_iau Cnc",
       "lines": [[44066, 42911, 40526, 42911, 42806, 43103]],
-      "common_name": {"english": "Cancer", "native": "Cancer"}
+      "common_name": {"english": "Crab", "native": "Cancer"}
     },
     {
       "id": "CON modern_iau Col",
       "lines": [[26634, 27628], [25859, 26634], [28328, 27628, 28199, 30277]],
-      "common_name": {"english": "Columba", "native": "Columba"}
+      "common_name": {"english": "Dove", "native": "Columba"}
     },
     {
       "id": "CON modern_iau Com",
       "lines": [[64241, 64241, 64394, 60742]],
-      "common_name": {"english": "Coma Berenices", "native": "Coma Berenices"}
+      "common_name": {"english": "Bernice's Hair", "native": "Coma Berenices"}
     },
     {
       "id": "CON modern_iau CrA",
       "lines": [[93825, 94114, 94160, 94005, 90982]],
-      "common_name": {"english": "Corona Australis", "native": "Corona Australis"}
+      "common_name": {"english": "Southern Crown", "native": "Corona Australis"}
     },
     {
       "id": "CON modern_iau CrB",
       "lines": [[76127, 75695, 76267, 76952, 77512, 78159, 78493]],
-      "common_name": {"english": "Corona Borealis", "native": "Corona Borealis"}
+      "common_name": {"english": "Northern Crown", "native": "Corona Borealis"}
     },
     {
       "id": "CON modern_iau Crt",
       "lines": [[53740, 54682, 55705, 57283, 58188, 57283, 55705, 55282, 55687, 56633, 55687, 55282, 53740]],
-      "common_name": {"english": "Crater", "native": "Crater"}
+      "common_name": {"english": "Cup", "native": "Crater"}
     },
     {
       "id": "CON modern_iau Cru",
       "lines": [[60718, 61084], [62434, 59747], [62434, 59747]],
-      "common_name": {"english": "Crux", "native": "Crux"}
+      "common_name": {"english": "Southern Cross", "native": "Crux"}
     },
     {
       "id": "CON modern_iau Crv",
       "lines": [[60965, 59803, 59316, 61359, 60965], [59316, 59199]],
-      "common_name": {"english": "Corvus", "native": "Corvus"}
+      "common_name": {"english": "Crow", "native": "Corvus"}
     },
     {
       "id": "CON modern_iau Cyg",
       "lines": [[102098, 100453, 102488, 100453, 95947, 100453, 97165, 95853, 94779, 95853, 99848, 102098, 103413, 104732, 102488]],
-      "common_name": {"english": "Cygnus", "native": "Cygnus"}
+      "common_name": {"english": "Swan", "native": "Cygnus"}
     },
     {
       "id": "CON modern_iau Del",
       "lines": [[101421, 101769, 101958, 102532, 102281, 101769]],
-      "common_name": {"english": "Delphinus", "native": "Delphinus"}
+      "common_name": {"english": "Dolphin", "native": "Delphinus"}
     },
     {
       "id": "CON modern_iau Dor",
       "lines": [[19893, 21281, 23693, 26069, 21281, 26069, 27100, 27890, 26069]],
-      "common_name": {"english": "Dorado", "native": "Dorado"}
+      "common_name": {"english": "Swordfish", "native": "Dorado"}
     },
     {
       "id": "CON modern_iau Dra",
       "lines": [[56211, 61281, 68756, 75458, 78527, 80331, 83895, 89908, 89937, 89908, 94376, 97433, 94376, 87585, 85829, 85670, 87833, 87585, 94376]],
-      "common_name": {"english": "Draco", "native": "Draco"}
+      "common_name": {"english": "Dragon", "native": "Draco"}
     },
     {
       "id": "CON modern_iau Equ",
       "lines": [[104987, 104858, 104521]],
-      "common_name": {"english": "Equuleus", "native": "Equuleus"}
+      "common_name": {"english": "Little Horse", "native": "Equuleus"}
     },
     {
       "id": "CON modern_iau Eri",
       "lines": [[23875, 22109, 21444, 19587, 18543, 17593, 17378, 16537, 13701, 12770, 12770, 12843, 14146, 15474, 16611, 17651, 18216, 18673, 21248, 21393, 20535, 20042, 17874, 17874, 16870, 15510, 13847, 12486, 12413, 11407, 9007, 7588]],
-      "common_name": {"english": "Eridanus", "native": "Eridanus"}
+      "common_name": {"english": "River", "native": "Eridanus"}
     },
     {
       "id": "CON modern_iau For",
       "lines": [[14879, 13147, 9677]],
-      "common_name": {"english": "Fornax", "native": "Fornax"}
+      "common_name": {"english": "Furnace", "native": "Fornax"}
     },
     {
       "id": "CON modern_iau Gem",
       "lines": [[32362, 35350, 35550, 34088, 31681, 34088, 35550, 36962, 37740, 36962, 37826, 36962, 36046, 34693, 36850, 34693, 33018, 34693, 32246, 30883, 32246, 30343, 29655, 28734]],
-      "common_name": {"english": "Gemini", "native": "Gemini"}
+      "common_name": {"english": "Twins", "native": "Gemini"}
     },
     {
       "id": "CON modern_iau Gru",
       "lines": [[108085, 109111, 110997, 109268, 112122, 110997, 112122, 112623, 113638]],
-      "common_name": {"english": "Grus", "native": "Grus"}
+      "common_name": {"english": "Crane", "native": "Grus"}
     },
     {
       "id": "CON modern_iau Her",
@@ -207,52 +207,52 @@
     {
       "id": "CON modern_iau Hor",
       "lines": [[19747, 12653, 12225, 12484, 14240, 13884]],
-      "common_name": {"english": "Horologium", "native": "Horologium"}
+      "common_name": {"english": "Clock", "native": "Horologium"}
     },
     {
       "id": "CON modern_iau Hya",
       "lines": [[43234, 42799, 42402, 42313, 43109, 43813, 45336, 47431, 46390, 48356, 49402, 49841, 51069, 52943, 53740], [54682, 56343, 57936, 64962, 68895, 72571]],
-      "common_name": {"english": "Hydra", "native": "Hydra"}
+      "common_name": {"english": "Female Water Snake", "native": "Hydra"}
     },
     {
       "id": "CON modern_iau Hyi",
       "lines": [[2021, 17678, 11001, 9236, 2021]],
-      "common_name": {"english": "Hydrus", "native": "Hydrus"}
+      "common_name": {"english": "Male Water Snake", "native": "Hydrus"}
     },
     {
       "id": "CON modern_iau Ind",
       "lines": [[103227, 102333, 101772, 105319, 108431, 103227]],
-      "common_name": {"english": "Indus", "native": "Indus"}
+      "common_name": {"english": "Indian", "native": "Indus"}
     },
     {
       "id": "CON modern_iau LMi",
       "lines": [[46952, 49593, 51233, 53229, 51056, 49593]],
-      "common_name": {"english": "Leo Minor", "native": "Leo Minor"}
+      "common_name": {"english": "Lesser Lion", "native": "Leo Minor"}
     },
     {
       "id": "CON modern_iau Lac",
       "lines": [[111022, 111169, 110538, 110609, 111022, 110351, 111104, 111944, 111104, 111944, 111022, 111944, 111104, 109754, 109937]],
-      "common_name": {"english": "Lacerta", "native": "Lacerta"}
+      "common_name": {"english": "Lizard", "native": "Lacerta"}
     },
     {
       "id": "CON modern_iau Leo",
       "lines": [[49669, 49583, 50583, 50335, 48455, 47908], [50583, 54872, 57632, 54879, 54872, 54879, 49583], [48455, 46146, 46750, 47908, 49583], [54879, 55642, 55434]],
-      "common_name": {"english": "Leo", "native": "Leo"}
+      "common_name": {"english": "Lion", "native": "Leo"}
     },
     {
       "id": "CON modern_iau Lep",
       "lines": [[23685, 24305, 25985, 25606, 23685], [24845, 24305, 24327], [25606, 27072, 27654, 28910, 28103, 27288, 25985]],
-      "common_name": {"english": "Lepus", "native": "Lepus"}
+      "common_name": {"english": "Hare", "native": "Lepus"}
     },
     {
       "id": "CON modern_iau Lib",
       "lines": [[72622, 74785], [72622, 73714], [74785, 76333, 72622, 76333, 76470, 76600]],
-      "common_name": {"english": "Libra", "native": "Libra"}
+      "common_name": {"english": "Scales", "native": "Libra"}
     },
     {
       "id": "CON modern_iau Lup",
       "lines": [[71860, 74395, 75264, 76297, 75141, 73273, 75141, 76297, 78384, 75177, 77634, 78384, 74395]],
-      "common_name": {"english": "Lupus", "native": "Lupus"}
+      "common_name": {"english": "Wolf", "native": "Lupus"}
     },
     {
       "id": "CON modern_iau Lyn",
@@ -262,62 +262,62 @@
     {
       "id": "CON modern_iau Lyr",
       "lines": [[91262, 91919, 91971, 91262, 91971, 92791, 93194, 92420, 91971]],
-      "common_name": {"english": "Lyra", "native": "Lyra"}
+      "common_name": {"english": "Lyre", "native": "Lyra"}
     },
     {
       "id": "CON modern_iau Men",
       "lines": [[29271, 23467]],
-      "common_name": {"english": "Mensa", "native": "Mensa"}
+      "common_name": {"english": "Table Mountain", "native": "Mensa"}
     },
     {
       "id": "CON modern_iau Mic",
       "lines": [[102831, 102989]],
-      "common_name": {"english": "Microscopium", "native": "Microscopium"}
+      "common_name": {"english": "Microscope", "native": "Microscopium"}
     },
     {
       "id": "CON modern_iau Mon",
       "lines": [[31978, 31216, 30419, 30419, 32578, 31216, 32578, 34769, 30867, 29651, 30867, 34769, 39863, 37447]],
-      "common_name": {"english": "Monoceros", "native": "Monoceros"}
+      "common_name": {"english": "Unicorn", "native": "Monoceros"}
     },
     {
       "id": "CON modern_iau Mus",
       "lines": [[57363, 59929, 61585, 62322, 63613, 61199, 61585]],
-      "common_name": {"english": "Musca", "native": "Musca"}
+      "common_name": {"english": "Fly", "native": "Musca"}
     },
     {
       "id": "CON modern_iau Nor",
       "lines": [[78639, 80000, 80582, 78914, 78639]],
-      "common_name": {"english": "Norma", "native": "Norma"}
+      "common_name": {"english": "Carpenter's Square", "native": "Norma"}
     },
     {
       "id": "CON modern_iau Oct",
       "lines": [[70638, 107089, 112405, 70638]],
-      "common_name": {"english": "Octans", "native": "Octans"}
+      "common_name": {"english": "Octant", "native": "Octans"}
     },
     {
       "id": "CON modern_iau Oph",
       "lines": [[86032, 83000, 80883, 79593, 79882, 80628, 81377, 80628, 79882, 79593, 80883, 83000, 81377, 84012, 86742, 87108, 88048, 87108, 86742, 86032], [84012, 84970, 85423], [81377, 80894, 80569, 80343, 80473]],
-      "common_name": {"english": "Ophiuchus", "native": "Ophiuchus"}
+      "common_name": {"english": "Serpent Bearer", "native": "Ophiuchus"}
     },
     {
       "id": "CON modern_iau Ori",
       "lines": [[27989, 26727, 27366, 26727, 26311, 25930, 25336, 25930, 25281, 24436], [27989, 25336, 26207, 26207, 27989], [23607, 22957, 22845, 22509, 22449, 25336, 22449, 22549, 22797, 23123], [27989, 28614, 29038], [29426, 28716, 27913, 29038]],
-      "common_name": {"english": "Orion", "native": "Orion"}
+      "common_name": {"english": "Hunter", "native": "Orion"}
     },
     {
       "id": "CON modern_iau Pav",
       "lines": [[100751, 99240, 102395], [100751, 105858, 102395], [91792, 99240, 98495, 99240, 93015, 88866, 86929, 88866, 90098, 92609, 99240]],
-      "common_name": {"english": "Pavo", "native": "Pavo"}
+      "common_name": {"english": "Peacock", "native": "Pavo"}
     },
     {
       "id": "CON modern_iau Peg",
       "lines": [[109410, 112158, 113881, 112748, 112440, 109176, 107354], [677, 113881, 113963, 1067, 677], [107315, 109427, 112029, 113963]],
-      "common_name": {"english": "Pegasus", "native": "Pegasus"}
+      "common_name": {"english": "Winged Horse", "native": "Pegasus"}
     },
     {
       "id": "CON modern_iau Per",
       "lines": [[17448, 18246, 18614, 18532, 17358, 15863, 14328, 13268, 13531, 14328, 13531, 14632, 15863, 14632, 14668, 14576, 18532, 14576, 14354], [17358, 19343, 19812, 20070, 19167], [14632, 12777, 8068]],
-      "common_name": {"english": "Perseus", "native": "Perseus"}
+      "common_name": {"english": "Hero", "native": "Perseus"}
     },
     {
       "id": "CON modern_iau Phe",
@@ -327,32 +327,32 @@
     {
       "id": "CON modern_iau Pic",
       "lines": [[32607, 27530, 27321]],
-      "common_name": {"english": "Pictor", "native": "Pictor"}
+      "common_name": {"english": "Painter's Easel", "native": "Pictor"}
     },
     {
       "id": "CON modern_iau PsA",
       "lines": [[113368, 113246, 112948, 111188, 109285, 107380, 107608, 109285, 111954, 113368]],
-      "common_name": {"english": "Piscis Austrinus", "native": "Piscis Austrinus"}
+      "common_name": {"english": "Southern Fish", "native": "Piscis Austrinus"}
     },
     {
       "id": "CON modern_iau Psc",
       "lines": [[5742, 6193, 5586, 5742, 7097, 8198, 9487, 7884, 4906, 3786, 118268, 116771, 115830, 114971, 115738, 116928, 116771]],
-      "common_name": {"english": "Pisces", "native": "Pisces"}
+      "common_name": {"english": "Fishes", "native": "Pisces"}
     },
     {
       "id": "CON modern_iau Pup",
       "lines": [[39953, 39429, 39757, 38170, 37229, 36917, 35264, 31685, 30438], [36917, 37677, 38070, 38170]],
-      "common_name": {"english": "Puppis", "native": "Puppis"}
+      "common_name": {"english": "Stern", "native": "Puppis"}
     },
     {
       "id": "CON modern_iau Pyx",
       "lines": [[39429, 42515, 42828, 43409]],
-      "common_name": {"english": "Pyxis", "native": "Pyxis"}
+      "common_name": {"english": "Mariner Compass", "native": "Pyxis"}
     },
     {
       "id": "CON modern_iau Ret",
       "lines": [[19780, 17440, 18597, 19921, 19780]],
-      "common_name": {"english": "Reticulum", "native": "Reticulum"}
+      "common_name": {"english": "Reticle", "native": "Reticulum"}
     },
     {
       "id": "CON modern_iau Scl",
@@ -362,87 +362,87 @@
     {
       "id": "CON modern_iau Sco",
       "lines": [[78820, 78401, 78265, 78401, 80112, 80763, 81266, 82396, 82514, 82729, 84143, 86228, 87073, 86670, 85696, 85927, 87261], [78820, 79374], [78265, 78104]],
-      "common_name": {"english": "Scorpius", "native": "Scorpius"}
+      "common_name": {"english": "Scorpion", "native": "Scorpius"}
     },
     {
       "id": "CON modern_iau Sct",
       "lines": [[92175, 91117, 90595, 91726, 92175]],
-      "common_name": {"english": "Scutum", "native": "Scutum"}
+      "common_name": {"english": "Shield", "native": "Scutum"}
     },
     {
       "id": "CON modern_iau Ser",
       "lines": [[77233, 78072, 77450, 76852, 77233, 76276, 77070, 77622, 77516, 79593], [84012, 86263, 88048, 89962, 92946]],
-      "common_name": {"english": "Serpens", "native": "Serpens"}
+      "common_name": {"english": "Serpent", "native": "Serpens"}
     },
     {
       "id": "CON modern_iau Sex",
       "lines": [[48437, 49641, 51437, 51362]],
-      "common_name": {"english": "Sextans", "native": "Sextans"}
+      "common_name": {"english": "Sextant", "native": "Sextans"}
     },
     {
       "id": "CON modern_iau Sge",
       "lines": [[98337, 97365, 96757, 97365, 96837]],
-      "common_name": {"english": "Sagitta", "native": "Sagitta"}
+      "common_name": {"english": "Arrow", "native": "Sagitta"}
     },
     {
       "id": "CON modern_iau Sgr",
       "lines": [[90185, 88635, 89931, 90185, 89931, 90496, 92041, 89931, 92041, 92855, 93864, 93506, 92041, 93506, 90185, 89642], [90496, 89341], [95168, 94141, 93683, 93085, 94141]],
-      "common_name": {"english": "Sagittarius", "native": "Sagittarius"}
+      "common_name": {"english": "Archer", "native": "Sagittarius"}
     },
     {
       "id": "CON modern_iau Tau",
       "lines": [[26451, 21421, 20894, 20205, 20455, 20889, 25428], [16083, 18907], [15900, 16852], [20205, 18724, 16083]],
-      "common_name": {"english": "Taurus", "native": "Taurus"}
+      "common_name": {"english": "Bull", "native": "Taurus"}
     },
     {
       "id": "CON modern_iau Tel",
       "lines": [[89112, 90422, 90568]],
-      "common_name": {"english": "Telescopium", "native": "Telescopium"}
+      "common_name": {"english": "Telescope", "native": "Telescopium"}
     },
     {
       "id": "CON modern_iau TrA",
       "lines": [[82273, 77952, 76440, 74946, 82273]],
-      "common_name": {"english": "Triangulum Australe", "native": "Triangulum Australe"}
+      "common_name": {"english": "Southern Triangle", "native": "Triangulum Australe"}
     },
     {
       "id": "CON modern_iau Tri",
       "lines": [[8796, 10064, 10670, 8796]],
-      "common_name": {"english": "Triangulum", "native": "Triangulum"}
+      "common_name": {"english": "Triangle", "native": "Triangulum"}
     },
     {
       "id": "CON modern_iau Tuc",
       "lines": [[2484, 1599, 118322, 110838, 110130, 114996, 2484]],
-      "common_name": {"english": "Tucana", "native": "Tucana"}
+      "common_name": {"english": "Toucan", "native": "Tucana"}
     },
     {
       "id": "CON modern_iau UMa",
       "lines": [[58001, 57399, 54539, 50801, 50372, 50801, 54539, 57399, 55219, 55203], [59774, 54061, 53910, 58001, 59774, 62956, 65378, 67301], [54061, 46733, 48319, 46733, 41704, 48319, 53910, 48319, 46853, 44471, 44127]],
-      "common_name": {"english": "Ursa Major", "native": "Ursa Major"}
+      "common_name": {"english": "Great Bear", "native": "Ursa Major"}
     },
     {
       "id": "CON modern_iau UMi",
       "lines": [[11767, 85822, 82080, 77055, 79822, 75097, 72607, 77055]],
-      "common_name": {"english": "Ursa Minor", "native": "Ursa Minor"}
+      "common_name": {"english": "Little Bear", "native": "Ursa Minor"}
     },
     {
       "id": "CON modern_iau Vel",
       "lines": [[42913, 39953, 44816, 46651, 50191, 52727, 48774, 45941, 42913]],
-      "common_name": {"english": "Vela", "native": "Vela"}
+      "common_name": {"english": "Sails", "native": "Vela"}
     },
     {
       "id": "CON modern_iau Vir",
       "lines": [[60129, 58948, 57380, 57757, 60129, 61941, 63090, 63608, 63090, 61941, 64238, 65474, 64238, 61941, 66249, 68520, 72220, 68520, 66249, 69701, 71957]],
-      "common_name": {"english": "Virgo", "native": "Virgo"}
+      "common_name": {"english": "Maiden", "native": "Virgo"}
     },
     {
       "id": "CON modern_iau Vol",
       "lines": [[44382, 41312, 39794, 35228, 34481, 39794, 44382]],
-      "common_name": {"english": "Volans", "native": "Volans"}
+      "common_name": {"english": "Flying Fish", "native": "Volans"}
     },
     {
       "id": "CON modern_iau Vul",
       "lines": [[95771, 97886]],
-      "common_name": {"english": "Vulpecula", "native": "Vulpecula"}
+      "common_name": {"english": "Fox", "native": "Vulpecula"}
     }
   ],
   "edges_type": "iau",

--- a/src/core/modules/Constellation.cpp
+++ b/src/core/modules/Constellation.cpp
@@ -76,6 +76,7 @@ bool Constellation::read(const QJsonObject& data, StarMgr *starMgr, const bool p
 	const auto names = data["common_name"].toObject();
 	nativeName = names["native"].toString();
 	englishName = preferNativeName && !nativeName.isEmpty() ? nativeName : names["english"].toString();
+	context = names["context"].toString();
 	if (englishName.isEmpty() && nativeName.isEmpty())
 		qWarning() << "No name for constellation" << id;
 

--- a/src/core/modules/ConstellationMgr.cpp
+++ b/src/core/modules/ConstellationMgr.cpp
@@ -688,9 +688,15 @@ void ConstellationMgr::updateI18n()
 
 	for (auto* constellation : constellations)
 	{
-		constellation->nameI18 = trans.tryQtranslate(constellation->englishName, "constellation");
+		QString context = constellation->context;
+		constellation->nameI18 = trans.tryQtranslate(constellation->englishName, context);
 		if (constellation->nameI18.isEmpty())
-			constellation->nameI18 = qc_(constellation->englishName, "constellation");
+		{
+			if (context.isEmpty())
+				constellation->nameI18 = q_(constellation->englishName);
+			else
+				constellation->nameI18 = qc_(constellation->englishName, context);
+		}
 	}
 }
 

--- a/util/skycultures/generate-pot.py
+++ b/util/skycultures/generate-pot.py
@@ -201,8 +201,11 @@ def update_cultures_pot():
                         if 'translators_comments' in name:
                             comment += '\n' + name['translators_comments']
 
+                        context = None
+                        if 'context' in name:
+                            context = name['context']
 
-                        entry = polib.POEntry(comment = comment, msgid = english, msgstr = "")
+                        entry = polib.POEntry(comment = comment, msgid = english, msgstr = "", msgctxt = context)
                         if entry in pot:
                             prev_entry = pot.find(entry.msgid)
                             assert prev_entry


### PR DESCRIPTION
### Description
This patch do switches to using English terms for English names of constellations for Modern and Modern (IAU) sky cultures

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] Housekeeping
