### PR TITLE
Take updated parallax into account when drawing marker and search for star selection

### DIFF
--- a/src/core/modules/Star.hpp
+++ b/src/core/modules/Star.hpp
@@ -180,7 +180,8 @@ struct Star
                                  double & RV,
                                  float    dyrs) const
    {
-      if (getX2() != 0. || getDx2() != 0.) {
+      if (getX2() != 0. || getDx2() != 0.) 
+      {  // for star data type 0, have full astrometric solution
          // as long as there is a 3rd component, we need to compute the full 3D position using the equation below
          double r0  = getX0();
          double r1  = getX1();
@@ -229,12 +230,28 @@ struct Star
          else
             Plx = 0.;
          RV  = (pmr1 / MAS2RAD / Plx2) * (AU / JYEAR_SECONDS);
-      } else {
+         return;
+      }
+      if (getDx1() != 0. || getDx2() != 0.)  // for star data type 1, have proper motion
+      {
          DE    = getX1();
          pmra  = getDx0() * cos(DE);
          pmdec = getDx1();
          RA    = getX0() + dyrs * getDx0() * MAS2RAD;
          DE    = getX1() + dyrs * getDx1() * MAS2RAD;
+         Plx   = getPlx();
+         RV    = getRV();
+         return;
+      }
+      else 
+      {  // for star data type 2, have no proper motion
+         RA    = getX0();
+         DE    = getX1();
+         Plx = 0.;
+         RV = 0.;
+         pmra = 0.;
+         pmdec = 0.;
+         return;
       }
    }
 

--- a/src/core/modules/StarWrapper.cpp
+++ b/src/core/modules/StarWrapper.cpp
@@ -294,14 +294,12 @@ QString StarWrapper1::getInfoString(const StelCore *core, const InfoStringGroup&
 		oss << getExtraInfoStrings(flags&ObjectType).join("");
 	}
 
-	double RA, DEC, pmra, pmdec;
+	double RA, DEC, pmra, pmdec, Plx, RadialVel;
 	double PlxErr = s->getPlxErr();
-	double Plx = s->getPlx();
-	double RadialVel = s->getRV();
 	float dyrs = static_cast<float>(core->getJDE()-STAR_CATALOG_JDEPOCH)/365.25;
 	s->getFull6DSolution(RA, DEC, Plx, pmra, pmdec, RadialVel, dyrs);
 	Vec3d v;
-	double binary_sep, binary_pa;  // binary star separation and position angle
+	double binary_sep = 0.0, binary_pa = 0.0;  // binary star separation and position angle
 	s->getBinaryOrbit(core->getJDE(), v, RA, DEC, Plx, pmra, pmdec, RadialVel, binary_sep, binary_pa);
 	binary_pa *= M_180_PIf;
 
@@ -670,10 +668,8 @@ QString StarWrapper2::getInfoString(const StelCore *core, const InfoStringGroup&
 
 	oss << getMagnitudeInfoString(core, flags, 2);
 
-	double RA, DEC, pmra, pmdec;
-	double Plx = s->getPlx();
+	double RA, DEC, pmra, pmdec, Plx, RadialVel;
 	double PlxErr = s->getPlxErr();
-	double RadialVel = s->getRV();
 	float dyrs = static_cast<float>(core->getJDE()-STAR_CATALOG_JDEPOCH)/365.25;
 	s->getFull6DSolution(RA, DEC, Plx, pmra, pmdec, RadialVel, dyrs);
 	bool computeAstrometryFlag = (flags&ProperMotion) && (pmra || pmdec);

--- a/src/core/modules/StarWrapper.hpp
+++ b/src/core/modules/StarWrapper.hpp
@@ -78,13 +78,18 @@ protected:
 	Vec3d getJ2000EquatorialPos(const StelCore* core) const override
 	{
 		Vec3d v;
-		s->getJ2000Pos((core->getJDE()-STAR_CATALOG_JDEPOCH)/365.25, v);
+
+		double RA, DEC, pmra, pmdec, Plx, RadialVel;
+		float dyrs = static_cast<float>(core->getJDE()-STAR_CATALOG_JDEPOCH)/365.25;
+		s->getFull6DSolution(RA, DEC, Plx, pmra, pmdec, RadialVel, dyrs);
+		StelUtils::spheToRect(RA, DEC, v);
+
 		// in case it is in a binary system
 		s->getBinaryOrbit(core->getJDE(), v);
 		double withParallax = core->getUseParallax() * core->getParallaxFactor();
 		if (withParallax) {
 			const Vec3d diffPos = core->getParallaxDiff(core->getJDE());
-			s->getPlxEffect(withParallax * s->getPlx(), v, diffPos);
+			s->getPlxEffect(withParallax * Plx, v, diffPos);
 			v.normalize();
 		}
 


### PR DESCRIPTION
Bugs introduced by #4023 taken parallax effect into account. For example for Barnard's star, exaggerate parallax effect by 100x and go to year 50000, Barnard's star marker location is off and became unselectable. The root cause is marker location and selection search do not take updated parallax into account but simply using catalog parallax (so affect nesrby fast moving stars the most).

### Screenshots (if appropriate):

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system: MacOS 15
* Graphics Card: Apple M3

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
