### PR TITLE
Add support for normal and horizon maps in planetary HiPS

### DIFF
--- a/data/shaders/planet.frag
+++ b/data/shaders/planet.frag
@@ -33,7 +33,8 @@ uniform mediump vec3 diffuseLight; // Must be in linear sRGB, without OETF appli
 uniform highp vec4 sunInfo;
 uniform mediump float skyBrightness;
 uniform bool hasAtmosphere;
-uniform bool isSurvey;
+uniform bool hasNormalMap;
+uniform bool hasHorizonMap;
 
 uniform int shadowCount;
 uniform highp mat4 shadowData;
@@ -286,16 +287,16 @@ void main()
 
 #ifdef IS_MOON
     mediump vec3 normal;
-    if(isSurvey)
-        normal = vec3(0,0,1); // Surveys' texture coordinates are unsuitable for non-survey normal maps
-    else
+    if(hasNormalMap)
         normal = texture2D(normalMap, texc).rgb-vec3(0.5, 0.5, 0);
+    else
+        normal = vec3(0,0,1);
 
     normal = normalize(normalX*normal.x+normalY*normal.y+normalZ*normal.z);
     // normal now contains the real surface normal taking normal map into account
 
     mediump float horizonShadowCoefficient = 1.;
-    if(!isSurvey) // Surveys' texture coordinates are unsuitable for non-survey horizon maps
+    if(hasHorizonMap)
     {
         // Check whether the fragment is in the shadow of surrounding mountains or the horizon
         mediump vec3 lonDir = normalX;

--- a/src/core/StelHips.hpp
+++ b/src/core/StelHips.hpp
@@ -95,6 +95,9 @@ public:
 
 	bool isPlanetarySurvey(void) const { return planetarySurvey; }
 
+	void setNormalsSurvey(const HipsSurveyP& normals);
+	void setHorizonsSurvey(const HipsSurveyP& horizons);
+
 	//! Parse a hipslist file into a list of surveys.
 	static QList<HipsSurveyP> parseHipslist(const QString& data);
 
@@ -109,7 +112,10 @@ private:
 	QString type;
 	QString hipsFrame;
 	QString planet;
+	HipsSurveyP normals;
+	HipsSurveyP horizons;
 	double releaseDate; // As UTC Julian day.
+	int order = -1;
 	bool planetarySurvey;
 	QCache<long int, HipsTile> tiles;
 	// reply to the initial download of the properties file and to the

--- a/src/core/modules/Planet.cpp
+++ b/src/core/modules/Planet.cpp
@@ -3128,7 +3128,8 @@ void Planet::PlanetShaderVars::initLocations(QOpenGLShaderProgram* p)
 	GL(orenNayarParameters = p->uniformLocation("orenNayarParameters"));
 	GL(outgasParameters = p->uniformLocation("outgasParameters"));
 	GL(hasAtmosphere = p->uniformLocation("hasAtmosphere"));
-	GL(isSurvey = p->uniformLocation("isSurvey"));
+	GL(hasNormalMap = p->uniformLocation("hasNormalMap"));
+	GL(hasHorizonMap = p->uniformLocation("hasHorizonMap"));
 
 	// Moon-specific variables
 	GL(earthShadow = p->uniformLocation("earthShadow"));
@@ -3957,8 +3958,8 @@ void Planet::computeModelMatrix(Mat4d &result, bool solarEclipseCase) const
 	}
 }
 
-Planet::RenderData Planet::setCommonShaderUniforms(const StelPainter& painter, QOpenGLShaderProgram* shader,
-                                                   const PlanetShaderVars& shaderVars, const bool isSurvey)
+Planet::RenderData Planet::setCommonShaderUniforms(const StelPainter& painter, QOpenGLShaderProgram* shader, const PlanetShaderVars& shaderVars,
+                                                   const bool hasNormalMap, const bool hasHorizonMap)
 {
 	RenderData data;
 
@@ -4006,7 +4007,8 @@ Planet::RenderData Planet::setCommonShaderUniforms(const StelPainter& painter, Q
 	static LandscapeMgr* lmgr=GETSTELMODULE(LandscapeMgr);
 	Q_ASSERT(lmgr);
 
-	GL(shader->setUniformValue(shaderVars.isSurvey, GLint(isSurvey)));
+	GL(shader->setUniformValue(shaderVars.hasNormalMap, GLint(hasNormalMap)));
+	GL(shader->setUniformValue(shaderVars.hasHorizonMap, GLint(hasHorizonMap)));
 
 	GL(shader->setUniformValue(shaderVars.projectionMatrix, qMat));
 	GL(shader->setUniformValue(shaderVars.hasAtmosphere, GLint(atmosphere)));
@@ -4137,7 +4139,7 @@ void Planet::drawSphere(StelPainter* painter, float screenRd, bool drawOnlyRing)
 
 	GL(shader->bind());
 
-	RenderData rData = setCommonShaderUniforms(*painter,shader,*shaderVars, false);
+	RenderData rData = setCommonShaderUniforms(*painter,shader,*shaderVars, isMoon,isMoon);
 	if(this==ssm->getSun())
 	{
 		const auto color = painter->getColor();
@@ -4364,6 +4366,11 @@ void Planet::drawSurvey(StelCore* core, StelPainter* painter)
 	if (!Planet::initShader()) return;
 	static SolarSystem* ssm = GETSTELMODULE(SolarSystem);
 
+	if (surveyForNormals && survey)
+		survey->setNormalsSurvey(surveyForNormals);
+	if (surveyForHorizons && survey)
+		survey->setHorizonsSurvey(surveyForHorizons);
+
 	painter->setDepthMask(true);
 	painter->setDepthTest(true);
 
@@ -4387,7 +4394,7 @@ void Planet::drawSurvey(StelCore* core, StelPainter* painter)
 	}
 
 	GL(shader->bind());
-	RenderData rData = setCommonShaderUniforms(*painter, shader, *shaderVars, true);
+	RenderData rData = setCommonShaderUniforms(*painter, shader, *shaderVars, surveyForNormals != nullptr, surveyForHorizons != nullptr);
 	QVector<Vec3f> projectedVertsArray;
 	QVector<Vec3f> vertsArray;
 	const double angle = 2 * getSpheroidAngularRadius(core) * M_PI_180;
@@ -4404,7 +4411,6 @@ void Planet::drawSurvey(StelCore* core, StelPainter* painter)
 
 	if (isMoon)
 	{
-		GL(normalMap->bind(2));
 		GL(moonShaderProgram->setUniformValue(moonShaderVars.normalMap, 2));
 		if (!rData.shadowCandidates.isEmpty())
 		{
@@ -4681,7 +4687,7 @@ bool Planet::drawObjModel(StelPainter *painter, float screenRd)
 	GL(shd->enableAttributeArray("vertex"));
 	objModel->projPosBuffer->release();
 
-	setCommonShaderUniforms(*painter,shd,*shdVars,false);
+	setCommonShaderUniforms(*painter,shd,*shdVars,false,false);
 
 	//draw that model using the array wrapper
 	objModel->arr->draw();

--- a/src/core/modules/Planet.hpp
+++ b/src/core/modules/Planet.hpp
@@ -795,6 +795,8 @@ protected:
 	QString objModelPath;
 
 	HipsSurveyP survey;
+	HipsSurveyP surveyForNormals;
+	HipsSurveyP surveyForHorizons;
 
 	Ring* rings;                     // Planet rings
 	double distance;                 // Temporary variable used to store the distance to a given point
@@ -888,7 +890,8 @@ private:
 		int eclipsePush; // apparent brightness push for partial Lunar Eclipse (make bright rim overbright)
 		int normalMap;
 		int horizonMap;
-		int isSurvey;
+		int hasNormalMap;
+		int hasHorizonMap;
 
 		// Rings-specific variables
 		int isRing;
@@ -917,7 +920,7 @@ private:
 
 	//! Calculates and uploads the common shader uniforms (projection matrix, texture, lighting&shadow data)
 	RenderData setCommonShaderUniforms(const StelPainter &painter, QOpenGLShaderProgram* shader,
-	                                   const PlanetShaderVars& shaderVars, bool isSurvey);
+	                                   const PlanetShaderVars& shaderVars, bool hasNormalMap, bool hasHorizonMap);
 
 	static PlanetShaderVars planetShaderVars;
 	static QOpenGLShaderProgram* planetShaderProgram;

--- a/src/core/modules/SolarSystem.cpp
+++ b/src/core/modules/SolarSystem.cpp
@@ -4167,16 +4167,31 @@ bool SolarSystem::removeMinorPlanet(const QString &name)
 
 void SolarSystem::onNewSurvey(HipsSurveyP survey)
 {
-	if (survey->getType() != "planet")
-	{
-		// We don't handle planet-normal yet
+	const auto type = survey->getType();
+	const bool isPlanetColor = type == "planet";
+	const bool isPlanetNormal = type == "planet-normal";
+	const bool isPlanetHorizon = type == "planet-horizon";
+	if (!isPlanetColor && !isPlanetNormal && !isPlanetHorizon)
 		return;
-	}
+
 	QString planetName = survey->getFrame();
 	PlanetP pl = searchByEnglishName(planetName);
-	if (!pl || pl->survey)
-		return;
-	pl->survey = survey;
+	if (!pl) return;
+	if (isPlanetColor)
+	{
+		if (pl->survey) return;
+		pl->survey = survey;
+	}
+	else if (isPlanetNormal)
+	{
+		if (pl->surveyForNormals) return;
+		pl->surveyForNormals = survey;
+	}
+	else if (isPlanetHorizon)
+	{
+		if (pl->surveyForHorizons) return;
+		pl->surveyForHorizons = survey;
+	}
 	survey->setProperty("planet", pl->getCommonEnglishName());
 	// Not visible by default for the moment.
 	survey->setProperty("visible", false);


### PR DESCRIPTION
### Description

This automatically adds the normal and horizon map surveys for a planet to the corresponding planet object, and these map surveys are passed to the albedo survey.

One limitation that I don't think is worth the trouble lifting is that if a normal or horizon map is present but has `hips_order` smaller than that of the albedo survey, the total order of the HiPS is reduced to the smallest of them. Particularly, with our `data.stellarium.org/surveys/moon-normal` this yields max order 2 instead of 3.

In the future I'm planning to add my versions of the Moon surveys, including all the items: albedo, normals, horizons, which will yield a better version of the current static Moon.

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system: Ubuntu 20.04
* Graphics Card: Intel UHD Graphics 620

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules