### PR TITLE
Use 1 byte for component in cross-id.cat

### DIFF
--- a/guide/app_star_catalogue.tex
+++ b/guide/app_star_catalogue.tex
@@ -237,7 +237,7 @@ num stars in zone $n$   & $4n$   & int & 4 &  number of records is this file whi
 \begin{table}[htbp]
 \begin{tabular}{llllp{75mm}}\toprule
 \emph{Name} & \emph{Offset} & \emph{Type} & \emph{Size} &\emph{Description}\\\midrule
-gaia\_id       &  0 & long long          & 8 & Gaia source id\\%\midrule
+gaia\_id       &  0 & int64_t            & 8 & Gaia source id\\%\midrule
 x0             &  8 & int                & 4 & Cartesian x position of the star on an unit sphere at the catalog epoch scaled by $2\times10^9$\\%\midrule
 x1             & 12 & int                & 4 & Cartesian y position of the star on an unit sphere at the catalog epoch scaled by $2\times10^9$\\%\midrule
 x2             & 16 & int                & 4 & Cartesian z position of the star on an unit sphere at the catalog epoch scaled by $2\times10^9$\\%\midrule
@@ -262,7 +262,7 @@ hip            & 45 & int                & 3 & Hipparcos catalogue number with c
 \begin{table}[htbp]
 \begin{tabularx}{\textwidth}{llllX}\toprule
 \emph{Name} & \emph{Offset}& \emph{Type} & \emph{Size} &\emph{Description}\\\midrule
-gaia\_id       &  0 & long long          & 8 & Gaia source id\\%\midrule
+gaia\_id       &  0 & int64_t            & 8 & Gaia source id\\%\midrule
 x0             &  8 & int                & 4 & Right ascension $\alpha$ of the star in mas unit.\\%\midrule
 x1             & 12 & int                & 4 & Declination $\delta$ of the star in mas unit.\\%\midrule
 dx0            & 16 & int                & 4 & Proper motion $\mu_{\alpha}$ of the star in $\mu$as/year\\%\midrule
@@ -280,7 +280,7 @@ plx\_err       & 30 & unsigned short     & 2 & parallax error of the star in 0.0
 \begin{table}[htbp]
 \begin{tabularx}{\textwidth}{llllX}\toprule
 \emph{Name} & \emph{Offset} & \emph{Type} & \emph{Size} & \emph{Description}\\\midrule
-gaia\_id       &  0 & long long          & 8 & Gaia source id\\%\midrule
+gaia\_id       &  0 & int64_t            & 8 & Gaia source id\\%\midrule
 x0             &  8 & int                & 3 & Right ascension $\alpha$ of the star in 0.1 arcsecond unit.\\%\midrule
 x1             & 11 & int                & 3 & Declination $\delta$ of the star in 0.1 arcsecond unit.\\%\midrule
 b\_v           & 14 & unsigned short     & 1 & $B-V$ colour in 25 milli-mag unit offset by $+1$ mag.\\
@@ -1840,11 +1840,11 @@ The file \file{cross-id.cat} contains cross reference data for catalogues HIP, S
 \begin{table}[htb]
 \begin{tabularx}{\textwidth}{l|c|X}\toprule
 \emph{Name} & \emph{Type} & \emph{Description}\\\midrule
-HIP	      & unsigned long long & HIP or Gaia identifier for the star. Used for reference to the main star catalogue.\\%\midrule
-Component & int 			   & Component of the star in the multiple star system.\\%\midrule
-SAO    	  & int 			   & SAO identifier for the star.\\%\midrule
-HD	      & int 			   & HD identifier for the star.\\%\midrule
-HR	      & int 			   & HR identifier for the star.\\\bottomrule
+HIP	      & uint64_t      & HIP or Gaia identifier for the star. Used for reference to the main star catalogue.\\%\midrule
+Component & unsigned char & Component of the star in the multiple star system.\\%\midrule
+SAO    	  & int           & SAO identifier for the star.\\%\midrule
+HD	      & int           & HD identifier for the star.\\%\midrule
+HR	      & int           & HR identifier for the star.\\\bottomrule
 \end{tabularx}
 \caption{Format of \file{cross-id.cat}}
 \label{tab:StarCatalogues:CrossIdentificationData:file}

--- a/src/core/modules/StarMgr.cpp
+++ b/src/core/modules/StarMgr.cpp
@@ -1184,7 +1184,8 @@ void StarMgr::loadCrossIdentificationData(const QString& crossIdFile)
 	int readOk = 0;
 	int totalRecords = 0;
 	StarId hip;
-	int component, sao, hd, hr;
+	unsigned char component;
+	int sao, hd, hr;
 	QString hipstar;
 	quint64 hipTemp;
 


### PR DESCRIPTION
As discussed in #4158, this PR switches to use 1 byte for component in ``cross-id.cat`` and update user guide for data type.

Fixes # (issue)

### Screenshots (if appropriate):

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] Housekeeping

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system: MacOS 15
* Graphics Card: Apple M3

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
