### PR TITLE
Set correct light pollution level when location=auto

### DIFF
--- a/src/core/StelLocationMgr.cpp
+++ b/src/core/StelLocationMgr.cpp
@@ -1165,7 +1165,7 @@ void StelLocationMgr::changeLocationFromNetworkLookup()
 			if (!ipCity.isEmpty())
 				ipLoc = locationForString(QString("%1, %2").arg(ipCity, regionName));
 			else
-				ipLoc = pickLocationsNearby("Earth", longitude, latitude, 5.f).first();
+				ipLoc = pickLocationsNearby("Earth", longitude, latitude, 1.f).first();
 
 			if (ipLoc.isValid())
 				luminance = ipLoc.lightPollutionLuminance.toFloat();

--- a/src/core/StelLocationMgr.cpp
+++ b/src/core/StelLocationMgr.cpp
@@ -1160,13 +1160,15 @@ void StelLocationMgr::changeLocationFromNetworkLookup()
 
 			QString regionName = pickRegionFromCountryCode(ipCountryCode.toLower());
 			float luminance = StelLocation::DEFAULT_LIGHT_POLLUTION_LUMINANCE;
+			StelLocation ipLoc;
+			// Check location in our database and fetch light pollution luminance if it possible
 			if (!ipCity.isEmpty())
-			{
-				// Check location in our database and fetch light pollution luminance if it possible
-				StelLocation loctmp = locationForString(QString("%1, %2").arg(ipCity, regionName));
-				if (loctmp.isValid())
-					luminance = loctmp.lightPollutionLuminance.toFloat();
-			}
+				ipLoc = locationForString(QString("%1, %2").arg(ipCity, regionName));
+			else
+				ipLoc = pickLocationsNearby("Earth", longitude, latitude, 5.f).first();
+
+			if (ipLoc.isValid())
+				luminance = ipLoc.lightPollutionLuminance.toFloat();
 
 			StelLocation loc;
 			loc.name    = (ipCity.isEmpty() ? QString("%1, %2").arg(latitude).arg(longitude) : ipCity);

--- a/src/core/StelLocationMgr.cpp
+++ b/src/core/StelLocationMgr.cpp
@@ -1158,7 +1158,7 @@ void StelLocationMgr::changeLocationFromNetworkLookup()
 
 			qDebug() << "Got location" << QString("%1, %2, %3 (%4, %5; %6)").arg(ipCity, ipRegion, ipCountry).arg(latitude).arg(longitude).arg(ipTimeZone) << "for IP" << locMap.value("ip").toString();
 
-			QString regionName = pickRegionFromCountryCode(ipCountryCode.isEmpty() ? "" : ipCountryCode.toLower());
+			QString regionName = pickRegionFromCountryCode(ipCountryCode.toLower());
 			float luminance = StelLocation::DEFAULT_LIGHT_POLLUTION_LUMINANCE;
 			if (!ipCity.isEmpty())
 			{

--- a/src/core/StelLocationMgr.cpp
+++ b/src/core/StelLocationMgr.cpp
@@ -1158,16 +1158,26 @@ void StelLocationMgr::changeLocationFromNetworkLookup()
 
 			qDebug() << "Got location" << QString("%1, %2, %3 (%4, %5; %6)").arg(ipCity, ipRegion, ipCountry).arg(latitude).arg(longitude).arg(ipTimeZone) << "for IP" << locMap.value("ip").toString();
 
+			QString regionName = pickRegionFromCountryCode(ipCountryCode.isEmpty() ? "" : ipCountryCode.toLower());
+			float luminance = StelLocation::DEFAULT_LIGHT_POLLUTION_LUMINANCE;
+			if (!ipCity.isEmpty())
+			{
+				// Check location in our database and fetch light pollution luminance if it possible
+				StelLocation loctmp = locationForString(QString("%1, %2").arg(ipCity, regionName));
+				if (loctmp.isValid())
+					luminance = loctmp.lightPollutionLuminance.toFloat();
+			}
+
 			StelLocation loc;
 			loc.name    = (ipCity.isEmpty() ? QString("%1, %2").arg(latitude).arg(longitude) : ipCity);
 			loc.state   = (ipRegion.isEmpty() ? "IPregion"  : ipRegion);
-			loc.region = pickRegionFromCountryCode(ipCountryCode.isEmpty() ? "" : ipCountryCode.toLower());
+			loc.region = regionName;
 			loc.role    = QChar(0x0058); // char 'X'
 			loc.population = 0;
 			loc.setLatitude  (static_cast<float>(latitude));
 			loc.setLongitude (static_cast<float>(longitude));
 			loc.altitude = 0;
-			loc.lightPollutionLuminance = StelLocation::DEFAULT_LIGHT_POLLUTION_LUMINANCE;
+			loc.lightPollutionLuminance = luminance;
 			loc.ianaTimeZone = (ipTimeZone.isEmpty() ? "" : ipTimeZone);
 			loc.planetName = "Earth";
 			loc.landscapeKey = "";


### PR DESCRIPTION
### Description
This patch should obtaining a realistic light pollution level for auto discovered locations (at least for big cities)

Fixes #2762 (issue)

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
