### PR TITLE
Map ObsListDialog index from proxy model back to the source

### DIFF
--- a/src/gui/ObsListDialog.cpp
+++ b/src/gui/ObsListDialog.cpp
@@ -758,12 +758,20 @@ QString ObsListDialog::saveBookmarksHashInObservingLists(const QHash<QString, ob
 */
 void ObsListDialog::selectAndGoToObject(QModelIndex index)
 {
-	QStandardItem *selectedItem = itemModel->itemFromIndex(index);
-	int rowNumber = selectedItem->row();
+    // Map the index from the proxy to the source model.
+    QSortFilterProxyModel* proxy = qobject_cast<QSortFilterProxyModel*>(ui->treeView->model());
+    QModelIndex sourceIndex = proxy ? proxy->mapToSource(index) : index;
 
-	QStandardItem *uuidItem = itemModel->item(rowNumber, ColumnUUID);
-	QString itemUuid = uuidItem->text();
-	observingListItem item = currentItemCollection.value(itemUuid);
+    QStandardItem *selectedItem = itemModel->itemFromIndex(sourceIndex);
+    if (!selectedItem)
+        return;
+    int rowNumber = selectedItem->row();
+
+    QStandardItem *uuidItem = itemModel->item(rowNumber, ColumnUUID);
+    if (!uuidItem)
+        return;
+    QString itemUuid = uuidItem->text();
+    observingListItem item = currentItemCollection.value(itemUuid);
 
 	// Load landscape/location before dealing with the object: It could be a view from another planet!
 	// We load stored landscape/location if the respective checkbox is checked.


### PR DESCRIPTION
### Description

I contributed #4098, but failed to notice that *after sorting*, when you double-click on a row, it segfaults.

This PR fixes the segfault.  The problem was that the double‐click slot is using an index from a proxy model without mapping it back to the source (itemModel).  When you sort the tree view, you set a new proxy model on the view.  Then the QModelIndex passed to selectAndGoToObject belongs to the proxy and must be mapped back to the source model before calling itemModel->itemFromIndex().


### Screenshots (if appropriate):

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?

I've built the code, run it, and tested on my own observing list — including double-clicking on a row.

**Test Configuration**:

* Operating system: macOS 14.6.1
* Graphics Card: Apple M2 Max (Metal 3)

## Checklist:
- [X] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
