### PR TITLE
Remove duplicate point in Coma Berenices line in Modern (IAU) sky culture

### DIFF
--- a/skycultures/modern_iau/index.json
+++ b/skycultures/modern_iau/index.json
@@ -126,7 +126,7 @@
     },
     {
       "id": "CON modern_iau Com",
-      "lines": [[64241, 64241, 64394, 60742]],
+      "lines": [[64241, 64394, 60742]],
       "common_name": {"english": "Bernice's Hair", "native": "Coma Berenices", "context": "IAU constellation name"}
     },
     {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
A duplicate point in the line for Coma Berenices in the Modern (IAU) sky culture shows up as a circle around the star Diadem when constellation lines are enabled. Removing the duplicate point fixes the constellation's appearance.

### Screenshots (if appropriate):
The duplicate point creating a circle around Diadem:
![image](https://github.com/user-attachments/assets/8f906849-e01e-426f-9b5f-b4cdf7e252bd)

And after removing this duplicate point:
![image](https://github.com/user-attachments/assets/c6b56820-eaa5-4396-8f77-a18857c062ae)


### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] Housekeeping

### How Has This Been Tested?
Verified circle around the star Diadem is gone after making change.
