### PR TITLE
Using SourceForge.net CDN for storing the stars catalogs

### DIFF
--- a/src/core/modules/StarMgr.cpp
+++ b/src/core/modules/StarMgr.cpp
@@ -68,7 +68,7 @@ Q_GLOBAL_STATIC(QStringList, objtype_array);
 // This number must be incremented each time the content or file format of the stars catalogs change
 // It can also be incremented when the defaultStarsConfig.json file change.
 // It should always match the version field of the defaultStarsConfig.json file
-static const int StarCatalogFormatVersion = 24;
+static const int StarCatalogFormatVersion = 25;
 
 // Initialise statics
 bool StarMgr::flagSciNames = true;

--- a/stars/hip_gaia3/defaultStarsConfig.json
+++ b/stars/hip_gaia3/defaultStarsConfig.json
@@ -1,5 +1,5 @@
 {
-	"version": 24,
+	"version": 25,
 	"hipSpectralFile": "stars_hip_sp_0v0_6.cat",
 	"objecttypesFile": "object_types_v0_1.cat",
 	"catalogs":
@@ -46,7 +46,7 @@
 			"count": 1.7,
 			"magRange": [10.50, 12.00],
 			"sizeMb": 53.1,
-			"url": "https://github.com/Stellarium/stellarium-data/releases/download/stars-3.0/stars_4_1v0_6.cat",
+			"url": "https://sourceforge.net/projects/stellarium/files/Extra-data-files/stars-3.0/stars_4_1v0_6.cat/download",
 			"checksum": "f5e57f400291d3d0c247ec669b1a4a07",
 			"checked": false
 		},
@@ -56,7 +56,7 @@
 			"count": 8.0,
 			"magRange": [12, 13.75],
 			"sizeMb": 245,
-			"url": "https://github.com/Stellarium/stellarium-data/releases/download/stars-3.0/stars_5_1v0_6.cat",
+			"url": "https://sourceforge.net/projects/stellarium/files/Extra-data-files/stars-3.0/stars_5_1v0_6.cat/download",
 			"checksum": "eb2834985d5885ac03695084cded6897",
 			"checked": false
 		},
@@ -66,7 +66,7 @@
 			"count": 29.8,
 			"magRange": [13.75, 15.50],
 			"sizeMb": 912,
-			"url": "https://github.com/Stellarium/stellarium-data/releases/download/stars-3.0/stars_6_1v0_4.cat",
+			"url": "https://sourceforge.net/projects/stellarium/files/Extra-data-files/stars-3.0/stars_6_1v0_4.cat/download",
 			"checksum": "c971d04d40606ed889faa8258e8ec640",
 			"checked": false
 		},
@@ -76,7 +76,7 @@
 			"count": 57.5,
 			"magRange": [15.50, 16.75],
 			"sizeMb": 1710,
-			"url": "https://github.com/Stellarium/stellarium-data/releases/download/stars-3.0/stars_7_1v0_4.cat",
+			"url": "https://sourceforge.net/projects/stellarium/files/Extra-data-files/stars-3.0/stars_7_1v0_4.cat/download",
 			"checksum": "15b1d97250b20f4e8101faa75965ba6c",
 			"checked": false
 		},
@@ -86,7 +86,7 @@
 			"count": 122.9,
 			"magRange": [16.75, 18.00],
 			"sizeMb": 1830,
-			"url": "https://github.com/Stellarium/stellarium-data/releases/download/stars-3.0/stars_8_2v0_3.cat",
+			"url": "https://sourceforge.net/projects/stellarium/files/Extra-data-files/stars-3.0/stars_8_2v0_3.cat/download",
 			"checksum": "0db9c200c27f903c54fc1d4b66da1016",
 			"checked": false
 		}


### PR DESCRIPTION
### Description
This patch is switched to use the CDN of SourceForge.net (23 mirrors) as default storage of our stars catalogs.

Fixes #4412 (issue)

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [X] Housekeeping

### How Has This Been Tested?
Run Stellarium and download star catalogs
