### PR TITLE
Add a JSONlint step to Code Quality checks

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -23,10 +23,13 @@ jobs:
         # https://github.com/actions/virtual-environments/issues/2703
         #sudo ACCEPT_EULA=Y apt upgrade -o Dpkg::Options::="--force-overwrite" --yes
         #sudo apt install -y qtbase5-private-dev qtscript5-dev libqt5svg5-dev qttools5-dev-tools qttools5-dev libqt5opengl5-dev qtmultimedia5-dev libqt5multimedia5-plugins libqt5serialport5 libqt5serialport5-dev qtpositioning5-dev libgps-dev libqt5positioning5 libqt5positioning5-plugins qtwebengine5-dev libqt5charts5-dev zlib1g-dev libgl1-mesa-dev libdrm-dev cmake lcov libexiv2-dev libnlopt-cxx-dev
-        sudo apt install -y qt6-base-private-dev qt6-multimedia-dev qt6-positioning-dev qt6-tools-dev qt6-tools-dev-tools qt6-base-dev-tools qt6-qpa-plugins qt6-image-formats-plugins qt6-l10n-tools qt6-webengine-dev qt6-webengine-dev-tools libqt6charts6-dev libqt6charts6 libqt6opengl6-dev libqt6positioning6-plugins libqt6serialport6-dev qt6-base-dev libqt6webenginecore6-bin libqt6webengine6-data libexiv2-dev libnlopt-cxx-dev zlib1g-dev libgl1-mesa-dev libdrm-dev libglx-dev libxkbcommon-x11-dev libgps-dev zlib1g-dev libgl1-mesa-dev libdrm-dev cmake lcov libexiv2-dev libnlopt-cxx-dev
+        sudo apt install -y qt6-base-private-dev qt6-multimedia-dev qt6-positioning-dev qt6-tools-dev qt6-tools-dev-tools qt6-base-dev-tools qt6-qpa-plugins qt6-image-formats-plugins qt6-l10n-tools qt6-webengine-dev qt6-webengine-dev-tools libqt6charts6-dev libqt6charts6 libqt6opengl6-dev libqt6positioning6-plugins libqt6serialport6-dev qt6-base-dev libqt6webenginecore6-bin libqt6webengine6-data libexiv2-dev libnlopt-cxx-dev zlib1g-dev libgl1-mesa-dev libdrm-dev libglx-dev libxkbcommon-x11-dev libgps-dev zlib1g-dev libgl1-mesa-dev libdrm-dev cmake lcov libexiv2-dev libnlopt-cxx-dev python3-demjson
 
     - name: Checkout repository
       uses: actions/checkout@v4
+
+    - name: JSONlint
+      run: jsonlint ${{github.workspace}}/skycultures/*/index.json
 
     - name: Configure CMake
       shell: bash


### PR DESCRIPTION
This will prevent leaving some mistakes as in d02727ea7c7bf2b8a65b248e99b37a4d248e7c7e undetected.

In the future we may want to go over all JSON files present in the repository, like so:
```
find ${{github.workspace}} -iname '*.json' -exec jsonlint {} +
```
Currently such a command already gives some warnings, which is why I don't put it in just yet.