### PR TITLE
cmake: increase minimum macos version for qt5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -639,7 +639,7 @@ IF(APPLE)
 	       # Qt6: by default - universal binary + minimal operating system is macOS Big Sur
 	       SET(CMAKE_OSX_DEPLOYMENT_TARGET "11.0" CACHE STRING "Minimum macOS deployment version" FORCE)
 	  ELSE()
-               SET(CMAKE_OSX_DEPLOYMENT_TARGET "10.13" CACHE STRING "Minimum macOS deployment version" FORCE)
+               SET(CMAKE_OSX_DEPLOYMENT_TARGET "10.15" CACHE STRING "Minimum macOS deployment version" FORCE)
 	  ENDIF()
      ENDIF()
 ENDIF()


### PR DESCRIPTION
Increasing the minimum macos version from 10.13 to 10.15 allows using C++17 features and will let the currently failing MacOS Qt5 builds pass again.

Interestingly, the SUG already mentions MacOS 10.15 as the minimum requirement.

Fixes Qt5 MacOS build

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?
I tested this using the CI pipeline of a fork of this repository.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
