### PR TITLE
Use hips_frame and type to determine planet

### DIFF
--- a/src/core/StelHips.cpp
+++ b/src/core/StelHips.cpp
@@ -63,8 +63,10 @@ QUrl HipsSurvey::getUrlFor(const QString& path) const
 	return QString("%1/%2%3").arg(base.url(), path, args);
 }
 
-HipsSurvey::HipsSurvey(const QString& url_, double releaseDate_):
+HipsSurvey::HipsSurvey(const QString& url_, const QString& frame, const QString& type, double releaseDate_):
 	url(url_),
+	type(type),
+	hipsFrame(frame),
 	releaseDate(releaseDate_),
 	planetarySurvey(false),
 	tiles(1000 * 512 * 512), // Cache max cost in pixels (enough for 1000 512x512 tiles).
@@ -550,6 +552,9 @@ QList<HipsSurveyP> HipsSurvey::parseHipslist(const QString& data)
 {
 	QList<HipsSurveyP> ret;
 	QString url;
+	QString type;
+	static const QString defaultFrame = "equatorial";
+	QString frame = defaultFrame;
 	double releaseDate = 0;
 	for (auto &line : data.split('\n'))
 	{
@@ -567,9 +572,14 @@ QList<HipsSurveyP> HipsSurvey::parseHipslist(const QString& data)
 			date.setTimeSpec(Qt::UTC);
 			releaseDate = StelUtils::qDateTimeToJd(date);
 		}
+		if (key == "hips_frame")
+			frame = value.toLower();
+		if (key == "type")
+			type = value.toLower();
 		if (key == "hips_status" && value.split(' ').contains("public")) {
-			ret.append(HipsSurveyP(new HipsSurvey(url, releaseDate)));
+			ret.append(HipsSurveyP(new HipsSurvey(url, frame, type, releaseDate)));
 			url = "";
+			frame = defaultFrame;
 			releaseDate = 0;
 		}
 	}

--- a/src/core/StelHips.hpp
+++ b/src/core/StelHips.hpp
@@ -60,8 +60,10 @@ public:
 							   const QVector<uint16_t>& indices)> DrawCallback;
 	//! Create a new HipsSurvey from its url.
 	//! @param url The location of the survey.
+	//! @param frame The reference frame from the survey's \c hips_frame property.
+	//! @param type Survey type from the survey's \c type property.
 	//! @param releaseDate If known the UTC JD release date of the survey.  Used for cache busting.
-	HipsSurvey(const QString& url, double releaseDate=0.0);
+	HipsSurvey(const QString& url, const QString& frame, const QString& type, double releaseDate=0.0);
 	~HipsSurvey() override;
 
 	//! Get whether the survey is visible.
@@ -82,6 +84,12 @@ public:
 	//! Return the source URL of the survey.
 	const QString& getUrl() const {return url;}
 
+	//! Return the frame name of the survey (its \c hips_frame property).
+	QString getFrame() const { return hipsFrame; }
+
+	//! Return the type of the survey (its \c type property).
+	QString getType() const { return type; }
+
 	//! Get whether the survey is still loading.
 	bool isLoading(void) const;
 
@@ -98,7 +106,8 @@ signals:
 private:
 	LinearFader fader;
 	QString url;
-	QString hipsFrame = "equatorial";
+	QString type;
+	QString hipsFrame;
 	QString planet;
 	double releaseDate; // As UTC Julian day.
 	bool planetarySurvey;

--- a/src/core/modules/SolarSystem.cpp
+++ b/src/core/modules/SolarSystem.cpp
@@ -4167,10 +4167,12 @@ bool SolarSystem::removeMinorPlanet(const QString &name)
 
 void SolarSystem::onNewSurvey(HipsSurveyP survey)
 {
-	// For the moment we only consider the survey url to decide if we
-	// assign it to a planet.  It would be better to use some property
-	// for that.
-	QString planetName = QUrl(survey->getUrl()).fileName();
+	if (survey->getType() != "planet")
+	{
+		// We don't handle planet-normal yet
+		return;
+	}
+	QString planetName = survey->getFrame();
 	PlanetP pl = searchByEnglishName(planetName);
 	if (!pl || pl->survey)
 		return;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

The current way of determining planet—by reading the filename of survey's URL—is quite hacky and doesn't let one find other survey components related to the same planet, e.g. the normal map. At the same time, all the planet HiPS currently available have properties that determine them as planetary, which planet they are for, and what type of map they represent.

So this PR uses these properties to determine planet.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
