### PR TITLE
Reduce HiPS split order when tile width is small

### DIFF
--- a/src/core/StelHips.cpp
+++ b/src/core/StelHips.cpp
@@ -303,6 +303,15 @@ void HipsSurvey::draw(StelPainter* sPainter, double angle, HipsSurvey::DrawCallb
 	}
 	drawOrder = qBound(orderMin, drawOrder, order);
 	int splitOrder = qMax(drawOrder, 4);
+	if (tileWidth < 512)
+	{
+		int w = 512;
+		while (tileWidth < w && splitOrder > 0)
+		{
+			w /= 2;
+			--splitOrder;
+		}
+	}
 
 	nbVisibleTiles = 0;
 	nbLoadedTiles = 0;


### PR DESCRIPTION
Some AKARI surveys appear to have hips_tile_width=32, which is much smaller than the default 512. This means that a FullHD screen will have roughly 2000 tiles shown, each of which would be split according to splitOrder computed. Thus, to achieve a level of splitting similar to the normal case of 512px tiles we should reduce splitOrder according to the log2(tileWidth/512).

<!--- Provide a general summary of your changes in the Title above -->

### Description

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system: Ubuntu 20.04
* Graphics Card: Intel UHD Graphics 620

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
