### PR TITLE
Allow elongation dependent cultural names

### DIFF
--- a/guide/ch_skycultures.tex
+++ b/guide/ch_skycultures.tex
@@ -858,11 +858,18 @@ When there is more than one name for a star, the first in the list is used as sc
 \subsubsection{Planet Names}
 \label{sec:skycultures:planetnames}
 
-The  \jtag{common\_names} dict can also contain native names of the planets. 
+The  \jtag{common\_names} array can also contain dicts of native names of the planets. 
 For these, the JSON key is formed from \jtag{NAME }, a space and the English name of the planet. 
-The value vector provides the dict entries (\jtag{native}, \jtag{english}, \ldots) listed above. 
+The value array provides the dict entries (\jtag{native}, \jtag{english}, \ldots) listed above. 
 
-Currently, if two \jtag{english} strings are given, the first is used as screen label. This may change as the features further evolve.
+Currently, if more than one \jtag{english} strings are given, the first is used as screen label. This may change as the features further evolve.
+
+In some cultures,\newFeature{25.2} Venus and even Mercury may have different names, depending on evening or morning visibility. 
+We can add a tag \jtag{visible} which may be either \jtag{morning} or \jtag{evening} to select the name. 
+If the base name should be the screen label, you must repeat it as first entry of the object's \jtag{NAME } name array. 
+If the elongation-dependent name should be screen label, place the names with \jtag{visible} first, then repeat the 
+standard name to be shown in the Info text. 
+See the examples for \indexterm{Venus} as \indexterm{Morning Star} and \indexterm{Evening Star} in the \texttt{modern} skyculture.
 
 In earlier versions it was recommended to combine the native name with an English translation. 
 In the new format here we should keep them separate, and the actual screen label can be combined from available 

--- a/skycultures/anutan/index.json
+++ b/skycultures/anutan/index.json
@@ -82,6 +82,7 @@
                {"english": "The Restrained Cloud"}],
     "PGC17223": [{"native": "Te Ao Rere"},
                  {"english": "The Running Cloud"}],
-    "NAME Venus": [{"english": "Te Petuu Ao/Tiuriuri", "native": "Te Petuu Ao/Tiuriuri"}]
+    "NAME Venus": [{"english": "Te Petuu Ao", "native": "Te Petuu Ao", "visible": "morning"},
+                   {"english": "Tiuriuri", "native": "Tiuriuri"}]
   }
 }

--- a/skycultures/arabic_arabian_peninsula/index.json
+++ b/skycultures/arabic_arabian_peninsula/index.json
@@ -240,6 +240,9 @@
     "HIP 113881": [{"english": "The Front 2", "references": [2]}],
     "HIP 113963": [{"english": "The Front 1", "references": [2]}],
     "M 45": [{"english": "Al-Thurayya", "translators_comments": "Al-Thurayya is a proper name"}],
-    "NAME Venus": [{"english": "Morning Star - Evening Star - The Sip - The Star Of Al-Hawdan", "native": "نجمة الصبح - نجمة االعشا - الجغمة - نجمة الهودان", "translators_comments": "Al-Hawdan is a proper name"}]
+    "NAME Venus": [{"english": "Evening Star", "visible": "evening", "pronounce": "Naǧmat al-ʿŠā",  "native": "نجمة االعشا"}, 
+                   {"english": "Morning Star", "visible": "morning", "pronounce": "Naǧmat al-ṣibḥ", "native": "نجمة الصبح"}, 
+                   {"english": "The Sip", "pronounce": "al-Ǧuġmah", "native": "الجغمة"}, 
+                   {"english": "The Star Of Al-Hawdan", "pronounce": "Naǧmat al-Hawdān", "native": "نجمة الهودان", "translators_comments": "Al-Hawdan is a proper name"}]
   }
 }

--- a/skycultures/modern/index.json
+++ b/skycultures/modern/index.json
@@ -3514,6 +3514,9 @@
     "HIP 116084": [{"native": "Poerava", "english": "Poerava", "references": [36]}],
     "HIP 116727": [{"native": "Errai", "english": "Errai", "references": [1,2,6,11,12]},
                    {"native": "Alrai", "english": "Alrai", "references": [23]}],
-    "HIP 118319": [{"native": "Axólotl", "english": "Axólotl", "references": [36]}]
+    "HIP 118319": [{"native": "Axólotl", "english": "Axólotl", "references": [36]}],
+    "NAME Venus": [{"native": "Venus", "english": "Venus"},
+                   {"native": "Vesper", "english": "Evening Star", "visible": "evening"},
+                   {"native": "Lucifer", "english": "Morning Star", "visible": "morning"}]
   }
 }

--- a/skycultures/samoan/index.json
+++ b/skycultures/samoan/index.json
@@ -91,6 +91,7 @@
     "NAME Moon": [{"english": "Moon", "native": "Māsina"}],
     "NAME Saturn": [{"english": "Garland Star", "native": "Fētūʻāsoa"}],
     "NAME Sun": [{"english": "Sun", "native": "Lā"}],
-    "NAME Venus": [{"english": "Morning Star / Forbidden Radiance", "native": "Tapu'itea"}]
+    "NAME Venus": [{"english": "Forbidden Radiance", "native": "Tapu'itea", "visible": "evening" },
+                   {"english": "Morning Star", "native": "Fētūao", "visible": "morning" }]
   }
 }

--- a/skycultures/vanuatu_netwar/index.json
+++ b/skycultures/vanuatu_netwar/index.json
@@ -145,7 +145,7 @@
     "NAME Jupiter": [{"native": "Karatéi", "english": "Karatéi"}],
     "NAME Moon": [{"native": "Mawuk", "english": "Mawuk"}],
     "NAME Sun": [{"native": "Met", "english": "Met"}],
-    "NAME Venus": [{"english": "Fétukai (on morning sky)", "native": "Fétukai"}, 
-                   {"english": "Kéwita (on evening sky)", "native": "Kéwita"}]
+    "NAME Venus": [{"english": "Fétukai", "native": "Fétukai", "visible": "morning"}, 
+                   {"english": "Kéwita", "native": "Kéwita", "visible": "evening"}]
   }
 }

--- a/src/core/StelObject.hpp
+++ b/src/core/StelObject.hpp
@@ -167,6 +167,13 @@ public:
 	//! @struct CulturalName
 	//! Contains name components belonging to an object.
 	//!
+	enum class CulturalNameSpecial
+	{
+		None = 0,        //!< Nothing special
+		Morning = 1,     //!< This name is used for Mercury or Venus in Western elongation, i.e., "morning star"
+		Evening = 2      //!< This name is used for Mercury or Venus in Eastern elongation, i.e., "evening star"
+	};
+	Q_ENUM(CulturalNameSpecial)
 	struct CulturalName
 	{
 		QString native;           //!< native name in native glyphs
@@ -176,6 +183,13 @@ public:
 		QString translated;       //!< Native name translated to English. NOT the same as the usual object's englishName!
 		QString translatedI18n;   //!< Translated name (user language)
 		QString IPA;              //!< native name expressed in International Phonetic Alphabet
+		StelObject::CulturalNameSpecial special;          //!< any particular extra application?
+		CulturalName(): special(StelObject::CulturalNameSpecial::None){};
+		CulturalName(QString nat, QString pr, QString prI18n, QString trl,
+			     QString tra, QString traI18n, QString ipa, StelObject::CulturalNameSpecial sp=StelObject::CulturalNameSpecial::None):
+			native(nat), pronounce(pr), pronounceI18n(prI18n), transliteration(trl),
+			translated(tra), translatedI18n(traI18n), IPA(ipa),
+			special(sp){};
 	};
 
 	//! A pre-defined "all available" set of specifiers for the getInfoString flags argument to getInfoString

--- a/src/core/modules/Planet.hpp
+++ b/src/core/modules/Planet.hpp
@@ -442,8 +442,15 @@ public:
 	double getPhaseAngle(const Vec3d& obsPos) const;
 	//! Check whether the planet is in a waning phase, i.e. its phase angle is increasing
 	bool isWaning(const Vec3d& observerPosition, const Vec3d& observerVelocity) const;
-	//! Get the elongation angle (radians) for an observer at pos obsPos in heliocentric coordinates (in AU)
+	//! Get the elongation angle (angular distance, radians, 0<e<2pi) for an observer at pos obsPos in heliocentric coordinates (in AU)
 	double getElongation(const Vec3d& obsPos) const;
+	//! Get the elongation angle from the Sun in terms of difference in ecliptical longitude (radians) from the Sun.
+	//! Result e is within [0...2pi[ :
+	//! - A result <pi implies eastern elongation, evening visibility.
+	//! - A result pi<e<2pi implies western elongation, morning visibility.
+	//! Calling this for the Sun returns 0.
+	double getElongationDLambda() const;
+
 	//! Get the angular radius (degrees) of the planet spheroid (i.e. without the rings)
 	double getSpheroidAngularRadius(const StelCore* core) const;
 	//! Get the planet phase (illuminated fraction of the planet disk, [0=dark..1=full]) for an observer at pos obsPos in heliocentric coordinates (in AU)

--- a/src/core/modules/SolarSystem.cpp
+++ b/src/core/modules/SolarSystem.cpp
@@ -579,6 +579,17 @@ void SolarSystem::loadCultureSpecificNames(const QJsonObject& data)
 				cName.transliteration=json["transliteration"].toString();
 				cName.IPA=json["IPA"].toString();
 
+				if (json.contains("visible"))
+				{
+					QString visible=json["visible"].toString();
+					if (visible==L1S("morning"))
+						cName.special=StelObject::CulturalNameSpecial::Morning;
+					else if (visible==L1S("evening"))
+						cName.special=StelObject::CulturalNameSpecial::Evening;
+					else
+						qWarning() << "Bad value for \"visible\". Ignoring.";
+				}
+
 				planet->addCulturalName(cName);
 			}
 		}

--- a/src/core/modules/StarMgr.cpp
+++ b/src/core/modules/StarMgr.cpp
@@ -800,7 +800,7 @@ void StarMgr::loadCultureSpecificNameForNamedObject(const QJsonArray& data, cons
 		}
 
 		StelObject::CulturalName cName{entry["native"].toString(), entry["pronounce"].toString(), trans.qTranslateStar(entry["pronounce"].toString()),
-					entry["transliteration"].toString(), entry["english"].toString(), trans.qTranslateStar(entry["english"].toString()), entry["IPA"].toString()};
+					entry["transliteration"].toString(), entry["english"].toString(), trans.qTranslateStar(entry["english"].toString()), entry["IPA"].toString(), StelObject::CulturalNameSpecial::None};
 
 		//if (culturalNamesMap.contains(HIP))
 		//	qInfo() << "Adding additional cultural name for HIP" << HIP << ":" <<  cName.native << "/" << cName.pronounceI18n << "/" << cName.translated;


### PR DESCRIPTION
Name the Morning Star and Evening Star only if visible as such.

<!--- Provide a general summary of your changes in the Title above -->

### Description

This little branch provides an extension of the CulturalName, introducing the first "special" constants. More might come as needed.

The index.json NAME entry for planets can now be extended with an "elongation" tag which can be eastern or western. 
In gthe code, this is translated to the Special constants Morning or Evening. I am not sure this is meaningful, maybe they should bear equal names. But also not sure which of the two is the better. opinions?

Fixes #4326 

### Screenshots (if appropriate):

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system: Win11
* Graphics Card: irrelevant

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (header file)
- [x] I have updated the respective chapter in the Stellarium User Guide
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
