### PR TITLE
CLI: Try to inhibit screensaver in fullscreen (Windows only)

### DIFF
--- a/src/CLIProcessor.cpp
+++ b/src/CLIProcessor.cpp
@@ -117,6 +117,9 @@ void CLIProcessor::parseCLIArgsPreConfig(const QStringList& argList)
 			  << "                          and want to send a bug report\n"
 			  << "--full-screen (or -f)   : With argument \"yes\" or \"no\" over-rides\n"
 			  << "                          the full screen setting in the config file\n"
+	     #ifdef Q_OS_WIN
+			  << "--no-screensaver (or -F): Inhibits screen saver when in fullscreen mode\n"
+	     #endif
 			  << "--screenshot-dir        : Specify directory to save screenshots\n"
 			  << "--startup-script        : Specify name of startup script\n"
 			  << "--home-planet           : Specify observer planet (English name)\n"
@@ -153,6 +156,10 @@ void CLIProcessor::parseCLIArgsPreConfig(const QStringList& argList)
 	if (argsGetOption(argList, "", "--verbose"))
 		qApp->setProperty("verbose", true);
 
+#ifdef Q_OS_WIN
+	if (argsGetOption(argList, "-F", "--no-screensaver"))
+		qApp->setProperty("onetime_inhibit_screensaver", true);
+#endif
 	if (argsGetOption(argList, "-C", "--opengl-compat"))
 		qApp->setProperty("onetime_opengl_compat", true);
 

--- a/src/StelMainView.cpp
+++ b/src/StelMainView.cpp
@@ -62,6 +62,8 @@
 #include <QStorageInfo>
 #ifdef Q_OS_WIN
 	#include <QPinchGesture>
+	#include <Windows.h>
+	#include <WinUser.h>
 #endif
 #include <QOpenGLShader>
 #include <QOpenGLShaderProgram>
@@ -1475,10 +1477,31 @@ void StelMainView::initTitleI18n()
 void StelMainView::setFullScreen(bool b)
 {
 	if (b)
+	{
 		showFullScreen();
+#ifdef Q_OS_WIN
+		if (qApp->property("onetime_inhibit_screensaver").toBool())
+		{
+			qDebug() << "Disabling screensaver while in fullscreen";
+			SystemParametersInfo(SPI_SETSCREENSAVEACTIVE, FALSE , NULL, SPIF_SENDWININICHANGE);
+		}
+		else
+			qDebug() << "Not touching screensaver business";
+#endif
+	}
 	else
 	{
 		showNormal();
+#ifdef Q_OS_WIN
+		if (qApp->property("onetime_inhibit_screensaver").toBool())
+		{
+			qDebug() << "Re-enabling screensaver when leaving fullscreen";
+			SystemParametersInfo(SPI_SETSCREENSAVEACTIVE, TRUE , NULL, SPIF_SENDWININICHANGE);
+		}
+		else
+			qDebug() << "Not touching screensaver business";
+#endif
+
 		// Not enough. If we had started in fullscreen, the inner part of the window is at 0/0, with the frame extending to top/left off screen.
 		// Therefore moving is not possible. We must move to the stored position or at least defaults.
 		if ( (x()<0)  && (y()<0))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Please include a summary of the change and which issue is fixed. -->
<!--- Please also include relevant motivation and context. -->
<!--- List any dependencies that are required for this change. -->

When running Stellarium in fullscreen mode for a presentation, it may annoy when the screensaver kicks in after a minute.
A new command-line option should inhibit this. 

Idea taken from https://forum.qt.io/topic/38504/solved-qdialog-in-fullscreen-disable-os-screensaver/20

Enabled for Windows for now. I don't know how to do this in Mac/Linux. Some old Mac solution is on this website. 


Fixes # (issue)

### Screenshots (if appropriate):

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system: Windows 11
* Graphics Card: irrelevant

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
