### PR TITLE
Check for star null pointer when loading constellation data

### DIFF
--- a/plugins/Exoplanets/src/Exoplanets.cpp
+++ b/plugins/Exoplanets/src/Exoplanets.cpp
@@ -570,10 +570,17 @@ void Exoplanets::setEPMap(const QVariantMap& map)
 		{
 			QStringList designations = epsData.value("starAltNames").toString().split(", ");
 			QString hip;
-			for(int i=0; i<designations.size(); i++)
+			for (int i = 0; i < designations.size(); i++)
 			{
-				if (designations.at(i).trimmed().startsWith("HIP"))
-					hip = designations.at(i).trimmed();
+				QString trimmedDesignation = designations.at(i).trimmed();
+				if (trimmedDesignation.startsWith("HIP") || 
+					trimmedDesignation.startsWith("GAIA DR3") || 
+					trimmedDesignation.startsWith("SAO") || 
+					trimmedDesignation.startsWith("HD") || 
+					trimmedDesignation.startsWith("HR"))
+				{
+					hip = trimmedDesignation;
+				}
 			}
 			if (!hip.isEmpty())
 				star = smgr->searchByName(hip);

--- a/src/core/modules/ConstellationMgr.cpp
+++ b/src/core/modules/ConstellationMgr.cpp
@@ -517,9 +517,20 @@ void ConstellationMgr::loadLinesNamesAndArt(const QJsonArray &constellationsData
 		const int texSizeX = sizeData[0].toInt(), texSizeY = sizeData[1].toInt();
 
 		StelCore* core = StelApp::getInstance().getCore();
-		const Vec3d s1 = hipStarMgr->searchHP(static_cast<int>(hp1))->getJ2000EquatorialPos(core);
-		const Vec3d s2 = hipStarMgr->searchHP(static_cast<int>(hp2))->getJ2000EquatorialPos(core);
-		const Vec3d s3 = hipStarMgr->searchHP(static_cast<int>(hp3))->getJ2000EquatorialPos(core);
+		StelObjectP s1obj = hipStarMgr->searchHP(static_cast<int>(hp1));
+		StelObjectP s2obj = hipStarMgr->searchHP(static_cast<int>(hp2));
+		StelObjectP s3obj = hipStarMgr->searchHP(static_cast<int>(hp3));
+
+		// check for null pointers
+		if (s1obj.isNull() || s2obj.isNull() || s3obj.isNull())
+		{
+			qWarning() << "ERROR: could not find stars:" << hp1 << hp2 << hp3 << " in constellation" << consObj["id"].toString();
+			continue;
+		}
+
+		const Vec3d s1 = s1obj->getJ2000EquatorialPos(core);
+		const Vec3d s2 = s2obj->getJ2000EquatorialPos(core);
+		const Vec3d s3 = s3obj->getJ2000EquatorialPos(core);
 
 		// To transform from texture coordinate to 2d coordinate we need to find X with XA = B
 		// A formed of 4 points in texture coordinate, B formed with 4 points in 3d coordinate space


### PR DESCRIPTION
Check for star null pointer when loading constellation data in case one of the major star catalog corrupted/missing, or constellation data points to HIP stars that do not exist (e.g., HIP 119000). Currently, stellarium will crash on startup when for example level 1 catalog is missing. With this PR no star catalog is needed to launch Stellarium (i.e., even level 0-3 are missing).

Another minor tweaks in this PR is search for other designations beside HIP when loading exoplanet data.

Fixes # (issue)

### Screenshots (if appropriate):

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system: MacOS 15
* Graphics Card: Apple M3

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
