### PR TITLE
Create and draw convex hulls for constellations

### DIFF
--- a/src/core/StelSkyCultureMgr.cpp
+++ b/src/core/StelSkyCultureMgr.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "StelSkyCultureMgr.hpp"
+#include "StarMgr.hpp"
 #include "StelFileMgr.hpp"
 #include "StelTranslator.hpp"
 #include "StelLocaleMgr.hpp"
@@ -755,4 +756,176 @@ QString StelSkyCultureMgr::skyCultureI18ToDirectory(const QString& cultureName) 
 			return i.key();
 	}
 	return "";
+}
+
+
+struct hullEntry
+{
+	StelObjectP obj;
+	double x;
+	double y;
+	//double angle;
+};
+// simple function only for ordering from Sedgewick 1990, Algorithms in C (p.353) used for sorting.
+// The result fulfills the same purpose as some atan2, but with simpler operations.
+static double theta(const hullEntry &p1, const hullEntry &p2)
+{
+	const double dx = p2.x-p1.x;
+	const double ax = abs(dx);
+	const double dy = p2.y-p1.y;
+	const double ay = abs(dy);
+	const double asum = ax+ay;
+	double t = (asum==0) ? 0.0 : dy/asum;
+	if (dx<0.)
+		t=2-t;
+	else if (dy<0.)
+		t=4+t;
+	return t*M_PI_2;
+}
+
+SphericalRegionP StelSkyCultureMgr::makeConvexHull(const std::vector<StelObjectP> &starLines, const std::vector<Vec3d> &darkLines, const Vec3d projectionCenter)
+{
+	static StelCore *core=StelApp::getInstance().getCore();
+	// 1. Project every first star of a line pair (or just coordinates from a dark constellation) into a 2D tangential plane around projectionCenter.
+	// Stars more than 90° from center cannot be projected of course and are skipped.
+	double raC, deC;
+	StelUtils::rectToSphe(&raC, &deC, projectionCenter);
+
+	// starLines contains pairs of vertices, and some stars occur more than twice.
+	QStringList idList;
+	QList<StelObjectP>uniqueStarList;
+	foreach(auto &star, starLines)
+	{
+		if (!idList.contains(star->getID()))
+		{
+			// Take this star into consideration. However, the "star"s may be pointers to the same star, we must compare IDs.
+			idList.append(star->getID());
+			uniqueStarList.append(star);
+		}
+	}
+
+	QList<hullEntry> hullList;
+	// Perspective (gnomonic) projection from Snyder 1987, Map Projections: A Working Manual (USGS).
+	foreach(auto &star, uniqueStarList)
+	{
+		hullEntry entry;
+		entry.obj=star;
+		double ra, de;
+		StelUtils::rectToSphe(&ra, &de, entry.obj->getJ2000EquatorialPos(core));
+		const double cosC=sin(deC)*sin(de) + cos(deC)*cos(de)*cos(ra-raC);
+		if (cosC<=0.)
+			continue;
+		const double kP=1./cosC;
+		entry.x=-kP*cos(de)*sin(ra-raC); // x must be inverted here.
+		entry.y=kP*(cos(deC)*sin(de)-sin(deC)*cos(de)*cos(ra-raC));
+		hullList.append(entry);
+		//qDebug().noquote().nospace() << "[ " << entry.x << " " << entry.y << " " << ra*M_180_PI/15 << " " << de*M_180_PI << " (" << entry.obj->getID() << ") ]"; // allows Postscript graphics, looks OK.
+	}
+	//qDebug() << "Hull candidates: " << hullList.length();
+	if (hullList.count() < 3)
+	{
+		//qDebug() << "List length" << hullList.count() << " not enough for a convex hull... skipping";
+		EmptySphericalRegion *empty = new EmptySphericalRegion;
+		return empty;
+	}
+
+	// 2. Apply Package Wrapping from Sedgewick 1990, Algorithms in C to find the outer points wrapping all points.
+	// find minY
+	int min=0;
+	for(int i=1; i<hullList.count(); ++i)
+	{
+		const hullEntry &entry=hullList.at(i);
+		if (entry.y<hullList.at(min).y)
+			min=i;
+	}
+	//qDebug() << "min entry is " << hullList.at(min).obj->getID();
+
+	const int N=hullList.count(); // N...number of unique stars in constellation.
+	//qDebug() << "unique stars N=" << N;
+	hullList.append(hullList.at(min));
+
+	//QStringList debugList;
+	//// DUMP HULL LINE
+	//for(int i=0; i<hullList.count(); ++i)
+	//{
+	//	const hullEntry &entry=hullList.at(i);
+	//	debugList << entry.obj->getID();
+	//}
+	//qDebug() << "Hull candidate: " << debugList.join(" - ");
+	//debugList.clear();
+
+	int M=0;
+	double th=0.0;
+	for (M=0; M<N; ++M)
+	{
+		hullList.swapItemsAt(M, min);
+
+		//// DUMP HULL LINE
+		//for(int i=0; i<hullList.count(); ++i)
+		//{
+		//	const hullEntry &entry=hullList.at(i);
+		//	debugList << entry.obj->getID();
+		//	if (i==M)
+		//		debugList << "|";
+		//}
+		//qDebug() << "Hull candidate after swap at M=" << M << debugList.join(" - ");
+		//debugList.clear();
+
+		min=N; double v=th; th=M_PI*2.0;
+		for (int i=M+1; i<=N; ++i)
+		{
+			//qDebug() << "From M:" << M << "(" << hullList.at(M).obj->getID() << ") to i: " << i << "=" << hullList.at(i).obj->getID() << ": th=" << theta(hullList.at(M), hullList.at(i)) * M_180_PI ;
+
+			if (theta(hullList.at(M), hullList.at(i)) > v)
+				if(theta(hullList.at(M), hullList.at(i))< th)
+				{
+					min=i;
+					th=theta(hullList.at(M), hullList.at(min));
+					//qDebug() << "min:" << min << "th:" << th * M_180_PI;
+				}
+		}
+
+		//// DUMP HULL LINE
+		//for(int i=0; i<hullList.count(); ++i)
+		//{
+		//	const hullEntry &entry=hullList.at(i);
+		//	debugList << entry.obj->getID();
+		//	if (i==M)
+		//		debugList << "|";
+		//}
+		//qDebug() << "Hull candidate after  sort at M=" << M << debugList.join(" - ");
+		//debugList.clear();
+
+		if (min==N)
+		{
+			//qDebug().nospace() << "min==N=" << N << ", we're done sorting. Hull should be of length M=" << M;
+			break; // now M+1 is holds number of "valid" hull points.
+		}
+	}
+	++M;
+	//qDebug() << "Hull length" << M << "of" << hullList.count();
+	hullList.remove(M, N-M);
+	//hullList.remove(M-1, N-M+1);
+
+	//// DUMP HULL LINE
+	//for(int i=0; i<hullList.count(); ++i)
+	//{
+	//	const hullEntry &entry=hullList.at(i);
+	//	debugList << entry.obj->getID();
+	//}
+	//qDebug() << "Final Hull, M=" << M << debugList.join(" - ");
+	//debugList.clear();
+
+	//Now create a SphericalRegion
+	QList<Vec3d> hullPoints;
+	foreach(const hullEntry &entry, hullList)
+	{
+		Vec3d pos=entry.obj->getJ2000EquatorialPos(core);
+		hullPoints.append(pos);
+	}
+	// With perspective x inverted, we don't need to reverse.
+	//std::reverse(hullPoints.begin(), hullPoints.end());
+	SphericalPolygon *hull=new SphericalPolygon(hullPoints);
+	//qDebug() << "Successful hull:" << hull->toJSON();
+	return hull;
 }

--- a/src/core/StelSkyCultureMgr.hpp
+++ b/src/core/StelSkyCultureMgr.hpp
@@ -26,6 +26,9 @@
 #include <QStringList>
 #include <QJsonObject>
 #include <QJsonArray>
+#include "StelObjectType.hpp"
+#include "StelSphereGeometry.hpp"
+#include "VecMath.hpp"
 
 class StelTranslator;
 
@@ -212,6 +215,19 @@ public slots:
 
 	//! Returns a map from sky culture IDs/folders to sky culture names.
 	QMap<QString, StelSkyCulture> getDirToNameMap() const { return dirToNameEnglish; }
+
+	//! Compute the convex hull of a constellation or asterism.
+	//! The convex hull around stars on the sphere is described as problematic.
+	//! For constellations of limited size we follow the recommendation to
+	//! - project the stars (perspectively) around the projectionCenter on a tangential plane on the unit sphere.
+	//! - apply simple Package-Wrapping from Sedgewick 1990, Algorithms in C, chapter 25.
+	//! @param starLines the line array for a single constellation (Constellation::constellation or Asterism::asterism).
+	//! @param darkOutline line array of simple Vec3d J2000 equatorial coordinates.
+	//! @param projectionCenter (normalized Vec3d) as computed from these stars when finding the label position (XYZname)
+	//! @return SphericalRegion in equatorial J2000 coordinates.
+	//! @note the hull should be recreated occasionally as it can change by stellar proper motion.
+	//! @todo Connect some time trigger to recreate automatically, maybe once per year, decade or so.
+	static SphericalRegionP makeConvexHull(const std::vector<StelObjectP> &starLines, const std::vector<Vec3d> &darkLines, const Vec3d projectionCenter);
 
 signals:
 	//! Emitted whenever the default sky culture changed.

--- a/src/core/modules/Constellation.cpp
+++ b/src/core/modules/Constellation.cpp
@@ -28,6 +28,7 @@
 #include "StelCore.hpp"
 #include "StelUtils.hpp"
 #include "ConstellationMgr.hpp"
+#include "StelSkyCultureMgr.hpp"
 #include "ZoneArray.hpp"
 
 #include <QString>
@@ -51,12 +52,15 @@ Constellation::Constellation()
 	, beginSeason(0)
 	, endSeason(0)
 	, singleStarConstellationRadius(cos(M_PI/360.)) // default radius of 1/2 degrees
+	, convexHull(nullptr)
 	, artOpacity(1.f)
 {
 }
 
 Constellation::~Constellation()
 {
+	if (convexHull)
+		delete convexHull.data();
 }
 
 bool Constellation::read(const QJsonObject& data, StarMgr *starMgr, const bool preferNativeName)
@@ -138,6 +142,9 @@ bool Constellation::read(const QJsonObject& data, StarMgr *starMgr, const bool p
 		XYZname+= constellation[ii]->getJ2000EquatorialPos(StelApp::getInstance().getCore());
 	}
 	XYZname.normalize();
+
+	//qDebug() << "Convex hull for " << englishName;
+	convexHull=StelSkyCultureMgr::makeConvexHull(constellation, std::vector<Vec3d>(), XYZname);
 
 	beginSeason = 1;
 	endSeason = 12;
@@ -304,6 +311,14 @@ void Constellation::drawBoundaryOptim(StelPainter& sPainter, const Vec3d& obsVel
 
 			sPainter.drawGreatCircleArc(point0, point1, &viewportHalfspace);
 		}
+	}
+
+	// Also draw Convex hull
+	// TODO: separate hull drawing, obviously...
+	if (convexHull)
+	{
+		sPainter.setColor(boundaryColor*1.7, boundaryFader.getInterstate());
+		sPainter.drawSphericalRegion(convexHull.data(), StelPainter::SphericalPolygonDrawModeBoundary);
 	}
 }
 

--- a/src/core/modules/Constellation.hpp
+++ b/src/core/modules/Constellation.hpp
@@ -185,6 +185,7 @@ private:
 	StelTextureSP artTexture;
 	StelVertexArray artPolygon;
 	SphericalCap boundingCap;
+	SphericalRegionP convexHull; // The convex hull formed by stars contained in the defined lines plus extra stars.
 
 	//! Define whether art, lines, names and boundary must be drawn
 	LinearFader artFader, lineFader, nameFader, boundaryFader;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
For specialized research around star or transient identification, the idea of convex hulls came up. 
This branch shall develop this feature. 

I don't yet know whether it really fulfills its task or whether it should be hidden behind some manual setting. @sushoff, what is the actual purpose, and what do you want to use them for? Just display, or any advanced scripting/query functions?  Practical issues arise for 1-2 star constellations, and a Voronoi-like splitting could actually form a connected spatial segmentation without overlaps and gaps. However, I have never played in these fields.


As technical issue, I have no idea why line drawing is suppressed in the long northern connection line of Hydra, eastern edge of Serpens (cauda) and for Draco intersecting UMi. Given I use SphericalPolygons for drawing, It may be similar to various issues reported around polygonal horizons. 

Fixes # (issue)

### Screenshots (if appropriate):
![stellarium-151](https://github.com/user-attachments/assets/b2197ea6-0803-4fdb-ab9d-29a052704a51)

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system:  Win11
* Graphics Card: Geforce 3700Ti (irrelevant)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
