### PR TITLE
Increase duration from 100 -> 1000 units of time

### DIFF
--- a/src/gui/astroCalcDialog.ui
+++ b/src/gui/astroCalcDialog.ui
@@ -938,7 +938,7 @@
                  <number>1</number>
                 </property>
                 <property name="maximum">
-                 <number>100</number>
+                 <number>1000</number>
                 </property>
                </widget>
               </item>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
We are currently limited by 100 times of unit in the ephemeris calculation menu. This is not enough e.g. if someone wishes to visualize one full orbit of Pluto, which covers 248 years, or if someone wants to see interstellar comets long-term paths.

This small fix increases the limit from 100 to 1000. One could set the limit even higher, but I don't see a reason.

Fixes # (issue)

### Screenshots (if appropriate):

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] Housekeeping

**Test Configuration**:
* Operating system: Irrelevant
* Graphics Card: Irrelevant

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
