### PR TITLE
Don't load any high level star catalog if a lower level star catalog is missing

### DIFF
--- a/doc/fileStructure.doxygen
+++ b/doc/fileStructure.doxygen
@@ -129,7 +129,7 @@ The catalogue downloader tool runs within Stellarium.  When it downloads extra s
 <User Data Directory>/stars/hip_gaia3/stars_4_1v0_6.cat
 <User Data Directory>/stars/hip_gaia3/stars_5_1v0_6.cat
 <User Data Directory>/stars/hip_gaia3/stars_6_1v0_4.cat
-<User Data Directory>/stars/hip_gaia3/stars_7_1v0_3.cat
+<User Data Directory>/stars/hip_gaia3/stars_7_1v0_4.cat
 <User Data Directory>/stars/hip_gaia3/stars_8_2v0_3.cat
 @endverbatim
 

--- a/guide/app_star_catalogue.tex
+++ b/guide/app_star_catalogue.tex
@@ -62,7 +62,7 @@ The main catalogue data is split into several files:
 \item[\file{stars\_4\_1v0\_6.cat}]
 \item[\file{stars\_5\_1v0\_6.cat}]
 \item[\file{stars\_6\_1v0\_4.cat}]
-\item[\file{stars\_7\_1v0\_3.cat}]
+\item[\file{stars\_7\_1v0\_4.cat}]
 \item[\file{stars\_8\_2v0\_3.cat}]
 \end{description}
 
@@ -111,8 +111,8 @@ know about the zone model to be able to extract positional data.
 \file{stars\_4\_1v0\_6.cat}  & 1 & 32 bytes & 4 &    1,741,849 & Gaia\\
 \file{stars\_5\_1v0\_6.cat}  & 1 & 32 bytes & 5 &    8,051,933 & Gaia\\
 \file{stars\_6\_1v0\_4.cat}  & 1 & 32 bytes & 6 &   29,879,734 & Gaia\\
-\file{stars\_7\_1v0\_3.cat}  & 1 & 32 bytes & 7 &   57,534,724 & Gaia\\
-\file{stars\_8\_2v0\_3.cat}  & 2 & 16 bytes & 8 & 1,229,081,84 & Gaia\\
+\file{stars\_7\_1v0\_4.cat}  & 1 & 32 bytes & 7 &   57,534,724 & Gaia\\
+\file{stars\_8\_2v0\_3.cat}  & 2 & 16 bytes & 8 &  122,908,184 & Gaia\\
 \bottomrule
 \end{tabular}
 

--- a/src/core/modules/StarMgr.cpp
+++ b/src/core/modules/StarMgr.cpp
@@ -631,11 +631,11 @@ void StarMgr::loadData(QVariantMap starsConfig)
 	qInfo() << "Loading star data ...";
 
 	catalogsDescription = starsConfig.value("catalogs").toList();
-	bool hasFailed = false;
+	bool isSuccessing = true;
 	foreach (const QVariant& catV, catalogsDescription)
 	{
 		QVariantMap m = catV.toMap();
-		hasFailed = not checkAndLoadCatalog(m, not hasFailed);
+		isSuccessing = checkAndLoadCatalog(m, isSuccessing);
 	}
 
 	for (int i=0; i<=NR_OF_HIP; i++)

--- a/src/core/modules/StarMgr.cpp
+++ b/src/core/modules/StarMgr.cpp
@@ -497,7 +497,7 @@ void StarMgr::drawPointer(StelPainter& sPainter, const StelCore* core)
 	}
 }
 
-bool StarMgr::checkAndLoadCatalog(const QVariantMap& catDesc)
+bool StarMgr::checkAndLoadCatalog(const QVariantMap& catDesc, const bool load)
 {
 	const bool checked = catDesc.value("checked").toBool();
 	QString catalogFileName = catDesc.value("fileName").toString();
@@ -574,21 +574,28 @@ bool StarMgr::checkAndLoadCatalog(const QVariantMap& catDesc)
 		}
 	}
 
-	ZoneArray* z = ZoneArray::create(catalogFilePath, true);
-	if (z)
-	{
-		if (z->level<gridLevels.size())
+	if (load) {
+		ZoneArray* z = ZoneArray::create(catalogFilePath, true);
+		if (z)
 		{
-			qWarning().noquote() << QDir::toNativeSeparators(catalogFileName) << ", " << z->level << ": duplicate level";
-			delete z;
-			return true;
+			if (z->level<gridLevels.size())
+			{
+				qWarning().noquote() << QDir::toNativeSeparators(catalogFileName) << ", " << z->level << ": duplicate level";
+				delete z;
+				return true;
+			}
+			Q_ASSERT(z->level==maxGeodesicGridLevel+1);
+			Q_ASSERT(z->level==gridLevels.size());
+			++maxGeodesicGridLevel;
+			gridLevels.append(z);
 		}
-		Q_ASSERT(z->level==maxGeodesicGridLevel+1);
-		Q_ASSERT(z->level==gridLevels.size());
-		++maxGeodesicGridLevel;
-		gridLevels.append(z);
+		return true;
 	}
-	return true;
+	else
+	{
+		qWarning().noquote() << "Star catalog: " << QDir::toNativeSeparators(catalogFileName) << "is found but not loaded because at least one of the lower levels is missing!";
+		return false;
+	}
 }
 
 void StarMgr::setCheckFlag(const QString& catId, bool b)
@@ -624,10 +631,11 @@ void StarMgr::loadData(QVariantMap starsConfig)
 	qInfo() << "Loading star data ...";
 
 	catalogsDescription = starsConfig.value("catalogs").toList();
+	bool hasFailed = false;
 	foreach (const QVariant& catV, catalogsDescription)
 	{
 		QVariantMap m = catV.toMap();
-		checkAndLoadCatalog(m);
+		hasFailed = not checkAndLoadCatalog(m, not hasFailed);
 	}
 
 	for (int i=0; i<=NR_OF_HIP; i++)

--- a/src/core/modules/StarMgr.hpp
+++ b/src/core/modules/StarMgr.hpp
@@ -420,8 +420,10 @@ public:
 
 	//! Try to load the given catalog, even if it is marched as unchecked.
 	//! Mark it as checked if checksum is correct.
+	//! @param m the catalog data.
+	//! @param load true if the catalog should be loaded, otherwise just check but don't load.
 	//! @return false in case of failure.
-	bool checkAndLoadCatalog(const QVariantMap& m);
+	bool checkAndLoadCatalog(const QVariantMap& m, bool load);
 
 	//! Get the list of all Hipparcos stars.
 	const QList<StelObjectP>& getHipparcosStars() const { return hipparcosStars; }	

--- a/src/gui/ConfigurationDialog.cpp
+++ b/src/gui/ConfigurationDialog.cpp
@@ -1724,7 +1724,7 @@ void ConfigurationDialog::downloadFinished()
 	progressBar=Q_NULLPTR;
 
 	ui->downloadLabel->setText(q_("Verifying file integrity..."));
-	if (GETSTELMODULE(StarMgr)->checkAndLoadCatalog(nextStarCatalogToDownload)==false)
+	if (GETSTELMODULE(StarMgr)->checkAndLoadCatalog(nextStarCatalogToDownload, true)==false)
 	{
 		ui->getStarsButton->setVisible(false);
 		ui->downloadLabel->setText(q_("Error downloading %1:\nFile is corrupted.").arg(nextStarCatalogToDownload.value("id").toString()));


### PR DESCRIPTION
Don't load any high level star catalog if a lower level star catalog is missing. Warning is provided, telling user a star catalog is found but not loaded because a lower level star catalog is missing.

Fixes #4181

### Screenshots (if appropriate):

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system: MacOS 15
* Graphics Card: Apple M3

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
