### PR TITLE
Fixes zodiac.ssc script

### DIFF
--- a/scripts/zodiac.ssc
+++ b/scripts/zodiac.ssc
@@ -8,7 +8,11 @@
 //              of a year.
 //
 
-var constellations = new Array("Gemini", "Cancer", "Leo", "Virgo", "Libra", "Scorpius", "Ophiuchus", "Sagittarius", "Capricornus", "Aquarius", "Pisces", "Aries", "Taurus");
+var constellations = new Array("Twins", "Crab", "Lion", "Maiden", "Scales", "Scorpion", "Serpent Bearer", "Archer", "Sea Goat", "Water Bearer", "Fishes", "Ram", "Bull");
+
+
+ConstellationMgr.setConstellationDisplayStyle(1);
+ConstellationMgr.deselectConstellations();
 
 core.setSkyCulture("modern");
 core.clear("deepspace");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

#### Issues addressed 

Addresses the following issues in the script `zodiac.scc`

- The script is intended to display the Zodiac constellations  in an animated sequence one after the other; however, the script doesn't clear the previously selected constellations, which destroys the effect of the sequence for subsequent calls (previously selected constellations remain selected)  
- The script doesn't work with the latest release (25.1) because `selectObjectByName` expects English names instead of I18N names. 

#### Solution

- Added a function call to clear the previously selected constellations before starting the animation
- Changed the constellation names to English but displayed them in the `native` style. 

#### Dependencies

No dependencies. No code changes.
<!--- Please also include relevant motivation and context. -->

### Type of change

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] Housekeeping

### How Has This Been Tested?

Verifying the expected behavior of the script.

I ran the script in both a Mac with M2 chipset and a Raspberry Pi 5.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
