### PR TITLE
Use real native Chinese names in SC index.json

### DIFF
--- a/skycultures/chinese/index.json
+++ b/skycultures/chinese/index.json
@@ -7,1592 +7,1592 @@
     {
       "id": "CON chinese 001",
       "lines": [[20889, 20648, 20455, 20205], [21421, 20885, 20713, 20205, 18724], [21421, 21683]],
-      "common_name": {"english": "Net", "native": "Bi Xiu"}
+      "common_name": {"english": "Net", "native": "毕宿", "pronounce": "Bi Xiu"}
     },
     {
       "id": "CON chinese 002",
       "lines": [[1067, 677]],
-      "common_name": {"english": "Wall", "native": "Bi Xiu"}
+      "common_name": {"english": "Wall", "native": "壁宿", "pronounce": "Bi Xiu"}
     },
     {
       "id": "CON chinese 003",
       "lines": [[27989, 26727, 26311, 25930, 24436], [25930, 25336], [26727, 27366]],
-      "common_name": {"english": "Three Stars", "native": "Shen Xiu"}
+      "common_name": {"english": "Three Stars", "native": "参宿", "pronounce": "Shen Xiu"}
     },
     {
       "id": "CON chinese 004",
       "lines": [[72622, 74392, 76333, 74785]],
-      "common_name": {"english": "Root", "native": "Di Xiu"}
+      "common_name": {"english": "Root", "native": "氐宿", "pronounce": "Di Xiu"}
     },
     {
       "id": "CON chinese 005",
       "lines": [[89341, 90496, 92041, 92855, 93864, 93506]],
-      "common_name": {"english": "Dipper", "native": "Dou Xiu"}
+      "common_name": {"english": "Dipper", "native": "斗宿", "pronounce": "Dou Xiu"}
     },
     {
       "id": "CON chinese 006",
       "lines": [[78820, 78401, 78265, 78104]],
-      "common_name": {"english": "Room", "native": "Fang Xiu"}
+      "common_name": {"english": "Room", "native": "房宿", "pronounce": "Fang Xiu"}
     },
     {
       "id": "CON chinese 007",
       "lines": [[41822, 41909, 42806, 42911]],
-      "common_name": {"english": "Ghosts", "native": "Gui Xiu"}
+      "common_name": {"english": "Ghosts", "native": "鬼宿", "pronounce": "Gui Xiu"}
     },
     {
       "id": "CON chinese 008",
       "lines": [[88635, 89931, 90185, 89642]],
-      "common_name": {"english": "Winnowing Basket", "native": "Ji Xiu"}
+      "common_name": {"english": "Winnowing Basket", "native": "箕宿", "pronounce": "Ji Xiu"}
     },
     {
       "id": "CON chinese 009",
       "lines": [[65474, 66249]],
-      "common_name": {"english": "Horn", "native": "Jiao Xiu"}
+      "common_name": {"english": "Horn", "native": "角宿", "pronounce": "Jiao Xiu"}
     },
     {
       "id": "CON chinese 010",
       "lines": [[35350, 34088, 32921, 32246], [32921, 30883, 30343], [30883, 31681, 34088], [31681, 32362], [30343, 29655]],
-      "common_name": {"english": "Well", "native": "Jing Xiu"}
+      "common_name": {"english": "Well", "native": "井宿", "pronounce": "Jing Xiu"}
     },
     {
       "id": "CON chinese 011",
       "lines": [[69427, 69701, 70755], [69427, 69974]],
-      "common_name": {"english": "Neck", "native": "Kang Xiu"}
+      "common_name": {"english": "Neck", "native": "亢宿", "pronounce": "Kang Xiu"}
     },
     {
       "id": "CON chinese 012",
       "lines": [[4463, 3693, 3885, 3031, 3092, 2912, 3881, 4436, 5447, 5175, 5586, 6315, 6193, 5742, 5571, 5131, 4463]],
-      "common_name": {"english": "Legs", "native": "Kui Xiu"}
+      "common_name": {"english": "Legs", "native": "奎宿", "pronounce": "Kui Xiu"}
     },
     {
       "id": "CON chinese 013",
       "lines": [[42402, 42799, 43234, 43109], [42313, 43109], [43234, 43813, 44659, 45336]],
-      "common_name": {"english": "Willow", "native": "Liu Xiu"}
+      "common_name": {"english": "Willow", "native": "柳宿", "pronounce": "Liu Xiu"}
     },
     {
       "id": "CON chinese 014",
       "lines": [[9884, 8903, 8832]],
-      "common_name": {"english": "Bond", "native": "Lou Xiu"}
+      "common_name": {"english": "Bond", "native": "娄宿", "pronounce": "Lou Xiu"}
     },
     {
       "id": "CON chinese 015",
       "lines": [[17499, 17531, 17579, 17573], [17499, 17608, 17702, 17847]],
-      "common_name": {"english": "Hairy Head", "native": "Mao Xiu"}
+      "common_name": {"english": "Hairy Head", "native": "昴宿", "pronounce": "Mao Xiu"}
     },
     {
       "id": "CON chinese 016",
       "lines": [[100345, 100064, 99572], [100345, 100881, 101123, 101027], [100881, 101027]],
-      "common_name": {"english": "Ox", "native": "Niu Xiu"}
+      "common_name": {"english": "Ox", "native": "牛宿", "pronounce": "Niu Xiu"}
     },
     {
       "id": "CON chinese 017",
       "lines": [[102618, 103045, 102945, 102624]],
-      "common_name": {"english": "Girl", "native": "Nü Xiu"}
+      "common_name": {"english": "Girl", "native": "女宿", "pronounce": "Nü Xiu"}
     },
     {
       "id": "CON chinese 018",
       "lines": [[113963, 113881]],
-      "common_name": {"english": "Encampment", "native": "Shi Xiu"}
+      "common_name": {"english": "Encampment", "native": "室宿", "pronounce": "Shi Xiu"}
     },
     {
       "id": "CON chinese 019",
       "lines": [[57757, 55434, 55642, 54879, 54872]],
-      "common_name": {"english": "Supreme Palace Right Wall", "native": "Tai Wei You Yuan"}
+      "common_name": {"english": "Supreme Palace Right Wall", "native": "太微右垣", "pronounce": "Tai Wei You Yuan"}
     },
     {
       "id": "CON chinese 020",
       "lines": [[60129, 61941, 63090, 63608, 64241]],
-      "common_name": {"english": "Supreme Palace Left Wall", "native": "Tai Wei Zuo Yuan"}
+      "common_name": {"english": "Supreme Palace Left Wall", "native": "太微左垣", "pronounce": "Tai Wei Zuo Yuan"}
     },
     {
       "id": "CON chinese 021",
       "lines": [[80816, 80170, 79043, 78072, 77233, 76276, 77070, 77622, 79593, 79882, 81377]],
-      "common_name": {"english": "Heavenly Market Right Wall", "native": "Tian Shi You Yuan"}
+      "common_name": {"english": "Heavenly Market Right Wall", "native": "天市右垣", "pronounce": "Tian Shi You Yuan"}
     },
     {
       "id": "CON chinese 022",
       "lines": [[84379, 85693, 86974, 88794, 92614, 93747, 92946, 89962, 88048, 86263, 84012]],
-      "common_name": {"english": "Heavenly Market Left Wall", "native": "Tian Shi Zuo Yuan"}
+      "common_name": {"english": "Heavenly Market Left Wall", "native": "天市左垣", "pronounce": "Tian Shi Zuo Yuan"}
     },
     {
       "id": "CON chinese 023",
       "lines": [[109074, 109427, 107315]],
-      "common_name": {"english": "Rooftop", "native": "Wei Xiu"}
+      "common_name": {"english": "Rooftop", "native": "危宿", "pronounce": "Wei Xiu"}
     },
     {
       "id": "CON chinese 024",
       "lines": [[82396, 82514, 82671, 84143, 86228, 87073, 86670, 85927, 85696], [82514, 82545]],
-      "common_name": {"english": "Tail", "native": "Wei Xiu"}
+      "common_name": {"english": "Tail", "native": "尾宿", "pronounce": "Wei Xiu"}
     },
     {
       "id": "CON chinese 025",
       "lines": [[12719, 13061, 13209]],
-      "common_name": {"english": "Stomach", "native": "Wei Xiu"}
+      "common_name": {"english": "Stomach", "native": "胃宿", "pronounce": "Wei Xiu"}
     },
     {
       "id": "CON chinese 026",
       "lines": [[80112, 80763, 81266]],
-      "common_name": {"english": "Heart", "native": "Xin Xiu"}
+      "common_name": {"english": "Heart", "native": "心宿", "pronounce": "Xin Xiu"}
     },
     {
       "id": "CON chinese 027",
       "lines": [[46390, 46509, 46776, 47431], [46390, 45811, 45751, 46744], [46390, 46744]],
-      "common_name": {"english": "Star", "native": "Xing Xiu"}
+      "common_name": {"english": "Star", "native": "星宿", "pronounce": "Xing Xiu"}
     },
     {
       "id": "CON chinese 028",
       "lines": [[106278, 104987]],
-      "common_name": {"english": "Emptiness", "native": "Xu Xiu"}
+      "common_name": {"english": "Emptiness", "native": "虚宿", "pronounce": "Xu Xiu"}
     },
     {
       "id": "CON chinese 029",
       "lines": [[53740, 55705], [53740, 55598], [53740, 52943], [55705, 57283, 55598], [57283, 58188], [55705, 55282, 56802, 55874, 55687, 54214, 53975], [55687, 56633, 57587], [55598, 54682, 56245, 54204, 56830]],
-      "common_name": {"english": "Wings", "native": "Yi Xiu"}
+      "common_name": {"english": "Wings", "native": "翼宿", "pronounce": "Yi Xiu"}
     },
     {
       "id": "CON chinese 030",
       "lines": [[48356, 49841, 51069, 49321], [48356, 49321], [48356, 47452], [51069, 52085]],
-      "common_name": {"english": "Extended Net", "native": "Zhang Xiu"}
+      "common_name": {"english": "Extended Net", "native": "张宿", "pronounce": "Zhang Xiu"}
     },
     {
       "id": "CON chinese 031",
       "lines": [[61359, 60965, 59803, 59316], [59803, 60189], [60965, 61174], [59316, 59199]],
-      "common_name": {"english": "Chariot", "native": "Zhen Xiu"}
+      "common_name": {"english": "Chariot", "native": "轸宿", "pronounce": "Zhen Xiu"}
     },
     {
       "id": "CON chinese 032",
       "lines": [[68756, 61281, 56211, 46977, 33104, 22783, 15520]],
-      "common_name": {"english": "Purple Forbidden Right Wall", "native": "Zi Wei You Yuan"}
+      "common_name": {"english": "Purple Forbidden Right Wall", "native": "紫微右垣", "pronounce": "Zi Wei You Yuan"}
     },
     {
       "id": "CON chinese 033",
       "lines": [[75458, 78527, 80331, 83895, 92782, 101260, 114222, 3721]],
-      "common_name": {"english": "Purple Forbidden Left Wall", "native": "Zi Wei Zuo Yuan"}
+      "common_name": {"english": "Purple Forbidden Left Wall", "native": "紫微左垣", "pronounce": "Zi Wei Zuo Yuan"}
     },
     {
       "id": "CON chinese 034",
       "lines": [[26207, 26176], [26207, 26366]],
-      "common_name": {"english": "Turtle Beak", "native": "Zi Xiu"}
+      "common_name": {"english": "Turtle Beak", "native": "觜宿", "pronounce": "Zi Xiu"}
     },
     {
       "id": "CON chinese 035",
       "lines": [[28358, 27949, 27249, 24348], [27249, 23040], [23783, 23734, 27971]],
-      "common_name": {"english": "Eight Kinds of Crops", "native": "Ba Gu"}
+      "common_name": {"english": "Eight Kinds of Crops", "native": "八谷", "pronounce": "Ba Gu"}
     },
     {
       "id": "CON chinese 036",
       "lines": [[910, 301, 118178], [910, 355], [910, 1803], [910, 1170]],
-      "common_name": {"english": "Net for Catching Birds", "native": "Ba Kui"}
+      "common_name": {"english": "Net for Catching Birds", "native": "八魁", "pronounce": "Ba Kui"}
     },
     {
       "id": "CON chinese 037",
       "lines": [[101421, 101483, 101882, 101800, 101916]],
-      "common_name": {"english": "Rotten Gourd", "native": "Bai Gua"}
+      "common_name": {"english": "Rotten Gourd", "native": "败瓜", "pronounce": "Bai Gua"}
     },
     {
       "id": "CON chinese 038",
       "lines": [[108085, 109111, 112948, 112102]],
-      "common_name": {"english": "Decayed Mortar", "native": "Bai Jiu"}
+      "common_name": {"english": "Decayed Mortar", "native": "败臼", "pronounce": "Bai Jiu"}
     },
     {
       "id": "CON chinese 039",
       "lines": [[54061, 53910, 58001, 59774, 62956, 65378, 67301]],
-      "common_name": {"english": "Northern Dipper", "native": "Bei Dou"}
+      "common_name": {"english": "Northern Dipper", "native": "北斗", "pronounce": "Bei Dou"}
     },
     {
       "id": "CON chinese 040",
       "lines": [[37826, 36850, 36366]],
-      "common_name": {"english": "North River", "native": "Bei He"}
+      "common_name": {"english": "North River", "native": "北河", "pronounce": "Bei He"}
     },
     {
       "id": "CON chinese 041",
       "lines": [[75097, 72607, 70692, 69112, 62572]],
-      "common_name": {"english": "Northern Pole", "native": "Bei Ji"}
+      "common_name": {"english": "Northern Pole", "native": "北极", "pronounce": "Bei Ji"}
     },
     {
       "id": "CON chinese 042",
       "lines": [[113368, 113368]],
-      "common_name": {"english": "North Gate of the Military Camp", "native": "Bei Luo Shi Men"}
+      "common_name": {"english": "North Gate of the Military Camp", "native": "北落师门", "pronounce": "Bei Luo Shi Men"}
     },
     {
       "id": "CON chinese 043",
       "lines": [[90422, 92308, 93542, 94005, 94160, 94114, 93825, 93174, 92989, 90968, 90982, 90422]],
-      "common_name": {"english": "River Turtle", "native": "Bie"}
+      "common_name": {"english": "River Turtle", "native": "鳖", "pronounce": "Bie"}
     },
     {
       "id": "CON chinese 044",
       "lines": [[97816, 101772, 106065, 108431, 108626, 102333, 102950]],
-      "common_name": {"english": "Persia", "native": "Bo Si"}
+      "common_name": {"english": "Persia", "native": "波斯", "pronounce": "Bo Si"}
     },
     {
       "id": "CON chinese 045",
       "lines": [[88267, 88886]],
-      "common_name": {"english": "Textile Ruler", "native": "Bo Du"}
+      "common_name": {"english": "Textile Ruler", "native": "帛度", "pronounce": "Bo Du"}
     },
     {
       "id": "CON chinese 046",
       "lines": [[22667, 22957, 22833, 22845, 22509, 22449, 22549, 22797, 23123]],
-      "common_name": {"english": "Banner of Three Stars", "native": "Can Qi"}
+      "common_name": {"english": "Banner of Three Stars", "native": "参旗", "pronounce": "Can Qi"}
     },
     {
       "id": "CON chinese 047",
       "lines": [[25985, 25606, 27072, 27654]],
-      "common_name": {"english": "Toilet", "native": "Ce"}
+      "common_name": {"english": "Toilet", "native": "厕", "pronounce": "Ce"}
     },
     {
       "id": "CON chinese 048",
       "lines": [[4427, 4427]],
-      "common_name": {"english": "Whip", "native": "Ce"}
+      "common_name": {"english": "Whip", "native": "策", "pronounce": "Ce"}
     },
     {
       "id": "CON chinese 049",
       "lines": [[63125, 62207, 61692, 61317, 60646, 59831, 58684]],
-      "common_name": {"english": "Royal Guards", "native": "Chang Chen"}
+      "common_name": {"english": "Royal Guards", "native": "常陈", "pronounce": "Chang Chen"}
     },
     {
       "id": "CON chinese 050",
       "lines": [[112917, 111944, 110351, 106481, 103632, 104060, 106711]],
-      "common_name": {"english": "Big Yard for Chariots", "native": "Che Fu"}
+      "common_name": {"english": "Big Yard for Chariots", "native": "车府", "pronounce": "Che Fu"}
     },
     {
       "id": "CON chinese 051",
       "lines": [[74395, 71536, 71121]],
-      "common_name": {"english": "Chariots and Cavalry", "native": "Che Qi"}
+      "common_name": {"english": "Chariots and Cavalry", "native": "车骑", "pronounce": "Che Qi"}
     },
     {
       "id": "CON chinese 052",
       "lines": [[80628, 82369]],
-      "common_name": {"english": "Commodity Market", "native": "Che Si"}
+      "common_name": {"english": "Commodity Market", "native": "车肆", "pronounce": "Che Si"}
     },
     {
       "id": "CON chinese 053",
       "lines": [[11345, 12002, 10642], [11261, 11029, 12390]],
-      "common_name": {"english": "Hay", "native": "Chu Gao"}
+      "common_name": {"english": "Hay", "native": "刍藁", "pronounce": "Chu Gao"}
     },
     {
       "id": "CON chinese 054",
       "lines": [[86092, 85792, 85258]],
-      "common_name": {"english": "Pestle (In Winnowing Basket Mansion)", "native": "Chu(Ji Xiu)"}
+      "common_name": {"english": "Pestle (In Winnowing Basket Mansion)", "native": "杵(箕宿)", "pronounce": "Chu(Ji Xiu)"}
     },
     {
       "id": "CON chinese 055",
       "lines": [[109937, 109410, 109056]],
-      "common_name": {"english": "Pestle (In Rooftop Mansion)", "native": "Chu(Wei Xiu)"}
+      "common_name": {"english": "Pestle (In Rooftop Mansion)", "native": "杵(危宿)", "pronounce": "Chu(Wei Xiu)"}
     },
     {
       "id": "CON chinese 056",
       "lines": [[60189, 60189]],
-      "common_name": {"english": "Changsha (Vassal of Chariot)", "native": "Chang Sha"}
+      "common_name": {"english": "Changsha (Vassal of Chariot)", "native": "长沙(附官)", "pronounce": "Chang Sha"}
     },
     {
       "id": "CON chinese 057",
       "lines": [[117371, 2707, 4714, 5589, 10438, 13665, 16228, 16281, 16292]],
-      "common_name": {"english": "Guest House", "native": "Chuan She"}
+      "common_name": {"english": "Guest House", "native": "传舍", "pronounce": "Chuan She"}
     },
     {
       "id": "CON chinese 058",
       "lines": [[77634, 76945]],
-      "common_name": {"english": "Retinue (In Room Mansion)", "native": "Cong Guan(Fang Xiu)"}
+      "common_name": {"english": "Retinue (In Room Mansion)", "native": "从官(房宿)", "pronounce": "Cong Guan(Fang Xiu)"}
     },
     {
       "id": "CON chinese 059",
       "lines": [[56975, 56975]],
-      "common_name": {"english": "Retinue (In Supreme Palace Enclosure)", "native": "Cong Guan(Tai Wei Yuan)"}
+      "common_name": {"english": "Retinue (In Supreme Palace Enclosure)", "native": "从官(太微垣)", "pronounce": "Cong Guan(Tai Wei Yuan)"}
     },
     {
       "id": "CON chinese 060",
       "lines": [[69673, 69673]],
-      "common_name": {"english": "Great Horn", "native": "Da Jiao"}
+      "common_name": {"english": "Great Horn", "native": "大角", "pronounce": "Da Jiao"}
     },
     {
       "id": "CON chinese 061",
       "lines": [[59504, 59504]],
-      "common_name": {"english": "Chief Judge", "native": "Da Li"}
+      "common_name": {"english": "Chief Judge", "native": "大理", "pronounce": "Da Li"}
     },
     {
       "id": "CON chinese 062",
       "lines": [[11060, 13531, 14632, 14668, 14576, 14354, 13254, 12623]],
-      "common_name": {"english": "Mausoleum", "native": "Da Ling"}
+      "common_name": {"english": "Mausoleum", "native": "大陵", "pronounce": "Da Ling"}
     },
     {
       "id": "CON chinese 063",
       "lines": [],
-      "common_name": {"english": "Celestial Temple", "native": "Tian Miao"}
+      "common_name": {"english": "Celestial Temple", "native": "天庙", "pronounce": "Tian Miao"}
     },
     {
       "id": "CON chinese 064",
       "lines": [[69226, 68478, 68103]],
-      "common_name": {"english": "Mattress of the Emperor", "native": "Di Xi"}
+      "common_name": {"english": "Mattress of the Emperor", "native": "帝席", "pronounce": "Di Xi"}
     },
     {
       "id": "CON chinese 065",
       "lines": [[84345, 84345]],
-      "common_name": {"english": "Emperor's Seat", "native": "Di Zuo"}
+      "common_name": {"english": "Emperor's Seat", "native": "帝座", "pronounce": "Di Zuo"}
     },
     {
       "id": "CON chinese 066",
       "lines": [[80894, 80569, 80343, 80975]],
-      "common_name": {"english": "Eastern Door", "native": "Dong Xian"}
+      "common_name": {"english": "Eastern Door", "native": "东咸", "pronounce": "Dong Xian"}
     },
     {
       "id": "CON chinese 067",
       "lines": [[80463, 79492, 79634, 81008, 81354]],
-      "common_name": {"english": "Dipper for Liquids", "native": "Dou"}
+      "common_name": {"english": "Dipper for Liquids", "native": "斗", "pronounce": "Dou"}
     },
     {
       "id": "CON chinese 068",
       "lines": [[74604, 75177]],
-      "common_name": {"english": "Trials", "native": "Dun Wan"}
+      "common_name": {"english": "Trials", "native": "顿顽", "pronounce": "Dun Wan"}
     },
     {
       "id": "CON chinese 069",
       "lines": [[26237, 26235, 26241], [26237, 26311]],
-      "common_name": {"english": "Send Armed Forces To Suppress (Vassal of Three Stars)", "native": "Fa"}
+      "common_name": {"english": "Send Armed Forces To Suppress (Vassal of Three Stars)", "native": "伐(附官)", "pronounce": "Fa"}
     },
     {
       "id": "CON chinese 070",
       "lines": [[79672, 79005, 78400]],
-      "common_name": {"english": "Punishment", "native": "Fa"}
+      "common_name": {"english": "Punishment", "native": "罚", "pronounce": "Fa"}
     },
     {
       "id": "CON chinese 071",
       "lines": [[44382, 34481], [44382, 41312], [44382, 40817], [44382, 35228], [44382, 37504]],
-      "common_name": {"english": "Flying Fish", "native": "Fei Yu"}
+      "common_name": {"english": "Flying Fish", "native": "飞鱼", "pronounce": "Fei Yu"}
     },
     {
       "id": "CON chinese 072",
       "lines": [[110960, 110395], [110960, 111497], [110960, 110672], [110960, 109074]],
-      "common_name": {"english": "Tomb (Vassal of Rooftop)", "native": "Fen Mu"}
+      "common_name": {"english": "Tomb (Vassal of Rooftop)", "native": "坟墓(附官)", "pronounce": "Fen Mu"}
     },
     {
       "id": "CON chinese 073",
       "lines": [[116889, 117089, 117629]],
-      "common_name": {"english": "Axe", "native": "Fu Yue"}
+      "common_name": {"english": "Axe", "native": "𫓧钺", "pronounce": "Fu Yue"}
     },
     {
       "id": "CON chinese 074",
       "lines": [[6960, 7679, 9347, 9061]],
-      "common_name": {"english": "Sickle", "native": "Fu Zhi"}
+      "common_name": {"english": "Sickle", "native": "𫓧锧", "pronounce": "Fu Zhi"}
     },
     {
       "id": "CON chinese 075",
       "lines": [[91755, 90905, 90156, 92512, 92997, 93340, 93713]],
-      "common_name": {"english": "Basket for Mulberry Leaves", "native": "Fu Kuang"}
+      "common_name": {"english": "Basket for Mulberry Leaves", "native": "扶筐", "pronounce": "Fu Kuang"}
     },
     {
       "id": "CON chinese 076",
       "lines": [[17678, 13244]],
-      "common_name": {"english": "White Patched Nearby", "native": "Fu Bai"}
+      "common_name": {"english": "White Patched Nearby", "native": "附白", "pronounce": "Fu Bai"}
     },
     {
       "id": "CON chinese 077",
       "lines": [[2920, 2920]],
-      "common_name": {"english": "Auxiliary Road", "native": "Fu Lu"}
+      "common_name": {"english": "Auxiliary Road", "native": "附路", "pronounce": "Fu Lu"}
     },
     {
       "id": "CON chinese 078",
       "lines": [[87261, 87261]],
-      "common_name": {"english": "Fu Yue", "native": "Fu Yue"}
+      "common_name": {"english": "Fu Yue", "native": "傅说", "pronounce": "Fu Yue"}
     },
     {
       "id": "CON chinese 079",
       "lines": [[108874, 108991]],
-      "common_name": {"english": "Roofing", "native": "Gai Wu"}
+      "common_name": {"english": "Roofing", "native": "盖屋", "pronounce": "Gai Wu"}
     },
     {
       "id": "CON chinese 080",
       "lines": [[17959, 14862, 9763, 9802, 9598, 10031, 9480, 8016, 7078]],
-      "common_name": {"english": "Canopy Support (Vassal of Canopy of the Emperor)", "native": "Gang"}
+      "common_name": {"english": "Canopy Support (Vassal of Canopy of the Emperor)", "native": "杠(附官)", "pronounce": "Gang"}
     },
     {
       "id": "CON chinese 081",
       "lines": [[11569, 8886, 6686, 5542, 3801, 3504]],
-      "common_name": {"english": "Flying Corridor", "native": "Ge Dao"}
+      "common_name": {"english": "Flying Corridor", "native": "阁道", "pronounce": "Ge Dao"}
     },
     {
       "id": "CON chinese 082",
       "lines": [[72105, 71284, 71053]],
-      "common_name": {"english": "Celestial Lance", "native": "Geng He"}
+      "common_name": {"english": "Celestial Lance", "native": "梗河", "pronounce": "Geng He"}
     },
     {
       "id": "CON chinese 083",
       "lines": [[113116, 5372, 11767, 85822, 82080, 77055]],
-      "common_name": {"english": "Curved Array", "native": "Gou Chen"}
+      "common_name": {"english": "Curved Array", "native": "勾陈", "pronounce": "Gou Chen"}
     },
     {
       "id": "CON chinese 084",
       "lines": [[78933, 78990], [78933, 78820]],
-      "common_name": {"english": "Lock (Vassal of Room)", "native": "Gou Qian"}
+      "common_name": {"english": "Lock (Vassal of Room)", "native": "钩钤(附官)", "pronounce": "Gou Qian"}
     },
     {
       "id": "CON chinese 085",
       "lines": [[96465, 95477]],
-      "common_name": {"english": "Dog", "native": "Gou"}
+      "common_name": {"english": "Dog", "native": "狗", "pronounce": "Gou"}
     },
     {
       "id": "CON chinese 086",
       "lines": [[98066, 98353, 98688, 98162, 98066]],
-      "common_name": {"english": "Territory of Dog", "native": "Gou Guo"}
+      "common_name": {"english": "Territory of Dog", "native": "狗国", "pronounce": "Gou Guo"}
     },
     {
       "id": "CON chinese 087",
       "lines": [[77048, 76127, 75695, 76267, 76952, 77512, 78159, 78493, 78459]],
-      "common_name": {"english": "Coiled Thong", "native": "Guan Suo"}
+      "common_name": {"english": "Coiled Thong", "native": "贯索", "pronounce": "Guan Suo"}
     },
     {
       "id": "CON chinese 088",
       "lines": [[40023, 40881, 41377, 40240]],
-      "common_name": {"english": "Beacon Fire", "native": "Guan"}
+      "common_name": {"english": "Beacon Fire", "native": "爟", "pronounce": "Guan"}
     },
     {
       "id": "CON chinese 089",
       "lines": [[83153, 85267, 85727, 82363, 83081]],
-      "common_name": {"english": "Tortoise", "native": "Gui"}
+      "common_name": {"english": "Tortoise", "native": "龟", "pronounce": "Gui"}
     },
     {
       "id": "CON chinese 090",
       "lines": [[51232, 52558, 56606, 56561, 57363]],
-      "common_name": {"english": "Sea and Mountain", "native": "Hai Shan"}
+      "common_name": {"english": "Sea and Mountain", "native": "海山", "pronounce": "Hai Shan"}
     },
     {
       "id": "CON chinese 091",
       "lines": [[41037, 45556, 46974, 47854, 48002]],
-      "common_name": {"english": "Sea Rock", "native": "Hai Shi"}
+      "common_name": {"english": "Sea Rock", "native": "海石", "pronounce": "Hai Shi"}
     },
     {
       "id": "CON chinese 092",
       "lines": [],
-      "common_name": {"english": "Military Gate", "native": "Jun Men"}
+      "common_name": {"english": "Military Gate", "native": "军门", "pronounce": "Jun Men"}
     },
     {
       "id": "CON chinese 093",
       "lines": [[98036, 97649, 97278]],
-      "common_name": {"english": "Drum at the River", "native": "He Gu"}
+      "common_name": {"english": "Drum at the River", "native": "河鼓", "pronounce": "He Gu"}
     },
     {
       "id": "CON chinese 094",
       "lines": [[109268, 112122, 112623, 112374, 114996, 113638, 112122, 114421], [112122, 114131], [112122, 112203, 110936], [112122, 111043, 109908]],
-      "common_name": {"english": "Crane", "native": "He"}
+      "common_name": {"english": "Crane", "native": "鹤", "pronounce": "He"}
     },
     {
       "id": "CON chinese 095",
       "lines": [[67464, 67472, 68245, 68862]],
-      "common_name": {"english": "Railings", "native": "Heng"}
+      "common_name": {"english": "Railings", "native": "衡", "pronounce": "Heng"}
     },
     {
       "id": "CON chinese 096",
       "lines": [[86032, 86032]],
-      "common_name": {"english": "Astrologer", "native": "Hou"}
+      "common_name": {"english": "Astrologer", "native": "候", "pronounce": "Hou"}
     },
     {
       "id": "CON chinese 097",
       "lines": [[34444, 35904, 37819, 38901, 38070, 37229, 35904, 33579, 32759, 35264, 37819]],
-      "common_name": {"english": "Bow and Arrow", "native": "Hu Shi"}
+      "common_name": {"english": "Bow and Arrow", "native": "弧矢", "pronounce": "Hu Shi"}
     },
     {
       "id": "CON chinese 098",
       "lines": [[82673, 83000, 82402, 82073]],
-      "common_name": {"english": "Dipper for Solids", "native": "Hu"}
+      "common_name": {"english": "Dipper for Solids", "native": "斛", "pronounce": "Hu"}
     },
     {
       "id": "CON chinese 099",
       "lines": [[54951, 54951]],
-      "common_name": {"english": "Emperor's Bodyguard", "native": "Hu Ben"}
+      "common_name": {"english": "Emperor's Bodyguard", "native": "虎贲", "pronounce": "Hu Ben"}
     },
     {
       "id": "CON chinese 100",
       "lines": [[102532, 101958, 101769, 102281, 102532], [101769, 101589]],
-      "common_name": {"english": "Good Gourd", "native": "Hu Gua"}
+      "common_name": {"english": "Good Gourd", "native": "瓠瓜", "pronounce": "Hu Gua"}
     },
     {
       "id": "CON chinese 101",
       "lines": [[7078, 7650], [7078, 5926], [7078, 5518], [7078, 6692], [7078, 7965], [7078, 9009]],
-      "common_name": {"english": "Canopy of the Emperor", "native": "Hua Gai"}
+      "common_name": {"english": "Canopy of the Emperor", "native": "华盖", "pronounce": "Hua Gai"}
     },
     {
       "id": "CON chinese 102",
       "lines": [[83430, 83478, 83613, 84177]],
-      "common_name": {"english": "Eunuch Official", "native": "Huan Zhe"}
+      "common_name": {"english": "Eunuch Official", "native": "宦者", "pronounce": "Huan Zhe"}
     },
     {
       "id": "CON chinese 103",
       "lines": [[116231, 116389, 116602, 765, 2072, 2081, 3245, 2472, 5165, 6867]],
-      "common_name": {"english": "Firebird", "native": "Huo Niao"}
+      "common_name": {"english": "Firebird", "native": "火鸟", "pronounce": "Huo Niao"}
     },
     {
       "id": "CON chinese 104",
       "lines": [[42673, 42673]],
-      "common_name": {"english": "Cumulative Corpses", "native": "Ji Shi(Gui Xiu)"}
+      "common_name": {"english": "Cumulative Corpses", "native": "积尸(鬼宿)", "pronounce": "Ji Shi(Gui Xiu)"}
     },
     {
       "id": "CON chinese 105",
       "lines": [[13879, 13879]],
-      "common_name": {"english": "Heap of Corpses", "native": "Ji Shi(Wei Xiu)"}
+      "common_name": {"english": "Heap of Corpses", "native": "积尸(胃宿)", "pronounce": "Ji Shi(Wei Xiu)"}
     },
     {
       "id": "CON chinese 106",
       "lines": [[19167, 19167]],
-      "common_name": {"english": "Stored water", "native": "Ji Shui(Wei Xiu)"}
+      "common_name": {"english": "Stored water", "native": "积水(胃宿)", "pronounce": "Ji Shui(Wei Xiu)"}
     },
     {
       "id": "CON chinese 107",
       "lines": [[37740, 37740]],
-      "common_name": {"english": "Pile of Firewood", "native": "Ji Xin"}
+      "common_name": {"english": "Pile of Firewood", "native": "积薪", "pronounce": "Ji Xin"}
     },
     {
       "id": "CON chinese 108",
       "lines": [[78918, 78384]],
-      "common_name": {"english": "Group of Soldiers", "native": "Ji Zu"}
+      "common_name": {"english": "Group of Soldiers", "native": "积卒", "pronounce": "Ji Zu"}
     },
     {
       "id": "CON chinese 109",
       "lines": [[24372, 19780]],
-      "common_name": {"english": "White Patches Attached", "native": "Jia Bai"}
+      "common_name": {"english": "White Patches Attached", "native": "夹白", "pronounce": "Jia Bai"}
     },
     {
       "id": "CON chinese 110",
       "lines": [[93085, 93683, 94141, 94820, 95168, 95176]],
-      "common_name": {"english": "Establishment", "native": "Jian"}
+      "common_name": {"english": "Establishment", "native": "建", "pronounce": "Jian"}
     },
     {
       "id": "CON chinese 111",
       "lines": [[92791, 92420, 93194, 93903]],
-      "common_name": {"english": "Clepsydra Terrace", "native": "Jian Tai"}
+      "common_name": {"english": "Clepsydra Terrace", "native": "渐台", "pronounce": "Jian Tai"}
     },
     {
       "id": "CON chinese 112",
       "lines": [[79374, 79374]],
-      "common_name": {"english": "Door Bolt", "native": "Jian Bi"}
+      "common_name": {"english": "Door Bolt", "native": "键闭", "pronounce": "Jian Bi"}
     },
     {
       "id": "CON chinese 113",
       "lines": [[19893, 21281, 26069, 27100, 29134]],
-      "common_name": {"english": "Goldfish", "native": "Jin Yu"}
+      "common_name": {"english": "Goldfish", "native": "金鱼", "pronounce": "Jin Yu"}
     },
     {
       "id": "CON chinese 114",
       "lines": [[63414, 63414]],
-      "common_name": {"english": "Recommending Virtuous Men", "native": "Jin Xian"}
+      "common_name": {"english": "Recommending Virtuous Men", "native": "进贤", "pronounce": "Jin Xian"}
     },
     {
       "id": "CON chinese 115",
       "lines": [[35710, 35710]],
-      "common_name": {"english": "Accumulated Water", "native": "Ji Shui(Jin Xiu)"}
+      "common_name": {"english": "Accumulated Water", "native": "积水(井宿)", "pronounce": "Ji Shui(Jin Xiu)"}
     },
     {
       "id": "CON chinese 116",
       "lines": [[104680, 104680]],
-      "common_name": {"english": "Nine Water Wells", "native": "Jiu Kan"}
+      "common_name": {"english": "Nine Water Wells", "native": "九坎", "pronounce": "Jiu Kan"}
     },
     {
       "id": "CON chinese 117",
       "lines": [[61960, 62267, 61579]],
-      "common_name": {"english": "Nine Senior Officers", "native": "Jiu Qing"}
+      "common_name": {"english": "Nine Senior Officers", "native": "九卿", "pronounce": "Jiu Qing"}
     },
     {
       "id": "CON chinese 118",
       "lines": [[21515, 22109, 22701, 23221, 23231, 22479, 22263, 21763, 23474]],
-      "common_name": {"english": "Imperial Military Flag", "native": "Jiu Liu"}
+      "common_name": {"english": "Imperial Military Flag", "native": "九斿", "pronounce": "Jiu Liu"}
     },
     {
       "id": "CON chinese 119",
       "lines": [[19777, 19587, 20507, 21444, 22024, 21986]],
-      "common_name": {"english": "Interpreters of Nine Dialects", "native": "Jiu Zhou Shu Kou"}
+      "common_name": {"english": "Interpreters of Nine Dialects", "native": "九州殊口", "pronounce": "Jiu Zhou Shu Kou"}
     },
     {
       "id": "CON chinese 120",
       "lines": [[47723, 46771, 46454]],
-      "common_name": {"english": "Banner of Wine Shop", "native": "Jiu Qi"}
+      "common_name": {"english": "Banner of Wine Shop", "native": "酒旗", "pronounce": "Jiu Qi"}
     },
     {
       "id": "CON chinese 121",
       "lines": [[110371, 109176, 107354, 107310]],
-      "common_name": {"english": "Mortar", "native": "Jiu"}
+      "common_name": {"english": "Mortar", "native": "臼", "pronounce": "Jiu"}
     },
     {
       "id": "CON chinese 122",
       "lines": [[17529, 18532, 18614, 18246, 17448, 17313]],
-      "common_name": {"english": "Rolled Tongue", "native": "Juan She"}
+      "common_name": {"english": "Rolled Tongue", "native": "卷舌", "pronounce": "Juan She"}
     },
     {
       "id": "CON chinese 123",
       "lines": [[24244, 24327, 24845, 24873]],
-      "common_name": {"english": "Military Well", "native": "Jun Jing"}
+      "common_name": {"english": "Military Well", "native": "军井", "pronounce": "Jun Jing"}
     },
     {
       "id": "CON chinese 124",
       "lines": [[5434, 5434]],
-      "common_name": {"english": "Southern Military Gate", "native": "Jun Nan Men"}
+      "common_name": {"english": "Southern Military Gate", "native": "军南门", "pronounce": "Jun Nan Men"}
     },
     {
       "id": "CON chinese 125",
       "lines": [[30324, 31700, 33092, 33248, 33152, 31125, 30324]],
-      "common_name": {"english": "Market for Soldiers", "native": "Jun Shi"}
+      "common_name": {"english": "Market for Soldiers", "native": "军市", "pronounce": "Jun Shi"}
     },
     {
       "id": "CON chinese 126",
       "lines": [[85423, 85423]],
-      "common_name": {"english": "Chaff", "native": "Kang"}
+      "common_name": {"english": "Chaff", "native": "糠", "pronounce": "Kang"}
     },
     {
       "id": "CON chinese 127",
       "lines": [[70027, 69260, 69536, 69989]],
-      "common_name": {"english": "Boats and Lake", "native": "Kang Chi"}
+      "common_name": {"english": "Boats and Lake", "native": "亢池", "pronounce": "Kang Chi"}
     },
     {
       "id": "CON chinese 128",
       "lines": [[86929, 88866, 90797, 92609, 93015, 99240, 102395, 91792, 98495, 105858, 100751]],
-      "common_name": {"english": "Peafowl", "native": "Kong Que"}
+      "common_name": {"english": "Peafowl", "native": "孔雀", "pronounce": "Kong Que"}
     },
     {
       "id": "CON chinese 129",
       "lines": [[108036, 109472]],
-      "common_name": {"english": "Crying", "native": "Ku"}
+      "common_name": {"english": "Crying", "native": "哭", "pronounce": "Ku"}
     },
     {
       "id": "CON chinese 130",
       "lines": [[68002, 71352, 68933, 67457, 65936, 63945, 61932, 61622, 60517, 60823]],
-      "common_name": {"english": "Arsenal", "native": "Ku Lou"}
+      "common_name": {"english": "Arsenal", "native": "库楼", "pronounce": "Ku Lou"}
     },
     {
       "id": "CON chinese 131",
       "lines": [[62763, 62763]],
-      "common_name": {"english": "Captain of the Bodyguards", "native": "Lang Jiang"}
+      "common_name": {"english": "Captain of the Bodyguards", "native": "郎将", "pronounce": "Lang Jiang"}
     },
     {
       "id": "CON chinese 132",
       "lines": [[60742, 60697, 60746, 60904, 60514, 60351, 61071, 60941, 59847, 61394, 61724, 60957, 59501, 58858]],
-      "common_name": {"english": "Officers of the Imperial Guard", "native": "Lang Wei"}
+      "common_name": {"english": "Officers of the Imperial Guard", "native": "郎位", "pronounce": "Lang Wei"}
     },
     {
       "id": "CON chinese 133",
       "lines": [[30438, 30438]],
-      "common_name": {"english": "Old Man", "native": "Lao Ren"}
+      "common_name": {"english": "Old Man", "native": "老人", "pronounce": "Lao Ren"}
     },
     {
       "id": "CON chinese 134",
       "lines": [[115919, 115444, 114144, 112935, 112447, 112029]],
-      "common_name": {"english": "Thunder and Lightning", "native": "Lei Dian"}
+      "common_name": {"english": "Thunder and Lightning", "native": "雷电", "pronounce": "Lei Dian"}
     },
     {
       "id": "CON chinese 135",
       "lines": [[145, 118209, 154, 443, 145], [118209, 114724, 112961, 111123, 109139, 107556, 106985, 106723, 107188, 107556]],
-      "common_name": {"english": "Line of Ramparts", "native": "Lei Bi Zhen"}
+      "common_name": {"english": "Line of Ramparts", "native": "垒壁阵", "pronounce": "Lei Bi Zhen"}
     },
     {
       "id": "CON chinese 136",
       "lines": [[112440, 112748], [112051, 112158], [115250, 115623], [113881, 112748], [113881, 112158], [113881, 115250]],
-      "common_name": {"english": "Resting Palace (Vassal of Encampment)", "native": "Li Gong"}
+      "common_name": {"english": "Resting Palace (Vassal of Encampment)", "native": "离宫(附官)", "pronounce": "Li Gong"}
     },
     {
       "id": "CON chinese 137",
       "lines": [[105140, 106067]],
-      "common_name": {"english": "Jade Ornament on Ladies' Wear", "native": "Li Yu"}
+      "common_name": {"english": "Jade Ornament on Ladies' Wear", "native": "离瑜", "pronounce": "Li Yu"}
     },
     {
       "id": "CON chinese 138",
       "lines": [[101936, 101847, 101692, 101101]],
-      "common_name": {"english": "Pearls on Ladies' Wear", "native": "Li Zhu"}
+      "common_name": {"english": "Pearls on Ladies' Wear", "native": "离珠", "pronounce": "Li Zhu"}
     },
     {
       "id": "CON chinese 139",
       "lines": [[19205, 19513, 20430, 20250]],
-      "common_name": {"english": "Whetstone", "native": "Li Shi"}
+      "common_name": {"english": "Whetstone", "native": "砺石", "pronounce": "Li Shi"}
     },
     {
       "id": "CON chinese 140",
       "lines": [[80179, 80883]],
-      "common_name": {"english": "Jewel Market", "native": "Lie Si"}
+      "common_name": {"english": "Jewel Market", "native": "列肆", "pronounce": "Lie Si"}
     },
     {
       "id": "CON chinese 141",
       "lines": [[54182, 53824, 53807]],
-      "common_name": {"english": "Astronomical Observatory", "native": "Ling Tai"}
+      "common_name": {"english": "Astronomical Observatory", "native": "灵台", "pronounce": "Ling Tai"}
     },
     {
       "id": "CON chinese 142",
       "lines": [[32439, 33694, 39538, 36547, 23265, 25110]],
-      "common_name": {"english": "Six Jia", "native": "Liu Jia"}
+      "common_name": {"english": "Six Jia", "native": "六甲", "pronounce": "Liu Jia"}
     },
     {
       "id": "CON chinese 143",
       "lines": [[101923, 101984, 102487]],
-      "common_name": {"english": "Network of Dykes", "native": "Luo Yan"}
+      "common_name": {"english": "Network of Dykes", "native": "罗堰", "pronounce": "Luo Yan"}
     },
     {
       "id": "CON chinese 144",
       "lines": [[68702, 65129]],
-      "common_name": {"english": "Horse's Abdomen", "native": "Ma Fu"}
+      "common_name": {"english": "Horse's Abdomen", "native": "马腹", "pronounce": "Ma Fu"}
     },
     {
       "id": "CON chinese 145",
       "lines": [[60710, 59449, 59196]],
-      "common_name": {"english": "Horse's Tail", "native": "Ma Wei"}
+      "common_name": {"english": "Horse's Tail", "native": "马尾", "pronounce": "Ma Wei"}
     },
     {
       "id": "CON chinese 146",
       "lines": [[62322, 61585], [62322, 61199], [62322, 63613]],
-      "common_name": {"english": "Bee", "native": "Mi Feng"}
+      "common_name": {"english": "Bee", "native": "蜜蜂", "pronounce": "Mi Feng"}
     },
     {
       "id": "CON chinese 147",
       "lines": [[55945, 56647, 56127]],
-      "common_name": {"english": "The Hall of Glory", "native": "Ming Tang"}
+      "common_name": {"english": "The Hall of Glory", "native": "明堂", "pronounce": "Ming Tang"}
     },
     {
       "id": "CON chinese 148",
       "lines": [[50371, 51576, 52419, 50099, 45238]],
-      "common_name": {"english": "Southern Boat", "native": "Nan Chuan"}
+      "common_name": {"english": "Southern Boat", "native": "南船", "pronounce": "Nan Chuan"}
     },
     {
       "id": "CON chinese 149",
       "lines": [[36041, 36188, 37279]],
-      "common_name": {"english": "South River", "native": "Nan He"}
+      "common_name": {"english": "South River", "native": "南河", "pronounce": "Nan He"}
     },
     {
       "id": "CON chinese 150",
       "lines": [],
-      "common_name": {"english": "Dongou", "native": "Dong Ou"}
+      "common_name": {"english": "Dongou", "native": "东瓯", "pronounce": "Dong Ou"}
     },
     {
       "id": "CON chinese 151",
       "lines": [[66657, 71683]],
-      "common_name": {"english": "Southern Gate", "native": "Nan Men"}
+      "common_name": {"english": "Southern Gate", "native": "南门", "pronounce": "Nan Men"}
     },
     {
       "id": "CON chinese 152",
       "lines": [[62423, 63076]],
-      "common_name": {"english": "Inner Kitchen", "native": "Nei Chu"}
+      "common_name": {"english": "Inner Kitchen", "native": "内厨", "pronounce": "Nei Chu"}
     },
     {
       "id": "CON chinese 153",
       "lines": [[41704, 45333, 43903], [46733, 43644, 45455]],
-      "common_name": {"english": "Inner Steps", "native": "Nei Jie"}
+      "common_name": {"english": "Inner Steps", "native": "内阶", "pronounce": "Nei Jie"}
     },
     {
       "id": "CON chinese 154",
       "lines": [[50218, 49593, 47631, 48742]],
-      "common_name": {"english": "High Judge", "native": "Nei Ping"}
+      "common_name": {"english": "High Judge", "native": "内平", "pronounce": "Nei Ping"}
     },
     {
       "id": "CON chinese 155",
       "lines": [[57328, 57380, 58590, 58948]],
-      "common_name": {"english": "Inner Screen", "native": "Nei Ping"}
+      "common_name": {"english": "Inner Screen", "native": "内屏", "pronounce": "Nei Ping"}
     },
     {
       "id": "CON chinese 156",
       "lines": [[92862, 94481, 94713, 95556, 97295]],
-      "common_name": {"english": "Imperial Passageway", "native": "Nian Dao"}
+      "common_name": {"english": "Imperial Passageway", "native": "辇道", "pronounce": "Nian Dao"}
     },
     {
       "id": "CON chinese 157",
       "lines": [[110130, 110838, 118092, 2484, 3330, 1599, 118322]],
-      "common_name": {"english": "Bird's Beak", "native": "Niao Hui"}
+      "common_name": {"english": "Bird's Beak", "native": "鸟喙", "pronounce": "Niao Hui"}
     },
     {
       "id": "CON chinese 158",
       "lines": [[91918, 91918]],
-      "common_name": {"english": "Peasant", "native": "Nong Zhang Ren"}
+      "common_name": {"english": "Peasant", "native": "农丈人", "pronounce": "Nong Zhang Ren"}
     },
     {
       "id": "CON chinese 159",
       "lines": [[84380, 84606, 85112]],
-      "common_name": {"english": "Woman's Bed", "native": "Nü Chuang"}
+      "common_name": {"english": "Woman's Bed", "native": "女床", "pronounce": "Nü Chuang"}
     },
     {
       "id": "CON chinese 160",
       "lines": [[87728, 87728]],
-      "common_name": {"english": "Female Protocol", "native": "Nü Shi"}
+      "common_name": {"english": "Female Protocol", "native": "女史", "pronounce": "Nü Shi"}
     },
     {
       "id": "CON chinese 161",
       "lines": [[113889, 114971, 115830, 116771, 118268]],
-      "common_name": {"english": "Thunderbolt", "native": "Pi Li"}
+      "common_name": {"english": "Thunderbolt", "native": "霹雳", "pronounce": "Pi Li"}
     },
     {
       "id": "CON chinese 162",
       "lines": [[64962, 68895]],
-      "common_name": {"english": "Judging", "native": "Ping"}
+      "common_name": {"english": "Judging", "native": "平", "pronounce": "Ping"}
     },
     {
       "id": "CON chinese 163",
       "lines": [[64238, 66803]],
-      "common_name": {"english": "Flat Road", "native": "Ping Dao"}
+      "common_name": {"english": "Flat Road", "native": "平道", "pronounce": "Ping Dao"}
     },
     {
       "id": "CON chinese 164",
       "lines": [[24305, 23685]],
-      "common_name": {"english": "Screen", "native": "Ping"}
+      "common_name": {"english": "Screen", "native": "屏", "pronounce": "Ping"}
     },
     {
       "id": "CON chinese 165",
       "lines": [[81497, 79992, 79101, 77760, 75973, 75411, 74666]],
-      "common_name": {"english": "Seven Excellencies", "native": "Qi Gong"}
+      "common_name": {"english": "Seven Excellencies", "native": "七公", "pronounce": "Qi Gong"}
     },
     {
       "id": "CON chinese 166",
       "lines": [],
-      "common_name": {"english": "House for Musical Instruments", "native": "Qi Fu"}
+      "common_name": {"english": "House for Musical Instruments", "native": "器府", "pronounce": "Qi Fu"}
     },
     {
       "id": "CON chinese 167",
       "lines": [[76297, 75141, 73334, 73273, 74117, 75264, 74911, 73807, 72683, 71860]],
-      "common_name": {"english": "Imperial Guards", "native": "Qi Guan"}
+      "common_name": {"english": "Imperial Guards", "native": "骑官", "pronounce": "Qi Guan"}
     },
     {
       "id": "CON chinese 168",
       "lines": [[74376, 74376]],
-      "common_name": {"english": "Chariots and Cavalry General", "native": "Qi Zhen Jiang Jun"}
+      "common_name": {"english": "Chariots and Cavalry General", "native": "骑阵将军", "pronounce": "Qi Zhen Jiang Jun"}
     },
     {
       "id": "CON chinese 169",
       "lines": [[110273, 110003]],
-      "common_name": {"english": "Weeping", "native": "Qi"}
+      "common_name": {"english": "Weeping", "native": "泣", "pronounce": "Qi"}
     },
     {
       "id": "CON chinese 170",
       "lines": [],
-      "common_name": {"english": "Celestial Cereals", "native": "Tian Ji"}
+      "common_name": {"english": "Celestial Cereals", "native": "天稷", "pronounce": "Tian Ji"}
     },
     {
       "id": "CON chinese 171",
       "lines": [[57936, 58158, 56280, 56332, 56343, 56452, 56922]],
-      "common_name": {"english": "Green Hill", "native": "Qing Qiu"}
+      "common_name": {"english": "Green Hill", "native": "青丘", "pronounce": "Qing Qiu"}
     },
     {
       "id": "CON chinese 172",
       "lines": [[34724, 32578]],
-      "common_name": {"english": "Palace Gate", "native": "Que Qiu"}
+      "common_name": {"english": "Palace Gate", "native": "阙丘", "pronounce": "Que Qiu"}
     },
     {
       "id": "CON chinese 173",
       "lines": [[106140, 105502, 107348, 107472]],
-      "common_name": {"english": "Humans", "native": "Ren"}
+      "common_name": {"english": "Humans", "native": "人", "pronounce": "Ren"}
     },
     {
       "id": "CON chinese 174",
       "lines": [[76880, 76880]],
-      "common_name": {"english": "Solar Star", "native": "Ri"}
+      "common_name": {"english": "Solar Star", "native": "日", "pronounce": "Ri"}
     },
     {
       "id": "CON chinese 175",
       "lines": [[61968, 62443]],
-      "common_name": {"english": "Three Excellencies (In Supreme Palace Enclosure)", "native": "San Gong(Tai Wei Yuan)"}
+      "common_name": {"english": "Three Excellencies (In Supreme Palace Enclosure)", "native": "三公(太微垣)", "pronounce": "San Gong(Tai Wei Yuan)"}
     },
     {
       "id": "CON chinese 176",
       "lines": [[66234, 64906]],
-      "common_name": {"english": "Three Excellencies (In Purple Forbidden Enclosure)", "native": "San gong(Zi Wei Yuan)"}
+      "common_name": {"english": "Three Excellencies (In Purple Forbidden Enclosure)", "native": "三公(紫微垣)", "pronounce": "San gong(Zi Wei Yuan)"}
     },
     {
       "id": "CON chinese 177",
       "lines": [[74946, 77952, 82273, 74946]],
-      "common_name": {"english": "Triangle", "native": "San Jiao Xing"}
+      "common_name": {"english": "Triangle", "native": "三角形", "pronounce": "San Jiao Xing"}
     },
     {
       "id": "CON chinese 178",
       "lines": [[44390, 44857]],
-      "common_name": {"english": "Three Top Instructors", "native": "San Shi"}
+      "common_name": {"english": "Three Top Instructors", "native": "三师", "pronounce": "San Shi"}
     },
     {
       "id": "CON chinese 179",
       "lines": [[44127, 44471, 50372, 50801, 55219, 55203]],
-      "common_name": {"english": "Three Steps", "native": "San Tai"}
+      "common_name": {"english": "Three Steps", "native": "三台", "pronounce": "San Tai"}
     },
     {
       "id": "CON chinese 180",
       "lines": [[85805, 80650], [85805, 81660], [85805, 80161], [85805, 82860]],
-      "common_name": {"english": "Royal Secretary", "native": "Shang Shu"}
+      "common_name": {"english": "Royal Secretary", "native": "尚书", "pronounce": "Shang Shu"}
     },
     {
       "id": "CON chinese 181",
       "lines": [[54347, 53417, 52457, 52686]],
-      "common_name": {"english": "Junior Officers", "native": "Shao Wei"}
+      "common_name": {"english": "Junior Officers", "native": "少微", "pronounce": "Shao Wei"}
     },
     {
       "id": "CON chinese 182",
       "lines": [[12876, 12394, 11001, 8928]],
-      "common_name": {"english": "Snake's Abdomen", "native": "She Fu"}
+      "common_name": {"english": "Snake's Abdomen", "native": "蛇腹", "pronounce": "She Fu"}
     },
     {
       "id": "CON chinese 183",
       "lines": [[9236, 17440]],
-      "common_name": {"english": "Snake's Head", "native": "She Shou"}
+      "common_name": {"english": "Snake's Head", "native": "蛇首", "pronounce": "She Shou"}
     },
     {
       "id": "CON chinese 184",
       "lines": [[2021, 110078, 107089, 104043]],
-      "common_name": {"english": "Snake's Tail", "native": "She Wei"}
+      "common_name": {"english": "Snake's Tail", "native": "蛇尾", "pronounce": "She Wei"}
     },
     {
       "id": "CON chinese 185",
       "lines": [[82676, 82676]],
-      "common_name": {"english": "Changing Room (Vassal of Tail)", "native": "Shen Gong"}
+      "common_name": {"english": "Changing Room (Vassal of Tail)", "native": "神宫(附官)", "pronounce": "Shen Gong"}
     },
     {
       "id": "CON chinese 186",
       "lines": [[104019, 103703], [104139, 105143], [105515, 106568], [104429, 104452]],
-      "common_name": {"english": "Twelve States", "native": "Shi Er Guo"}
+      "common_name": {"english": "Twelve States", "native": "十二国", "pronounce": "Shi Er Guo"}
     },
     {
       "id": "CON chinese 187",
       "lines": [[61084, 60718], [62434, 59747]],
-      "common_name": {"english": "Cross", "native": "Shi Zi Jia"}
+      "common_name": {"english": "Cross", "native": "十字架", "pronounce": "Shi Zi Jia"}
     },
     {
       "id": "CON chinese 188",
       "lines": [[27204, 27204]],
-      "common_name": {"english": "Excrement", "native": "Shi"}
+      "common_name": {"english": "Excrement", "native": "屎", "pronounce": "Shi"}
     },
     {
       "id": "CON chinese 189",
       "lines": [[86284, 86565], [88404, 84880], [85397, 86768]],
-      "common_name": {"english": "Municipal Office", "native": "Shi Lou"}
+      "common_name": {"english": "Municipal Office", "native": "市楼", "pronounce": "Shi Lou"}
     },
     {
       "id": "CON chinese 190",
       "lines": [[51685, 51556, 52638, 53229]],
-      "common_name": {"english": "Eunuch", "native": "Shi"}
+      "common_name": {"english": "Eunuch", "native": "势", "pronounce": "Shi"}
     },
     {
       "id": "CON chinese 191",
       "lines": [[29038, 29426, 29704, 29434]],
-      "common_name": {"english": "Official for Irrigation", "native": "Shui Fu"}
+      "common_name": {"english": "Official for Irrigation", "native": "水府", "pronounce": "Shui Fu"}
     },
     {
       "id": "CON chinese 192",
       "lines": [[7588, 5348, 3405]],
-      "common_name": {"english": "Crooked Running Water", "native": "Shui Wei"}
+      "common_name": {"english": "Crooked Running Water", "native": "水委", "pronounce": "Shui Wei"}
     },
     {
       "id": "CON chinese 193",
       "lines": [[36425, 37921, 39567, 40167]],
-      "common_name": {"english": "Water Level", "native": "Shui Wei"}
+      "common_name": {"english": "Water Level", "native": "水位", "pronounce": "Shui Wei"}
     },
     {
       "id": "CON chinese 194",
       "lines": [[104521, 104858]],
-      "common_name": {"english": "Deified Judge of Right and Wrong", "native": "Si Fei"}
+      "common_name": {"english": "Deified Judge of Right and Wrong", "native": "司非", "pronounce": "Si Fei"}
     },
     {
       "id": "CON chinese 195",
       "lines": [[28237, 28734, 28716, 27913]],
-      "common_name": {"english": "Deity in Charge of Monsters", "native": "Si Guai"}
+      "common_name": {"english": "Deity in Charge of Monsters", "native": "司怪", "pronounce": "Si Guai"}
     },
     {
       "id": "CON chinese 196",
       "lines": [[107575, 106944]],
-      "common_name": {"english": "Deified Judge of Rank", "native": "Si Lu"}
+      "common_name": {"english": "Deified Judge of Rank", "native": "司禄", "pronounce": "Si Lu"}
     },
     {
       "id": "CON chinese 197",
       "lines": [[106942, 107144]],
-      "common_name": {"english": "Deified Judge of Life", "native": "Si Ming"}
+      "common_name": {"english": "Deified Judge of Life", "native": "司命", "pronounce": "Si Ming"}
     },
     {
       "id": "CON chinese 198",
       "lines": [[105570, 105413]],
-      "common_name": {"english": "Deified Judge of Disaster and Good Fortune", "native": "Si wei"}
+      "common_name": {"english": "Deified Judge of Disaster and Good Fortune", "native": "司危", "pronounce": "Si wei"}
     },
     {
       "id": "CON chinese 199",
       "lines": [[34033, 32533, 31216, 30419]],
-      "common_name": {"english": "Four Channels", "native": "Si Du"}
+      "common_name": {"english": "Four Channels", "native": "四渎", "pronounce": "Si Du"}
     },
     {
       "id": "CON chinese 200",
       "lines": [[58874, 51502, 51384]],
-      "common_name": {"english": "Four Advisors", "native": "Si Fu"}
+      "common_name": {"english": "Four Advisors", "native": "四辅", "pronounce": "Si Fu"}
     },
     {
       "id": "CON chinese 201",
       "lines": [[29807, 29034]],
-      "common_name": {"english": "Grandson", "native": "Sun"}
+      "common_name": {"english": "Grandson", "native": "孙", "pronounce": "Sun"}
     },
     {
       "id": "CON chinese 202",
       "lines": [[57399, 57399]],
-      "common_name": {"english": "Guard of the Sun", "native": "Tai Yang Shou"}
+      "common_name": {"english": "Guard of the Sun", "native": "太阳守", "pronounce": "Tai Yang Shou"}
     },
     {
       "id": "CON chinese 203",
       "lines": [[66798, 66798]],
-      "common_name": {"english": "First Great One", "native": "Tai Yi"}
+      "common_name": {"english": "First Great One", "native": "太乙", "pronounce": "Tai Yi"}
     },
     {
       "id": "CON chinese 204",
       "lines": [[57565, 57565]],
-      "common_name": {"english": "Crown Prince", "native": "Tai Zi"}
+      "common_name": {"english": "Crown Prince", "native": "太子", "pronounce": "Tai Zi"}
     },
     {
       "id": "CON chinese 205",
       "lines": [[54539, 54539]],
-      "common_name": {"english": "Royals", "native": "Tai Zun"}
+      "common_name": {"english": "Royals", "native": "太尊", "pronounce": "Tai Zun"}
     },
     {
       "id": "CON chinese 206",
       "lines": [[111169, 110609, 107533, 107136, 105064, 106886, 108165, 109857, 110538, 118243, 117863, 117301, 115990, 111674, 113919, 114570, 115022, 116584, 117221, 116805, 116631]],
-      "common_name": {"english": "Flying Serpent", "native": "Teng She"}
+      "common_name": {"english": "Flying Serpent", "native": "螣蛇", "pronounce": "Teng She"}
     },
     {
       "id": "CON chinese 207",
       "lines": [[15696, 15696]],
-      "common_name": {"english": "Celestial Concave", "native": "Tian E"}
+      "common_name": {"english": "Celestial Concave", "native": "天阿", "pronounce": "Tian E"}
     },
     {
       "id": "CON chinese 208",
       "lines": [[87585, 85829, 85670, 87833, 86414]],
-      "common_name": {"english": "Celestial Flail", "native": "Tian Bang"}
+      "common_name": {"english": "Celestial Flail", "native": "天棓", "pronounce": "Tian Bang"}
     },
     {
       "id": "CON chinese 209",
       "lines": [[91117, 91726, 91845, 92175, 93026, 93429, 93805, 93717, 93526]],
-      "common_name": {"english": "Market Officer", "native": "Tian Bian"}
+      "common_name": {"english": "Market Officer", "native": "天弁", "pronounce": "Tian Bian"}
     },
     {
       "id": "CON chinese 210",
       "lines": [[1562, 5364, 6537, 8645, 8102, 9326]],
-      "common_name": {"english": "Square Celestial Granary", "native": "Tian Cang"}
+      "common_name": {"english": "Square Celestial Granary", "native": "天仓", "pronounce": "Tian Cang"}
     },
     {
       "id": "CON chinese 211",
       "lines": [[17886, 17886]],
-      "common_name": {"english": "Celestial Slander", "native": "Tian Chan"}
+      "common_name": {"english": "Celestial Slander", "native": "天谗", "pronounce": "Tian Chan"}
     },
     {
       "id": "CON chinese 212",
       "lines": [[94376, 96100, 97433, 98702, 98583, 95081]],
-      "common_name": {"english": "Celestial Kitchen", "native": "Tian Chu"}
+      "common_name": {"english": "Celestial Kitchen", "native": "天厨", "pronounce": "Tian Chu"}
     },
     {
       "id": "CON chinese 213",
       "lines": [[13268, 14328, 15863, 16826, 17358, 19343, 19812, 20156, 19949]],
-      "common_name": {"english": "Celestial Boat", "native": "Tian Chuan"}
+      "common_name": {"english": "Celestial Boat", "native": "天船", "pronounce": "Tian Chuan"}
     },
     {
       "id": "CON chinese 214",
       "lines": [[69373, 74605, 77277], [79414, 73199, 72181]],
-      "common_name": {"english": "Celestial Bed", "native": "Tian Chuang"}
+      "common_name": {"english": "Celestial Bed", "native": "天床", "pronounce": "Tian Chuang"}
     },
     {
       "id": "CON chinese 215",
       "lines": [[9640, 8068, 7607, 6999, 7719, 7513, 7818, 9021, 10064, 10670, 10644, 9640]],
-      "common_name": {"english": "Great General of Heaven", "native": "Tian Da Jiang Jun"}
+      "common_name": {"english": "Great General of Heaven", "native": "天大将军", "pronounce": "Tian Da Jiang Jun"}
     },
     {
       "id": "CON chinese 216",
       "lines": [[99473, 98844, 97980, 97804]],
-      "common_name": {"english": "Celestial Drumstick", "native": "Tian Fu"}
+      "common_name": {"english": "Celestial Drumstick", "native": "天桴", "pronounce": "Tian Fu"}
     },
     {
       "id": "CON chinese 217",
       "lines": [[76470, 76600]],
-      "common_name": {"english": "Celestial Spokes", "native": "Tian Fu"}
+      "common_name": {"english": "Celestial Spokes", "native": "天辐", "pronounce": "Tian Fu"}
     },
     {
       "id": "CON chinese 218",
       "lines": [[113246, 113246]],
-      "common_name": {"english": "Materials for Making Tents", "native": "Tian Gang"}
+      "common_name": {"english": "Materials for Making Tents", "native": "天纲", "pronounce": "Tian Gang"}
     },
     {
       "id": "CON chinese 219",
       "lines": [[23497, 22565, 23949, 24822, 23497]],
-      "common_name": {"english": "Celestial High Terrace", "native": "Tian Gao"}
+      "common_name": {"english": "Celestial High Terrace", "native": "天高", "pronounce": "Tian Gao"}
     },
     {
       "id": "CON chinese 220",
       "lines": [[102253, 99731, 101093, 102422, 105199, 108917, 110817, 112724, 115088]],
-      "common_name": {"english": "Celestial Hook", "native": "Tian Gou"}
+      "common_name": {"english": "Celestial Hook", "native": "天钩", "pronounce": "Tian Gou"}
     },
     {
       "id": "CON chinese 221",
       "lines": [[42312, 42884, 43603, 42515, 42828, 43409, 43825]],
-      "common_name": {"english": "Celestial Dog", "native": "Tian Gou"}
+      "common_name": {"english": "Celestial Dog", "native": "天狗", "pronounce": "Tian Gou"}
     },
     {
       "id": "CON chinese 222",
       "lines": [[26451, 26451]],
-      "common_name": {"english": "Celestial Pass", "native": "Tian Guan"}
+      "common_name": {"english": "Celestial Pass", "native": "天关", "pronounce": "Tian Guan"}
     },
     {
       "id": "CON chinese 223",
       "lines": [[109693, 109693]],
-      "common_name": {"english": "Great Emperor of Heaven", "native": "Tian Huang Da Di"}
+      "common_name": {"english": "Great Emperor of Heaven", "native": "天皇大帝", "pronounce": "Tian Huang Da Di"}
     },
     {
       "id": "CON chinese 224",
       "lines": [[24879, 25541], [24879, 25292], [24879, 24340], [24879, 24504]],
-      "common_name": {"english": "Celestial Pier", "native": "Tian Huang"}
+      "common_name": {"english": "Celestial Pier", "native": "天潢", "pronounce": "Tian Huang"}
     },
     {
       "id": "CON chinese 225",
       "lines": [[4257, 4371, 3559, 3455]],
-      "common_name": {"english": "Celestial Pigsty", "native": "Tian Hun"}
+      "common_name": {"english": "Celestial Pigsty", "native": "天溷", "pronounce": "Tian Hun"}
     },
     {
       "id": "CON chinese 226",
       "lines": [[96950, 97290]],
-      "common_name": {"english": "Celestial Cock", "native": "Tian Ji"}
+      "common_name": {"english": "Celestial Cock", "native": "天鸡", "pronounce": "Tian Ji"}
     },
     {
       "id": "CON chinese 227",
       "lines": [[44816, 44816]],
-      "common_name": {"english": "Judge for Estimating the Age of Animals", "native": "Tian Ji"}
+      "common_name": {"english": "Judge for Estimating the Age of Animals", "native": "天记", "pronounce": "Tian Ji"}
     },
     {
       "id": "CON chinese 228",
       "lines": [[80181, 81693, 83207, 83313, 83462, 84573, 86178, 87808]],
-      "common_name": {"english": "Celestial Discipline", "native": "Tian Ji"}
+      "common_name": {"english": "Celestial Discipline", "native": "天纪", "pronounce": "Tian Ji"}
     },
     {
       "id": "CON chinese 229",
       "lines": [[84314, 84405, 84970, 85340]],
-      "common_name": {"english": "Celestial River", "native": "Tian Jiang"}
+      "common_name": {"english": "Celestial River", "native": "天江", "pronounce": "Tian Jiang"}
     },
     {
       "id": "CON chinese 230",
       "lines": [[20641, 19990]],
-      "common_name": {"english": "Celestial Street", "native": "Tian Jie"}
+      "common_name": {"english": "Celestial Street", "native": "天街", "pronounce": "Tian Jie"}
     },
     {
       "id": "CON chinese 231",
       "lines": [[20732, 21273], [20732, 20219, 20901, 21589, 21735, 21402, 20522]],
-      "common_name": {"english": "Celestial Tally", "native": "Tian Jie"}
+      "common_name": {"english": "Celestial Tally", "native": "天节", "pronounce": "Tian Jie"}
     },
     {
       "id": "CON chinese 232",
       "lines": [[104732, 105138, 104887, 103413, 102098, 99639, 97165, 100453, 102488, 104732]],
-      "common_name": {"english": "Celestial Ford", "native": "Tian Jin"}
+      "common_name": {"english": "Celestial Ford", "native": "天津", "pronounce": "Tian Jin"}
     },
     {
       "id": "CON chinese 233",
       "lines": [[1366, 1686, 1473]],
-      "common_name": {"english": "Celestial Stable", "native": "Tian Jiu"}
+      "common_name": {"english": "Celestial Stable", "native": "天厩", "pronounce": "Tian Jiu"}
     },
     {
       "id": "CON chinese 234",
       "lines": [[32349, 32349]],
-      "common_name": {"english": "Celestial Wolf", "native": "Tian Lang"}
+      "common_name": {"english": "Celestial Wolf", "native": "天狼", "pronounce": "Tian Lang"}
     },
     {
       "id": "CON chinese 235",
       "lines": [[53295, 56034], [53721, 56148], [53838, 55560]],
-      "common_name": {"english": "Celestial Prison", "native": "Tian Lao"}
+      "common_name": {"english": "Celestial Prison", "native": "天牢", "pronounce": "Tian Lao"}
     },
     {
       "id": "CON chinese 236",
       "lines": [[106786, 107382, 107487, 107517, 107527, 105668, 104974, 103728, 103640, 104459, 105019, 105574, 105761]],
-      "common_name": {"english": "Celestial Ramparts", "native": "Tian Lei Cheng"}
+      "common_name": {"english": "Celestial Ramparts", "native": "天垒城", "pronounce": "Tian Lei Cheng"}
     },
     {
       "id": "CON chinese 237",
       "lines": [[55060, 55797, 58181, 58259, 55060]],
-      "common_name": {"english": "Judge for Nobility", "native": "Tian Li"}
+      "common_name": {"english": "Judge for Nobility", "native": "天理", "pronounce": "Tian Li"}
     },
     {
       "id": "CON chinese 238",
       "lines": [[16369, 16322, 16083, 15900]],
-      "common_name": {"english": "Celestial Foodstuff", "native": "Tian Lin"}
+      "common_name": {"english": "Celestial Foodstuff", "native": "天廪", "pronounce": "Tian Lin"}
     },
     {
       "id": "CON chinese 239",
       "lines": [[64407, 65639]],
-      "common_name": {"english": "Celestial Gate", "native": "Tian Men"}
+      "common_name": {"english": "Celestial Gate", "native": "天门", "pronounce": "Tian Men"}
     },
     {
       "id": "CON chinese 240",
       "lines": [[108952, 107608, 107380, 109285, 109422, 108952]],
-      "common_name": {"english": "Celestial Money", "native": "Tian Qian"}
+      "common_name": {"english": "Celestial Money", "native": "天钱", "pronounce": "Tian Qian"}
     },
     {
       "id": "CON chinese 241",
       "lines": [[69481, 69713, 70497]],
-      "common_name": {"english": "Celestial Spear", "native": "Tian Qiang"}
+      "common_name": {"english": "Celestial Spear", "native": "天枪", "pronounce": "Tian Qiang"}
     },
     {
       "id": "CON chinese 242",
       "lines": [[14135, 15619, 13954, 12828, 10324, 11484, 12093, 12706, 12387, 11791, 11046, 10234, 10305]],
-      "common_name": {"english": "Circular Celestial Granary", "native": "Tian Qun"}
+      "common_name": {"english": "Circular Celestial Granary", "native": "天囷", "pronounce": "Tian Qun"}
     },
     {
       "id": "CON chinese 243",
       "lines": [[77516, 77516]],
-      "common_name": {"english": "Celestial Milk", "native": "Tian Ru"}
+      "common_name": {"english": "Celestial Milk", "native": "天乳", "pronounce": "Tian Ru"}
     },
     {
       "id": "CON chinese 244",
       "lines": [[39953, 42570, 42913, 45941, 46701]],
-      "common_name": {"english": "Celestial Earth God's Temple", "native": "Tian She"}
+      "common_name": {"english": "Celestial Earth God's Temple", "native": "天社", "pronounce": "Tian She"}
     },
     {
       "id": "CON chinese 245",
       "lines": [[68520, 66200]],
-      "common_name": {"english": "Celestial Farmland (In Horn Mansion)", "native": "Tian Tian(Jiao Xiu)"}
+      "common_name": {"english": "Celestial Farmland (In Horn Mansion)", "native": "天田(角宿)", "pronounce": "Tian Tian(Jiao Xiu)"}
     },
     {
       "id": "CON chinese 246",
       "lines": [[104750, 102978], [104750, 104234, 102485], [102978, 102485]],
-      "common_name": {"english": "Celestial Farmland (In Ox Mansion)", "native": "Tian Tian(Niu Xiu)"}
+      "common_name": {"english": "Celestial Farmland (In Ox Mansion)", "native": "天田(牛宿)", "pronounce": "Tian Tian(Niu Xiu)"}
     },
     {
       "id": "CON chinese 247",
       "lines": [[49812, 50414]],
-      "common_name": {"english": "Celestial Premier", "native": "Tian Xiang"}
+      "common_name": {"english": "Celestial Premier", "native": "天相", "pronounce": "Tian Xiang"}
     },
     {
       "id": "CON chinese 248",
       "lines": [[67627, 67627]],
-      "common_name": {"english": "Celestial Great One", "native": "Tian Yi"}
+      "common_name": {"english": "Celestial Great One", "native": "天乙", "pronounce": "Tian Yi"}
     },
     {
       "id": "CON chinese 249",
       "lines": [[15737, 15110, 14838], [15110, 16181]],
-      "common_name": {"english": "Celestial Yin Force", "native": "Tian Yin"}
+      "common_name": {"english": "Celestial Yin Force", "native": "天阴", "pronounce": "Tian Yin"}
     },
     {
       "id": "CON chinese 250",
       "lines": [[9677, 11918, 13147]],
-      "common_name": {"english": "Ricks of Grain", "native": "Tian Yu"}
+      "common_name": {"english": "Ricks of Grain", "native": "天庾", "pronounce": "Tian Yu"}
     },
     {
       "id": "CON chinese 251",
       "lines": [[95294, 95241, 95347]],
-      "common_name": {"english": "Celestial Spring", "native": "Tian Yuan"}
+      "common_name": {"english": "Celestial Spring", "native": "天渊", "pronounce": "Tian Yuan"}
     },
     {
       "id": "CON chinese 252",
       "lines": [[7083, 9007, 10602, 11407, 12413, 13847, 17351, 17797, 17874, 20042, 20535, 21393, 21248]],
-      "common_name": {"english": "Celestial Orchard", "native": "Tian Yuan"}
+      "common_name": {"english": "Celestial Orchard", "native": "天园", "pronounce": "Tian Yuan"}
     },
     {
       "id": "CON chinese 253",
       "lines": [[18543, 17593, 17378, 16537, 15197, 13701, 12770, 12843, 13288, 14146, 15474, 16611, 17651, 17717, 18216, 18673]],
-      "common_name": {"english": "Celestial Meadows", "native": "Tian Yuan"}
+      "common_name": {"english": "Celestial Meadows", "native": "天苑", "pronounce": "Tian Yuan"}
     },
     {
       "id": "CON chinese 254",
       "lines": [[87706, 87099, 86736, 86352, 86060, 85755, 85783, 87072]],
-      "common_name": {"english": "Celestial Keyhole", "native": "Tian Yue"}
+      "common_name": {"english": "Celestial Keyhole", "native": "天籥", "pronounce": "Tian Yue"}
     },
     {
       "id": "CON chinese 255",
       "lines": [[102208, 104105, 98401, 94083, 88127]],
-      "common_name": {"english": "Celestial Pillar", "native": "Tian Zhu"}
+      "common_name": {"english": "Celestial Pillar", "native": "天柱", "pronounce": "Tian Zhu"}
     },
     {
       "id": "CON chinese 256",
       "lines": [[35846, 35550, 33927]],
-      "common_name": {"english": "Celestial Wine Cup", "native": "Tian Zun"}
+      "common_name": {"english": "Celestial Wine Cup", "native": "天樽", "pronounce": "Tian Zun"}
     },
     {
       "id": "CON chinese 257",
       "lines": [[90139, 88657]],
-      "common_name": {"english": "Butcher's Shops", "native": "Tu Si"}
+      "common_name": {"english": "Butcher's Shops", "native": "屠肆", "pronounce": "Tu Si"}
     },
     {
       "id": "CON chinese 258",
       "lines": [[194, 2025]],
-      "common_name": {"english": "Official for Earthworks and Buildings", "native": "Tu Gong"}
+      "common_name": {"english": "Official for Earthworks and Buildings", "native": "土公", "pronounce": "Tu Gong"}
     },
     {
       "id": "CON chinese 259",
       "lines": [[110386, 110986]],
-      "common_name": {"english": "Official for Materials Supply", "native": "Tu Gong Li"}
+      "common_name": {"english": "Official for Materials Supply", "native": "土公吏", "pronounce": "Tu Gong Li"}
     },
     {
       "id": "CON chinese 260",
       "lines": [[3419, 3419]],
-      "common_name": {"english": "Master of Constructions", "native": "Tu Si Kong"}
+      "common_name": {"english": "Master of Constructions", "native": "土司空", "pronounce": "Tu Si Kong"}
     },
     {
       "id": "CON chinese 261",
       "lines": [[41375, 42835, 43305, 43142]],
-      "common_name": {"english": "Outer Kitchen", "native": "Wai Chu"}
+      "common_name": {"english": "Outer Kitchen", "native": "外厨", "pronounce": "Wai Chu"}
     },
     {
       "id": "CON chinese 262",
       "lines": [[9487, 8833, 7884, 7007, 5737, 4906, 3786]],
-      "common_name": {"english": "Outer Fence", "native": "Wai Ping"}
+      "common_name": {"english": "Outer Fence", "native": "外屏", "pronounce": "Wai Ping"}
     },
     {
       "id": "CON chinese 263",
       "lines": [[746, 2599, 3821, 3179, 2505]],
-      "common_name": {"english": "Wang Liang", "native": "Wang Liang"}
+      "common_name": {"english": "Wang Liang", "native": "王良", "pronounce": "Wang Liang"}
     },
     {
       "id": "CON chinese 264",
       "lines": [],
-      "common_name": {"english": "Master of Constructions (In Legs Mansion)", "native": "Tu Si Kong"}
+      "common_name": {"english": "Master of Constructions (In Legs Mansion)", "native": "土司空(奎宿)", "pronounce": "Tu Si Kong"}
     },
     {
       "id": "CON chinese 265",
       "lines": [[48319, 48402, 46853, 44901, 45493]],
-      "common_name": {"english": "Administrative Center", "native": "Wen Chang"}
+      "common_name": {"english": "Administrative Center", "native": "文昌", "pronounce": "Wen Chang"}
     },
     {
       "id": "CON chinese 266",
       "lines": [[23015, 24608, 28360, 28380, 25428]],
-      "common_name": {"english": "Five Chariots", "native": "Wu Che"}
+      "common_name": {"english": "Five Chariots", "native": "五车", "pronounce": "Wu Che"}
     },
     {
       "id": "CON chinese 267",
       "lines": [[14417, 9727], [14417, 13055], [14417, 15547], [14417, 19461]],
-      "common_name": {"english": "Interior Seats of the Five Emperors", "native": "Wu Di Nei Zuo"}
+      "common_name": {"english": "Interior Seats of the Five Emperors", "native": "五帝内座", "pronounce": "Wu Di Nei Zuo"}
     },
     {
       "id": "CON chinese 268",
       "lines": [[57632, 57646], [57632, 57320], [57632, 58159], [57632, 57779]],
-      "common_name": {"english": "Seats of the Five Emperors", "native": "Wu Di Zuo"}
+      "common_name": {"english": "Seats of the Five Emperors", "native": "五帝座", "pronounce": "Wu Di Zuo"}
     },
     {
       "id": "CON chinese 269",
       "lines": [[33018, 34693, 36046, 36962, 38538]],
-      "common_name": {"english": "Five Feudal Kings", "native": "Wu Zhu Hou(JingXiu)"}
+      "common_name": {"english": "Five Feudal Kings", "native": "五诸侯(井宿)", "pronounce": "Wu Zhu Hou(JingXiu)"}
     },
     {
       "id": "CON chinese 270",
       "lines": [[63948, 63355, 62356, 59819]],
-      "common_name": {"english": "Five Lords", "native": "Wu Zhu Hou(Tai Wei Yuan)"}
+      "common_name": {"english": "Five Lords", "native": "五诸侯(太微垣)", "pronounce": "Wu Zhu Hou(Tai Wei Yuan)"}
     },
     {
       "id": "CON chinese 271",
       "lines": [[78727, 78207, 77853, 77060]],
-      "common_name": {"english": "Western Door", "native": "Xi Xian"}
+      "common_name": {"english": "Western Door", "native": "西咸", "pronounce": "Xi Xian"}
     },
     {
       "id": "CON chinese 272",
       "lines": [[94779, 95853, 96441, 96895]],
-      "common_name": {"english": "Xi Zhong", "native": "Xi Zhong"}
+      "common_name": {"english": "Xi Zhong", "native": "奚仲", "pronounce": "Xi Zhong"}
     },
     {
       "id": "CON chinese 273",
       "lines": [[25048, 25810, 24813]],
-      "common_name": {"english": "Pool of Harmony", "native": "Xian Chi"}
+      "common_name": {"english": "Pool of Harmony", "native": "咸池", "pronounce": "Xian Chi"}
     },
     {
       "id": "CON chinese 274",
       "lines": [[60485, 60485]],
-      "common_name": {"english": "Prime Minister", "native": "Xiang"}
+      "common_name": {"english": "Prime Minister", "native": "相", "pronounce": "Xiang"}
     },
     {
       "id": "CON chinese 275",
       "lines": [[60000, 58484, 51839, 52633, 46928, 46107, 43012, 40888, 36982]],
-      "common_name": {"english": "Little Dipper", "native": "Xiao Dou"}
+      "common_name": {"english": "Little Dipper", "native": "小斗", "pronounce": "Xiao Dou"}
     },
     {
       "id": "CON chinese 276",
       "lines": [[58519, 58519]],
-      "common_name": {"english": "Officer of Honour", "native": "Xing Chen"}
+      "common_name": {"english": "Officer of Honour", "native": "幸臣", "pronounce": "Xing Chen"}
     },
     {
       "id": "CON chinese 277",
       "lines": [[110023, 110578, 111710, 113345]],
-      "common_name": {"english": "Temple", "native": "Xu Liang"}
+      "common_name": {"english": "Temple", "native": "虚梁", "pronounce": "Xu Liang"}
     },
     {
       "id": "CON chinese 278",
       "lines": [[44248, 44700, 45688, 45860, 47617, 47701, 46146, 46750, 47908, 48455, 50335, 50583, 49583, 49669, 47508], [49669, 51624], [49669, 49637]],
-      "common_name": {"english": "Xuanyuan", "native": "Xuan Yuan"}
+      "common_name": {"english": "Xuanyuan", "native": "轩辕", "pronounce": "Xuan Yuan"}
     },
     {
       "id": "CON chinese 279",
       "lines": [[69732, 69732]],
-      "common_name": {"english": "Sombre Lance", "native": "Xuan Ge"}
+      "common_name": {"english": "Sombre Lance", "native": "玄戈", "pronounce": "Xuan Ge"}
     },
     {
       "id": "CON chinese 280",
       "lines": [[29655, 29655]],
-      "common_name": {"english": "Battle Axe (Vassal of Well)", "native": "Yue"}
+      "common_name": {"english": "Battle Axe (Vassal of Well)", "native": "钺(附官)", "pronounce": "Yue"}
     },
     {
       "id": "CON chinese 281",
       "lines": [[71865, 72010]],
-      "common_name": {"english": "Gate of Yang", "native": "Yang Men"}
+      "common_name": {"english": "Gate of Yang", "native": "阳门", "pronounce": "Yang Men"}
     },
     {
       "id": "CON chinese 282",
       "lines": [[31592, 31592]],
-      "common_name": {"english": "Wild Cockerel", "native": "Ye Ji"}
+      "common_name": {"english": "Wild Cockerel", "native": "野鸡", "pronounce": "Ye Ji"}
     },
     {
       "id": "CON chinese 283",
       "lines": [[60172, 60172]],
-      "common_name": {"english": "Usher to the Court", "native": "Ye Zhe"}
+      "common_name": {"english": "Usher to the Court", "native": "谒者", "pronounce": "Ye Zhe"}
     },
     {
       "id": "CON chinese 284",
       "lines": [[84969, 84979, 81852, 81065, 70638], [81852, 80047, 69896], [81852, 72370, 70248]],
-      "common_name": {"english": "Exotic Bird", "native": "Yi Que"}
+      "common_name": {"english": "Exotic Bird", "native": "异雀", "pronounce": "Yi Que"}
     },
     {
       "id": "CON chinese 285",
       "lines": [[51734, 51808]],
-      "common_name": {"english": "Hidden Virtue", "native": "Yin De"}
+      "common_name": {"english": "Hidden Virtue", "native": "阴德", "pronounce": "Yin De"}
     },
     {
       "id": "CON chinese 286",
       "lines": [[6706, 7097, 7535, 8198, 7710]],
-      "common_name": {"english": "Official in Charge of Pasturing", "native": "You Geng"}
+      "common_name": {"english": "Official in Charge of Pasturing", "native": "右更", "pronounce": "You Geng"}
     },
     {
       "id": "CON chinese 287",
       "lines": [[96229, 96665, 95501, 95585, 96468, 96392, 96556, 96483, 97928]],
-      "common_name": {"english": "Right Flag", "native": "You Qi"}
+      "common_name": {"english": "Right Flag", "native": "右旗", "pronounce": "You Qi"}
     },
     {
       "id": "CON chinese 288",
       "lines": [[67927, 67275, 67459]],
-      "common_name": {"english": "Right Conductor", "native": "You She Ti"}
+      "common_name": {"english": "Right Conductor", "native": "右摄提", "pronounce": "You She Ti"}
     },
     {
       "id": "CON chinese 289",
       "lines": [[87616, 87616]],
-      "common_name": {"english": "Fish", "native": "Yu"}
+      "common_name": {"english": "Fish", "native": "鱼", "pronounce": "Yu"}
     },
     {
       "id": "CON chinese 290",
       "lines": [[108797, 109332, 109786], [110391, 110529, 109789], [110641, 111954, 112862], [112362, 111449, 112529], [112211, 111539, 110778], [111086, 110602, 110179], [111200, 111843, 112161], [112615, 113031, 112716], [112542, 113136, 113148], [114341, 114375, 114119], [116247, 116118, 115669], [115438, 115404, 115125], [115115, 115033, 114855], [114164, 114054, 113996], [114939, 116758, 116971]],
-      "common_name": {"english": "Palace Guard", "native": "Yu Lin Jun"}
+      "common_name": {"english": "Palace Guard", "native": "羽林军", "pronounce": "Yu Lin Jun"}
     },
     {
       "id": "CON chinese 291",
       "lines": [[23972, 23364, 23875, 24674]],
-      "common_name": {"english": "Jade Well", "native": "Yu Jing"}
+      "common_name": {"english": "Jade Well", "native": "玉井", "pronounce": "Yu Jing"}
     },
     {
       "id": "CON chinese 292",
       "lines": [[94648, 92112, 85852], [94648, 89937]],
-      "common_name": {"english": "Maids-in-waiting", "native": "Yu Nü"}
+      "common_name": {"english": "Maids-in-waiting", "native": "御女", "pronounce": "Yu Nü"}
     },
     {
       "id": "CON chinese 293",
       "lines": [[19038, 19038]],
-      "common_name": {"english": "Lunar Star", "native": "Yue"}
+      "common_name": {"english": "Lunar Star", "native": "月", "pronounce": "Yue"}
     },
     {
       "id": "CON chinese 294",
       "lines": [[21683, 21683]],
-      "common_name": {"english": "Whisper (Vassal of Net)", "native": "Fu Er"}
+      "common_name": {"english": "Whisper (Vassal of Net)", "native": "附耳(附官)", "pronounce": "Fu Er"}
     },
     {
       "id": "CON chinese 295",
       "lines": [[115738, 115951, 117491, 116928]],
-      "common_name": {"english": "Cloud and Rain", "native": "Yun Yu"}
+      "common_name": {"english": "Cloud and Rain", "native": "云雨", "pronounce": "Yun Yu"}
     },
     {
       "id": "CON chinese 296",
       "lines": [[110991, 109492, 109556, 107259, 107418]],
-      "common_name": {"english": "Zaofu", "native": "Zao Fu"}
+      "common_name": {"english": "Zaofu", "native": "造父", "pronounce": "Zao Fu"}
     },
     {
       "id": "CON chinese 297",
       "lines": [[51585, 52689, 52911, 51775]],
-      "common_name": {"english": "Long Wall", "native": "Chang Yuan"}
+      "common_name": {"english": "Long Wall", "native": "长垣", "pronounce": "Chang Yuan"}
     },
     {
       "id": "CON chinese 298",
       "lines": [[26634, 25859]],
-      "common_name": {"english": "Grandfather", "native": "Zhang Ren"}
+      "common_name": {"english": "Grandfather", "native": "丈人", "pronounce": "Zhang Ren"}
     },
     {
       "id": "CON chinese 299",
       "lines": [[71075, 71075]],
-      "common_name": {"english": "Twinkling Indicator", "native": "Zhao Yao"}
+      "common_name": {"english": "Twinkling Indicator", "native": "招摇", "pronounce": "Zhao Yao"}
     },
     {
       "id": "CON chinese 300",
       "lines": [[65477, 65477]],
-      "common_name": {"english": "Assistant (Vassal of Northern Dipper)", "native": "Fu"}
+      "common_name": {"english": "Assistant (Vassal of Northern Dipper)", "native": "辅(附官)", "pronounce": "Fu"}
     },
     {
       "id": "CON chinese 301",
       "lines": [[69415, 71652, 71974, 72929, 73714]],
-      "common_name": {"english": "Executions", "native": "Zhe Wei"}
+      "common_name": {"english": "Executions", "native": "折威", "pronounce": "Zhe Wei"}
     },
     {
       "id": "CON chinese 302",
       "lines": [[72571, 73566, 74857]],
-      "common_name": {"english": "Battle Chariots", "native": "Zhen Che"}
+      "common_name": {"english": "Battle Chariots", "native": "阵车", "pronounce": "Zhen Che"}
     },
     {
       "id": "CON chinese 303",
       "lines": [[59199, 59199]],
-      "common_name": {"english": "Right linchpin (Vassal of Chariot)", "native": "You Xia"}
+      "common_name": {"english": "Right linchpin (Vassal of Chariot)", "native": "右辖(附官)", "pronounce": "You Xia"}
     },
     {
       "id": "CON chinese 304",
       "lines": [[91919, 91262, 91971]],
-      "common_name": {"english": "Weaving Girl", "native": "Zhi Nü"}
+      "common_name": {"english": "Weaving Girl", "native": "织女", "pronounce": "Zhi Nü"}
     },
     {
       "id": "CON chinese 305",
       "lines": [[61174, 61174]],
-      "common_name": {"english": "Left linchpin (Vassal of Chariot)", "native": "Zuo Xia"}
+      "common_name": {"english": "Left linchpin (Vassal of Chariot)", "native": "左辖(附官)", "pronounce": "Zuo Xia"}
     },
     {
       "id": "CON chinese 306",
       "lines": [[64394, 63462, 64022]],
-      "common_name": {"english": "Tripod of the Zhou", "native": "Zhou Ding"}
+      "common_name": {"english": "Tripod of the Zhou", "native": "周鼎", "pronounce": "Zhou Ding"}
     },
     {
       "id": "CON chinese 307",
       "lines": [[27830, 26640, 25695, 23900, 23068, 21881]],
-      "common_name": {"english": "Feudal Kings", "native": "Zhu Wang"}
+      "common_name": {"english": "Feudal Kings", "native": "诸王", "pronounce": "Zhu Wang"}
     },
     {
       "id": "CON chinese 308",
       "lines": [[23416, 23453, 23767, 23416], [27639, 27673, 27483, 27639], [25984, 26536]],
-      "common_name": {"english": "Pillars (In Net Mansion)", "native": "Zhu(Bi Xiu)"}
+      "common_name": {"english": "Pillars (In Net Mansion)", "native": "柱(毕宿)", "pronounce": "Zhu(Bi Xiu)"}
     },
     {
       "id": "CON chinese 309",
       "lines": [[70300, 70090], [68523, 68282], [69996, 70574], [67786, 67669, 67153], [65109, 65109]],
-      "common_name": {"english": "Pillars (In Horn Mansion)", "native": "Zhu(Jiao Xiu)"}
+      "common_name": {"english": "Pillars (In Horn Mansion)", "native": "柱(角宿)", "pronounce": "Zhu(Jiao Xiu)"}
     },
     {
       "id": "CON chinese 310",
       "lines": [[89908, 89908]],
-      "common_name": {"english": "Official of Royal Archives", "native": "Zhu Shi"}
+      "common_name": {"english": "Official of Royal Archives", "native": "柱史", "pronounce": "Zhu Shi"}
     },
     {
       "id": "CON chinese 311",
       "lines": [[27810, 27628]],
-      "common_name": {"english": "Son", "native": "Zi"}
+      "common_name": {"english": "Son", "native": "子", "pronounce": "Zi"}
     },
     {
       "id": "CON chinese 312",
       "lines": [[92043, 92161]],
-      "common_name": {"english": "Patriarchal Clan", "native": "Zong"}
+      "common_name": {"english": "Patriarchal Clan", "native": "宗", "pronounce": "Zong"}
     },
     {
       "id": "CON chinese 313",
       "lines": [[88149, 88192, 88290, 88601]],
-      "common_name": {"english": "Official of Religious Ceremonies", "native": "Zong Ren"}
+      "common_name": {"english": "Official of Religious Ceremonies", "native": "宗人", "pronounce": "Zong Ren"}
     },
     {
       "id": "CON chinese 314",
       "lines": [[86742, 87108]],
-      "common_name": {"english": "Official for the Royal Clan", "native": "Zong Zheng"}
+      "common_name": {"english": "Official for the Royal Clan", "native": "宗正", "pronounce": "Zong Zheng"}
     },
     {
       "id": "CON chinese 315",
       "lines": [[12332, 12640, 12803, 13327, 13165]],
-      "common_name": {"english": "Official in Charge of the Forest", "native": "Zuo Geng"}
+      "common_name": {"english": "Official in Charge of the Forest", "native": "左更", "pronounce": "Zuo Geng"}
     },
     {
       "id": "CON chinese 316",
       "lines": [[96757, 96837, 97365, 97496, 98337, 98438, 98234, 98754, 99742]],
-      "common_name": {"english": "Left Flag", "native": "Zuo Qi"}
+      "common_name": {"english": "Left Flag", "native": "左旗", "pronounce": "Zuo Qi"}
     },
     {
       "id": "CON chinese 317",
       "lines": [[72125, 71762, 71795]],
-      "common_name": {"english": "Left Conductor", "native": "Zuo She Ti"}
+      "common_name": {"english": "Left Conductor", "native": "左摄提", "pronounce": "Zuo She Ti"}
     },
     {
       "id": "CON chinese 318",
       "lines": [[32562, 33485, 32173, 32480, 31832, 32844, 31789, 31771, 33041]],
-      "common_name": {"english": "Seat Flags", "native": "Zuo Qi"}
+      "common_name": {"english": "Seat Flags", "native": "座旗", "pronounce": "Zuo Qi"}
     }
   ],
   "edges_type": "own",

--- a/skycultures/chinese_medieval/index.json
+++ b/skycultures/chinese_medieval/index.json
@@ -7,307 +7,307 @@
     {
       "id": "CON chinese_medieval P01",
       "lines": [[75097, 72607, 70692, 69112, 62572]],
-      "common_name": {"english": "Northern Pole", "native": "Bei Ji"}
+      "common_name": {"english": "Northern Pole", "native": "北极", "pronounce": "Bei Ji"}
     },
     {
       "id": "CON chinese_medieval P02",
       "lines": [[72573, 59767, 51384, 56253]],
-      "common_name": {"english": "Four Advisors", "native": "Si Fu"}
+      "common_name": {"english": "Four Advisors", "native": "四辅", "pronounce": "Si Fu"}
     },
     {
       "id": "CON chinese_medieval P03",
       "lines": [[67627, 67627]],
-      "common_name": {"english": "Celestial Great One", "native": "Tian Yi"}
+      "common_name": {"english": "Celestial Great One", "native": "天乙", "pronounce": "Tian Yi"}
     },
     {
       "id": "CON chinese_medieval P04",
       "lines": [[66798, 66798]],
-      "common_name": {"english": "First Great One", "native": "Tai Yi"}
+      "common_name": {"english": "First Great One", "native": "太乙", "pronounce": "Tai Yi"}
     },
     {
       "id": "CON chinese_medieval P05",
       "lines": [[75458, 78527, 80331, 83895, 89908, 99255, 111056, 6522]],
-      "common_name": {"english": "Purple Forbidden East Wall", "native": "Zi Wei Zuo Yuan"}
+      "common_name": {"english": "Purple Forbidden East Wall", "native": "紫微垣东蕃", "pronounce": "Zi Wei Zuo Yuan"}
     },
     {
       "id": "CON chinese_medieval P06",
       "lines": [[68756, 61281, 56211, 46977, 33827, 24254, 14862]],
-      "common_name": {"english": "Purple Forbidden West Wall", "native": "Zi Wei You Yuan"}
+      "common_name": {"english": "Purple Forbidden West Wall", "native": "紫微垣西蕃", "pronounce": "Zi Wei You Yuan"}
     },
     {
       "id": "CON chinese_medieval P07",
       "lines": [[74605, 73199]],
-      "common_name": {"english": "Hidden Virtue", "native": "Yin De"}
+      "common_name": {"english": "Hidden Virtue", "native": "阴德", "pronounce": "Yin De"}
     },
     {
       "id": "CON chinese_medieval P08",
       "lines": [[78893, 80161, 80650, 80682, 79414, 78893]],
-      "common_name": {"english": "Royal Secretary", "native": "Shang Shu"}
+      "common_name": {"english": "Royal Secretary", "native": "尚书", "pronounce": "Shang Shu"}
     },
     {
       "id": "CON chinese_medieval P09",
       "lines": [[86614, 86614]],
-      "common_name": {"english": "Female Protocol", "native": "Nü Shi"}
+      "common_name": {"english": "Female Protocol", "native": "女史", "pronounce": "Nü Shi"}
     },
     {
       "id": "CON chinese_medieval P10",
       "lines": [[89937, 89937]],
-      "common_name": {"english": "Official of Royal Archives", "native": "Zhu Shi"}
+      "common_name": {"english": "Official of Royal Archives", "native": "柱史", "pronounce": "Zhu Shi"}
     },
     {
       "id": "CON chinese_medieval P11",
       "lines": [[87234, 92112, 94083, 90647]],
-      "common_name": {"english": "Maids-in-waiting", "native": "Yu Nü"}
+      "common_name": {"english": "Maids-in-waiting", "native": "御女", "pronounce": "Yu Nü"}
     },
     {
       "id": "CON chinese_medieval P12",
       "lines": [[100965, 101082, 102599, 104756, 102208, 100965]],
-      "common_name": {"english": "Celestial Pillar", "native": "Tian Zhu"}
+      "common_name": {"english": "Celestial Pillar", "native": "天柱", "pronounce": "Tian Zhu"}
     },
     {
       "id": "CON chinese_medieval P13",
       "lines": [[77277, 75974]],
-      "common_name": {"english": "Chief Judge", "native": "Da Li"}
+      "common_name": {"english": "Chief Judge", "native": "大理", "pronounce": "Da Li"}
     },
     {
       "id": "CON chinese_medieval P14",
       "lines": [[112833, 5372, 11767, 85822, 82080, 77055]],
-      "common_name": {"english": "Curved Array", "native": "Gou Chen"}
+      "common_name": {"english": "Curved Array", "native": "勾陈", "pronounce": "Gou Chen"}
     },
     {
       "id": "CON chinese_medieval P15",
       "lines": [[10054, 10623, 4283, 3132, 2142, 5626, 10054]],
-      "common_name": {"english": "Six Jia", "native": "Liu Jia"}
+      "common_name": {"english": "Six Jia", "native": "六甲", "pronounce": "Liu Jia"}
     },
     {
       "id": "CON chinese_medieval P16",
       "lines": [[115746, 115746]],
-      "common_name": {"english": "Great Emperor of Heaven", "native": "Tian Huang Da Di"}
+      "common_name": {"english": "Great Emperor of Heaven", "native": "天皇大帝", "pronounce": "Tian Huang Da Di"}
     },
     {
       "id": "CON chinese_medieval P17",
       "lines": [[112519, 113116], [112519, 108456], [112519, 118027], [112519, 110724]],
-      "common_name": {"english": "Interior Seats of the Five Emperors", "native": "Wu Di Nei Zuo"}
+      "common_name": {"english": "Interior Seats of the Five Emperors", "native": "五帝内座", "pronounce": "Wu Di Nei Zuo"}
     },
     {
       "id": "CON chinese_medieval P18",
       "lines": [[9480, 13367, 12821, 11569, 9009, 8016, 7650]],
-      "common_name": {"english": "Canopy of the Emperor", "native": "Hua Gai"}
+      "common_name": {"english": "Canopy of the Emperor", "native": "华盖", "pronounce": "Hua Gai"}
     },
     {
       "id": "CON chinese_medieval P19",
       "lines": [[19461, 14844, 13055, 10309, 9568, 9727, 9763, 9586, 9598]],
-      "common_name": {"english": "Canopy Support (Vassal of Canopy of the Emperor)", "native": "Gang"}
+      "common_name": {"english": "Canopy Support (Vassal of Canopy of the Emperor)", "native": "杠(附华盖)", "pronounce": "Gang"}
     },
     {
       "id": "CON chinese_medieval P20",
       "lines": [[20266, 19177, 17884, 15890, 8362, 6312, 5566, 4572, 3951]],
-      "common_name": {"english": "Guest House", "native": "Chuan She"}
+      "common_name": {"english": "Guest House", "native": "传舍", "pronounce": "Chuan She"}
     },
     {
       "id": "CON chinese_medieval P21",
       "lines": [[44390, 37949, 36528], [42527, 40215, 36211]],
-      "common_name": {"english": "Inner Steps", "native": "Nei Jie"}
+      "common_name": {"english": "Inner Steps", "native": "内阶", "pronounce": "Nei Jie"}
     },
     {
       "id": "CON chinese_medieval P22",
       "lines": [[97433, 95081, 90344], [91315, 94376, 98702]],
-      "common_name": {"english": "Celestial Kitchen", "native": "Tian Chu"}
+      "common_name": {"english": "Celestial Kitchen", "native": "天厨", "pronounce": "Tian Chu"}
     },
     {
       "id": "CON chinese_medieval P23",
       "lines": [[23522, 21601, 20376, 21452, 22783, 24017, 22626, 24914]],
-      "common_name": {"english": "Eight Kinds of Crops", "native": "Ba Gu"}
+      "common_name": {"english": "Eight Kinds of Crops", "native": "八谷", "pronounce": "Ba Gu"}
     },
     {
       "id": "CON chinese_medieval P24",
       "lines": [[87585, 85829, 85670, 87833, 86414]],
-      "common_name": {"english": "Celestial Flail", "native": "Tian Bang"}
+      "common_name": {"english": "Celestial Flail", "native": "天棓", "pronounce": "Tian Bang"}
     },
     {
       "id": "CON chinese_medieval P25",
       "lines": [[73507, 71040, 70952], [72664, 71876, 68184]],
-      "common_name": {"english": "Celestial Bed", "native": "Tian Chuang"}
+      "common_name": {"english": "Celestial Bed", "native": "天床", "pronounce": "Tian Chuang"}
     },
     {
       "id": "CON chinese_medieval P26",
       "lines": [[62423, 63076]],
-      "common_name": {"english": "Inner Kitchen", "native": "Nei Chu"}
+      "common_name": {"english": "Inner Kitchen", "native": "内厨", "pronounce": "Nei Chu"}
     },
     {
       "id": "CON chinese_medieval P27",
       "lines": [[46733, 48319, 48402, 46853, 44901, 44504]],
-      "common_name": {"english": "Administrative Center", "native": "Wen Chang"}
+      "common_name": {"english": "Administrative Center", "native": "文昌", "pronounce": "Wen Chang"}
     },
     {
       "id": "CON chinese_medieval P28",
       "lines": [[52353, 50933, 51448]],
-      "common_name": {"english": "Three Top Instructors", "native": "San Shi"}
+      "common_name": {"english": "Three Top Instructors", "native": "三师", "pronounce": "San Shi"}
     },
     {
       "id": "CON chinese_medieval P29",
       "lines": [[54539, 54539]],
-      "common_name": {"english": "Royals", "native": "Tai Zun"}
+      "common_name": {"english": "Royals", "native": "太尊", "pronounce": "Tai Zun"}
     },
     {
       "id": "CON chinese_medieval P30",
       "lines": [[51814, 51459, 52136, 53261, 53043, 52478, 51814]],
-      "common_name": {"english": "Celestial Prison", "native": "Tian Lao"}
+      "common_name": {"english": "Celestial Prison", "native": "天牢", "pronounce": "Tian Lao"}
     },
     {
       "id": "CON chinese_medieval P31",
       "lines": [[57399, 57399]],
-      "common_name": {"english": "Guard of the Sun", "native": "Tai Yang Shou"}
+      "common_name": {"english": "Guard of the Sun", "native": "太阳守", "pronounce": "Tai Yang Shou"}
     },
     {
       "id": "CON chinese_medieval P32",
       "lines": [[57045, 55797, 54765, 56510, 57045]],
-      "common_name": {"english": "Eunuch", "native": "Shi"}
+      "common_name": {"english": "Eunuch", "native": "势", "pronounce": "Shi"}
     },
     {
       "id": "CON chinese_medieval P33",
       "lines": [[60988, 60988]],
-      "common_name": {"english": "Prime Minister", "native": "Xiang"}
+      "common_name": {"english": "Prime Minister", "native": "相", "pronounce": "Xiang"}
     },
     {
       "id": "CON chinese_medieval P34",
       "lines": [[66234, 64906, 65550]],
-      "common_name": {"english": "Three Excellencies (In Purple Forbidden Enclosure)", "native": "San gong(Zi Wei Yuan)"}
+      "common_name": {"english": "Three Excellencies (In Purple Forbidden Enclosure)", "native": "三公(紫微垣)", "pronounce": "San gong(Zi Wei Yuan)"}
     },
     {
       "id": "CON chinese_medieval P35",
       "lines": [[69732, 69732]],
-      "common_name": {"english": "Sombre Lance", "native": "Xuan Ge"}
+      "common_name": {"english": "Sombre Lance", "native": "玄戈", "pronounce": "Xuan Ge"}
     },
     {
       "id": "CON chinese_medieval P36",
       "lines": [[57477, 56083, 56944, 58181, 57477]],
-      "common_name": {"english": "Judge for Nobility", "native": "Tian Li"}
+      "common_name": {"english": "Judge for Nobility", "native": "天理", "pronounce": "Tian Li"}
     },
     {
       "id": "CON chinese_medieval P37",
       "lines": [[54061, 53910, 58001, 59774, 62956, 65378, 67301]],
-      "common_name": {"english": "Northern Dipper", "native": "Bei Dou"}
+      "common_name": {"english": "Northern Dipper", "native": "北斗", "pronounce": "Bei Dou"}
     },
     {
       "id": "CON chinese_medieval P38",
       "lines": [[65477, 65477]],
-      "common_name": {"english": "Assistant (Vassal of Northern Dipper)", "native": "Fu"}
+      "common_name": {"english": "Assistant (Vassal of Northern Dipper)", "native": "辅(附北斗)", "pronounce": "Fu"}
     },
     {
       "id": "CON chinese_medieval P39",
       "lines": [[70497, 69713, 69483]],
-      "common_name": {"english": "Celestial Spear", "native": "Tian Qiang"}
+      "common_name": {"english": "Celestial Spear", "native": "天枪", "pronounce": "Tian Qiang"}
     },
     {
       "id": "CON chinese_medieval S01",
       "lines": [[60129, 61941, 63090, 63608, 64241]],
-      "common_name": {"english": "Supreme Palace East Wall", "native": "Tai Wei Zuo Yuan"}
+      "common_name": {"english": "Supreme Palace East Wall", "native": "太微垣东蕃", "pronounce": "Tai Wei Zuo Yuan"}
     },
     {
       "id": "CON chinese_medieval S02",
       "lines": [[57757, 55434, 55642, 54879, 54872]],
-      "common_name": {"english": "Supreme Palace West Wall", "native": "Tai Wei You Yuan"}
+      "common_name": {"english": "Supreme Palace West Wall", "native": "太微垣西蕃", "pronounce": "Tai Wei You Yuan"}
     },
     {
       "id": "CON chinese_medieval S03",
       "lines": [[60172, 60172]],
-      "common_name": {"english": "Usher to the Court", "native": "Ye Zhe"}
+      "common_name": {"english": "Usher to the Court", "native": "谒者", "pronounce": "Ye Zhe"}
     },
     {
       "id": "CON chinese_medieval S04",
       "lines": [[60353, 61103, 61658]],
-      "common_name": {"english": "Three Excellencies (In Supreme Palace Enclosure)", "native": "San Gong(Tai Wei Yuan)"}
+      "common_name": {"english": "Three Excellencies (In Supreme Palace Enclosure)", "native": "三公(太微垣)", "pronounce": "San Gong(Tai Wei Yuan)"}
     },
     {
       "id": "CON chinese_medieval S05",
       "lines": [[62541, 62394, 61960]],
-      "common_name": {"english": "Nine Senior Officers", "native": "Jiu Qing"}
+      "common_name": {"english": "Nine Senior Officers", "native": "九卿", "pronounce": "Jiu Qing"}
     },
     {
       "id": "CON chinese_medieval S06",
       "lines": [[62886, 61724, 60957, 60202, 59819]],
-      "common_name": {"english": "Five Lords", "native": "Wu Zhu Hou(Tai Wei Yuan)"}
+      "common_name": {"english": "Five Lords", "native": "五诸侯(太微垣)", "pronounce": "Wu Zhu Hou(Tai Wei Yuan)"}
     },
     {
       "id": "CON chinese_medieval S07",
       "lines": [[57328, 57380, 58590, 58948]],
-      "common_name": {"english": "Inner Screen", "native": "Nei Ping"}
+      "common_name": {"english": "Inner Screen", "native": "内屏", "pronounce": "Nei Ping"}
     },
     {
       "id": "CON chinese_medieval S08",
       "lines": [[58159, 57632, 57320], [57646, 57632, 57779]],
-      "common_name": {"english": "Seats of the Five Emperors", "native": "Wu Di Zuo"}
+      "common_name": {"english": "Seats of the Five Emperors", "native": "五帝座", "pronounce": "Wu Di Zuo"}
     },
     {
       "id": "CON chinese_medieval S09",
       "lines": [[58858, 58858]],
-      "common_name": {"english": "Officer of Honour", "native": "Xing Chen"}
+      "common_name": {"english": "Officer of Honour", "native": "幸臣", "pronounce": "Xing Chen"}
     },
     {
       "id": "CON chinese_medieval S10",
       "lines": [[57565, 57565]],
-      "common_name": {"english": "Crown Prince", "native": "Tai Zi"}
+      "common_name": {"english": "Crown Prince", "native": "太子", "pronounce": "Tai Zi"}
     },
     {
       "id": "CON chinese_medieval S11",
       "lines": [[56975, 56975]],
-      "common_name": {"english": "Retinue (In Supreme Palace Enclosure)", "native": "Cong Guan(Tai Wei Yuan)"}
+      "common_name": {"english": "Retinue (In Supreme Palace Enclosure)", "native": "从官(太微垣)", "pronounce": "Cong Guan(Tai Wei Yuan)"}
     },
     {
       "id": "CON chinese_medieval S12",
       "lines": [[63121, 63121]],
-      "common_name": {"english": "Captain of the Bodyguards", "native": "Lang Jiang"}
+      "common_name": {"english": "Captain of the Bodyguards", "native": "郎将", "pronounce": "Lang Jiang"}
     },
     {
       "id": "CON chinese_medieval S13",
       "lines": [[54951, 54951]],
-      "common_name": {"english": "Emperor's Bodyguard", "native": "Hu Ben"}
+      "common_name": {"english": "Emperor's Bodyguard", "native": "虎贲", "pronounce": "Hu Ben"}
     },
     {
       "id": "CON chinese_medieval S14",
       "lines": [[59856, 58386, 58460, 58654, 57670, 56997, 56410]],
-      "common_name": {"english": "Royal Guards", "native": "Chang Chen"}
+      "common_name": {"english": "Royal Guards", "native": "常陈", "pronounce": "Chang Chen"}
     },
     {
       "id": "CON chinese_medieval S15",
       "lines": [[60018, 60742], [60018, 59923, 60742, 60697, 60098, 59489, 59923], [60880, 60746, 60170, 59364, 59489], [60697, 60746], [60880, 60904, 60514, 60351, 60168, 59468, 59364]],
-      "common_name": {"english": "Officers of the Imperial Guard", "native": "Lang Wei"}
+      "common_name": {"english": "Officers of the Imperial Guard", "native": "郎位", "pronounce": "Lang Wei"}
     },
     {
       "id": "CON chinese_medieval S16",
       "lines": [[56647, 56127, 55084]],
-      "common_name": {"english": "The Hall of Glory", "native": "Ming Tang"}
+      "common_name": {"english": "The Hall of Glory", "native": "明堂", "pronounce": "Ming Tang"}
     },
     {
       "id": "CON chinese_medieval S17",
       "lines": [[54863, 54182, 53824]],
-      "common_name": {"english": "Astronomical Observatory", "native": "Ling Tai"}
+      "common_name": {"english": "Astronomical Observatory", "native": "灵台", "pronounce": "Ling Tai"}
     },
     {
       "id": "CON chinese_medieval S18",
       "lines": [[52638, 52959, 53417, 53954]],
-      "common_name": {"english": "Junior Officers", "native": "Shao Wei"}
+      "common_name": {"english": "Junior Officers", "native": "少微", "pronounce": "Shao Wei"}
     },
     {
       "id": "CON chinese_medieval S19",
       "lines": [[52457, 52686, 52689, 52911]],
-      "common_name": {"english": "Long Wall", "native": "Chang Yuan"}
+      "common_name": {"english": "Long Wall", "native": "长垣", "pronounce": "Chang Yuan"}
     },
     {
       "id": "CON chinese_medieval S20",
       "lines": [[44127, 44471]],
-      "common_name": {"english": "Three Steps (Upper Step)", "native": "San Tai"}
+      "common_name": {"english": "Three Steps (Upper Step)", "native": "三台(上台)", "pronounce": "San Tai"}
     },
     {
       "id": "CON chinese_medieval S21",
       "lines": [[50372, 50801]],
-      "common_name": {"english": "Three Steps (Middle Step)", "native": "San Tai"}
+      "common_name": {"english": "Three Steps (Middle Step)", "native": "三台(中台)", "pronounce": "San Tai"}
     },
     {
       "id": "CON chinese_medieval S22",
       "lines": [[55219, 55203]],
-      "common_name": {"english": "Three Steps (Lower Step)", "native": "San Tai"}
+      "common_name": {"english": "Three Steps (Lower Step)", "native": "三台(下台)", "pronounce": "San Tai"}
     },
     {
       "id": "CON chinese_medieval S23",
@@ -317,1387 +317,1387 @@
     {
       "id": "CON chinese_medieval H01",
       "lines": [[84379, 85693, 86974, 88794, 92043, 93747, 92946, 89962, 88048, 86263, 84012]],
-      "common_name": {"english": "Heavenly Market East Wall", "native": "Tian Shi Zuo Yuan"}
+      "common_name": {"english": "Heavenly Market East Wall", "native": "天市垣东蕃", "pronounce": "Tian Shi Zuo Yuan"}
     },
     {
       "id": "CON chinese_medieval H02",
       "lines": [[80816, 80170, 79043, 78072, 77233, 76276, 77070, 77622, 79593, 79882, 81377]],
-      "common_name": {"english": "Heavenly Market West Wall", "native": "Tian Shi You Yuan"}
+      "common_name": {"english": "Heavenly Market West Wall", "native": "天市垣西蕃", "pronounce": "Tian Shi You Yuan"}
     },
     {
       "id": "CON chinese_medieval H03",
       "lines": [[85474, 86284, 86768, 85922, 85365, 84524, 85474]],
-      "common_name": {"english": "Municipal Office", "native": "Shi Lou"}
+      "common_name": {"english": "Municipal Office", "native": "市楼", "pronounce": "Shi Lou"}
     },
     {
       "id": "CON chinese_medieval H04",
       "lines": [[82979, 82369]],
-      "common_name": {"english": "Commodity Market", "native": "Che Si"}
+      "common_name": {"english": "Commodity Market", "native": "车肆", "pronounce": "Che Si"}
     },
     {
       "id": "CON chinese_medieval H05",
       "lines": [[86742, 87108]],
-      "common_name": {"english": "Official for the Royal Clan", "native": "Zong Zheng"}
+      "common_name": {"english": "Official for the Royal Clan", "native": "宗正", "pronounce": "Zong Zheng"}
     },
     {
       "id": "CON chinese_medieval H06",
       "lines": [[88601, 88192], [88290, 88601, 88149]],
-      "common_name": {"english": "Official of Religious Ceremonies", "native": "Zong Ren"}
+      "common_name": {"english": "Official of Religious Ceremonies", "native": "宗人", "pronounce": "Zong Ren"}
     },
     {
       "id": "CON chinese_medieval H07",
       "lines": [[88765, 88771]],
-      "common_name": {"english": "Patriarchal Clan", "native": "Zong"}
+      "common_name": {"english": "Patriarchal Clan", "native": "宗", "pronounce": "Zong"}
     },
     {
       "id": "CON chinese_medieval H08",
       "lines": [[88899, 88331]],
-      "common_name": {"english": "Textile Ruler", "native": "Bo Du"}
+      "common_name": {"english": "Textile Ruler", "native": "帛度", "pronounce": "Bo Du"}
     },
     {
       "id": "CON chinese_medieval H09",
       "lines": [[88886, 88267]],
-      "common_name": {"english": "Butcher's Shops", "native": "Tu Si"}
+      "common_name": {"english": "Butcher's Shops", "native": "屠肆", "pronounce": "Tu Si"}
     },
     {
       "id": "CON chinese_medieval H10",
       "lines": [[86032, 86032]],
-      "common_name": {"english": "Astrologer", "native": "Hou"}
+      "common_name": {"english": "Astrologer", "native": "候", "pronounce": "Hou"}
     },
     {
       "id": "CON chinese_medieval H11",
       "lines": [[84345, 84345]],
-      "common_name": {"english": "Emperor's Seat", "native": "Di Zuo"}
+      "common_name": {"english": "Emperor's Seat", "native": "帝座", "pronounce": "Di Zuo"}
     },
     {
       "id": "CON chinese_medieval H12",
       "lines": [[82802, 83430, 83504, 83613]],
-      "common_name": {"english": "Eunuch Official", "native": "Huan Zhe"}
+      "common_name": {"english": "Eunuch Official", "native": "宦者", "pronounce": "Huan Zhe"}
     },
     {
       "id": "CON chinese_medieval H13",
       "lines": [[80179, 80883]],
-      "common_name": {"english": "Jewel Market", "native": "Lie Si"}
+      "common_name": {"english": "Jewel Market", "native": "列肆", "pronounce": "Lie Si"}
     },
     {
       "id": "CON chinese_medieval H14",
       "lines": [[83000, 82673, 82073, 82402, 82216]],
-      "common_name": {"english": "Dipper for Liquids", "native": "Dou"}
+      "common_name": {"english": "Dipper for Liquids", "native": "斗", "pronounce": "Dou"}
     },
     {
       "id": "CON chinese_medieval H15",
       "lines": [[81641, 82037, 84500, 85355]],
-      "common_name": {"english": "Dipper for Solids", "native": "Hu"}
+      "common_name": {"english": "Dipper for Solids", "native": "斛", "pronounce": "Hu"}
     },
     {
       "id": "CON chinese_medieval H16",
       "lines": [[77655, 76127, 75695, 76267, 76952, 77512, 78159, 78493, 78459, 77655]],
-      "common_name": {"english": "Coiled Thong", "native": "Guan Suo"}
+      "common_name": {"english": "Coiled Thong", "native": "贯索", "pronounce": "Guan Suo"}
     },
     {
       "id": "CON chinese_medieval H17",
       "lines": [[83947, 81833, 80460, 78012, 75411, 73555, 71075]],
-      "common_name": {"english": "Seven Excellencies", "native": "Qi Gong"}
+      "common_name": {"english": "Seven Excellencies", "native": "七公", "pronounce": "Qi Gong"}
     },
     {
       "id": "CON chinese_medieval H18",
       "lines": [[87563, 87808, 85382, 84862, 83313, 83207, 81693, 80197, 80181]],
-      "common_name": {"english": "Celestial Discipline", "native": "Tian Ji"}
+      "common_name": {"english": "Celestial Discipline", "native": "天纪", "pronounce": "Tian Ji"}
     },
     {
       "id": "CON chinese_medieval H19",
       "lines": [[84380, 84606, 85112]],
-      "common_name": {"english": "Woman's Bed", "native": "Nü Chuang"}
+      "common_name": {"english": "Woman's Bed", "native": "女床", "pronounce": "Nü Chuang"}
     },
     {
       "id": "CON chinese_medieval 01A",
       "lines": [[65474, 66249]],
-      "common_name": {"english": "Horn", "native": "Jiao Xiu"}
+      "common_name": {"english": "Horn", "native": "角宿", "pronounce": "Jiao Xiu"}
     },
     {
       "id": "CON chinese_medieval 01B",
       "lines": [[65323, 66006]],
-      "common_name": {"english": "Flat Road", "native": "Ping Dao"}
+      "common_name": {"english": "Flat Road", "native": "平道", "pronounce": "Ping Dao"}
     },
     {
       "id": "CON chinese_medieval 01C",
       "lines": [[66936, 66200]],
-      "common_name": {"english": "Celestial Farmland (In Horn Mansion)", "native": "Tian Tian(Jiao Xiu)"}
+      "common_name": {"english": "Celestial Farmland (In Horn Mansion)", "native": "天田(角宿)", "pronounce": "Tian Tian(Jiao Xiu)"}
     },
     {
       "id": "CON chinese_medieval 01D",
       "lines": [[64238, 64238]],
-      "common_name": {"english": "Recommending Virtuous Men", "native": "Jin Xian"}
+      "common_name": {"english": "Recommending Virtuous Men", "native": "进贤", "pronounce": "Jin Xian"}
     },
     {
       "id": "CON chinese_medieval 01E",
       "lines": [[67480, 66763, 66727]],
-      "common_name": {"english": "Tripod of the Zhou", "native": "Zhou Ding"}
+      "common_name": {"english": "Tripod of the Zhou", "native": "周鼎", "pronounce": "Zhou Ding"}
     },
     {
       "id": "CON chinese_medieval 01F",
       "lines": [[66015, 64924]],
-      "common_name": {"english": "Celestial Gate", "native": "Tian Men"}
+      "common_name": {"english": "Celestial Gate", "native": "天门", "pronounce": "Tian Men"}
     },
     {
       "id": "CON chinese_medieval 01G",
       "lines": [[66400, 64962]],
-      "common_name": {"english": "Judging", "native": "Ping"}
+      "common_name": {"english": "Judging", "native": "平", "pronounce": "Ping"}
     },
     {
       "id": "CON chinese_medieval 01H",
       "lines": [[68282, 71352, 68933, 67457, 65109, 64408, 63972, 64332, 64557, 64348]],
-      "common_name": {"english": "Arsenal", "native": "Ku Lou"}
+      "common_name": {"english": "Arsenal", "native": "库楼", "pronounce": "Ku Lou"}
     },
     {
       "id": "CON chinese_medieval 01I",
       "lines": [[67464, 67472], [68245, 68862, 67464]],
-      "common_name": {"english": "Railings", "native": "Heng"}
+      "common_name": {"english": "Railings", "native": "衡", "pronounce": "Heng"}
     },
     {
       "id": "CON chinese_medieval 01J",
       "lines": [[64004, 66657]],
-      "common_name": {"english": "Southern Gate", "native": "Nan Men"}
+      "common_name": {"english": "Southern Gate", "native": "南门", "pronounce": "Nan Men"}
     },
     {
       "id": "CON chinese_medieval 01K",
       "lines": [[71860, 71536, 70931]],
-      "common_name": {"english": "Pillars (In Horn Mansion)", "native": "Zhu(Jiao Xiu)"}
+      "common_name": {"english": "Pillars (In Horn Mansion)", "native": "柱(角宿)", "pronounce": "Zhu(Jiao Xiu)"}
     },
     {
       "id": "CON chinese_medieval 01L",
       "lines": [[70574, 70104, 69996]],
-      "common_name": {"english": "Pillars (In Horn Mansion)", "native": "Zhu(Jiao Xiu)"}
+      "common_name": {"english": "Pillars (In Horn Mansion)", "native": "柱(角宿)", "pronounce": "Zhu(Jiao Xiu)"}
     },
     {
       "id": "CON chinese_medieval 01M",
       "lines": [[68523, 68002, 67663]],
-      "common_name": {"english": "Pillars (In Horn Mansion)", "native": "Zhu(Jiao Xiu)"}
+      "common_name": {"english": "Pillars (In Horn Mansion)", "native": "柱(角宿)", "pronounce": "Zhu(Jiao Xiu)"}
     },
     {
       "id": "CON chinese_medieval 01N",
       "lines": [[70300, 70090, 68493]],
-      "common_name": {"english": "Pillars (In Horn Mansion)", "native": "Zhu(Jiao Xiu)"}
+      "common_name": {"english": "Pillars (In Horn Mansion)", "native": "柱(角宿)", "pronounce": "Zhu(Jiao Xiu)"}
     },
     {
       "id": "CON chinese_medieval 01O",
       "lines": [[65936, 65535, 65593]],
-      "common_name": {"english": "Pillars (In Horn Mansion)", "native": "Zhu(Jiao Xiu)"}
+      "common_name": {"english": "Pillars (In Horn Mansion)", "native": "柱(角宿)", "pronounce": "Zhu(Jiao Xiu)"}
     },
     {
       "id": "CON chinese_medieval 02A",
       "lines": [[69427, 69701, 70755], [69427, 69974]],
-      "common_name": {"english": "Neck", "native": "Kang Xiu"}
+      "common_name": {"english": "Neck", "native": "亢宿", "pronounce": "Kang Xiu"}
     },
     {
       "id": "CON chinese_medieval 02B",
       "lines": [[69673, 69673]],
-      "common_name": {"english": "Great Horn", "native": "Da Jiao"}
+      "common_name": {"english": "Great Horn", "native": "大角", "pronounce": "Da Jiao"}
     },
     {
       "id": "CON chinese_medieval 02C",
       "lines": [[71295, 70518, 69929, 69658, 69269, 68763, 67057]],
-      "common_name": {"english": "Executions", "native": "Zhe Wei"}
+      "common_name": {"english": "Executions", "native": "折威", "pronounce": "Zhe Wei"}
     },
     {
       "id": "CON chinese_medieval 02D",
       "lines": [[72125, 71762, 71795]],
-      "common_name": {"english": "Left Conductor", "native": "Zuo She Ti"}
+      "common_name": {"english": "Left Conductor", "native": "左摄提", "pronounce": "Zuo She Ti"}
     },
     {
       "id": "CON chinese_medieval 02E",
       "lines": [[67927, 67275, 67459]],
-      "common_name": {"english": "Right Conductor", "native": "You She Ti"}
+      "common_name": {"english": "Right Conductor", "native": "右摄提", "pronounce": "You She Ti"}
     },
     {
       "id": "CON chinese_medieval 02F",
       "lines": [[70469, 70306]],
-      "common_name": {"english": "Trials", "native": "Dun Wan"}
+      "common_name": {"english": "Trials", "native": "顿顽", "pronounce": "Dun Wan"}
     },
     {
       "id": "CON chinese_medieval 02G",
       "lines": [[69415, 68895]],
-      "common_name": {"english": "Gate of Yang", "native": "Yang Men"}
+      "common_name": {"english": "Gate of Yang", "native": "阳门", "pronounce": "Yang Men"}
     },
     {
       "id": "CON chinese_medieval 03A",
       "lines": [[72622, 74392, 76333, 74785]],
-      "common_name": {"english": "Root", "native": "Di Xiu"}
+      "common_name": {"english": "Root", "native": "氐宿", "pronounce": "Di Xiu"}
     },
     {
       "id": "CON chinese_medieval 03B",
       "lines": [[77516, 77516]],
-      "common_name": {"english": "Celestial Milk", "native": "Tian Ru"}
+      "common_name": {"english": "Celestial Milk", "native": "天乳", "pronounce": "Tian Ru"}
     },
     {
       "id": "CON chinese_medieval 03C",
       "lines": [[69879, 69879]],
-      "common_name": {"english": "Twinkling Indicator", "native": "Zhao Yao"}
+      "common_name": {"english": "Twinkling Indicator", "native": "招摇", "pronounce": "Zhao Yao"}
     },
     {
       "id": "CON chinese_medieval 03D",
       "lines": [[72105, 71284, 71053]],
-      "common_name": {"english": "Celestial Lance", "native": "Geng He"}
+      "common_name": {"english": "Celestial Lance", "native": "梗河", "pronounce": "Geng He"}
     },
     {
       "id": "CON chinese_medieval 03E",
       "lines": [[72659, 71115, 70602]],
-      "common_name": {"english": "Mattress of the Emperor", "native": "Di Xi"}
+      "common_name": {"english": "Mattress of the Emperor", "native": "帝席", "pronounce": "Di Xi"}
     },
     {
       "id": "CON chinese_medieval 03F",
       "lines": [[70027, 69829, 69585, 69536, 69612, 69989, 70027]],
-      "common_name": {"english": "Boats and Lake", "native": "Kang Chi"}
+      "common_name": {"english": "Boats and Lake", "native": "亢池", "pronounce": "Kang Chi"}
     },
     {
       "id": "CON chinese_medieval 03G",
       "lines": [[73714, 73184, 72929]],
-      "common_name": {"english": "Battle Chariots", "native": "Zhen Che"}
+      "common_name": {"english": "Battle Chariots", "native": "阵车", "pronounce": "Zhen Che"}
     },
     {
       "id": "CON chinese_medieval 03H",
       "lines": [[74395, 74006, 72290]],
-      "common_name": {"english": "Chariots and Cavalry", "native": "Che Qi"}
+      "common_name": {"english": "Chariots and Cavalry", "native": "车骑", "pronounce": "Che Qi"}
     },
     {
       "id": "CON chinese_medieval 03I",
       "lines": [[76470, 76742]],
-      "common_name": {"english": "Celestial Spokes", "native": "Tian Fu"}
+      "common_name": {"english": "Celestial Spokes", "native": "天辐", "pronounce": "Tian Fu"}
     },
     {
       "id": "CON chinese_medieval 03J",
       "lines": [[74376, 74376]],
-      "common_name": {"english": "Chariots and Cavalry General", "native": "Qi Zhen Jiang Jun"}
+      "common_name": {"english": "Chariots and Cavalry General", "native": "骑阵将军", "pronounce": "Qi Zhen Jiang Jun"}
     },
     {
       "id": "CON chinese_medieval 03K",
       "lines": [[73559, 72959, 72010]],
-      "common_name": {"english": "Imperial Guards", "native": "Qi Guan"}
+      "common_name": {"english": "Imperial Guards", "native": "骑官", "pronounce": "Qi Guan"}
     },
     {
       "id": "CON chinese_medieval 03L",
       "lines": [[74604, 74857, 73937]],
-      "common_name": {"english": "Imperial Guards", "native": "Qi Guan"}
+      "common_name": {"english": "Imperial Guards", "native": "骑官", "pronounce": "Qi Guan"}
     },
     {
       "id": "CON chinese_medieval 03M",
       "lines": [[72800, 72432, 71865]],
-      "common_name": {"english": "Imperial Guards", "native": "Qi Guan"}
+      "common_name": {"english": "Imperial Guards", "native": "骑官", "pronounce": "Qi Guan"}
     },
     {
       "id": "CON chinese_medieval 03N",
       "lines": [[75177, 75304, 75647]],
-      "common_name": {"english": "Imperial Guards", "native": "Qi Guan"}
+      "common_name": {"english": "Imperial Guards", "native": "骑官", "pronounce": "Qi Guan"}
     },
     {
       "id": "CON chinese_medieval 03O",
       "lines": [[75501, 75141, 76297]],
-      "common_name": {"english": "Imperial Guards", "native": "Qi Guan"}
+      "common_name": {"english": "Imperial Guards", "native": "骑官", "pronounce": "Qi Guan"}
     },
     {
       "id": "CON chinese_medieval 03P",
       "lines": [[73334, 73273, 72683]],
-      "common_name": {"english": "Imperial Guards", "native": "Qi Guan"}
+      "common_name": {"english": "Imperial Guards", "native": "骑官", "pronounce": "Qi Guan"}
     },
     {
       "id": "CON chinese_medieval 03Q",
       "lines": [[75264, 74117, 73807]],
-      "common_name": {"english": "Imperial Guards", "native": "Qi Guan"}
+      "common_name": {"english": "Imperial Guards", "native": "骑官", "pronounce": "Qi Guan"}
     },
     {
       "id": "CON chinese_medieval 03R",
       "lines": [[75828, 74911, 75206]],
-      "common_name": {"english": "Imperial Guards", "native": "Qi Guan"}
+      "common_name": {"english": "Imperial Guards", "native": "骑官", "pronounce": "Qi Guan"}
     },
     {
       "id": "CON chinese_medieval 03S",
       "lines": [[76552, 76829, 76371]],
-      "common_name": {"english": "Imperial Guards", "native": "Qi Guan"}
+      "common_name": {"english": "Imperial Guards", "native": "骑官", "pronounce": "Qi Guan"}
     },
     {
       "id": "CON chinese_medieval 04A",
       "lines": [[78820, 78401, 78265, 78104], [78933, 78820]],
-      "common_name": {"english": "Room", "native": "Fang Xiu"}
+      "common_name": {"english": "Room", "native": "房宿", "pronounce": "Fang Xiu"}
     },
     {
       "id": "CON chinese_medieval 04B",
       "lines": [[78933, 78990]],
-      "common_name": {"english": "Lock (Vassal of Room)", "native": "Gou Qian"}
+      "common_name": {"english": "Lock (Vassal of Room)", "native": "钩钤(附房宿)", "pronounce": "Gou Qian"}
     },
     {
       "id": "CON chinese_medieval 04C",
       "lines": [[79374, 79374]],
-      "common_name": {"english": "Door Bolt", "native": "Jian Bi"}
+      "common_name": {"english": "Door Bolt", "native": "键闭", "pronounce": "Jian Bi"}
     },
     {
       "id": "CON chinese_medieval 04D",
       "lines": [[80343, 80569, 80894]],
-      "common_name": {"english": "Punishment", "native": "Fa"}
+      "common_name": {"english": "Punishment", "native": "罚", "pronounce": "Fa"}
     },
     {
       "id": "CON chinese_medieval 04E",
       "lines": [[81724, 80975, 80473, 80815]],
-      "common_name": {"english": "Eastern Door", "native": "Dong Xian"}
+      "common_name": {"english": "Eastern Door", "native": "东咸", "pronounce": "Dong Xian"}
     },
     {
       "id": "CON chinese_medieval 04F",
       "lines": [[78727, 78207, 77853, 77060]],
-      "common_name": {"english": "Western Door", "native": "Xi Xian"}
+      "common_name": {"english": "Western Door", "native": "西咸", "pronounce": "Xi Xian"}
     },
     {
       "id": "CON chinese_medieval 04G",
       "lines": [[77840, 77840]],
-      "common_name": {"english": "Solar Star", "native": "Ri"}
+      "common_name": {"english": "Solar Star", "native": "日", "pronounce": "Ri"}
     },
     {
       "id": "CON chinese_medieval 04H",
       "lines": [[78918, 77634]],
-      "common_name": {"english": "Retinue (In Room Mansion)", "native": "Cong Guan(Fang Xiu)"}
+      "common_name": {"english": "Retinue (In Room Mansion)", "native": "从官(房宿)", "pronounce": "Cong Guan(Fang Xiu)"}
     },
     {
       "id": "CON chinese_medieval 05A",
       "lines": [[80112, 80763, 81266]],
-      "common_name": {"english": "Heart", "native": "Xin Xiu"}
+      "common_name": {"english": "Heart", "native": "心宿", "pronounce": "Xin Xiu"}
     },
     {
       "id": "CON chinese_medieval 05B",
       "lines": [[80337, 81304], [80337, 80911], [79320, 78384], [79320, 78323], [80212, 79653], [80212, 80582], [80945, 81305], [80945, 81972], [80337, 79320, 80212, 80945, 80337]],
-      "common_name": {"english": "Group of Soldiers", "native": "Ji Zu"}
+      "common_name": {"english": "Group of Soldiers", "native": "积卒", "pronounce": "Ji Zu"}
     },
     {
       "id": "CON chinese_medieval 06A",
       "lines": [[82396, 82514, 82671, 84143, 86228, 87073, 86670, 85927], [86670, 85696], [82514, 82545]],
-      "common_name": {"english": "Tail", "native": "Wei Xiu"}
+      "common_name": {"english": "Tail", "native": "尾宿", "pronounce": "Wei Xiu"}
     },
     {
       "id": "CON chinese_medieval 06B",
       "lines": [[82545, 82545]],
-      "common_name": {"english": "Changing Room (Vassal of Tail)", "native": "Shen Gong"}
+      "common_name": {"english": "Changing Room (Vassal of Tail)", "native": "神宫(附房宿)", "pronounce": "Shen Gong"}
     },
     {
       "id": "CON chinese_medieval 06C",
       "lines": [[84720, 86092, 86486, 85792, 84105]],
-      "common_name": {"english": "Tortoise", "native": "Gui"}
+      "common_name": {"english": "Tortoise", "native": "龟", "pronounce": "Gui"}
     },
     {
       "id": "CON chinese_medieval 06D",
       "lines": [[85755, 85340, 84970, 84405]],
-      "common_name": {"english": "Celestial River", "native": "Tian Jiang"}
+      "common_name": {"english": "Celestial River", "native": "天江", "pronounce": "Tian Jiang"}
     },
     {
       "id": "CON chinese_medieval 06E",
       "lines": [[87261, 87261]],
-      "common_name": {"english": "Fu Yue", "native": "Fu Yue"}
+      "common_name": {"english": "Fu Yue", "native": "傅说", "pronounce": "Fu Yue"}
     },
     {
       "id": "CON chinese_medieval 06F",
       "lines": [[87616, 87616]],
-      "common_name": {"english": "Fish", "native": "Yu"}
+      "common_name": {"english": "Fish", "native": "鱼", "pronounce": "Yu"}
     },
     {
       "id": "CON chinese_medieval 07A",
       "lines": [[88635, 89931, 90185, 89642]],
-      "common_name": {"english": "Winnowing Basket", "native": "Ji Xiu"}
+      "common_name": {"english": "Winnowing Basket", "native": "箕宿", "pronounce": "Ji Xiu"}
     },
     {
       "id": "CON chinese_medieval 07B",
       "lines": [[90842, 90422, 90568]],
-      "common_name": {"english": "Pestle (In Winnowing Basket Mansion)", "native": "Chu(Ji Xiu)"}
+      "common_name": {"english": "Pestle (In Winnowing Basket Mansion)", "native": "杵(箕宿)", "pronounce": "Chu(Ji Xiu)"}
     },
     {
       "id": "CON chinese_medieval 07C",
       "lines": [[88550, 88550]],
-      "common_name": {"english": "Chaff", "native": "Kang"}
+      "common_name": {"english": "Chaff", "native": "糠", "pronounce": "Kang"}
     },
     {
       "id": "CON chinese_medieval 08A",
       "lines": [[89341, 90496, 92041, 92855, 93864, 93506]],
-      "common_name": {"english": "Dipper", "native": "Dou Xiu"}
+      "common_name": {"english": "Dipper", "native": "斗宿", "pronounce": "Dou Xiu"}
     },
     {
       "id": "CON chinese_medieval 08B",
       "lines": [[93085, 93683, 94141, 94820, 95168, 95176]],
-      "common_name": {"english": "Establishment", "native": "Jian"}
+      "common_name": {"english": "Establishment", "native": "建", "pronounce": "Jian"}
     },
     {
       "id": "CON chinese_medieval 08C",
       "lines": [[93580, 94149, 93805, 93526, 93429, 93026, 92488, 91726, 91117]],
-      "common_name": {"english": "Market Officer", "native": "Tian Bian"}
+      "common_name": {"english": "Market Officer", "native": "天弁", "pronounce": "Tian Bian"}
     },
     {
       "id": "CON chinese_medieval 08D",
       "lines": [[94114, 93825, 93174, 92989, 91875, 90968, 90887, 90982, 91494, 92308, 92953, 93542, 94005, 94160, 94114]],
-      "common_name": {"english": "River Turtle", "native": "Bie"}
+      "common_name": {"english": "River Turtle", "native": "鳖", "pronounce": "Bie"}
     },
     {
       "id": "CON chinese_medieval 08E",
       "lines": [[96950, 97783]],
-      "common_name": {"english": "Celestial Cock", "native": "Tian Ji"}
+      "common_name": {"english": "Celestial Cock", "native": "天鸡", "pronounce": "Tian Ji"}
     },
     {
       "id": "CON chinese_medieval 08F",
       "lines": [[88012, 87836, 87706, 88116, 89153, 89980, 89678, 88839, 88012]],
-      "common_name": {"english": "Celestial Keyhole", "native": "Tian Yue"}
+      "common_name": {"english": "Celestial Keyhole", "native": "天籥", "pronounce": "Tian Yue"}
     },
     {
       "id": "CON chinese_medieval 08G",
       "lines": [[96465, 95477]],
-      "common_name": {"english": "Dog", "native": "Gou"}
+      "common_name": {"english": "Dog", "native": "狗", "pronounce": "Gou"}
     },
     {
       "id": "CON chinese_medieval 08H",
       "lines": [[98066, 98353, 98688, 98162, 98066]],
-      "common_name": {"english": "Territory of Dog", "native": "Gou Guo"}
+      "common_name": {"english": "Territory of Dog", "native": "狗国", "pronounce": "Gou Guo"}
     },
     {
       "id": "CON chinese_medieval 08I",
       "lines": [[97067, 96234, 95823, 96721, 98032, 97749, 97067], [98412, 97749], [94986, 96234], [95823, 95241], [98512, 98032]],
-      "common_name": {"english": "Celestial Spring", "native": "Tian Yuan"}
+      "common_name": {"english": "Celestial Spring", "native": "天渊", "pronounce": "Tian Yuan"}
     },
     {
       "id": "CON chinese_medieval 08J",
       "lines": [[90763, 90763]],
-      "common_name": {"english": "Peasant", "native": "Nong Zhang Ren"}
+      "common_name": {"english": "Peasant", "native": "农丈人", "pronounce": "Nong Zhang Ren"}
     },
     {
       "id": "CON chinese_medieval 09A",
       "lines": [[100345, 100881, 101123, 101027, 100345, 100310], [100345, 100064]],
-      "common_name": {"english": "Ox", "native": "Niu Xiu"}
+      "common_name": {"english": "Ox", "native": "牛宿", "pronounce": "Niu Xiu"}
     },
     {
       "id": "CON chinese_medieval 09B",
       "lines": [[100195, 100062, 99825], [101090, 101384, 100738], [101997, 102094, 102092], [102094, 101384, 100062]],
-      "common_name": {"english": "Celestial Farmland (In Ox Mansion)", "native": "Tian Tian(Niu Xiu)"}
+      "common_name": {"english": "Celestial Farmland (In Ox Mansion)", "native": "天田(牛宿)", "pronounce": "Tian Tian(Niu Xiu)"}
     },
     {
       "id": "CON chinese_medieval 09C",
       "lines": [[101772, 102790, 101477], [102790, 105685, 105334], [105685, 105425], [105685, 107649], [106429, 107649, 107409]],
-      "common_name": {"english": "Nine Water Wells", "native": "Jiu Kan"}
+      "common_name": {"english": "Nine Water Wells", "native": "九坎", "pronounce": "Jiu Kan"}
     },
     {
       "id": "CON chinese_medieval 09D",
       "lines": [[98036, 97649, 97278]],
-      "common_name": {"english": "Drum at the River", "native": "He Gu"}
+      "common_name": {"english": "Drum at the River", "native": "河鼓", "pronounce": "He Gu"}
     },
     {
       "id": "CON chinese_medieval 09E",
       "lines": [[91919, 91262, 91971]],
-      "common_name": {"english": "Weaving Girl", "native": "Zhi Nü"}
+      "common_name": {"english": "Weaving Girl", "native": "织女", "pronounce": "Zhi Nü"}
     },
     {
       "id": "CON chinese_medieval 09F",
       "lines": [[98754, 98234, 97365, 98337, 98920, 99352, 100276, 99742, 100256]],
-      "common_name": {"english": "Left Flag", "native": "Zuo Qi"}
+      "common_name": {"english": "Left Flag", "native": "左旗", "pronounce": "Zuo Qi"}
     },
     {
       "id": "CON chinese_medieval 09G",
       "lines": [[96665, 97229, 96229, 94727, 95501, 96468, 95937, 95066, 96483]],
-      "common_name": {"english": "Right Flag", "native": "You Qi"}
+      "common_name": {"english": "Right Flag", "native": "右旗", "pronounce": "You Qi"}
     },
     {
       "id": "CON chinese_medieval 09H",
       "lines": [[100232, 99473, 98844, 97804]],
-      "common_name": {"english": "Celestial Drumstick", "native": "Tian Fu"}
+      "common_name": {"english": "Celestial Drumstick", "native": "天桴", "pronounce": "Tian Fu"}
     },
     {
       "id": "CON chinese_medieval 09I",
       "lines": [[101923, 102026, 101984]],
-      "common_name": {"english": "Network of Dykes", "native": "Luo Yan"}
+      "common_name": {"english": "Network of Dykes", "native": "罗堰", "pronounce": "Luo Yan"}
     },
     {
       "id": "CON chinese_medieval 09J",
       "lines": [[92791, 92420, 93194, 93903]],
-      "common_name": {"english": "Clepsydra Terrace", "native": "Jian Tai"}
+      "common_name": {"english": "Clepsydra Terrace", "native": "渐台", "pronounce": "Jian Tai"}
     },
     {
       "id": "CON chinese_medieval 09K",
       "lines": [[92862, 94481, 94713, 95556, 96052]],
-      "common_name": {"english": "Imperial Passageway", "native": "Nian Dao"}
+      "common_name": {"english": "Imperial Passageway", "native": "辇道", "pronounce": "Nian Dao"}
     },
     {
       "id": "CON chinese_medieval 10A",
       "lines": [[102618, 103045, 103005, 102624]],
-      "common_name": {"english": "Girl", "native": "Nü Xiu"}
+      "common_name": {"english": "Girl", "native": "女宿", "pronounce": "Nü Xiu"}
     },
     {
       "id": "CON chinese_medieval 10B",
       "lines": [[101692, 101847, 101101, 100977]],
-      "common_name": {"english": "Pearls on Ladies' Wear", "native": "Li Zhu"}
+      "common_name": {"english": "Pearls on Ladies' Wear", "native": "离珠", "pronounce": "Li Zhu"}
     },
     {
       "id": "CON chinese_medieval 10C",
       "lines": [[101483, 101882, 101800, 101421, 101483, 101589]],
-      "common_name": {"english": "Rotten Gourd", "native": "Bai Gua"}
+      "common_name": {"english": "Rotten Gourd", "native": "败瓜", "pronounce": "Bai Gua"}
     },
     {
       "id": "CON chinese_medieval 10D",
       "lines": [[102532, 101958, 101769, 102080, 102281, 102532]],
-      "common_name": {"english": "Good Gourd", "native": "Hu Gua"}
+      "common_name": {"english": "Good Gourd", "native": "瓠瓜", "pronounce": "Hu Gua"}
     },
     {
       "id": "CON chinese_medieval 10E",
       "lines": [[104732, 105138, 104887, 103413, 102098, 99639, 97165, 100453, 102488, 104732]],
-      "common_name": {"english": "Celestial Ford", "native": "Tian Jin"}
+      "common_name": {"english": "Celestial Ford", "native": "天津", "pronounce": "Tian Jin"}
     },
     {
       "id": "CON chinese_medieval 10F",
       "lines": [[94779, 95853, 96620, 97635]],
-      "common_name": {"english": "Xi Zhong", "native": "Xi Zhong"}
+      "common_name": {"english": "Xi Zhong", "native": "奚仲", "pronounce": "Xi Zhong"}
     },
     {
       "id": "CON chinese_medieval 10G",
       "lines": [[92549, 91755, 90905, 90156, 89401, 89047, 88732]],
-      "common_name": {"english": "Basket for Mulberry Leaves", "native": "Fu Kuang"}
+      "common_name": {"english": "Basket for Mulberry Leaves", "native": "扶筐", "pronounce": "Fu Kuang"}
     },
     {
       "id": "CON chinese_medieval 10H",
       "lines": [[102978, 102485]],
-      "common_name": {"english": "Twelve States (Zhao State)", "native": "Shi Er Guo (Zhao)"}
+      "common_name": {"english": "Twelve States (Zhao State)", "native": "十二国(赵)", "pronounce": "Shi Er Guo (Zhao)"}
     },
     {
       "id": "CON chinese_medieval 10I",
       "lines": [[102014, 102014]],
-      "common_name": {"english": "Twelve States (Yue State)", "native": "Shi Er Guo (Yue)"}
+      "common_name": {"english": "Twelve States (Yue State)", "native": "十二国(越)", "pronounce": "Shi Er Guo (Yue)"}
     },
     {
       "id": "CON chinese_medieval 10J",
       "lines": [[103226, 102487]],
-      "common_name": {"english": "Twelve States (Zhou State)", "native": "Shi Er Guo (Zhou)"}
+      "common_name": {"english": "Twelve States (Zhou State)", "native": "十二国(周)", "pronounce": "Shi Er Guo (Zhou)"}
     },
     {
       "id": "CON chinese_medieval 10K",
       "lines": [[102831, 102831]],
-      "common_name": {"english": "Twelve States (Qi State)", "native": "Shi Er Guo (Qi)"}
+      "common_name": {"english": "Twelve States (Qi State)", "native": "十二国(齐)", "pronounce": "Shi Er Guo (Qi)"}
     },
     {
       "id": "CON chinese_medieval 10L",
       "lines": [[103738, 103738]],
-      "common_name": {"english": "Twelve States (Zheng State)", "native": "Shi Er Guo (Zheng)"}
+      "common_name": {"english": "Twelve States (Zheng State)", "native": "十二国(郑)", "pronounce": "Shi Er Guo (Zheng)"}
     },
     {
       "id": "CON chinese_medieval 10M",
       "lines": [[103777, 103777]],
-      "common_name": {"english": "Twelve States (Chu State)", "native": "Shi Er Guo (Chu)"}
+      "common_name": {"english": "Twelve States (Chu State)", "native": "十二国(楚)", "pronounce": "Shi Er Guo (Chu)"}
     },
     {
       "id": "CON chinese_medieval 10N",
       "lines": [[104139, 104019]],
-      "common_name": {"english": "Twelve States (Qin State)", "native": "Shi Er Guo (Qin)"}
+      "common_name": {"english": "Twelve States (Qin State)", "native": "十二国(秦)", "pronounce": "Shi Er Guo (Qin)"}
     },
     {
       "id": "CON chinese_medieval 10O",
       "lines": [[104174, 104174]],
-      "common_name": {"english": "Twelve States (Yan State)", "native": "Shi Er Guo (Yan)"}
+      "common_name": {"english": "Twelve States (Yan State)", "native": "十二国(燕)", "pronounce": "Shi Er Guo (Yan)"}
     },
     {
       "id": "CON chinese_medieval 10P",
       "lines": [[104234, 104234]],
-      "common_name": {"english": "Twelve States (Wei State)", "native": "Shi Er Guo (Wei)"}
+      "common_name": {"english": "Twelve States (Wei State)", "native": "十二国(魏)", "pronounce": "Shi Er Guo (Wei)"}
     },
     {
       "id": "CON chinese_medieval 10Q",
       "lines": [[104963, 105515]],
-      "common_name": {"english": "Twelve States (Dai State)", "native": "Shi Er Guo (Dai)"}
+      "common_name": {"english": "Twelve States (Dai State)", "native": "十二国(代)", "pronounce": "Shi Er Guo (Dai)"}
     },
     {
       "id": "CON chinese_medieval 10R",
       "lines": [[105140, 105140]],
-      "common_name": {"english": "Twelve States (Jin State)", "native": "Shi Er Guo (Jin)"}
+      "common_name": {"english": "Twelve States (Jin State)", "native": "十二国(晋)", "pronounce": "Shi Er Guo (Jin)"}
     },
     {
       "id": "CON chinese_medieval 10S",
       "lines": [[104750, 104750]],
-      "common_name": {"english": "Twelve States (Han State)", "native": "Shi Er Guo (Han)"}
+      "common_name": {"english": "Twelve States (Han State)", "native": "十二国(韩)", "pronounce": "Shi Er Guo (Han)"}
     },
     {
       "id": "CON chinese_medieval 11A",
       "lines": [[106278, 104987]],
-      "common_name": {"english": "Emptiness", "native": "Xu Xiu"}
+      "common_name": {"english": "Emptiness", "native": "虚宿", "pronounce": "Xu Xiu"}
     },
     {
       "id": "CON chinese_medieval 11B",
       "lines": [[107575, 106944]],
-      "common_name": {"english": "Deified Judge of Life", "native": "Si Ming"}
+      "common_name": {"english": "Deified Judge of Life", "native": "司命", "pronounce": "Si Ming"}
     },
     {
       "id": "CON chinese_medieval 11C",
       "lines": [[107151, 106856]],
-      "common_name": {"english": "Deified Judge of Rank", "native": "Si Lu"}
+      "common_name": {"english": "Deified Judge of Rank", "native": "司禄", "pronounce": "Si Lu"}
     },
     {
       "id": "CON chinese_medieval 11D",
       "lines": [[104858, 104521]],
-      "common_name": {"english": "Deified Judge of Disaster and Good Fortune", "native": "Si wei"}
+      "common_name": {"english": "Deified Judge of Disaster and Good Fortune", "native": "司危", "pronounce": "Si wei"}
     },
     {
       "id": "CON chinese_medieval 11E",
       "lines": [[107348, 107788]],
-      "common_name": {"english": "Deified Judge of Right and Wrong", "native": "Si Fei"}
+      "common_name": {"english": "Deified Judge of Right and Wrong", "native": "司非", "pronounce": "Si Fei"}
     },
     {
       "id": "CON chinese_medieval 11F",
       "lines": [[106039, 105881]],
-      "common_name": {"english": "Crying", "native": "Ku"}
+      "common_name": {"english": "Crying", "native": "哭", "pronounce": "Ku"}
     },
     {
       "id": "CON chinese_medieval 11G",
       "lines": [[110273, 110003]],
-      "common_name": {"english": "Weeping", "native": "Qi"}
+      "common_name": {"english": "Weeping", "native": "泣", "pronounce": "Qi"}
     },
     {
       "id": "CON chinese_medieval 11H",
       "lines": [[108085, 108294, 108681, 109289, 109285, 109422, 108952, 108661, 106913, 106564, 106703, 106907, 107019, 108085]],
-      "common_name": {"english": "Celestial Ramparts", "native": "Tian Lei Cheng"}
+      "common_name": {"english": "Celestial Ramparts", "native": "天垒城", "pronounce": "Tian Lei Cheng"}
     },
     {
       "id": "CON chinese_medieval 11I",
       "lines": [[109973, 109268, 112122, 112203]],
-      "common_name": {"english": "Decayed Mortar", "native": "Bai Jiu"}
+      "common_name": {"english": "Decayed Mortar", "native": "败臼", "pronounce": "Bai Jiu"}
     },
     {
       "id": "CON chinese_medieval 11J",
       "lines": [[106340, 106067, 105476]],
-      "common_name": {"english": "Jade Ornament on Ladies' Wear", "native": "Li Yu"}
+      "common_name": {"english": "Jade Ornament on Ladies' Wear", "native": "离瑜", "pronounce": "Li Yu"}
     },
     {
       "id": "CON chinese_medieval 12A",
       "lines": [[109074, 109427, 107315], [109427, 110672]],
-      "common_name": {"english": "Rooftop", "native": "Wei Xiu"}
+      "common_name": {"english": "Rooftop", "native": "危宿", "pronounce": "Wei Xiu"}
     },
     {
       "id": "CON chinese_medieval 12B",
       "lines": [[110960, 110395], [110960, 111497], [110960, 110672]],
-      "common_name": {"english": "Tomb (Vassal of Rooftop)", "native": "Fen Mu"}
+      "common_name": {"english": "Tomb (Vassal of Rooftop)", "native": "坟墓(附危宿)", "pronounce": "Fen Mu"}
     },
     {
       "id": "CON chinese_medieval 12C",
       "lines": [[107763, 107975], [107763, 107310], [107763, 108022], [107763, 107354]],
-      "common_name": {"english": "Humans", "native": "Ren"}
+      "common_name": {"english": "Humans", "native": "人", "pronounce": "Ren"}
     },
     {
       "id": "CON chinese_medieval 12D",
       "lines": [[110371, 109056, 109176]],
-      "common_name": {"english": "Mortar", "native": "Jiu"}
+      "common_name": {"english": "Mortar", "native": "臼", "pronounce": "Jiu"}
     },
     {
       "id": "CON chinese_medieval 12E",
       "lines": [[109937, 109654, 109410]],
-      "common_name": {"english": "Pestle (In Rooftop Mansion)", "native": "Chu(Wei Xiu)"}
+      "common_name": {"english": "Pestle (In Rooftop Mansion)", "native": "杵(危宿)", "pronounce": "Chu(Wei Xiu)"}
     },
     {
       "id": "CON chinese_medieval 12F",
       "lines": [[111944, 111104, 109831, 107856, 107253, 106551, 106711, 107856]],
-      "common_name": {"english": "Big Yard for Chariots", "native": "Che Fu"}
+      "common_name": {"english": "Big Yard for Chariots", "native": "车府", "pronounce": "Che Fu"}
     },
     {
       "id": "CON chinese_medieval 12G",
       "lines": [[116727, 114222, 111532, 109400, 107119, 106032, 102370, 100261, 101134]],
-      "common_name": {"english": "Celestial Hook", "native": "Tian Gou"}
+      "common_name": {"english": "Celestial Hook", "native": "天钩", "pronounce": "Tian Gou"}
     },
     {
       "id": "CON chinese_medieval 12H",
       "lines": [[110991, 113561, 111795], [109492, 113561, 109857]],
-      "common_name": {"english": "Zaofu", "native": "Zao Fu"}
+      "common_name": {"english": "Zaofu", "native": "造父", "pronounce": "Zao Fu"}
     },
     {
       "id": "CON chinese_medieval 12I",
       "lines": [[111710, 111170, 110532, 110023]],
-      "common_name": {"english": "Temple", "native": "Xu Liang"}
+      "common_name": {"english": "Temple", "native": "虚梁", "pronounce": "Xu Liang"}
     },
     {
       "id": "CON chinese_medieval 12J",
       "lines": [[110391, 110746, 110529, 109990, 109737, 109375, 109199, 109509, 109786, 110135, 110391]],
-      "common_name": {"english": "Celestial Money", "native": "Tian Qian"}
+      "common_name": {"english": "Celestial Money", "native": "天钱", "pronounce": "Tian Qian"}
     },
     {
       "id": "CON chinese_medieval 12K",
       "lines": [[108991, 108874]],
-      "common_name": {"english": "Roofing", "native": "Gai Wu"}
+      "common_name": {"english": "Roofing", "native": "盖屋", "pronounce": "Gai Wu"}
     },
     {
       "id": "CON chinese_medieval 13A",
       "lines": [[113963, 113881, 115250], [113881, 112748], [113881, 112051]],
-      "common_name": {"english": "Encampment", "native": "Shi Xiu"}
+      "common_name": {"english": "Encampment", "native": "室宿", "pronounce": "Shi Xiu"}
     },
     {
       "id": "CON chinese_medieval 13B",
       "lines": [[112051, 112158]],
-      "common_name": {"english": "Resting Palace (Vassal of Encampment)", "native": "Li Gong"}
+      "common_name": {"english": "Resting Palace (Vassal of Encampment)", "native": "离宫(附室宿)", "pronounce": "Li Gong"}
     },
     {
       "id": "CON chinese_medieval 13C",
       "lines": [[112748, 112440]],
-      "common_name": {"english": "Resting Palace (Vassal of Encampment)", "native": "Li Gong"}
+      "common_name": {"english": "Resting Palace (Vassal of Encampment)", "native": "离宫(附室宿)", "pronounce": "Li Gong"}
     },
     {
       "id": "CON chinese_medieval 13D",
       "lines": [[115250, 115623]],
-      "common_name": {"english": "Resting Palace (Vassal of Encampment)", "native": "Li Gong"}
+      "common_name": {"english": "Resting Palace (Vassal of Encampment)", "native": "离宫(附室宿)", "pronounce": "Li Gong"}
     },
     {
       "id": "CON chinese_medieval 13E",
       "lines": [[117020, 115919, 114389, 114144, 113503, 112935]],
-      "common_name": {"english": "Thunder and Lightning", "native": "Lei Dian"}
+      "common_name": {"english": "Thunder and Lightning", "native": "雷电", "pronounce": "Lei Dian"}
     },
     {
       "id": "CON chinese_medieval 13F",
       "lines": [[112447, 112029]],
-      "common_name": {"english": "Official for Materials Supply", "native": "Tu Gong Li"}
+      "common_name": {"english": "Official for Materials Supply", "native": "土公吏", "pronounce": "Tu Gong Li"}
     },
     {
       "id": "CON chinese_medieval 13G",
       "lines": [[118209, 154, 443, 145, 118209, 114724, 112961, 111123, 109139, 107556, 106985, 106723, 107188, 107556]],
-      "common_name": {"english": "Line of Ramparts", "native": "Lei Bi Zhen"}
+      "common_name": {"english": "Line of Ramparts", "native": "垒壁阵", "pronounce": "Lei Bi Zhen"}
     },
     {
       "id": "CON chinese_medieval 13H",
       "lines": [[116231, 115833, 115102]],
-      "common_name": {"english": "Axe", "native": "Fu Yue"}
+      "common_name": {"english": "Axe", "native": "𫓧钺", "pronounce": "Fu Yue"}
     },
     {
       "id": "CON chinese_medieval 13I",
       "lines": [[113368, 113368]],
-      "common_name": {"english": "North Gate of the Military Camp", "native": "Bei Luo Shi Men"}
+      "common_name": {"english": "North Gate of the Military Camp", "native": "北落师门", "pronounce": "Bei Luo Shi Men"}
     },
     {
       "id": "CON chinese_medieval 13J",
       "lines": [[111188, 111188]],
-      "common_name": {"english": "Materials for Making Tents", "native": "Tian Gang"}
+      "common_name": {"english": "Materials for Making Tents", "native": "天纲", "pronounce": "Tian Gang"}
     },
     {
       "id": "CON chinese_medieval 13K",
       "lines": [[115990, 117301, 117863, 117299, 114924, 114162, 113501, 112761, 111169, 113288, 113919, 114570, 115022, 115152, 116584, 116805, 116631], [111169, 111674], [111169, 110538], [111169, 109521], [111169, 110609], [111169, 111022]],
-      "common_name": {"english": "Flying Serpent", "native": "Teng She"}
+      "common_name": {"english": "Flying Serpent", "native": "螣蛇", "pronounce": "Teng She"}
     },
     {
       "id": "CON chinese_medieval 13L",
       "lines": [[3521, 3456, 2240, 133, 950], [5042, 2663, 2240, 2081, 966]],
-      "common_name": {"english": "Net for Catching Birds", "native": "Ba Kui"}
+      "common_name": {"english": "Net for Catching Birds", "native": "八魁", "pronounce": "Ba Kui"}
     },
     {
       "id": "CON chinese_medieval 13M",
       "lines": [[1158, 1562, 355]],
-      "common_name": {"english": "Palace Guard", "native": "Yu Lin Jun"}
+      "common_name": {"english": "Palace Guard", "native": "羽林军", "pronounce": "Yu Lin Jun"}
     },
     {
       "id": "CON chinese_medieval 13N",
       "lines": [[117541, 117314, 117567]],
-      "common_name": {"english": "Palace Guard", "native": "Yu Lin Jun"}
+      "common_name": {"english": "Palace Guard", "native": "羽林军", "pronounce": "Yu Lin Jun"}
     },
     {
       "id": "CON chinese_medieval 13O",
       "lines": [[116957, 116971, 116758]],
-      "common_name": {"english": "Palace Guard", "native": "Yu Lin Jun"}
+      "common_name": {"english": "Palace Guard", "native": "羽林军", "pronounce": "Yu Lin Jun"}
     },
     {
       "id": "CON chinese_medieval 13P",
       "lines": [[117629, 117218, 116901]],
-      "common_name": {"english": "Palace Guard", "native": "Yu Lin Jun"}
+      "common_name": {"english": "Palace Guard", "native": "羽林军", "pronounce": "Yu Lin Jun"}
     },
     {
       "id": "CON chinese_medieval 13Q",
       "lines": [[116247, 115669, 115438]],
-      "common_name": {"english": "Palace Guard", "native": "Yu Lin Jun"}
+      "common_name": {"english": "Palace Guard", "native": "羽林军", "pronounce": "Yu Lin Jun"}
     },
     {
       "id": "CON chinese_medieval 13R",
       "lines": [[115033, 114939, 114855]],
-      "common_name": {"english": "Palace Guard", "native": "Yu Lin Jun"}
+      "common_name": {"english": "Palace Guard", "native": "羽林军", "pronounce": "Yu Lin Jun"}
     },
     {
       "id": "CON chinese_medieval 13S",
       "lines": [[113998, 113136, 113080]],
-      "common_name": {"english": "Palace Guard", "native": "Yu Lin Jun"}
+      "common_name": {"english": "Palace Guard", "native": "羽林军", "pronounce": "Yu Lin Jun"}
     },
     {
       "id": "CON chinese_medieval 13T",
       "lines": [[113531, 113031, 112716]],
-      "common_name": {"english": "Palace Guard", "native": "Yu Lin Jun"}
+      "common_name": {"english": "Palace Guard", "native": "羽林军", "pronounce": "Yu Lin Jun"}
     },
     {
       "id": "CON chinese_medieval 13U",
       "lines": [[112211, 112529, 111449]],
-      "common_name": {"english": "Palace Guard", "native": "Yu Lin Jun"}
+      "common_name": {"english": "Palace Guard", "native": "羽林军", "pronounce": "Yu Lin Jun"}
     },
     {
       "id": "CON chinese_medieval 13V",
       "lines": [[111515, 111138, 111954]],
-      "common_name": {"english": "Palace Guard", "native": "Yu Lin Jun"}
+      "common_name": {"english": "Palace Guard", "native": "羽林军", "pronounce": "Yu Lin Jun"}
     },
     {
       "id": "CON chinese_medieval 13W",
       "lines": [[111539, 111086, 110778]],
-      "common_name": {"english": "Palace Guard", "native": "Yu Lin Jun"}
+      "common_name": {"english": "Palace Guard", "native": "羽林军", "pronounce": "Yu Lin Jun"}
     },
     {
       "id": "CON chinese_medieval 13X",
       "lines": [[107797, 108784, 107901]],
-      "common_name": {"english": "Palace Guard", "native": "Yu Lin Jun"}
+      "common_name": {"english": "Palace Guard", "native": "羽林军", "pronounce": "Yu Lin Jun"}
     },
     {
       "id": "CON chinese_medieval 13Y",
       "lines": [[109624, 110000, 110602]],
-      "common_name": {"english": "Palace Guard", "native": "Yu Lin Jun"}
+      "common_name": {"english": "Palace Guard", "native": "羽林军", "pronounce": "Yu Lin Jun"}
     },
     {
       "id": "CON chinese_medieval 13Z",
       "lines": [[116591, 115126, 115839]],
-      "common_name": {"english": "Palace Guard", "native": "Yu Lin Jun"}
+      "common_name": {"english": "Palace Guard", "native": "羽林军", "pronounce": "Yu Lin Jun"}
     },
     {
       "id": "CON chinese_medieval 130",
       "lines": [[114341, 114375, 114119]],
-      "common_name": {"english": "Palace Guard", "native": "Yu Lin Jun"}
+      "common_name": {"english": "Palace Guard", "native": "羽林军", "pronounce": "Yu Lin Jun"}
     },
     {
       "id": "CON chinese_medieval 14A",
       "lines": [[1067, 677]],
-      "common_name": {"english": "Wall", "native": "Bi Xiu"}
+      "common_name": {"english": "Wall", "native": "壁宿", "pronounce": "Bi Xiu"}
     },
     {
       "id": "CON chinese_medieval 14B",
       "lines": [[118268, 116771, 115830, 114971, 113889]],
-      "common_name": {"english": "Thunderbolt", "native": "Pi Li"}
+      "common_name": {"english": "Thunderbolt", "native": "霹雳", "pronounce": "Pi Li"}
     },
     {
       "id": "CON chinese_medieval 14C",
       "lines": [[117887, 116928, 115738, 116323]],
-      "common_name": {"english": "Cloud and Rain", "native": "Yun Yu"}
+      "common_name": {"english": "Cloud and Rain", "native": "云雨", "pronounce": "Yun Yu"}
     },
     {
       "id": "CON chinese_medieval 14D",
       "lines": [[3300, 3504, 3478, 3414, 2900, 2225, 841, 967, 1415, 1921, 3300]],
-      "common_name": {"english": "Celestial Stable", "native": "Tian Jiu"}
+      "common_name": {"english": "Celestial Stable", "native": "天厩", "pronounce": "Tian Jiu"}
     },
     {
       "id": "CON chinese_medieval 14E",
       "lines": [[6502, 4577, 4852], [4577, 2661, 2210]],
-      "common_name": {"english": "Sickle", "native": "Fu Zhi"}
+      "common_name": {"english": "Sickle", "native": "𫓧锧", "pronounce": "Fu Zhi"}
     },
     {
       "id": "CON chinese_medieval 14F",
       "lines": [[1465, 813]],
-      "common_name": {"english": "Official for Earthworks and Buildings", "native": "Tu Gong"}
+      "common_name": {"english": "Official for Earthworks and Buildings", "native": "土公", "pronounce": "Tu Gong"}
     },
     {
       "id": "CON chinese_medieval 15A",
       "lines": [[3881, 4436, 5447, 5936, 5544, 5586, 6193, 5742, 5571, 4463, 3693, 3031, 3092, 2912, 2942, 3231, 3881]],
-      "common_name": {"english": "Legs", "native": "Kui Xiu"}
+      "common_name": {"english": "Legs", "native": "奎宿", "pronounce": "Kui Xiu"}
     },
     {
       "id": "CON chinese_medieval 15B",
       "lines": [[9487, 8833, 7884, 7007, 5737, 4906, 3786]],
-      "common_name": {"english": "Outer Fence", "native": "Wai Ping"}
+      "common_name": {"english": "Outer Fence", "native": "外屏", "pronounce": "Wai Ping"}
     },
     {
       "id": "CON chinese_medieval 15C",
       "lines": [[4147, 4914, 5951, 6226, 6061, 5346, 3992, 4147]],
-      "common_name": {"english": "Celestial Pigsty", "native": "Tian Hun"}
+      "common_name": {"english": "Celestial Pigsty", "native": "天溷", "pronounce": "Tian Hun"}
     },
     {
       "id": "CON chinese_medieval 15D",
       "lines": [[3419, 3419]],
-      "common_name": {"english": "Master of Constructions (In Legs Mansion)", "native": "Tu Si Kong(Kui Xiu)"}
+      "common_name": {"english": "Master of Constructions (In Legs Mansion)", "native": "土司空(奎宿)", "pronounce": "Tu Si Kong(Kui Xiu)"}
     },
     {
       "id": "CON chinese_medieval 15E",
       "lines": [[8796, 8796]],
-      "common_name": {"english": "Southern Military Gate", "native": "Jun Nan Men"}
+      "common_name": {"english": "Southern Military Gate", "native": "军南门", "pronounce": "Jun Nan Men"}
     },
     {
       "id": "CON chinese_medieval 15F",
       "lines": [[5434, 5542, 7294, 8046, 8886, 9312]],
-      "common_name": {"english": "Flying Corridor", "native": "Ge Dao"}
+      "common_name": {"english": "Flying Corridor", "native": "阁道", "pronounce": "Ge Dao"}
     },
     {
       "id": "CON chinese_medieval 15G",
       "lines": [[6686, 6686]],
-      "common_name": {"english": "Auxiliary Road", "native": "Fu Lu"}
+      "common_name": {"english": "Auxiliary Road", "native": "附路", "pronounce": "Fu Lu"}
     },
     {
       "id": "CON chinese_medieval 15H",
       "lines": [[4427, 3821, 3179, 2920], [746, 4427], [746, 3821], [746, 3179], [746, 2920]],
-      "common_name": {"english": "Wang Liang", "native": "Wang Liang"}
+      "common_name": {"english": "Wang Liang", "native": "王良", "pronounce": "Wang Liang"}
     },
     {
       "id": "CON chinese_medieval 15I",
       "lines": [[2599, 2599]],
-      "common_name": {"english": "Whip", "native": "Ce"}
+      "common_name": {"english": "Whip", "native": "策", "pronounce": "Ce"}
     },
     {
       "id": "CON chinese_medieval 16A",
       "lines": [[9884, 8903, 8832]],
-      "common_name": {"english": "Bond", "native": "Lou Xiu"}
+      "common_name": {"english": "Bond", "native": "娄宿", "pronounce": "Lou Xiu"}
     },
     {
       "id": "CON chinese_medieval 16B",
       "lines": [[10795, 10732, 10155, 10306, 10795, 11670]],
-      "common_name": {"english": "Official in Charge of the Forest", "native": "Zuo Geng"}
+      "common_name": {"english": "Official in Charge of the Forest", "native": "左更", "pronounce": "Zuo Geng"}
     },
     {
       "id": "CON chinese_medieval 16C",
       "lines": [[7981, 7359, 6981, 7097, 7740, 7359]],
-      "common_name": {"english": "Official in Charge of Pasturing", "native": "You Geng"}
+      "common_name": {"english": "Official in Charge of Pasturing", "native": "右更", "pronounce": "You Geng"}
     },
     {
       "id": "CON chinese_medieval 16D",
       "lines": [[9347, 8102, 8645, 6537, 5364, 3455]],
-      "common_name": {"english": "Square Celestial Granary", "native": "Tian Cang"}
+      "common_name": {"english": "Square Celestial Granary", "native": "天仓", "pronounce": "Tian Cang"}
     },
     {
       "id": "CON chinese_medieval 16E",
       "lines": [[10320, 9677, 9440]],
-      "common_name": {"english": "Ricks of Grain", "native": "Tian Yu"}
+      "common_name": {"english": "Ricks of Grain", "native": "天庾", "pronounce": "Tian Yu"}
     },
     {
       "id": "CON chinese_medieval 16F",
       "lines": [[8068, 7607, 7719, 7513, 7818, 8423, 9021, 10064, 10280, 10793, 9640, 8068]],
-      "common_name": {"english": "Great General of Heaven", "native": "Tian Da Jiang Jun"}
+      "common_name": {"english": "Great General of Heaven", "native": "天大将军", "pronounce": "Tian Da Jiang Jun"}
     },
     {
       "id": "CON chinese_medieval 17A",
       "lines": [[12719, 13061, 13209]],
-      "common_name": {"english": "Stomach", "native": "Wei Xiu"}
+      "common_name": {"english": "Stomach", "native": "胃宿", "pronounce": "Wei Xiu"}
     },
     {
       "id": "CON chinese_medieval 17B",
       "lines": [[12828, 11484, 10324, 11249, 12828, 13954, 14135, 12093, 12706, 12387, 12530, 11791, 11046, 10826]],
-      "common_name": {"english": "Circular Celestial Granary", "native": "Tian Qun"}
+      "common_name": {"english": "Circular Celestial Granary", "native": "天囷", "pronounce": "Tian Qun"}
     },
     {
       "id": "CON chinese_medieval 17C",
       "lines": [[16369, 16322, 16083, 15900]],
-      "common_name": {"english": "Celestial Foodstuff", "native": "Tian Lin"}
+      "common_name": {"english": "Celestial Foodstuff", "native": "天廪", "pronounce": "Tian Lin"}
     },
     {
       "id": "CON chinese_medieval 17D",
       "lines": [[12692, 13531, 14632, 14668, 14576, 14354, 13254, 12623]],
-      "common_name": {"english": "Mausoleum", "native": "Da Ling"}
+      "common_name": {"english": "Mausoleum", "native": "大陵", "pronounce": "Da Ling"}
     },
     {
       "id": "CON chinese_medieval 17E",
       "lines": [[13268, 14328, 15863, 16826, 17358, 19343, 19812, 20070, 19167]],
-      "common_name": {"english": "Celestial Boat", "native": "Tian Chuan"}
+      "common_name": {"english": "Celestial Boat", "native": "天船", "pronounce": "Tian Chuan"}
     },
     {
       "id": "CON chinese_medieval 17F",
       "lines": [[13879, 13879]],
-      "common_name": {"english": "Heap of Corpses", "native": "Ji Shi(Wei Xiu)"}
+      "common_name": {"english": "Heap of Corpses", "native": "积尸(胃宿)", "pronounce": "Ji Shi(Wei Xiu)"}
     },
     {
       "id": "CON chinese_medieval 17G",
       "lines": [[18453, 18453]],
-      "common_name": {"english": "Stored water", "native": "Ji Shui(Wei Xiu)"}
+      "common_name": {"english": "Stored water", "native": "积水(胃宿)", "pronounce": "Ji Shui(Wei Xiu)"}
     },
     {
       "id": "CON chinese_medieval 18A",
       "lines": [[17531, 17489, 17573, 17499, 17702, 17608, 17847]],
-      "common_name": {"english": "Hairy Head", "native": "Mao Xiu"}
+      "common_name": {"english": "Hairy Head", "native": "昴宿", "pronounce": "Mao Xiu"}
     },
     {
       "id": "CON chinese_medieval 18B",
       "lines": [[15696, 15696]],
-      "common_name": {"english": "Celestial Concave", "native": "Tian E"}
+      "common_name": {"english": "Celestial Concave", "native": "天阿", "pronounce": "Tian E"}
     },
     {
       "id": "CON chinese_medieval 18C",
       "lines": [[19038, 19038]],
-      "common_name": {"english": "Lunar Star", "native": "Yue"}
+      "common_name": {"english": "Lunar Star", "native": "月", "pronounce": "Yue"}
     },
     {
       "id": "CON chinese_medieval 18D",
       "lines": [[15737, 15870], [15737, 15627], [15737, 15110], [15737, 14838]],
-      "common_name": {"english": "Celestial Yin Force", "native": "Tian Yin"}
+      "common_name": {"english": "Celestial Yin Force", "native": "天阴", "pronounce": "Tian Yin"}
     },
     {
       "id": "CON chinese_medieval 18E",
       "lines": [[17529, 18532, 18614, 18246, 17448, 17313]],
-      "common_name": {"english": "Rolled Tongue", "native": "Juan She"}
+      "common_name": {"english": "Rolled Tongue", "native": "卷舌", "pronounce": "Juan She"}
     },
     {
       "id": "CON chinese_medieval 18F",
       "lines": [[17886, 17886]],
-      "common_name": {"english": "Celestial Slander", "native": "Tian Chan"}
+      "common_name": {"english": "Celestial Slander", "native": "天谗", "pronounce": "Tian Chan"}
     },
     {
       "id": "CON chinese_medieval 18G",
       "lines": [[19205, 19171, 19513, 20430]],
-      "common_name": {"english": "Whetstone", "native": "Li Shi"}
+      "common_name": {"english": "Whetstone", "native": "砺石", "pronounce": "Li Shi"}
     },
     {
       "id": "CON chinese_medieval 18H",
       "lines": [[11783, 11345, 12444], [11348, 12390, 11029]],
-      "common_name": {"english": "Hay", "native": "Chu Hao"}
+      "common_name": {"english": "Hay", "native": "刍藁", "pronounce": "Chu Hao"}
     },
     {
       "id": "CON chinese_medieval 18I",
       "lines": [[18543, 17593, 17378, 16537, 15197, 13701, 12770, 12843, 13288, 14146, 15474, 16611, 17651, 17717, 18216, 18673]],
-      "common_name": {"english": "Celestial Meadows", "native": "Tian Yuan"}
+      "common_name": {"english": "Celestial Meadows", "native": "天苑", "pronounce": "Tian Yuan"}
     },
     {
       "id": "CON chinese_medieval 19A",
       "lines": [[20889, 20648, 20455, 20205], [21421, 20894, 20713, 20205, 18724], [21421, 21683]],
-      "common_name": {"english": "Net", "native": "Bi Xiu"}
+      "common_name": {"english": "Net", "native": "毕宿", "pronounce": "Bi Xiu"}
     },
     {
       "id": "CON chinese_medieval 19B",
       "lines": [[21683, 21683]],
-      "common_name": {"english": "Whisper (Vassal of Net)", "native": "Fu Er"}
+      "common_name": {"english": "Whisper (Vassal of Net)", "native": "附耳(附毕宿)", "pronounce": "Fu Er"}
     },
     {
       "id": "CON chinese_medieval 19C",
       "lines": [[20711, 20635]],
-      "common_name": {"english": "Celestial Street", "native": "Tian Jie"}
+      "common_name": {"english": "Celestial Street", "native": "天街", "pronounce": "Tian Jie"}
     },
     {
       "id": "CON chinese_medieval 19D",
       "lines": [[21402, 22044, 22157, 21589, 21402, 20522, 19860, 18975, 18907]],
-      "common_name": {"english": "Celestial Tally", "native": "Tian Jie"}
+      "common_name": {"english": "Celestial Tally", "native": "天节", "pronounce": "Tian Jie"}
     },
     {
       "id": "CON chinese_medieval 19E",
       "lines": [[25539, 24822, 24512, 23883, 23497, 21881]],
-      "common_name": {"english": "Feudal Kings", "native": "Zhu Wang"}
+      "common_name": {"english": "Feudal Kings", "native": "诸王", "pronounce": "Zhu Wang"}
     },
     {
       "id": "CON chinese_medieval 19F",
       "lines": [[22176, 22565, 23043, 22441, 22176]],
-      "common_name": {"english": "Celestial High Terrace", "native": "Tian Gao"}
+      "common_name": {"english": "Celestial High Terrace", "native": "天高", "pronounce": "Tian Gao"}
     },
     {
       "id": "CON chinese_medieval 19G",
       "lines": [[20507, 21278, 21296, 21297, 21239, 20922, 19777, 19996, 19849, 20507]],
-      "common_name": {"english": "Interpreters of Nine Dialects", "native": "Jiu Zhou Shu Kou"}
+      "common_name": {"english": "Interpreters of Nine Dialects", "native": "九州殊口", "pronounce": "Jiu Zhou Shu Kou"}
     },
     {
       "id": "CON chinese_medieval 19H",
       "lines": [[23015, 24608, 28360, 28380, 25428]],
-      "common_name": {"english": "Five Chariots", "native": "Wu Che"}
+      "common_name": {"english": "Five Chariots", "native": "五车", "pronounce": "Wu Che"}
     },
     {
       "id": "CON chinese_medieval 19I",
       "lines": [[26536, 26712, 25984]],
-      "common_name": {"english": "Pillars (In Net Mansion)", "native": "Zhu(Bi Xiu)"}
+      "common_name": {"english": "Pillars (In Net Mansion)", "native": "柱(毕宿)", "pronounce": "Zhu(Bi Xiu)"}
     },
     {
       "id": "CON chinese_medieval 19J",
       "lines": [[27639, 27673, 27483]],
-      "common_name": {"english": "Pillars (In Net Mansion)", "native": "Zhu(Bi Xiu)"}
+      "common_name": {"english": "Pillars (In Net Mansion)", "native": "柱(毕宿)", "pronounce": "Zhu(Bi Xiu)"}
     },
     {
       "id": "CON chinese_medieval 19K",
       "lines": [[23767, 23416, 23453]],
-      "common_name": {"english": "Pillars (In Net Mansion)", "native": "Zhu(Bi Xiu)"}
+      "common_name": {"english": "Pillars (In Net Mansion)", "native": "柱(毕宿)", "pronounce": "Zhu(Bi Xiu)"}
     },
     {
       "id": "CON chinese_medieval 19L",
       "lines": [[25475, 25580, 25541, 24879, 24727]],
-      "common_name": {"english": "Celestial Pier", "native": "Tian Huang"}
+      "common_name": {"english": "Celestial Pier", "native": "天潢", "pronounce": "Tian Huang"}
     },
     {
       "id": "CON chinese_medieval 19M",
       "lines": [[25143, 25048, 24902]],
-      "common_name": {"english": "Pool of Harmony", "native": "Xian Chi"}
+      "common_name": {"english": "Pool of Harmony", "native": "咸池", "pronounce": "Xian Chi"}
     },
     {
       "id": "CON chinese_medieval 19N",
       "lines": [[26451, 26451]],
-      "common_name": {"english": "Celestial Pass", "native": "Tian Guan"}
+      "common_name": {"english": "Celestial Pass", "native": "天关", "pronounce": "Tian Guan"}
     },
     {
       "id": "CON chinese_medieval 19O",
       "lines": [[24010, 23607, 22957, 22833, 22845, 22509, 22449, 22549, 22797]],
-      "common_name": {"english": "Banner of Three Stars", "native": "Can Qi"}
+      "common_name": {"english": "Banner of Three Stars", "native": "参旗", "pronounce": "Can Qi"}
     },
     {
       "id": "CON chinese_medieval 19P",
       "lines": [[20884, 21139, 21547, 21444, 22024, 21986, 22439, 22479, 23362]],
-      "common_name": {"english": "Imperial Military Flag", "native": "Jiu Liu"}
+      "common_name": {"english": "Imperial Military Flag", "native": "九斿", "pronounce": "Jiu Liu"}
     },
     {
       "id": "CON chinese_medieval 19Q",
       "lines": [[21248, 21393, 20535, 20042, 17797, 17874, 17351, 16870, 16310, 15510, 13847, 12486, 12413]],
-      "common_name": {"english": "Celestial Orchard", "native": "Tian Yuan"}
+      "common_name": {"english": "Celestial Orchard", "native": "天园", "pronounce": "Tian Yuan"}
     },
     {
       "id": "CON chinese_medieval 20A",
       "lines": [[26207, 26176], [26207, 26366]],
-      "common_name": {"english": "Turtle Beak", "native": "Zi Xiu"}
+      "common_name": {"english": "Turtle Beak", "native": "觜宿", "pronounce": "Zi Xiu"}
     },
     {
       "id": "CON chinese_medieval 20B",
       "lines": [[27830, 28237, 28734, 28716]],
-      "common_name": {"english": "Deity in Charge of Monsters", "native": "Si Guai"}
+      "common_name": {"english": "Deity in Charge of Monsters", "native": "司怪", "pronounce": "Si Guai"}
     },
     {
       "id": "CON chinese_medieval 20C",
       "lines": [[29696, 31173, 31579, 31771, 31789, 31832, 30972, 30520, 30247]],
-      "common_name": {"english": "Seat Flags", "native": "Zuo Qi"}
+      "common_name": {"english": "Seat Flags", "native": "座旗", "pronounce": "Zuo Qi"}
     },
     {
       "id": "CON chinese_medieval 21A",
       "lines": [[27989, 26727, 26311, 25930, 24436], [25930, 25336], [26727, 27366]],
-      "common_name": {"english": "Three Stars", "native": "Shen Xiu"}
+      "common_name": {"english": "Three Stars", "native": "参宿", "pronounce": "Shen Xiu"}
     },
     {
       "id": "CON chinese_medieval 21B",
       "lines": [[26237, 26235, 26241]],
-      "common_name": {"english": "Send Armed Forces To Suppress (Vassal of Three Stars)", "native": "Fa"}
+      "common_name": {"english": "Send Armed Forces To Suppress (Vassal of Three Stars)", "native": "伐(附参宿)", "pronounce": "Fa"}
     },
     {
       "id": "CON chinese_medieval 21C",
       "lines": [[23972, 23364, 23875, 24674]],
-      "common_name": {"english": "Jade Well", "native": "Yu Jing"}
+      "common_name": {"english": "Jade Well", "native": "玉井", "pronounce": "Yu Jing"}
     },
     {
       "id": "CON chinese_medieval 21D",
       "lines": [[23685, 24927]],
-      "common_name": {"english": "Screen", "native": "Ping"}
+      "common_name": {"english": "Screen", "native": "屏", "pronounce": "Ping"}
     },
     {
       "id": "CON chinese_medieval 21E",
       "lines": [[24244, 24327, 24845, 24873]],
-      "common_name": {"english": "Military Well", "native": "Jun Jing"}
+      "common_name": {"english": "Military Well", "native": "军井", "pronounce": "Jun Jing"}
     },
     {
       "id": "CON chinese_medieval 21F",
       "lines": [[25985, 25606, 27072, 27654]],
-      "common_name": {"english": "Toilet", "native": "Ce"}
+      "common_name": {"english": "Toilet", "native": "厕", "pronounce": "Ce"}
     },
     {
       "id": "CON chinese_medieval 21G",
       "lines": [[26865, 26865]],
-      "common_name": {"english": "Excrement", "native": "Shi"}
+      "common_name": {"english": "Excrement", "native": "屎", "pronounce": "Shi"}
     },
     {
       "id": "CON chinese_medieval 22A",
       "lines": [[35350, 34088, 32921, 32246], [32921, 30883, 30343], [30883, 31681, 34088], [31681, 32362], [30343, 29655]],
-      "common_name": {"english": "Well", "native": "Jing Xiu"}
+      "common_name": {"english": "Well", "native": "井宿", "pronounce": "Jing Xiu"}
     },
     {
       "id": "CON chinese_medieval 22B",
       "lines": [[29655, 29655]],
-      "common_name": {"english": "Battle Axe (Vassal of Well)", "native": "Yue"}
+      "common_name": {"english": "Battle Axe (Vassal of Well)", "native": "钺(井宿)", "pronounce": "Yue"}
     },
     {
       "id": "CON chinese_medieval 22C",
       "lines": [[37279, 36188, 35987]],
-      "common_name": {"english": "South River", "native": "Nan He"}
+      "common_name": {"english": "South River", "native": "南河", "pronounce": "Nan He"}
     },
     {
       "id": "CON chinese_medieval 22D",
       "lines": [[37826, 36850, 36366]],
-      "common_name": {"english": "North River", "native": "Bei He"}
+      "common_name": {"english": "North River", "native": "北河", "pronounce": "Bei He"}
     },
     {
       "id": "CON chinese_medieval 22E",
       "lines": [[35550, 35699, 36238]],
-      "common_name": {"english": "Celestial Wine Cup", "native": "Tian Zun"}
+      "common_name": {"english": "Celestial Wine Cup", "native": "天樽", "pronounce": "Tian Zun"}
     },
     {
       "id": "CON chinese_medieval 22F",
       "lines": [[33018, 34693, 36046, 36962, 37740]],
-      "common_name": {"english": "Five Feudal Kings", "native": "Wu Zhu Hou(JingXiu)"}
+      "common_name": {"english": "Five Feudal Kings", "native": "五诸侯(井宿)", "pronounce": "Wu Zhu Hou(JingXiu)"}
     },
     {
       "id": "CON chinese_medieval 22G",
       "lines": [[37265, 37265]],
-      "common_name": {"english": "Accumulated Water", "native": "Ji Shui(Jin Xiu)"}
+      "common_name": {"english": "Accumulated Water", "native": "积水(井宿)", "pronounce": "Ji Shui(Jin Xiu)"}
     },
     {
       "id": "CON chinese_medieval 22H",
       "lines": [[39659, 39659]],
-      "common_name": {"english": "Pile of Firewood", "native": "Ji Xin"}
+      "common_name": {"english": "Pile of Firewood", "native": "积薪", "pronounce": "Ji Xin"}
     },
     {
       "id": "CON chinese_medieval 22I",
       "lines": [[29038, 29426, 29704, 29434, 29038]],
-      "common_name": {"english": "Official for Irrigation", "native": "Shui Fu"}
+      "common_name": {"english": "Official for Irrigation", "native": "水府", "pronounce": "Shui Fu"}
     },
     {
       "id": "CON chinese_medieval 22J",
       "lines": [[38722, 37908, 37300, 36760]],
-      "common_name": {"english": "Water Level", "native": "Shui Wei"}
+      "common_name": {"english": "Water Level", "native": "水位", "pronounce": "Shui Wei"}
     },
     {
       "id": "CON chinese_medieval 22K",
       "lines": [[34033, 32533, 31216, 30419]],
-      "common_name": {"english": "Four Channels", "native": "Si Du"}
+      "common_name": {"english": "Four Channels", "native": "四渎", "pronounce": "Si Du"}
     },
     {
       "id": "CON chinese_medieval 22L",
       "lines": [[31700, 31592, 31416, 31125, 29843, 29150, 29048, 28816, 28910, 30214, 30457, 31084, 31827, 31700]],
-      "common_name": {"english": "Market for Soldiers", "native": "Jun Shi"}
+      "common_name": {"english": "Market for Soldiers", "native": "军市", "pronounce": "Jun Shi"}
     },
     {
       "id": "CON chinese_medieval 22M",
       "lines": [[30324, 30324]],
-      "common_name": {"english": "Wild Cockerel", "native": "Ye Ji"}
+      "common_name": {"english": "Wild Cockerel", "native": "野鸡", "pronounce": "Ye Ji"}
     },
     {
       "id": "CON chinese_medieval 22N",
       "lines": [[30788, 30277]],
-      "common_name": {"english": "Grandson", "native": "Sun"}
+      "common_name": {"english": "Grandson", "native": "孙", "pronounce": "Sun"}
     },
     {
       "id": "CON chinese_medieval 22O",
       "lines": [[28199, 27628]],
-      "common_name": {"english": "Son", "native": "Zi"}
+      "common_name": {"english": "Son", "native": "子", "pronounce": "Zi"}
     },
     {
       "id": "CON chinese_medieval 22P",
       "lines": [[26634, 25859]],
-      "common_name": {"english": "Grandfather", "native": "Zhang Ren"}
+      "common_name": {"english": "Grandfather", "native": "丈人", "pronounce": "Zhang Ren"}
     },
     {
       "id": "CON chinese_medieval 22Q",
       "lines": [[36641, 34769]],
-      "common_name": {"english": "Palace Gate", "native": "Que Qiu"}
+      "common_name": {"english": "Palace Gate", "native": "阙丘", "pronounce": "Que Qiu"}
     },
     {
       "id": "CON chinese_medieval 22R",
       "lines": [[32349, 32349]],
-      "common_name": {"english": "Wolf", "native": "Lang"}
+      "common_name": {"english": "Wolf", "native": "狼", "pronounce": "Lang"}
     },
     {
       "id": "CON chinese_medieval 22S",
       "lines": [[38170, 35904, 32759, 33579, 33856, 34444, 35415, 36721, 38170], [33977, 34444, 35904]],
-      "common_name": {"english": "Bow and Arrow", "native": "Hu Shi"}
+      "common_name": {"english": "Bow and Arrow", "native": "弧矢", "pronounce": "Hu Shi"}
     },
     {
       "id": "CON chinese_medieval 22T",
       "lines": [[30438, 30438]],
-      "common_name": {"english": "Old Man", "native": "Lao Ren"}
+      "common_name": {"english": "Old Man", "native": "老人", "pronounce": "Lao Ren"}
     },
     {
       "id": "CON chinese_medieval 23A",
       "lines": [[41822, 41909, 42806, 42911, 41822]],
-      "common_name": {"english": "Ghosts", "native": "Gui Xiu"}
+      "common_name": {"english": "Ghosts", "native": "鬼宿", "pronounce": "Gui Xiu"}
     },
     {
       "id": "CON chinese_medieval 23B",
       "lines": [[42578, 42578]],
-      "common_name": {"english": "Cumulative Corpse Gas", "native": "Ji Shi Qi"}
+      "common_name": {"english": "Cumulative Corpse Gas", "native": "积尸气", "pronounce": "Ji Shi Qi"}
     },
     {
       "id": "CON chinese_medieval 23C",
       "lines": [[41816, 41404, 40843, 40881, 41816]],
-      "common_name": {"english": "Beacon Fire", "native": "Guan"}
+      "common_name": {"english": "Beacon Fire", "native": "爟", "pronounce": "Guan"}
     },
     {
       "id": "CON chinese_medieval 23D",
       "lines": [[37447, 37394], [37447, 36640], [37447, 38048, 37891, 37379, 36773]],
-      "common_name": {"english": "Celestial Dog", "native": "Tian Gou"}
+      "common_name": {"english": "Celestial Dog", "native": "天狗", "pronounce": "Tian Gou"}
     },
     {
       "id": "CON chinese_medieval 23E",
       "lines": [[43142, 42028, 41307, 42146, 42835, 43305, 43142]],
-      "common_name": {"english": "Outer Kitchen", "native": "Wai Chu"}
+      "common_name": {"english": "Outer Kitchen", "native": "外厨", "pronounce": "Wai Chu"}
     },
     {
       "id": "CON chinese_medieval 23F",
       "lines": [[43067, 43067]],
-      "common_name": {"english": "Judge for Estimating the Age of Animals", "native": "Tian Ji"}
+      "common_name": {"english": "Judge for Estimating the Age of Animals", "native": "天记", "pronounce": "Tian Ji"}
     },
     {
       "id": "CON chinese_medieval 23G",
       "lines": [[37819, 35264, 34802, 34339, 32537, 31685]],
-      "common_name": {"english": "Celestial Earth God's Temple", "native": "Tian She"}
+      "common_name": {"english": "Celestial Earth God's Temple", "native": "天社", "pronounce": "Tian She"}
     },
     {
       "id": "CON chinese_medieval 24A",
       "lines": [[42799, 42402, 42313, 43109, 43234, 43813, 44659, 45336]],
-      "common_name": {"english": "Willow", "native": "Liu Xiu"}
+      "common_name": {"english": "Willow", "native": "柳宿", "pronounce": "Liu Xiu"}
     },
     {
       "id": "CON chinese_medieval 24B",
       "lines": [[46771, 46774, 47205]],
-      "common_name": {"english": "Banner of Wine Shop", "native": "Jiu Qi"}
+      "common_name": {"english": "Banner of Wine Shop", "native": "酒旗", "pronounce": "Jiu Qi"}
     },
     {
       "id": "CON chinese_medieval 25A",
       "lines": [[46390, 46509, 46776, 47431], [46390, 45811, 45751, 46744], [46390, 46744]],
-      "common_name": {"english": "Star", "native": "Xing Xiu"}
+      "common_name": {"english": "Star", "native": "星宿", "pronounce": "Xing Xiu"}
     },
     {
       "id": "CON chinese_medieval 25B",
       "lines": [[44248, 44700, 45688, 45860, 47168, 47701, 46146, 46750, 47908, 48455, 50335, 50583, 49583, 49669, 47508], [49669, 51624], [49669, 49637]],
-      "common_name": {"english": "Xuanyuan", "native": "Xuan Yuan"}
+      "common_name": {"english": "Xuanyuan", "native": "轩辕", "pronounce": "Xuan Yuan"}
     },
     {
       "id": "CON chinese_medieval 25C",
       "lines": [[51233, 51056, 52098, 53229]],
-      "common_name": {"english": "High Judge", "native": "Nei Ping"}
+      "common_name": {"english": "High Judge", "native": "内平", "pronounce": "Nei Ping"}
     },
     {
       "id": "CON chinese_medieval 25D",
       "lines": [[46982, 48341, 48437]],
-      "common_name": {"english": "Celestial Premier", "native": "Tian Xiang"}
+      "common_name": {"english": "Celestial Premier", "native": "天相", "pronounce": "Tian Xiang"}
     },
     {
       "id": "CON chinese_medieval 25E",
       "lines": [[44816, 44511, 42570, 42312, 44191, 44816]],
-      "common_name": {"english": "Celestial Cereals", "native": "Tian Ji"}
+      "common_name": {"english": "Celestial Cereals", "native": "天稷", "pronounce": "Tian Ji"}
     },
     {
       "id": "CON chinese_medieval 26A",
       "lines": [[48356, 49841, 51069, 48615], [48356, 48615], [48356, 47452], [51069, 52085]],
-      "common_name": {"english": "Extended Net", "native": "Zhang Xiu"}
+      "common_name": {"english": "Extended Net", "native": "张宿", "pronounce": "Zhang Xiu"}
     },
     {
       "id": "CON chinese_medieval 26B",
       "lines": [[48219, 46515, 46734, 46026, 45001, 45754, 45448, 42515, 42828, 43409, 44824, 45902, 46578, 47758, 48219]],
-      "common_name": {"english": "Celestial Temple", "native": "Tian Miao"}
+      "common_name": {"english": "Celestial Temple", "native": "天庙", "pronounce": "Tian Miao"}
     },
     {
       "id": "CON chinese_medieval 27A",
       "lines": [[57587, 56633, 55687, 54029, 52980], [55687, 55874, 56802, 55282, 55705], [58188, 57283, 55705, 53740, 52943], [57283, 55598, 53740], [55598, 54682, 56078, 54204, 54477], [58158, 56280, 54477, 51979, 50066]],
-      "common_name": {"english": "Wings", "native": "Yi Xiu"}
+      "common_name": {"english": "Wings", "native": "翼宿", "pronounce": "Yi Xiu"}
     },
     {
       "id": "CON chinese_medieval 27B",
       "lines": [[53773, 53502, 50888, 50191], [50888, 48926]],
-      "common_name": {"english": "Dongou", "native": "Dong Ou"}
+      "common_name": {"english": "Dongou", "native": "东瓯", "pronounce": "Dong Ou"}
     },
     {
       "id": "CON chinese_medieval 28A",
       "lines": [[61359, 60965, 59803, 59316, 61359], [59803, 60189], [60965, 61174], [59316, 59199]],
-      "common_name": {"english": "Chariot", "native": "Zhen Xiu"}
+      "common_name": {"english": "Chariot", "native": "轸宿", "pronounce": "Zhen Xiu"}
     },
     {
       "id": "CON chinese_medieval 28B",
       "lines": [[60189, 60189]],
-      "common_name": {"english": "Changsha (Vassal of Chariot)", "native": "Chang Sha"}
+      "common_name": {"english": "Changsha (Vassal of Chariot)", "native": "长沙(附轸宿)", "pronounce": "Chang Sha"}
     },
     {
       "id": "CON chinese_medieval 28C",
       "lines": [[61174, 61174]],
-      "common_name": {"english": "Left linchpin (Vassal of Chariot)", "native": "Zuo Xia"}
+      "common_name": {"english": "Left linchpin (Vassal of Chariot)", "native": "左辖(附轸宿)", "pronounce": "Zuo Xia"}
     },
     {
       "id": "CON chinese_medieval 28D",
       "lines": [[59199, 59199]],
-      "common_name": {"english": "Right linchpin (Vassal of Chariot)", "native": "You Xia"}
+      "common_name": {"english": "Right linchpin (Vassal of Chariot)", "native": "右辖(附轸宿)", "pronounce": "You Xia"}
     },
     {
       "id": "CON chinese_medieval 28E",
       "lines": [[57613, 58082]],
-      "common_name": {"english": "Military Gate", "native": "Jun Men"}
+      "common_name": {"english": "Military Gate", "native": "军门", "pronounce": "Jun Men"}
     },
     {
       "id": "CON chinese_medieval 28F",
       "lines": [[56332, 56343, 56620, 57936]],
-      "common_name": {"english": "Master of Constructions (In Chariot Mansion)", "native": "Tu Si Kong(Zhen Xiu)"}
+      "common_name": {"english": "Master of Constructions (In Chariot Mansion)", "native": "土司空(轸宿)", "pronounce": "Tu Si Kong(Zhen Xiu)"}
     },
     {
       "id": "CON chinese_medieval 28G",
       "lines": [[61468, 61789, 62896, 63066, 63033, 61916, 61379, 61468]],
-      "common_name": {"english": "Green Hill", "native": "Qing Qiu"}
+      "common_name": {"english": "Green Hill", "native": "青丘", "pronounce": "Qing Qiu"}
     },
     {
       "id": "CON chinese_medieval 28H",
       "lines": [[63003, 62327, 61084, 60379, 58642, 57870, 56480, 55425], [63007, 62434, 61966, 61136, 59747, 58901, 57512, 55581], [62268, 60260, 58921, 57439, 56243, 54463], [60718, 58758, 57175, 56986, 55831, 54751], [60009, 59072, 57669, 56561]],
-      "common_name": {"english": "House for Musical Instruments", "native": "Qi Fu"}
+      "common_name": {"english": "House for Musical Instruments", "native": "器府", "pronounce": "Qi Fu"}
     }
   ],
   "edges_type": "own",


### PR DESCRIPTION
This is a result of fetching all the constellation names from `constellation_names.zh_CN.fab` into `index.json`, yielding native names made of hieroglyphs and "pronounce" entries made of (diacriticless) pinyin.