### PR TITLE
Make it possible to choose between multiple planetary HiPS per planet

### DIFF
--- a/data/gui/normalStyle.css
+++ b/data/gui/normalStyle.css
@@ -55,6 +55,7 @@ QSizeGrip {
 QTextEdit,
 QPlainTextEdit,
 QListWidget,
+QTreeWidget,
 QLineEdit {
 	border: 1px solid rgb(0, 0, 0);
 	border-radius: 0;
@@ -67,6 +68,7 @@ QLineEdit {
 
 QTextEdit:disabled,
 QListWidget:disabled,
+QTreeWidget:disabled,
 QLineEdit:disabled {
 	background: rgb(90, 90, 90);
 }
@@ -424,6 +426,7 @@ QGroupBox::indicator {
  * indicators, but there's a problem with spacing discussed at
  * https://stackoverflow.com/q/77422984 */
 QListWidget::indicator,
+QTreeWidget::indicator,
 QListView::indicator {
 	margin: 0;
 	background: none;
@@ -431,6 +434,7 @@ QListView::indicator {
 
 QCheckBox::indicator:checked,
 QListWidget::indicator:checked,
+QTreeWidget::indicator:checked,
 QListView::indicator:checked,
 QGroupBox::indicator:checked {
 	image: url(:/graphicGui/uieCheckbox-checked.png);
@@ -438,6 +442,7 @@ QGroupBox::indicator:checked {
 
 QCheckBox::indicator:indeterminate,
 QListWidget::indicator:indeterminate,
+QTreeWidget::indicator:indeterminate,
 QListView::indicator:indeterminate,
 QGroupBox::indicator:indeterminate {
 	image: url(:/graphicGui/uieCheckbox-partial.png);
@@ -445,6 +450,7 @@ QGroupBox::indicator:indeterminate {
 
 QCheckBox::indicator:unchecked,
 QListWidget::indicator:unchecked,
+QTreeWidget::indicator:unchecked,
 QListView::indicator:unchecked,
 QGroupBox::indicator:unchecked {
 	image: url(:/graphicGui/uieCheckbox-unchecked.png);
@@ -452,6 +458,7 @@ QGroupBox::indicator:unchecked {
 
 QCheckBox::indicator:hover:checked,
 QListWidget::indicator:hover:checked,
+QTreeWidget::indicator:hover:checked,
 QListView::indicator:hover:checked,
 QGroupBox::indicator:hover:checked {
 	image: url(:/graphicGui/uieCheckbox-checked-hover.png);
@@ -459,6 +466,7 @@ QGroupBox::indicator:hover:checked {
 
 QCheckBox::indicator:hover:indeterminate,
 QListWidget::indicator:hover:indeterminate,
+QTreeWidget::indicator:hover:indeterminate,
 QListView::indicator:hover:indeterminate,
 QGroupBox::indicator:hover:indeterminate {
 	image: url(:/graphicGui/uieCheckbox-partial-hover.png);
@@ -466,6 +474,7 @@ QGroupBox::indicator:hover:indeterminate {
 
 QCheckBox::indicator:hover:unchecked,
 QListWidget::indicator:hover:unchecked,
+QTreeWidget::indicator:hover:unchecked,
 QListView::indicator:hover:unchecked,
 QGroupBox::indicator:hover:unchecked {
 	image: url(:/graphicGui/uieCheckbox-unchecked-hover.png);
@@ -473,6 +482,7 @@ QGroupBox::indicator:hover:unchecked {
 
 QCheckBox::indicator:checked:disabled,
 QListWidget::indicator:checked:disabled,
+QTreeWidget::indicator:checked:disabled,
 QListView::indicator:checked:disabled,
 QGroupBox::indicator:checked:disabled {
 	image: url(:/graphicGui/uieCheckbox-checked-disabled.png);
@@ -480,6 +490,7 @@ QGroupBox::indicator:checked:disabled {
 
 QCheckBox::indicator:indeterminate:disabled,
 QListWidget::indicator:indeterminate:disabled,
+QTreeWidget::indicator:indeterminate:disabled,
 QListView::indicator:indeterminate:disabled,
 QGroupBox::indicator:indeterminate:disabled {
 	image: url(:/graphicGui/uieCheckbox-partial-disabled.png);
@@ -487,6 +498,7 @@ QGroupBox::indicator:indeterminate:disabled {
 
 QCheckBox::indicator:unchecked:disabled,
 QListWidget::indicator:unchecked:disabled,
+QTreeWidget::indicator:unchecked:disabled,
 QListView::indicator:unchecked:disabled,
 QGroupBox::indicator:unchecked:disabled {
 	image: url(:/graphicGui/uieCheckbox-unchecked-disabled.png);

--- a/src/core/StelHips.cpp
+++ b/src/core/StelHips.cpp
@@ -127,6 +127,10 @@ void HipsSurvey::checkForPlanetarySurvey()
 	planetarySurvey = !QStringList{"equatorial","galactic","ecliptic"}.contains(hipsFrame, Qt::CaseInsensitive) ||
 	                  std::as_const(properties)["creator_did"].toString().contains("moon", Qt::CaseInsensitive) ||
 	                  std::as_const(properties)["client_category"].toString().contains("solar system", Qt::CaseInsensitive);
+
+	// Assume that all the planetary HiPS describe color maps by default
+	if (planetarySurvey && type.isEmpty())
+		type = "planet";
 }
 
 bool HipsSurvey::isVisible() const

--- a/src/core/StelHips.hpp
+++ b/src/core/StelHips.hpp
@@ -60,10 +60,12 @@ public:
 	                           const QVector<uint16_t>& indices)> DrawCallback;
 	//! Create a new HipsSurvey from its url.
 	//! @param url The location of the survey.
+	//! @param group A string that identifies a group of color/normals/horizons
+	//!              surveys that this survey belongs to.
 	//! @param frame The reference frame from the survey's \c hips_frame property.
 	//! @param type Survey type from the survey's \c type property.
 	//! @param releaseDate If known the UTC JD release date of the survey.  Used for cache busting.
-	HipsSurvey(const QString& url, const QString& frame, const QString& type,
+	HipsSurvey(const QString& url, const QString& group, const QString& frame, const QString& type,
 	           const QMap<QString, QString>& hipslistProps, double releaseDate=0.0);
 	~HipsSurvey() override;
 
@@ -91,6 +93,9 @@ public:
 	//! Return the type of the survey (its \c type property).
 	QString getType() const { return type; }
 
+	//! Return the group of of color/normals/horizons surveys that this survey belongs to.
+	QString getGroup() const { return group; }
+
 	//! Get whether the survey is still loading.
 	bool isLoading(void) const;
 
@@ -100,7 +105,7 @@ public:
 	void setHorizonsSurvey(const HipsSurveyP& horizons);
 
 	//! Parse a hipslist file into a list of surveys.
-	static QList<HipsSurveyP> parseHipslist(const QString& data);
+	static QList<HipsSurveyP> parseHipslist(const QString& hipslistURL, const QString& data);
 
 signals:
 	void propertiesChanged(void);
@@ -113,6 +118,7 @@ private:
 private:
 	LinearFader fader;
 	QString url;
+	QString group;
 	QString type;
 	QString hipsFrame;
 	QString planet;

--- a/src/core/modules/HipsMgr.cpp
+++ b/src/core/modules/HipsMgr.cpp
@@ -114,7 +114,7 @@ void HipsMgr::loadSources()
 		QNetworkReply* networkReply = StelApp::getInstance().getNetworkAccessManager()->get(req);
 		connect(networkReply, &QNetworkReply::finished, this, [=] {
 			QByteArray data = networkReply->readAll();
-			QList<HipsSurveyP> newSurveys = HipsSurvey::parseHipslist(data);
+			QList<HipsSurveyP> newSurveys = HipsSurvey::parseHipslist(source.toString(), data);
 			for (HipsSurveyP &survey: newSurveys)
 			{
 				connect(survey.data(), SIGNAL(propertiesChanged()), this, SIGNAL(surveysChanged()));

--- a/src/core/modules/Planet.hpp
+++ b/src/core/modules/Planet.hpp
@@ -670,7 +670,9 @@ public:
 	void resetTextures();
 	//! Use texture from @param texName (must reside inside the scripts directory!)
 	void replaceTexture(const QString& texName);
-	
+
+	void setSurvey(const HipsSurveyP& colors, const HipsSurveyP& normals, const HipsSurveyP& horizons);
+
 protected:
 	// These components for getInfoString() can be overridden in subclasses
 	virtual QString getInfoStringName(const StelCore *core, const InfoStringGroup& flags) const;
@@ -808,9 +810,15 @@ protected:
 	QFuture<PlanetOBJModel*>* objModelLoader; //!< For async loading of the OBJ file
 	QString objModelPath;
 
-	HipsSurveyP survey;
-	HipsSurveyP surveyForNormals;
-	HipsSurveyP surveyForHorizons;
+	struct SurveyPack
+	{
+		HipsSurveyP colors;
+		HipsSurveyP normals;
+		HipsSurveyP horizons;
+		operator bool() const { return !!colors; }
+	};
+
+	SurveyPack survey;
 
 	Ring* rings;                     //!< Planet rings
 	double distance;                 //!< Temporary variable used to store the distance to a given point

--- a/src/core/modules/SolarSystem.cpp
+++ b/src/core/modules/SolarSystem.cpp
@@ -357,9 +357,6 @@ void SolarSystem::init()
 	addAction("actionShow_Planets_EnlargeSun", displayGroup, N_("Enlarge Sun"), "flagSunScale");
 	addAction("actionShow_Planets_ShowMinorBodyMarkers", displayGroup, N_("Mark minor bodies"), "flagMarkers");
 
-	connect(StelApp::getInstance().getModule("HipsMgr"), SIGNAL(gotNewSurvey(HipsSurveyP)),
-			this, SLOT(onNewSurvey(HipsSurveyP)));
-
 	// Fill ephemeris dates
 	connect(this, SIGNAL(requestEphemerisVisualization()), this, SLOT(fillEphemerisDates()));
 	connect(this, SIGNAL(ephemerisDataStepChanged(int)), this, SLOT(fillEphemerisDates()));
@@ -4174,40 +4171,6 @@ bool SolarSystem::removeMinorPlanet(const QString &name)
 	return true;
 }
 
-void SolarSystem::onNewSurvey(HipsSurveyP survey)
-{
-	if (!survey->isPlanetarySurvey()) return;
-
-	const auto type = survey->getType();
-	const bool isPlanetColor = type == "planet";
-	const bool isPlanetNormal = type == "planet-normal";
-	const bool isPlanetHorizon = type == "planet-horizon";
-	if (!isPlanetColor && !isPlanetNormal && !isPlanetHorizon)
-		return;
-
-	QString planetName = survey->getFrame();
-	PlanetP pl = searchByEnglishName(planetName);
-	if (!pl) return;
-	if (isPlanetColor)
-	{
-		if (pl->survey) return;
-		pl->survey = survey;
-	}
-	else if (isPlanetNormal)
-	{
-		if (pl->surveyForNormals) return;
-		pl->surveyForNormals = survey;
-	}
-	else if (isPlanetHorizon)
-	{
-		if (pl->surveyForHorizons) return;
-		pl->surveyForHorizons = survey;
-	}
-	survey->setProperty("planet", pl->getEnglishName());
-	// Not visible by default for the moment.
-	survey->setProperty("visible", false);
-}
-
 void SolarSystem::setExtraThreads(int n)
 {
 	extraThreads=qBound(0,n,QThreadPool::globalInstance()->maxThreadCount()-1);
@@ -4232,3 +4195,13 @@ const QMap<Planet::ApparentMagnitudeAlgorithm, QString> SolarSystem::vMagAlgorit
 	{Planet::Generic,			"Generic"},
 	{Planet::UndefinedAlgorithm,		""}
 };
+
+void SolarSystem::enableSurvey(const HipsSurveyP& colors, const HipsSurveyP& normals, const HipsSurveyP& horizons)
+{
+	Q_ASSERT(colors);
+	QString planetName = colors->getFrame();
+	PlanetP pl = searchByEnglishName(planetName);
+	if (!pl) return;
+
+	pl->setSurvey(colors, normals, horizons);
+}

--- a/src/core/modules/SolarSystem.hpp
+++ b/src/core/modules/SolarSystem.hpp
@@ -787,6 +787,9 @@ public slots:
 	//! Configure the limiting absolute magnitude for plotting minor bodies. Configured value is clamped to -2..37 (practical limit)
 	void setMarkerMagThreshold(double m);
 
+	//! Enable the survey for use on the planet it describes
+	void enableSurvey(const HipsSurveyP& colors, const HipsSurveyP& normals, const HipsSurveyP& horizons);
+
 signals:
 	void labelsDisplayedChanged(bool b);
 	void flagOrbitsChanged(bool b);
@@ -1056,9 +1059,6 @@ private slots:
 
 	void setEphemerisSaturnMarkerColor(const Vec3f& c);
 	Vec3f getEphemerisSaturnMarkerColor(void) const;
-
-	//! Called when a new Hips survey has been loaded by the hips mgr.
-	void onNewSurvey(HipsSurveyP survey);
 
 	//! Taking the JD dates for each ephemeride and preparation the human readable dates according to the settings for dates
 	void fillEphemerisDates();

--- a/src/gui/ViewDialog.hpp
+++ b/src/gui/ViewDialog.hpp
@@ -97,7 +97,9 @@ private slots:
 	void updateSelectedCatalogsCheckBoxes();
 	void updateSelectedTypesCheckBoxes();
 
+	void clearHips();
 	void updateHips();
+	void updateHipsText();
 	void filterSurveys();
 	void hipsListItemChanged(QTreeWidgetItem* item);
 	void populateHipsGroups();
@@ -123,6 +125,7 @@ private:
 	GreatRedSpotDialog * greatRedSpotDialog;
 	ConfigureDSOColorsDialog * configureDSOColorsDialog;
 	ConfigureOrbitColorsDialog * configureOrbitColorsDialog;
+
 	QTimer hipsUpdateTimer;
 	struct PlanetSurveyPack
 	{
@@ -130,6 +133,8 @@ private:
 		QHash<QString/*group*/, QTreeWidgetItem* /*groupItem*/> groupsMap;
 	};
 	QHash<QString/*planet English name*/, PlanetSurveyPack> planetarySurveys;
+	QHash<QString/*survey URL*/, QTreeWidgetItem*> surveysInTheList;
+	QString selectedSurveyType;
 };
 
 #endif // _VIEWDIALOG_HPP

--- a/src/gui/ViewDialog.hpp
+++ b/src/gui/ViewDialog.hpp
@@ -24,6 +24,7 @@
 
 #include <QObject>
 #include <QTimer>
+#include <QHash>
 
 class Ui_viewDialogForm;
 class QListWidgetItem;
@@ -123,6 +124,12 @@ private:
 	ConfigureDSOColorsDialog * configureDSOColorsDialog;
 	ConfigureOrbitColorsDialog * configureOrbitColorsDialog;
 	QTimer hipsUpdateTimer;
+	struct PlanetSurveyPack
+	{
+		QTreeWidgetItem* planetItem = nullptr;
+		QHash<QString/*group*/, QTreeWidgetItem* /*groupItem*/> groupsMap;
+	};
+	QHash<QString/*planet English name*/, PlanetSurveyPack> planetarySurveys;
 };
 
 #endif // _VIEWDIALOG_HPP

--- a/src/gui/ViewDialog.hpp
+++ b/src/gui/ViewDialog.hpp
@@ -27,6 +27,7 @@
 
 class Ui_viewDialogForm;
 class QListWidgetItem;
+class QTreeWidgetItem;
 class QToolButton;
 
 class AddRemoveLandscapesDialog;
@@ -97,7 +98,7 @@ private slots:
 
 	void updateHips();
 	void filterSurveys();
-	void hipsListItemChanged(QListWidgetItem* item);
+	void hipsListItemChanged(QTreeWidgetItem* item);
 	void populateHipsGroups();
 	void toggleHipsDialog();
 

--- a/src/gui/viewDialog.ui
+++ b/src/gui/viewDialog.ui
@@ -5904,13 +5904,6 @@
           <item row="0" column="0">
            <widget class="QComboBox" name="surveyTypeComboBox"/>
           </item>
-          <item row="2" column="0">
-           <widget class="QListWidget" name="surveysListWidget">
-            <property name="horizontalScrollBarPolicy">
-             <enum>Qt::ScrollBarAlwaysOff</enum>
-            </property>
-           </widget>
-          </item>
           <item row="1" column="0">
            <widget class="QLineEdit" name="surveysFilter">
             <property name="placeholderText">
@@ -5919,6 +5912,24 @@
             <property name="clearButtonEnabled">
              <bool>true</bool>
             </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QTreeWidget" name="surveysTreeWidget">
+            <property name="horizontalScrollBarPolicy">
+             <enum>Qt::ScrollBarAlwaysOff</enum>
+            </property>
+            <property name="rootIsDecorated">
+             <bool>false</bool>
+            </property>
+            <property name="headerHidden">
+             <bool>true</bool>
+            </property>
+            <column>
+             <property name="text">
+              <string/>
+             </property>
+            </column>
            </widget>
           </item>
          </layout>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

Currently we can only have one HiPS pack per planet (albedo, normals, horizons). This PR enables multiple HiPS per planet to choose from.

The surveys are arranged into groups, with the groups defined either by `group` property of a set of surveys, or by the hipslist's URL.

To test this, you can use my new Moon survey pack: http://86.106.181.97/hips/hipslist. Additional set of surveys can be obtained from [this URL](https://alasky.cds.unistra.fr/MocServer/query?expr=hips_frame!%3Dequatorial%2Cgalactic%2Cecliptic+%26%26+hips_frame%3D*+%26%26+dataproduct_type!%3Dcatalog%2Ccube+%26%26+hips_service_url%3D*&get=record) (with a nuance that their coordinate system is shifted by 180° of longitude with respect to ours, which should be taken care of in a later change).

If you are going to merge this, please keep the commits separate.

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system: Ubuntu 25.04
* Graphics Card: AMD Ryzen AI 9 HX 370 w/ Radeon 890M

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
