### PR TITLE
QtWebEnginee & Online Query Plugin

### DIFF
--- a/util/appimage/stellarium-appimage-qt5.yml
+++ b/util/appimage/stellarium-appimage-qt5.yml
@@ -1,7 +1,7 @@
 version: 1
 
 script:
-    - cmake ../.. -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release -DENABLE_QTWEBENGINE=Off -DENABLE_MEDIA=Off
+    - cmake ../.. -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release -DENABLE_MEDIA=Off
     - make -j3
     - make install DESTDIR=AppDir
 
@@ -37,10 +37,10 @@ AppDir:
       - libqt5script5
       - libqt5serialport5
       - libqt5widgets5
-#      - libqt5webengine5
-#      - libqt5webenginecore5
-#      - libqt5webenginewidgets5
-#      - libqt5webengine-data
+      - libqt5webengine5
+      - libqt5webenginecore5
+      - libqt5webenginewidgets5
+      - libqt5webengine-data
       - libqt5charts5
       - libqt5opengl5
       - libgps28
@@ -62,7 +62,9 @@ AppDir:
   runtime:
     env:
       APPDIR_LIBRARY_PATH: $APPDIR/lib/x86_64-linux-gnu:$APPDIR/usr/lib/x86_64-linux-gnu:$APPDIR/usr/lib/x86_64-linux-gnu/pulseaudio
-
+      QTWEBENGINEPROCESS_PATH: $APPDIR/usr/lib/qt5/libexec/QtWebEngineProcess:$APPDIR/usr/lib/x86_64-linux-gnu/qt5/libexec/QtWebEngineProcess
+      QTWEBENGINE_DISABLE_SANDBOX: 1
+      
 #  test:
 #    debian:
 #      image: appimagecrafters/tests-env:debian-stable

--- a/util/appimage/stellarium-appimage-qt6.yml
+++ b/util/appimage/stellarium-appimage-qt6.yml
@@ -72,7 +72,7 @@ AppDir:
   runtime:
     env:
       APPDIR_LIBRARY_PATH: $APPDIR/lib/x86_64-linux-gnu:$APPDIR/usr/lib/x86_64-linux-gnu:$APPDIR/usr/lib/x86_64-linux-gnu/pulseaudio
-      QTWEBENGINEPROCESS_PATH: $APPDIR/usr/lib/qt6/libexec/QtWebEngineProcess
+      QTWEBENGINEPROCESS_PATH: $APPDIR/usr/lib/qt6/libexec/QtWebEngineProcess:$APPDIR/usr/lib/x86_64-linux-gnu/qt6/libexec/QtWebEngineProcess
       QTWEBENGINE_DISABLE_SANDBOX: 1
 
 #  test:

--- a/util/appimage/stellarium-appimage-qt6.yml
+++ b/util/appimage/stellarium-appimage-qt6.yml
@@ -1,7 +1,7 @@
 version: 1
 
 script:
-    - cmake ../.. -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release -DENABLE_QTWEBENGINE=Off -DENABLE_MEDIA=Off
+    - cmake ../.. -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release -DENABLE_MEDIA=Off
     - make -j3
     - make install DESTDIR=AppDir
 
@@ -33,15 +33,15 @@ AppDir:
       - libqt6positioning6-plugins
       - libqt6printsupport6
       - libqt6concurrent6
-#      - libqt6webchannel6
+      - libqt6webchannel6
       - libqt6serialport6
       - libqt6widgets6
-#      - libqt6webenginecore6
-#      - libqt6webenginecore6-bin
-#      - libqt6webenginewidgets6
-#      - libqt6webenginequick6
-#      - libqt6webenginequickdelegatesqml6
-#      - libqt6webengine6-data
+      - libqt6webenginecore6
+      - libqt6webenginecore6-bin
+      - libqt6webenginewidgets6
+      - libqt6webenginequick6
+      - libqt6webenginequickdelegatesqml6
+      - libqt6webengine6-data
       - libqt6charts6
       - libqt6opengl6
       - libqt6openglwidgets6
@@ -72,6 +72,8 @@ AppDir:
   runtime:
     env:
       APPDIR_LIBRARY_PATH: $APPDIR/lib/x86_64-linux-gnu:$APPDIR/usr/lib/x86_64-linux-gnu:$APPDIR/usr/lib/x86_64-linux-gnu/pulseaudio
+      QTWEBENGINEPROCESS_PATH: $APPDIR/usr/lib/qt6/libexec/QtWebEngineProcess
+      QTWEBENGINE_DISABLE_SANDBOX: 1
 
 #  test:
 #    debian:


### PR DESCRIPTION
Online Query Plugin Fix for AppImage built

### Description
Enable Online Query Plugin to use Internal Web Engine instead of External Web Browser.

Fixes # (issue)

### Screenshots (if appropriate): 
![Screenshot from 2025-07-04 11-10-14](https://github.com/user-attachments/assets/20e9f974-71d8-4c72-8ab1-7204f610fa69)


### Type of change
Update AppImage built script

### How Has This Been Tested?
Run as Expected

**Test Configuration**:
* Operating system: Ubuntu 24.04
* Graphics Card: Integrated

