### PR TITLE
Fix z fighting of HiPS levels

### DIFF
--- a/src/core/StelHips.cpp
+++ b/src/core/StelHips.cpp
@@ -41,9 +41,6 @@ public:
 	StelTextureSP allsky; // allsky low res version of the texture.
 	StelTextureSP normalAllsky; // allsky low res version of the texture.
 	StelTextureSP horizonAllsky; // allsky low res version of the texture.
-
-	// Used for smooth fade in
-	QTimeLine texFader;
 };
 
 static QString getExt(const QString& format)
@@ -437,7 +434,7 @@ static bool isClipped(int n, double (*pos)[4])
     return false;
 }
 
-bool HipsSurvey::bindTextures(const HipsTile& tile)
+bool HipsSurvey::bindTextures(HipsTile& tile, const int orderMin, Vec2f& texCoordShift, float& texCoordScale, bool& tileIsLoaded)
 {
 	constexpr int colorTexUnit = 0;
 	constexpr int normalTexUnit = 2;
@@ -446,22 +443,53 @@ bool HipsSurvey::bindTextures(const HipsTile& tile)
 	if (normals && !tile.normalTexture && !tile.normalAllsky) return false;
 	if (horizons && !tile.horizonTexture && !tile.horizonAllsky) return false;
 
-	if (!tile.texture->bind(colorTexUnit) && (!tile.allsky || !tile.allsky->bind(colorTexUnit)))
-		return false;
-	if (normals && tile.normalTexture && !tile.normalTexture->bind(normalTexUnit) && (!tile.normalAllsky || !tile.normalAllsky->bind(normalTexUnit)))
-		return false;
-	if (horizons && tile.horizonTexture && !tile.horizonTexture->bind(horizonTexUnit) && (!tile.horizonAllsky || !tile.horizonAllsky->bind(horizonTexUnit)))
-		return false;
+	bool ok = tile.texture->bind(colorTexUnit);
+	if (!ok) ok = tile.allsky && tile.allsky->bind(colorTexUnit);
+	if (ok && normals)
+	{
+		ok = tile.normalTexture && tile.normalTexture->bind(normalTexUnit);
+		if (!ok) ok = tile.normalAllsky && tile.normalAllsky->bind(normalTexUnit);
+	}
+	if (ok && horizons)
+	{
+		ok = tile.horizonTexture && tile.horizonTexture->bind(horizonTexUnit);
+		if (!ok) ok = tile.horizonAllsky && tile.horizonAllsky->bind(horizonTexUnit);
+	}
 
-	return true;
+	if (!ok) tileIsLoaded = false;
+
+	if (!ok && tile.order > orderMin)
+	{
+		// Current-level textures failed to bind, let's try the previous level
+		const auto parentTile = getTile(tile.order - 1, tile.pix / 4);
+		if (!parentTile) return false;
+		assert(parentTile->order == tile.order - 1);
+		assert(parentTile->order >= orderMin);
+
+		static const Vec2f bottomLeftPartUV[] = {Vec2f(0,0.5), Vec2f(0,0), Vec2f(0.5,0.5), Vec2f(0.5,0)};
+		const int pos = tile.pix % 4;
+		// Like the multiplication of the texture transform by scale and shift matrix on the left:
+		// transform = shift(bottomLeftPartUV[pos]) * scale(0.5) * transform
+		texCoordShift = texCoordShift * 0.5f + bottomLeftPartUV[pos];
+		texCoordScale *= 0.5f;
+
+		ok = bindTextures(*parentTile, orderMin, texCoordShift, texCoordScale, tileIsLoaded);
+		if (!ok) return false;
+	}
+
+	return ok;
 }
 
 void HipsSurvey::drawTile(int order, int pix, int drawOrder, int splitOrder, bool outside,
-                          const SphericalCap& viewportShape, StelPainter* sPainter, Vec3d observerVelocity, DrawCallback callback)
+                          const SphericalCap& viewportShape, StelPainter* sPainter,
+                          Vec3d observerVelocity, DrawCallback callback)
 {
 	Vec3d pos;
 	Mat3d mat3;
 	const Vec2d uv[4] = {Vec2d(0, 0), Vec2d(0, 1), Vec2d(1, 0), Vec2d(1, 1)};
+	bool tileLoaded = true;
+	Vec2f texCoordShift(0,0);
+	float texCoordScale = 1;
 	HipsTile *tile;
 	int orderMin = getPropertyInt("hips_order_min", 3);
 	QVector<Vec3d> vertsArray;
@@ -521,26 +549,16 @@ void HipsSurvey::drawTile(int order, int pix, int drawOrder, int splitOrder, boo
 	tile = getTile(order, pix);
 
 	if (!tile) return;
-	if (!bindTextures(*tile)) return;
+	if (!bindTextures(*tile, orderMin, texCoordShift, texCoordScale, tileLoaded))
+		return;
 
-	if (tile->texFader.state() == QTimeLine::NotRunning && tile->texFader.currentValue() == 0.0)
-		tile->texFader.start();
-	nbLoadedTiles++;
+	if (tileLoaded)
+		nbLoadedTiles++;
 
-	if (order < drawOrder)
-	{
-		// If all the children tiles are loaded, we can skip the parent.
-		int i;
-		for (i = 0; i < 4; i++)
-		{
-			HipsTile* child = getTile(order + 1, pix * 4 + i);
-			if (!child || child->texFader.currentValue() < 1.0) break;
-		}
-		if (i == 4) goto skip_render;
-	}
+	if (order < drawOrder) goto skip_render;
 
 	// Actually draw the tile, as a single quad.
-	alpha = color[3] * static_cast<float>(tile->texFader.currentValue());
+	alpha = color[3];
 	if (alpha < 1.0f)
 	{
 		sPainter->setBlending(true);
@@ -553,7 +571,7 @@ void HipsSurvey::drawTile(int order, int pix, int drawOrder, int splitOrder, boo
 	}
 	sPainter->setCullFace(true);
 	nb = fillArrays(order, pix, drawOrder, splitOrder, outside, sPainter, observerVelocity,
-	                vertsArray, texArray, indicesArray);
+	                texCoordShift, texCoordScale, vertsArray, texArray, indicesArray);
 	if (!callback) {
 		sPainter->setArrays(vertsArray.constData(), texArray.constData());
 		sPainter->drawFromArray(StelPainter::Triangles, nb, 0, true, indicesArray.constData());
@@ -577,6 +595,7 @@ skip_render:
 
 int HipsSurvey::fillArrays(int order, int pix, int drawOrder, int splitOrder,
                            bool outside, StelPainter* sPainter, Vec3d observerVelocity,
+                           const Vec2f& texCoordShift, const float texCoordScale,
                            QVector<Vec3d>& verts, QVector<Vec2f>& tex, QVector<uint16_t>& indices)
 {
 	Q_UNUSED(sPainter)
@@ -611,7 +630,7 @@ int HipsSurvey::fillArrays(int order, int pix, int drawOrder, int splitOrder,
 			}
 
 			verts << pos;
-			tex << texPos;
+			tex << texPos * texCoordScale + texCoordShift;
 		}
 	}
 	for (uint16_t i = 0; i < gridSize; i++)

--- a/src/core/StelHips.hpp
+++ b/src/core/StelHips.hpp
@@ -143,7 +143,27 @@ private:
 	int getPropertyInt(const QString& key, int fallback = 0);
 	bool getAllsky();
 	HipsTile* getTile(int order, int pix);
-	bool bindTextures(const HipsTile& tile);
+	/*! @brief Bind textures for drawing
+
+	    If @p tile is not ready for drawing (e.g. not fully loaded), alter
+	    @p texCoordShift and @p texCoordScale so that they let us address
+	    the corresponding part of a parent texture that will be bound.
+
+	    @param tile The tile to draw
+	    @param orderMin Smallest available HiPS order of the current survey
+	    @param texCoordShift The UV coordinates shift to be applied to the
+	     texture coordinates to address a subtexture in the parent. Must be
+	     set to 0 before the initial call to this function.
+	    @param texCoordScale The UV coordinates scale to be applied to the
+	     texture coordinates to address a subtexture in the parent. Must be
+	     set to 1 before the initial call to this function.
+	    @param tileIsLoaded Gets set to \c false if it was the requested
+	     HiPS level isn't fully loaded. Must be set to \c true before the
+	     initial call to this function.
+
+	    @return Whether a tile has been successfully bound.
+	 */
+	bool bindTextures(HipsTile& tile, int orderMin, Vec2f& texCoordShift, float& texCoordScale, bool& tileIsLoaded);
 	// draw a single tile. observerVelocity (in the correct hipsFrame) is necessary for aberration correction. Set to 0 for no aberration correction.
 	void drawTile(int order, int pix, int drawOrder, int splitOrder, bool outside,
 	              const SphericalCap& viewportShape, StelPainter* sPainter, Vec3d observerVelocity, DrawCallback callback);
@@ -151,6 +171,7 @@ private:
 	// Fill the array for a given tile.
 	int fillArrays(int order, int pix, int drawOrder, int splitOrder,
 	               bool outside, StelPainter* sPainter, Vec3d observerVelocity,
+	               const Vec2f& texCoordShift, const float texCoordScale,
 	               QVector<Vec3d>& verts, QVector<Vec2f>& tex, QVector<uint16_t>& indices);
 
 	void updateProgressBar(int nb, int total);


### PR DESCRIPTION
### Description

When a tile is drawn in a planetary survey, and then its child of a higher level is drawn over, we can often observe the lower-level tile shining through the higher-level one, and the shape that shines through depends on the position of the planet, which resembles z fighting.

To combat this, we now draw only the deepest HiPS level requested for the current zoom level, substituting lower-resolution textures for the tiles whose native-resolution textures haven't been loaded yet.

This makes it much harder to support fading between levels, so fading support is removed.

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system: Ubuntu 20.04
* Graphics Card: Intel UHD Graphics 620

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
