### PR TITLE
Add pronounce and IPA tags in Siberian SC

### DIFF
--- a/skycultures/russian_siberian/index.json
+++ b/skycultures/russian_siberian/index.json
@@ -7,21 +7,21 @@
     {
       "id": "CON russian_siberian Elk",
       "lines": [[67301, 65378, 62956, 59774, 58001, 53910, 54061, 59774]],
-      "common_name": {"english": "Elk", "native": "Лось", "IPA": "ɫ̪os̪ʲ"}
+      "common_name": {"english": "Elk", "native": "Лось", "pronounce": "Los’", "IPA": "ɫ̪os̪ʲ"}
     },
     {
       "id": "CON russian_siberian Kic",
       "lines": [[26241, 26268, 26727, 26311, 25930]],
-      "common_name": {"english": "Threshers", "native": "Кичиги", "IPA": "k̟ʲɪˈt̠̪͡ʲɕ̪iɡ̟ʲɪ"}
+      "common_name": {"english": "Threshers", "native": "Кичиги", "pronounce": "Kichigi", "IPA": "k̟ʲɪˈt̠̪͡ʲɕ̪iɡ̟ʲɪ"}
     },
     {
       "id": "CON russian_siberian DNe",
       "lines": [[17499, 17489, 17531, 17579, 17664, 17851, 17847, 17608, 17499]],
-      "common_name": {"english": "Duck Nest", "native": "Утиное гнездо", "IPA": "uˈt̪ʲin̪ə.jə ɡn̪ʲɪˈz̪d̪o"}
+      "common_name": {"english": "Duck Nest", "native": "Утиное гнездо", "pronounce": "Utinoye gnyezdo", "IPA": "uˈt̪ʲin̪ə.jə ɡn̪ʲɪˈz̪d̪o"}
     }
   ],
   "common_names": {
     "HIP 11767": [{"english": "Golden stake"}],
-    "NAME Venus": [{"english": "Night Star", "native": "Ночная звёздочка", "IPA": "n̪əˈt̠̪͡ʲɕ̪n̪a.jə ˈz̪vʲo.zd̪ə.t̠̪͡ʲɕ̪kə", "translators_comments": "Native name of Venus in Siberian culture"}]
+    "NAME Venus": [{"english": "Night Star", "native": "Ночная звёздочка", "pronounce": "Nochnaya zvyozdochka", "IPA": "n̪əˈt̠̪͡ʲɕ̪n̪a.jə ˈz̪vʲo.zd̪ə.t̠̪͡ʲɕ̪kə", "translators_comments": "Native name of Venus in Siberian culture"}]
   }
 }

--- a/skycultures/russian_siberian/index.json
+++ b/skycultures/russian_siberian/index.json
@@ -21,7 +21,7 @@
     }
   ],
   "common_names": {
-    "HIP 11767": [{"english": "Golden stake", "native": "Золотой кол", "pronounce": "Zolotoy kol"}],
+    "HIP 11767": [{"english": "Golden stake", "native": "Золотой кол", "pronounce": "Zolotoy kol", "IPA": "z̪əɫ̪ɐˈt̪oj koɫ̪"}],
     "NAME Venus": [{"english": "Night Star", "native": "Ночная звёздочка", "pronounce": "Nochnaya zvyozdochka", "IPA": "n̪əˈt̠̪͡ʲɕ̪n̪a.jə ˈz̪vʲo.zd̪ə.t̠̪͡ʲɕ̪kə", "translators_comments": "Native name of Venus in Siberian culture"}]
   }
 }

--- a/skycultures/russian_siberian/index.json
+++ b/skycultures/russian_siberian/index.json
@@ -7,21 +7,21 @@
     {
       "id": "CON russian_siberian Elk",
       "lines": [[67301, 65378, 62956, 59774, 58001, 53910, 54061, 59774]],
-      "common_name": {"english": "Elk", "native": "Лось"}
+      "common_name": {"english": "Elk", "native": "Лось", "IPA": "ɫ̪os̪ʲ"}
     },
     {
       "id": "CON russian_siberian Kic",
       "lines": [[26241, 26268, 26727, 26311, 25930]],
-      "common_name": {"english": "Threshers", "native": "Кичиги"}
+      "common_name": {"english": "Threshers", "native": "Кичиги", "IPA": "k̟ʲɪˈt̠̪͡ʲɕ̪iɡ̟ʲɪ"}
     },
     {
       "id": "CON russian_siberian DNe",
       "lines": [[17499, 17489, 17531, 17579, 17664, 17851, 17847, 17608, 17499]],
-      "common_name": {"english": "Duck Nest", "native": "Утиное гнездо"}
+      "common_name": {"english": "Duck Nest", "native": "Утиное гнездо", "IPA": "uˈt̪ʲin̪ə.jə ɡn̪ʲɪˈz̪d̪o"}
     }
   ],
   "common_names": {
     "HIP 11767": [{"english": "Golden stake"}],
-    "NAME Venus": [{"english": "Night Star", "native": "Ночная звёздочка", "translators_comments": "Native name of Venus in Siberian culture"}]
+    "NAME Venus": [{"english": "Night Star", "native": "Ночная звёздочка", "IPA": "n̪əˈt̠̪͡ʲɕ̪n̪a.jə ˈz̪vʲo.zd̪ə.t̠̪͡ʲɕ̪kə", "translators_comments": "Native name of Venus in Siberian culture"}]
   }
 }

--- a/skycultures/russian_siberian/index.json
+++ b/skycultures/russian_siberian/index.json
@@ -21,7 +21,7 @@
     }
   ],
   "common_names": {
-    "HIP 11767": [{"english": "Golden stake"}],
+    "HIP 11767": [{"english": "Golden stake", "native": "Золотой кол", "pronounce": "Zolotoy kol"}],
     "NAME Venus": [{"english": "Night Star", "native": "Ночная звёздочка", "pronounce": "Nochnaya zvyozdochka", "IPA": "n̪əˈt̠̪͡ʲɕ̪n̪a.jə ˈz̪vʲo.zd̪ə.t̠̪͡ʲɕ̪kə", "translators_comments": "Native name of Venus in Siberian culture"}]
   }
 }


### PR DESCRIPTION
So the recently added SC TODO mentions a lack of pronounce tags in the Siberian SC. This commit adds them. They might be not 100% correct, but reflect most of what I know about the Russian phonetics (however strange this might sound from a native speaker).

Notice how ugly IPA looks in monospaced font. Even in LibreOffice Writer (with proportional fonts) it looks wrong. It's OK in the browser's address bar though... I suppose most translators will use Transifex or poedit, so this might be OK for them.

Also I didn't try rendering it using Qt, but I suppose this may be doubly ugly in our texture-based rendering on the scene.

Thus, we may have to think twice before showing pronunciations of names on the screen.