### PR TITLE
Adjustments for MinGW compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -311,8 +311,14 @@ IF(WIN32)
      # This should also prevent some Winsock.h warnings
      ADD_DEFINITIONS(-DWIN32_LEAN_AND_MEAN)
      IF(NOT MSVC)
-          # MinGW requires enabling of exceptions, version number storage and MinGW-specific threading
-          SET(STEL_MINGW_FLAGS "-fexceptions -fident -mthreads")
+          # MinGW requires enabling of exceptions
+          SET(STEL_MINGW_FLAGS "-fexceptions")
+          # -Og and -s removes symbols an relocation information as otherwise the ordinal gets out of maximum 16-bit range.
+          SET(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Og") 
+          # MinGW clang compiler does not have a these flag, but MinGW gcc requires MinGW-specific threading, version number storage
+          IF(NOT ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang"))
+               SET(STEL_MINGW_FLAGS "${STEL_MINGW_FLAGS} -fident -mthreads -s")
+          ENDIF()
           SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${STEL_GCC_C_FLAGS} ${STEL_MINGW_FLAGS}")
           SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${STEL_GCC_CXX_FLAGS} ${STEL_MINGW_FLAGS}")
      ELSE()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -313,7 +313,7 @@ IF(WIN32)
      IF(NOT MSVC)
           # MinGW requires enabling of exceptions
           SET(STEL_MINGW_FLAGS "-fexceptions")
-          # -Og and -s removes symbols an relocation information as otherwise the ordinal gets out of maximum 16-bit range.
+          # -Og removes some symbols as otherwise the ordinal exceeds the maximum of the 16-bit range.
           SET(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Og") 
           # MinGW clang compiler does not have a these flag, but MinGW gcc requires MinGW-specific threading, version number storage
           IF(NOT ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang"))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -317,7 +317,7 @@ IF(WIN32)
           SET(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Og") 
           # MinGW clang compiler does not have a these flag, but MinGW gcc requires MinGW-specific threading, version number storage
           IF(NOT ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang"))
-               SET(STEL_MINGW_FLAGS "${STEL_MINGW_FLAGS} -fident -mthreads -s")
+               SET(STEL_MINGW_FLAGS "${STEL_MINGW_FLAGS} -fident -mthreads")
           ENDIF()
           SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${STEL_GCC_C_FLAGS} ${STEL_MINGW_FLAGS}")
           SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${STEL_GCC_CXX_FLAGS} ${STEL_MINGW_FLAGS}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -315,7 +315,7 @@ IF(WIN32)
           SET(STEL_MINGW_FLAGS "-fexceptions")
           # -Og removes some symbols as otherwise the ordinal exceeds the maximum of the 16-bit range.
           SET(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Og") 
-          # MinGW clang compiler does not have a these flag, but MinGW gcc requires MinGW-specific threading, version number storage
+          # MinGW clang compiler does not have these flags, but MinGW gcc requires MinGW-specific threading, version number storage
           IF(NOT ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang"))
                SET(STEL_MINGW_FLAGS "${STEL_MINGW_FLAGS} -fident -mthreads")
           ENDIF()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -539,6 +539,11 @@ IF(HAIKU)
      SET(STELMAIN_DEPS ${STELMAIN_DEPS} network)
 ENDIF()
 
+IF(WIN32 AND NOT MSVC)
+     # explicit link to wbemuuid for mingw setup, otherwise CLSID_WbemLocator and IID_IWbemLocator are undefined.
+     SET(STELMAIN_DEPS ${STELMAIN_DEPS} wbemuuid)
+ENDIF()
+
 # Main executable/library setup
 IF(GENERATE_STELMAINLIB)
      ADD_LIBRARY(stelMain SHARED ${stellarium_lib_SRCS} ${stellarium_RES_CXX})

--- a/src/StelSystemInfo.cpp
+++ b/src/StelSystemInfo.cpp
@@ -105,7 +105,7 @@ void printSystemInfo()
 	res &= CoCreateInstance(CLSID_WbemLocator, nullptr, CLSCTX_INPROC_SERVER, IID_IWbemLocator, (LPVOID*)&locator);
 	if (locator)
 	{
-		res &= locator->ConnectServer(_bstr_t("ROOT\\CIMV2"), nullptr, nullptr, nullptr, 0, nullptr, nullptr, &service);
+		res &= locator->ConnectServer(_bstr_t(L"ROOT\\CIMV2"), nullptr, nullptr, nullptr, 0, nullptr, nullptr, &service);
 		if (service)
 		{
 			res &= CoSetProxyBlanket(service, RPC_C_AUTHN_WINNT, RPC_C_AUTHZ_NONE, nullptr, RPC_C_AUTHN_LEVEL_CALL, RPC_C_IMP_LEVEL_IMPERSONATE, nullptr, EOAC_NONE);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Please include a summary of the change and which issue is fixed. -->
<!--- Please also include relevant motivation and context. -->
<!--- List any dependencies that are required for this change. -->

Compiling with MinGW in ``DEBUG`` mode resulted in the following 4 compile errors:
1. 
```
ld.lld: error: undefined symbol: _com_util::ConvertStringToBSTR(char const*)
>>>   src/CMakeFiles/stelMain.dir/StelSystemInfo.cpp.obj:(_bstr_t::Data_t::Data_t(char const*))
```
2. 
```
ld.lld: error: undefined symbol: CLSID_WbemLocator
>>> referenced by src/CMakeFiles/stelMain.dir/StelSystemInfo.cpp.obj:(.refptr.CLSID_WbemLocator)
```
3. 
```
ld.lld: error: undefined symbol: IID_IWbemLocator
>>> referenced by src/CMakeFiles/stelMain.dir/StelSystemInfo.cpp.obj:(.refptr.IID_IWbemLocator)
```
4.
```
ld.lld: error: too many exported symbols (got 76117, max 65535)
````
Compiling in ``RELEASE`` mode does fix the 4. compile issue.

This pull request fixes the compilation.
The executable works correctly with the ucrt64.
The clang64 environment compiles, but does not launch. 
Starting stellarium compiled with the clang64 environment, result in the startup exception: 
```
The procedure entry point "_ZN19QUnhandledExecptionC1ESt13excption_ptr" was not found in the DLL "<path>\libstelMain.dll".
```

### Screenshots (if appropriate):
Startup exception of stellarium compiled with the clang64 environment (in German):
![image](https://github.com/user-attachments/assets/5d481247-fe06-4665-a545-364973abd8cb)


### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
No additional tests done, other than compiling.

**Test Configuration**:
* Operating system: Windows 20 22H2 (Build 19045.5796)
* Graphics Card: Nvidia GeForce RTX 3070, driver version 572.47
* MinGW: Tested with ucrt64 (gcc v14.2.0-3) and clang64 (clang v20.1.3-1) compilers with qt6 (6.9.0-1)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
