### PR TITLE
Add padding to bounding cap to avoid clipping on small FOV

### DIFF
--- a/src/core/StelProjector.cpp
+++ b/src/core/StelProjector.cpp
@@ -554,12 +554,15 @@ void StelProjector::computeBoundingCap()
 	// Now need to determine the aperture
 	Vec3d e0,e1,e2,e3,e4,e5;
 	const Vec4i& vp = viewportXywh;
-	ok &= unProject(vp[0],vp[1],e0);               // e0: bottom left
-	ok &= unProject(vp[0]+vp[2],vp[1],e1);         // e1: bottom right
-	ok &= unProject(vp[0]+vp[2],vp[1]+vp[3],e2);   // e2: top right
-	ok &= unProject(vp[0],vp[1]+vp[3],e3);         // e3: top left
-	ok &= unProject(vp[0],vp[1]+vp[3]/2,e4);       // e4: left center
-	ok &= unProject(vp[0]+vp[2],vp[1]+vp[3]/2,e5); // e5: right center
+	// Saemundsson's inversion formula for atmospheric refraction is not exact, so need some padding in terms of arcseconds
+	const double margin = 30000. * MAS2RAD * getPixelPerRadAtCenter();  // 0.5 arcmin
+
+	ok &= unProject(vp[0]-margin, vp[1]-margin, e0);             // e0: bottom left
+	ok &= unProject(vp[0]+vp[2]+margin, vp[1]-margin,e1);        // e1: bottom right
+	ok &= unProject(vp[0]+vp[2]+margin, vp[1]+vp[3]+margin, e2); // e2: top right
+	ok &= unProject(vp[0]-margin, vp[1]+vp[3]+margin, e3);       // e3: top left
+	ok &= unProject(vp[0]-margin,vp[1]+vp[3]/2+margin,e4);       // e4: left center
+	ok &= unProject(vp[0]+vp[2]+margin,vp[1]+vp[3]/2+margin,e5); // e5: right center
 	if (!ok)
 	{
 		// Some points were in invalid positions, use full sky.

--- a/src/core/modules/StarMgr.cpp
+++ b/src/core/modules/StarMgr.cpp
@@ -1350,7 +1350,14 @@ void StarMgr::draw(StelCore* core)
 		return;
 
 	int maxSearchLevel = getMaxSearchLevel();
-	QVector<SphericalCap> viewportCaps = prj->getViewportConvexPolygon()->getBoundingSphericalCaps();
+	double margin = 0.;  // pixel margin to be applied to viewport convex polygon
+	if (core->getSkyDrawer()->getFlagHasAtmosphere())
+	{
+		// Saemundsson's inversion formula for atmospheric refraction is not exact, so need some padding in terms of arcseconds
+		margin = 30000. * MAS2RAD * prj->getPixelPerRadAtCenter();  // 0.5 arcmin
+	}
+	
+	QVector<SphericalCap> viewportCaps = prj->getViewportConvexPolygon(margin, margin)->getBoundingSphericalCaps();
 	viewportCaps.append(core->getVisibleSkyArea());
 	const GeodesicSearchResult* geodesic_search_result = core->getGeodesicGrid(maxSearchLevel)->search(viewportCaps,maxSearchLevel);
 


### PR DESCRIPTION
Add padding to bounding cap to avoid clipping on small FOV. The root cause is Saemundsson's inversion formula for atmospheric refraction is not exact as stated in https://github.com/Stellarium/stellarium/blob/8a129b6b398519386b22cd0a2dcab3161654adb6/src/core/RefractionExtinction.cpp#L253

0.5 arcmin padding seems to work well except a few arcminute above the horizon (which is really close and I think this is good enough).

Fixes #365, #538

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system: MacOS 15
* Graphics Card: Apple M3

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
