### PR TITLE
Expanding AstroCalc/Almanac tool

### DIFF
--- a/src/gui/AstroCalcAlmanacWidget.cpp
+++ b/src/gui/AstroCalcAlmanacWidget.cpp
@@ -89,6 +89,10 @@ void AstroCalcAlmanacWidget::setup()
 	connect(ui->buttonJuneSolsticeCurrent, &QPushButton::clicked, this, [=](){setTodayTimes();});
 	connect(ui->buttonDecemberSolsticeCurrent, &QPushButton::clicked, this, [=](){setTodayTimes();});
 
+	// handling yesterday/tomorrow
+	connect(ui->buttonYesterday, &QPushButton::clicked, this, [=](){core->addSolarDays(-1.0);});
+	connect(ui->buttonTomorrow, &QPushButton::clicked, this, [=](){core->addSolarDays(1.0);});
+
 	// handling special times
 	connect(ui->buttonSunrise, &QPushButton::clicked, this, [=](){core->setJD(sunriseJD);});
 	connect(ui->buttonSunset, &QPushButton::clicked, this, [=](){core->setJD(sunsetJD);});
@@ -124,6 +128,8 @@ void AstroCalcAlmanacWidget::setup()
 	ui->buttonSunset->setFixedSize(button);
 	ui->buttonMoonrise->setFixedSize(button);
 	ui->buttonMoonset->setFixedSize(button);
+	ui->buttonYesterday->setFixedSize(button);
+	ui->buttonTomorrow->setFixedSize(button);
 }
 
 void AstroCalcAlmanacWidget::retranslate()

--- a/src/gui/AstroCalcAlmanacWidget.cpp
+++ b/src/gui/AstroCalcAlmanacWidget.cpp
@@ -28,27 +28,32 @@
 
 #include <QPushButton>
 #include <QToolTip>
-#include <QSettings>
 
 AstroCalcAlmanacWidget::AstroCalcAlmanacWidget(QWidget* parent)
-	: QWidget(parent)
-	, core(nullptr)
-	, specMgr(nullptr)
-	, localeMgr(nullptr)
-	, sunriseJD(0.)
-	, sunsetJD(0.)
-	, moonriseJD(0.)
-	, moonsetJD(0.)
-	, civilDawnJD(0.)
-	, civilDuskJD(0.)
-	, nauticalDawnJD(0.)
-	, nauticalDuskJD(0.)
-	, astronomicalDawnJD(0.)
-	, astronomicalDuskJD(0.)
+        : QWidget(parent)
+        , core(nullptr)
+        , specMgr(nullptr)
+        , localeMgr(nullptr)
+        , sunriseJD(0.)
+        , sunsetJD(0.)
+        , moonriseJD(0.)
+        , moonsetJD(0.)
+        , civilDawnJD(0.)
+        , civilDuskJD(0.)
+        , nauticalDawnJD(0.)
+        , nauticalDuskJD(0.)
+        , astronomicalDawnJD(0.)
+        , astronomicalDuskJD(0.)
         , beforeSunriseJD(0.)
         , afterSunsetJD(0.)
         , minutesJD(0.)
-	, ui(new Ui_astroCalcAlmanacWidget)
+        , customSunriseJD(0.)
+        , customSunsetJD(0.)
+        , customSunAltitude(-7.) // obvious defaults
+        , customMoonriseJD(0.)
+        , customMoonsetJD(0.)
+        , customMoonAltitude(18.) // obvious defaults
+        , ui(new Ui_astroCalcAlmanacWidget)
 {
 }
 
@@ -66,6 +71,14 @@ void AstroCalcAlmanacWidget::setup()
 	minutesJD = customMinutes / (24.*60.);
 	ui->spinBoxMinutes->setValue(customMinutes);
 	connect(ui->spinBoxMinutes, SIGNAL(valueChanged(int)), this, SLOT(saveMinutes(int)));
+
+	customSunAltitude = conf->value("astro/custom_sun_altitude", -7.0).toDouble();
+	ui->spinBoxCustomSunAltitude->setValue(customSunAltitude);
+	connect(ui->spinBoxCustomSunAltitude, SIGNAL(valueChanged(double)), this, SLOT(saveCustomSunAltitue(double)));
+
+	customMoonAltitude = conf->value("astro/custom_moon_altitude", 18.0).toDouble();
+	ui->spinBoxCustomMoonAltitude->setValue(customMoonAltitude);
+	connect(ui->spinBoxCustomMoonAltitude, SIGNAL(valueChanged(double)), this, SLOT(saveCustomMoonAltitue(double)));
 
 	populateData();
 
@@ -107,6 +120,10 @@ void AstroCalcAlmanacWidget::setup()
 	connect(ui->buttonSunset, &QPushButton::clicked, this, [=](){core->setJD(sunsetJD);});
 	connect(ui->buttonBeforeSunrise, &QPushButton::clicked, this, [=](){core->setJD(beforeSunriseJD);});
 	connect(ui->buttonAfterSunset, &QPushButton::clicked, this, [=](){core->setJD(afterSunsetJD);});
+	connect(ui->buttonCustomSunrise, &QPushButton::clicked, this, [=](){core->setJD(customSunriseJD);});
+	connect(ui->buttonCustomSunset, &QPushButton::clicked, this, [=](){core->setJD(customSunsetJD);});
+	connect(ui->buttonCustomMoonrise, &QPushButton::clicked, this, [=](){core->setJD(customMoonriseJD);});
+	connect(ui->buttonCustomMoonset, &QPushButton::clicked, this, [=](){core->setJD(customMoonsetJD);});
 	connect(ui->buttonMoonrise, &QPushButton::clicked, this, [=](){core->setJD(moonriseJD);});
 	connect(ui->buttonMoonset, &QPushButton::clicked, this, [=](){core->setJD(moonsetJD);});
 	connect(ui->buttonCivilDawn, &QPushButton::clicked, this, [=](){core->setJD(civilDawnJD);});
@@ -143,6 +160,10 @@ void AstroCalcAlmanacWidget::setup()
 	ui->buttonTomorrow->setFixedSize(button);
 	ui->buttonBeforeSunrise->setFixedSize(button);
 	ui->buttonAfterSunset->setFixedSize(button);
+	ui->buttonCustomSunrise->setFixedSize(button);
+	ui->buttonCustomSunset->setFixedSize(button);
+	ui->buttonCustomMoonrise->setFixedSize(button);
+	ui->buttonCustomMoonset->setFixedSize(button);
 }
 
 void AstroCalcAlmanacWidget::retranslate()
@@ -155,6 +176,20 @@ void AstroCalcAlmanacWidget::saveMinutes(int minutes)
 {
 	minutesJD = minutes / (24.*60.);
 	conf->setValue("astro/custom_minutes", minutes);
+	setTodayTimes();
+}
+
+void AstroCalcAlmanacWidget::saveCustomSunAltitue(double altitude)
+{
+	customSunAltitude = altitude;
+	conf->setValue("astro/custom_sun_altitude", altitude);
+	setTodayTimes();
+}
+
+void AstroCalcAlmanacWidget::saveCustomMoonAltitue(double altitude)
+{
+	customMoonAltitude = altitude;
+	conf->setValue("astro/custom_moon_altitude", altitude);
 	setTodayTimes();
 }
 
@@ -216,7 +251,7 @@ void AstroCalcAlmanacWidget::setSeasonTimes()
 	const double septemberEquinox = specMgr->getEquinox(year, SpecificTimeMgr::Equinox::September);
 	const double juneSolstice = specMgr->getSolstice(year, SpecificTimeMgr::Solstice::June);
 	const double decemberSolstice = specMgr->getSolstice(year, SpecificTimeMgr::Solstice::December);
-	QString days = qc_("days", "duration");	
+	QString days = qc_("days", "duration");
 	int jdDepth = 5;
 	int daysDepth = 2;
 
@@ -252,11 +287,11 @@ void AstroCalcAlmanacWidget::setTodayTimes()
 	const double utcShift = utcOffsetHrs / 24.; // Fix DST shift...
 	PlanetP sun = GETSTELMODULE(SolarSystem)->getSun();
 	double duration, duration1, duration2;
-	bool astronomicalTwilightBtn, nauticalTwilightBtn, civilTwilightBtn, sunBtn;
+	bool astronomicalTwilightBtn, nauticalTwilightBtn, civilTwilightBtn, sunBtn, cstSunBtn;
 	QString moonrise, moonset, sunrise, sunset, civilTwilightBegin, civilTwilightEnd, nauticalTwilightBegin,
-		nauticalTwilightEnd, astronomicalTwilightBegin, astronomicalTwilightEnd, dayDuration, nightDuration,
-	        civilTwilightDuration, nauticalTwilightDuration, astronomicalTwilightDuration, beforeSunrise,
-	        afterSunset, dash = QChar(0x2014);
+	                nauticalTwilightEnd, astronomicalTwilightBegin, astronomicalTwilightEnd, dayDuration, nightDuration,
+	                civilTwilightDuration, nauticalTwilightDuration, astronomicalTwilightDuration, beforeSunrise,
+	                afterSunset, customSunrise, customSunset, customMoonrise, customMoonset, dash = QChar(0x2014);
 
 	// Moon
 	Vec4d moon = GETSTELMODULE(SolarSystem)->getMoon()->getRTSTime(core, 0.);
@@ -308,6 +343,48 @@ void AstroCalcAlmanacWidget::setTodayTimes()
 	}
 	dayDuration = StelUtils::hoursToHmsStr(duration, true);
 
+	// Sun at custom altitude
+	Vec4d cday = sun->getRTSTime(core, customSunAltitude);
+	if (cday[3]==0.)
+	{
+		customSunriseJD = cday[0];
+		customSunsetJD = cday[2];
+		customSunrise = StelUtils::hoursToHmsStr(StelUtils::getHoursFromJulianDay(customSunriseJD+utcShift), true);
+		customSunset = StelUtils::hoursToHmsStr(StelUtils::getHoursFromJulianDay(customSunsetJD+utcShift), true);
+		cstSunBtn = true;
+	}
+	else
+	{
+		customSunrise = customSunset = dash;
+		cstSunBtn = false;
+	}
+
+	// Moon at custom altitude
+	Vec4d cmoon = GETSTELMODULE(SolarSystem)->getMoon()->getRTSTime(core, customMoonAltitude);
+	if (cmoon[3]==30 || cmoon[3]<0 || cmoon[3]>50) // no moonrise on current date
+	{
+		customMoonrise = dash;
+		ui->buttonCustomMoonrise->setEnabled(false);
+	}
+	else
+	{
+		customMoonriseJD = cmoon[0];
+		customMoonrise = StelUtils::hoursToHmsStr(StelUtils::getHoursFromJulianDay(customMoonriseJD+utcShift), true);
+		ui->buttonCustomMoonrise->setEnabled(true);
+	}
+
+	if (cmoon[3]==40 || cmoon[3]<0 || cmoon[3]>50) // no moonset on current date
+	{
+		customMoonset = dash;
+		ui->buttonCustomMoonset->setEnabled(false);
+	}
+	else
+	{
+		customMoonsetJD = cmoon[2];
+		customMoonset = StelUtils::hoursToHmsStr(StelUtils::getHoursFromJulianDay(customMoonsetJD+utcShift), true);
+		ui->buttonCustomMoonset->setEnabled(true);
+	}
+
 	// twilights
 	Vec4d civilTwilight = sun->getRTSTime(core, -6.);
 	Vec4d nauticalTwilight = sun->getRTSTime(core, -12.);
@@ -328,6 +405,8 @@ void AstroCalcAlmanacWidget::setTodayTimes()
 	// TRANSLATORS: duration in minutes
 	QString minutes = qc_("m", "duration, suffix");
 	ui->spinBoxMinutes->setSuffix(minutes);
+	ui->spinBoxCustomSunAltitude->setSuffix("°");
+	ui->spinBoxCustomMoonAltitude->setSuffix("°");
 
 	if (astronomicalTwilight[3]==0.)
 	{
@@ -355,7 +434,7 @@ void AstroCalcAlmanacWidget::setTodayTimes()
 		if (day[3]<-99.)
 			nightDuration = StelUtils::hoursToHmsStr(24., true);
 		else
-			nightDuration = StelUtils::hoursToHmsStr(duration, true);		
+			nightDuration = StelUtils::hoursToHmsStr(duration, true);
 		astronomicalTwilightBtn = false;
 	}
 	astronomicalTwilightDuration = StelUtils::hoursToHmsStr(duration, true);
@@ -427,6 +506,10 @@ void AstroCalcAlmanacWidget::setTodayTimes()
 	ui->labelAfterSunset->setText(afterSunset);
 	ui->labelMoonRise->setText(moonrise);
 	ui->labelMoonSet->setText(moonset);
+	ui->labelCustomSunrise->setText(customSunrise);
+	ui->labelCustomSunset->setText(customSunset);
+	ui->labelCustomMoonrise->setText(customMoonrise);
+	ui->labelCustomMoonset->setText(customMoonset);
 
 	// buttons
 	ui->buttonSunrise->setEnabled(sunBtn);
@@ -439,6 +522,8 @@ void AstroCalcAlmanacWidget::setTodayTimes()
 	ui->buttonNauticalDusk->setEnabled(nauticalTwilightBtn);
 	ui->buttonCivilDawn->setEnabled(civilTwilightBtn);
 	ui->buttonCivilDusk->setEnabled(civilTwilightBtn);
+	ui->buttonCustomSunrise->setEnabled(cstSunBtn);
+	ui->buttonCustomSunset->setEnabled(cstSunBtn);
 
 	// spinboxes
 	ui->spinBoxMinutes->setEnabled(sunBtn);

--- a/src/gui/AstroCalcAlmanacWidget.hpp
+++ b/src/gui/AstroCalcAlmanacWidget.hpp
@@ -22,6 +22,7 @@
 
 #include <memory>
 #include <QWidget>
+#include "StelDialog.hpp"
 #include "ui_astroCalcAlmanacWidget.h"
 
 class AstroCalcAlmanacWidget : public QWidget
@@ -36,13 +37,15 @@ private slots:
     void setSeasonLabels();
     void setSeasonTimes();
     void setTodayTimes();
+    void saveMinutes(int minutes);
 
 private:
     class StelCore* core;
     class SpecificTimeMgr* specMgr;
     class StelLocaleMgr* localeMgr;
+    QSettings* conf;
 
-    double sunriseJD, sunsetJD, moonriseJD, moonsetJD, civilDawnJD, civilDuskJD, nauticalDawnJD, nauticalDuskJD, astronomicalDawnJD, astronomicalDuskJD;
+    double sunriseJD, sunsetJD, moonriseJD, moonsetJD, civilDawnJD, civilDuskJD, nauticalDawnJD, nauticalDuskJD, astronomicalDawnJD, astronomicalDuskJD, beforeSunriseJD, afterSunsetJD, minutesJD;
 
     void populateData();
     // method to get a formatted string for date and time of equinox/solstice

--- a/src/gui/AstroCalcAlmanacWidget.hpp
+++ b/src/gui/AstroCalcAlmanacWidget.hpp
@@ -22,36 +22,39 @@
 
 #include <memory>
 #include <QWidget>
-#include "StelDialog.hpp"
+#include <QSettings>
 #include "ui_astroCalcAlmanacWidget.h"
 
 class AstroCalcAlmanacWidget : public QWidget
 {
-    Q_OBJECT
+	Q_OBJECT
 public:
-    AstroCalcAlmanacWidget(QWidget* parent = nullptr);
-    void setup();
-    void retranslate();
+	AstroCalcAlmanacWidget(QWidget* parent = nullptr);
+	void setup();
+	void retranslate();
 
 private slots:
-    void setSeasonLabels();
-    void setSeasonTimes();
-    void setTodayTimes();
-    void saveMinutes(int minutes);
+	void setSeasonLabels();
+	void setSeasonTimes();
+	void setTodayTimes();
+	void saveMinutes(int minutes);
+	void saveCustomSunAltitue(double altitude);
+	void saveCustomMoonAltitue(double altitude);
 
 private:
-    class StelCore* core;
-    class SpecificTimeMgr* specMgr;
-    class StelLocaleMgr* localeMgr;
-    QSettings* conf;
+	class StelCore* core;
+	class SpecificTimeMgr* specMgr;
+	class StelLocaleMgr* localeMgr;
+	QSettings* conf;
 
-    double sunriseJD, sunsetJD, moonriseJD, moonsetJD, civilDawnJD, civilDuskJD, nauticalDawnJD, nauticalDuskJD, astronomicalDawnJD, astronomicalDuskJD, beforeSunriseJD, afterSunsetJD, minutesJD;
+	double sunriseJD, sunsetJD, moonriseJD, moonsetJD, civilDawnJD, civilDuskJD, nauticalDawnJD, nauticalDuskJD, astronomicalDawnJD, astronomicalDuskJD,
+	beforeSunriseJD, afterSunsetJD, minutesJD, customSunriseJD, customSunsetJD, customSunAltitude, customMoonriseJD, customMoonsetJD, customMoonAltitude;
 
-    void populateData();
-    // method to get a formatted string for date and time of equinox/solstice
-    QString getFormattedDateTime(const double JD, const double utcShift);
+	void populateData();
+	// method to get a formatted string for date and time of equinox/solstice
+	QString getFormattedDateTime(const double JD, const double utcShift);
 
-    std::unique_ptr<Ui_astroCalcAlmanacWidget> ui;
+	std::unique_ptr<Ui_astroCalcAlmanacWidget> ui;
 };
 
 #endif

--- a/src/gui/astroCalcAlmanacWidget.ui
+++ b/src/gui/astroCalcAlmanacWidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>638</width>
-    <height>323</height>
+    <height>324</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -51,8 +51,18 @@
        <string>Specific Time</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayoutSpecificTime">
-       <item row="8" column="8" colspan="2">
-        <widget class="QLabel" name="labelSunrise">
+       <item row="8" column="1">
+        <widget class="QLabel" name="labelLT2">
+         <property name="text">
+          <string>Local Time</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="11" colspan="2">
+        <widget class="QLabel" name="labelAstronomicalTwilightEnd">
          <property name="text">
           <string/>
          </property>
@@ -61,6 +71,21 @@
          </property>
          <property name="textInteractionFlags">
           <set>Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="10">
+        <widget class="QPushButton" name="buttonNauticalDawn">
+         <property name="toolTip">
+          <string>Morning nautical twilight</string>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="icon">
+          <iconset resource="../../data/gui/guiRes.qrc">
+           <normaloff>:/graphicGui/bbtTime-off.png</normaloff>
+           <disabledoff>:/graphicGui/bbtTime-off.png</disabledoff>:/graphicGui/bbtTime-off.png</iconset>
          </property>
         </widget>
        </item>
@@ -74,6 +99,555 @@
          </property>
         </widget>
        </item>
+       <item row="5" column="5">
+        <widget class="QLabel" name="labelJuneSolsticeDuration">
+         <property name="textInteractionFlags">
+          <set>Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="11" colspan="2">
+        <widget class="QLabel" name="labelNauticalTwilightEnd">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="9" column="10">
+        <widget class="QPushButton" name="buttonMoonrise">
+         <property name="toolTip">
+          <string>Today's moonrise</string>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="icon">
+          <iconset resource="../../data/gui/guiRes.qrc">
+           <normaloff>:/graphicGui/bbtTime-off.png</normaloff>
+           <disabledoff>:/graphicGui/bbtTime-off.png</disabledoff>:/graphicGui/bbtTime-off.png</iconset>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="5">
+        <widget class="QLabel" name="labelDecemberSolsticeLT">
+         <property name="textInteractionFlags">
+          <set>Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="11" colspan="2">
+        <widget class="QLabel" name="labelCivilTwilightEnd">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="9" column="8" colspan="2">
+        <widget class="QLabel" name="labelMoonRise">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="14">
+        <widget class="QLabel" name="labelAstronomicalTwilightDuration">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="2" rowspan="10">
+        <widget class="Line" name="line_4">
+         <property name="minimumSize">
+          <size>
+           <width>1</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>1</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="8" colspan="2">
+        <widget class="QLabel" name="labelSunrise">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="10" column="5">
+        <widget class="QLabel" name="labelDecemberSolsticeDuration">
+         <property name="textInteractionFlags">
+          <set>Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="7">
+        <widget class="QLabel" name="labelSun">
+         <property name="text">
+          <string>Sun</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="3">
+        <widget class="QLabel" name="labelMarchEquinoxLT">
+         <property name="textInteractionFlags">
+          <set>Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="14">
+        <widget class="QLabel" name="labelNauticalTwilightDuration">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="8" colspan="3">
+        <widget class="QLabel" name="labelRise">
+         <property name="text">
+          <string>Rise</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="13">
+        <widget class="QPushButton" name="buttonSunset">
+         <property name="toolTip">
+          <string>Today's sunset</string>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="icon">
+          <iconset resource="../../data/gui/guiRes.qrc">
+           <normaloff>:/graphicGui/bbtTime-off.png</normaloff>
+           <disabledoff>:/graphicGui/bbtTime-off.png</disabledoff>:/graphicGui/bbtTime-off.png</iconset>
+         </property>
+        </widget>
+       </item>
+       <item row="9" column="11" colspan="2">
+        <widget class="QLabel" name="labelMoonSet">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="9" column="13">
+        <widget class="QPushButton" name="buttonMoonset">
+         <property name="toolTip">
+          <string>Today's moonset</string>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="icon">
+          <iconset resource="../../data/gui/guiRes.qrc">
+           <normaloff>:/graphicGui/bbtTime-off.png</normaloff>
+           <disabledoff>:/graphicGui/bbtTime-off.png</disabledoff>:/graphicGui/bbtTime-off.png</iconset>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="13">
+        <widget class="QPushButton" name="buttonCivilDusk">
+         <property name="toolTip">
+          <string>Evening civil twilight</string>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="icon">
+          <iconset resource="../../data/gui/guiRes.qrc">
+           <normaloff>:/graphicGui/bbtTime-off.png</normaloff>
+           <disabledoff>:/graphicGui/bbtTime-off.png</disabledoff>:/graphicGui/bbtTime-off.png</iconset>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="10">
+        <widget class="QPushButton" name="buttonSunrise">
+         <property name="toolTip">
+          <string>Today's sunrise</string>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="icon">
+          <iconset resource="../../data/gui/guiRes.qrc">
+           <normaloff>:/graphicGui/bbtTime-off.png</normaloff>
+           <disabledoff>:/graphicGui/bbtTime-off.png</disabledoff>:/graphicGui/bbtTime-off.png</iconset>
+         </property>
+        </widget>
+       </item>
+       <item row="9" column="7">
+        <widget class="QLabel" name="labelMoon">
+         <property name="text">
+          <string>Moon</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="5">
+        <layout class="QHBoxLayout" name="DecemberSolsticeLayout">
+         <item>
+          <widget class="QLabel" name="labelDecemberSolstice">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string comment="season">Winter</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="buttonDecemberSolsticePrevious">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>Previous December Solstice</string>
+           </property>
+           <property name="icon">
+            <iconset resource="../../data/gui/guiRes.qrc">
+             <normaloff>:/graphicGui/btTimeRewind-off.png</normaloff>
+             <disabledoff>:/graphicGui/btTimeRewind-off.png</disabledoff>:/graphicGui/btTimeRewind-off.png</iconset>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="buttonDecemberSolsticeCurrent">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>Current December Solstice</string>
+           </property>
+           <property name="icon">
+            <iconset resource="../../data/gui/guiRes.qrc">
+             <normaloff>:/graphicGui/bbtTime-off.png</normaloff>
+             <disabledoff>:/graphicGui/bbtTime-off.png</disabledoff>:/graphicGui/bbtTime-off.png</iconset>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="buttonDecemberSolsticeNext">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>Next December Solstice</string>
+           </property>
+           <property name="icon">
+            <iconset resource="../../data/gui/guiRes.qrc">
+             <normaloff>:/graphicGui/btTimeForward-off.png</normaloff>
+             <disabledoff>:/graphicGui/btTimeForward-off.png</disabledoff>:/graphicGui/btTimeForward-off.png</iconset>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item row="1" column="14">
+        <widget class="QLabel" name="labelDurationColumn1">
+         <property name="text">
+          <string>Duration</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="8" colspan="3">
+        <widget class="QLabel" name="labelDawn">
+         <property name="text">
+          <string>Dawn</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="1">
+        <widget class="QLabel" name="labelDuration1">
+         <property name="text">
+          <string>Duration</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="11" column="1">
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="10" column="14">
+        <widget class="QLabel" name="labelNightDuration">
+         <property name="font">
+          <font>
+           <italic>true</italic>
+          </font>
+         </property>
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <layout class="QHBoxLayout" name="YearLayout">
+         <item>
+          <widget class="QLabel" name="labelYear">
+           <property name="text">
+            <string>Year</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="labelCurrentYear">
+           <property name="font">
+            <font>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="labelYearDuration">
+           <property name="text">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item row="1" column="4" rowspan="5">
+        <widget class="Line" name="line_2">
+         <property name="minimumSize">
+          <size>
+           <width>1</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>1</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="10">
+        <widget class="QPushButton" name="buttonAstronomicalDawn">
+         <property name="toolTip">
+          <string>Morning astronomical twilight</string>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="icon">
+          <iconset resource="../../data/gui/guiRes.qrc">
+           <normaloff>:/graphicGui/bbtTime-off.png</normaloff>
+           <disabledoff>:/graphicGui/bbtTime-off.png</disabledoff>:/graphicGui/bbtTime-off.png</iconset>
+         </property>
+        </widget>
+       </item>
+       <item row="10" column="3">
+        <widget class="QLabel" name="labelSeptemberEquinoxDuration">
+         <property name="textInteractionFlags">
+          <set>Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="6" rowspan="11">
+        <widget class="Line" name="lineDelimiterSections">
+         <property name="minimumSize">
+          <size>
+           <width>1</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>1</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="8" colspan="2">
+        <widget class="QLabel" name="labelNauticalTwilightBegin">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="7">
+        <widget class="QLabel" name="labelNauticalTwilight">
+         <property name="text">
+          <string comment="twilight">Nautical</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="10" column="1">
+        <widget class="QLabel" name="labelDuration2">
+         <property name="text">
+          <string>Duration</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="3">
+        <widget class="QLabel" name="labelMarchEquinoxDuration">
+         <property name="textInteractionFlags">
+          <set>Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="5">
+        <widget class="QLabel" name="labelJuneSolsticeJD">
+         <property name="textInteractionFlags">
+          <set>Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="13">
+        <widget class="QPushButton" name="buttonAstronomicalDusk">
+         <property name="toolTip">
+          <string>Evening astronomical twilight</string>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="icon">
+          <iconset resource="../../data/gui/guiRes.qrc">
+           <normaloff>:/graphicGui/bbtTime-off.png</normaloff>
+           <disabledoff>:/graphicGui/bbtTime-off.png</disabledoff>:/graphicGui/bbtTime-off.png</iconset>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="7">
+        <widget class="QLabel" name="labelTwilight">
+         <property name="text">
+          <string>Twilight</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
        <item row="4" column="1">
         <widget class="QLabel" name="labelJD1">
          <property name="text">
@@ -81,6 +655,229 @@
          </property>
          <property name="alignment">
           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="5">
+        <widget class="QLabel" name="labelJuneSolsticeLT">
+         <property name="textInteractionFlags">
+          <set>Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="9" column="3">
+        <widget class="QLabel" name="labelSeptemberEquinoxJD">
+         <property name="textInteractionFlags">
+          <set>Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="5">
+        <layout class="QHBoxLayout" name="JuneSolsticeLayout">
+         <item>
+          <widget class="QLabel" name="labelJuneSolstice">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string comment="season">Summer</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="buttonJuneSolsticePrevious">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>Previous June Solstice</string>
+           </property>
+           <property name="icon">
+            <iconset resource="../../data/gui/guiRes.qrc">
+             <normaloff>:/graphicGui/btTimeRewind-off.png</normaloff>
+             <disabledoff>:/graphicGui/btTimeRewind-off.png</disabledoff>:/graphicGui/btTimeRewind-off.png</iconset>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="buttonJuneSolsticeCurrent">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>Current June Solstice</string>
+           </property>
+           <property name="icon">
+            <iconset resource="../../data/gui/guiRes.qrc">
+             <normaloff>:/graphicGui/bbtTime-off.png</normaloff>
+             <disabledoff>:/graphicGui/bbtTime-off.png</disabledoff>:/graphicGui/bbtTime-off.png</iconset>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="buttonJuneSolsticeNext">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>Next June Solstice</string>
+           </property>
+           <property name="icon">
+            <iconset resource="../../data/gui/guiRes.qrc">
+             <normaloff>:/graphicGui/btTimeForward-off.png</normaloff>
+             <disabledoff>:/graphicGui/btTimeForward-off.png</disabledoff>:/graphicGui/btTimeForward-off.png</iconset>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item row="8" column="14">
+        <widget class="QLabel" name="labelDayDuration">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="7" colspan="8">
+        <widget class="Line" name="line_5">
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>1</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>16777215</width>
+           <height>1</height>
+          </size>
+         </property>
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="10" column="7" colspan="7">
+        <widget class="QLabel" name="labelNight">
+         <property name="font">
+          <font>
+           <italic>true</italic>
+          </font>
+         </property>
+         <property name="text">
+          <string>Astronomical Night</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="3">
+        <layout class="QHBoxLayout" name="SeptemberEquinoxLayout">
+         <item>
+          <widget class="QLabel" name="labelSeptemberEquinox">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string comment="season">Fall</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="buttonSeptemberEquinoxPrevious">
+           <property name="toolTip">
+            <string>Previous September Equinox</string>
+           </property>
+           <property name="icon">
+            <iconset resource="../../data/gui/guiRes.qrc">
+             <normaloff>:/graphicGui/btTimeRewind-off.png</normaloff>
+             <disabledoff>:/graphicGui/btTimeRewind-off.png</disabledoff>:/graphicGui/btTimeRewind-off.png</iconset>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="buttonSeptemberEquinoxCurrent">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>Current September Equinox</string>
+           </property>
+           <property name="icon">
+            <iconset resource="../../data/gui/guiRes.qrc">
+             <normaloff>:/graphicGui/bbtTime-off.png</normaloff>
+             <disabledoff>:/graphicGui/bbtTime-off.png</disabledoff>:/graphicGui/bbtTime-off.png</iconset>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="buttonSeptemberEquinoxNext">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>Next September Equinox</string>
+           </property>
+           <property name="icon">
+            <iconset resource="../../data/gui/guiRes.qrc">
+             <normaloff>:/graphicGui/btTimeForward-off.png</normaloff>
+             <disabledoff>:/graphicGui/btTimeForward-off.png</disabledoff>:/graphicGui/btTimeForward-off.png</iconset>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item row="5" column="8" colspan="2">
+        <widget class="QLabel" name="labelCivilTwilightBegin">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="11" colspan="2">
+        <widget class="QLabel" name="labelSunset">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::TextSelectableByMouse</set>
          </property>
         </widget>
        </item>
@@ -162,62 +959,6 @@
          </item>
         </layout>
        </item>
-       <item row="9" column="13">
-        <widget class="QPushButton" name="buttonMoonset">
-         <property name="toolTip">
-          <string>Today's moonset</string>
-         </property>
-         <property name="text">
-          <string/>
-         </property>
-         <property name="icon">
-          <iconset resource="../../data/gui/guiRes.qrc">
-           <normaloff>:/graphicGui/bbtTime-off.png</normaloff>
-           <disabledoff>:/graphicGui/bbtTime-off.png</disabledoff>:/graphicGui/bbtTime-off.png</iconset>
-         </property>
-        </widget>
-       </item>
-       <item row="9" column="3">
-        <widget class="QLabel" name="labelSeptemberEquinoxJD">
-         <property name="textInteractionFlags">
-          <set>Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item row="9" column="5">
-        <widget class="QLabel" name="labelDecemberSolsticeJD">
-         <property name="textInteractionFlags">
-          <set>Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="8" colspan="3">
-        <widget class="QLabel" name="labelDawn">
-         <property name="text">
-          <string>Dawn</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="8" column="5">
-        <widget class="QLabel" name="labelDecemberSolsticeLT">
-         <property name="textInteractionFlags">
-          <set>Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item row="7" column="11" colspan="3">
-        <widget class="QLabel" name="labelSet">
-         <property name="text">
-          <string>Set</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
        <item row="7" column="4" rowspan="4">
         <widget class="Line" name="line_3">
          <property name="minimumSize">
@@ -237,81 +978,6 @@
          </property>
         </widget>
        </item>
-       <item row="5" column="11" colspan="2">
-        <widget class="QLabel" name="labelCivilTwilightEnd">
-         <property name="text">
-          <string/>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item row="6" column="7" colspan="8">
-        <widget class="Line" name="line_5">
-         <property name="minimumSize">
-          <size>
-           <width>0</width>
-           <height>1</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>16777215</width>
-           <height>1</height>
-          </size>
-         </property>
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="3">
-        <widget class="QLabel" name="labelMarchEquinoxJD">
-         <property name="textInteractionFlags">
-          <set>Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item row="11" column="1">
-        <spacer name="verticalSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="5" column="8" colspan="2">
-        <widget class="QLabel" name="labelCivilTwilightBegin">
-         <property name="text">
-          <string/>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item row="10" column="1">
-        <widget class="QLabel" name="labelDuration2">
-         <property name="text">
-          <string>Duration</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-         </property>
-        </widget>
-       </item>
        <item row="5" column="14">
         <widget class="QLabel" name="labelCivilTwilightDuration">
          <property name="text">
@@ -322,6 +988,38 @@
          </property>
          <property name="textInteractionFlags">
           <set>Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="11" colspan="3">
+        <widget class="QLabel" name="labelSet">
+         <property name="text">
+          <string>Set</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="14">
+        <widget class="QLabel" name="labelDurationColumn2">
+         <property name="text">
+          <string>Duration</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1" colspan="5">
+        <widget class="QLabel" name="labelSeasons">
+         <property name="font">
+          <font>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Seasons</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
          </property>
         </widget>
        </item>
@@ -344,220 +1042,6 @@
          </property>
         </widget>
        </item>
-       <item row="1" column="7">
-        <widget class="QLabel" name="labelTwilight">
-         <property name="text">
-          <string>Twilight</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="10" column="3">
-        <widget class="QLabel" name="labelSeptemberEquinoxDuration">
-         <property name="textInteractionFlags">
-          <set>Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="1">
-        <layout class="QHBoxLayout" name="YearLayout">
-         <item>
-          <widget class="QLabel" name="labelYear">
-           <property name="text">
-            <string>Year</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLabel" name="labelCurrentYear">
-           <property name="font">
-            <font>
-             <bold>true</bold>
-            </font>
-           </property>
-           <property name="text">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLabel" name="labelYearDuration">
-           <property name="text">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item row="3" column="1">
-        <widget class="QLabel" name="labelLT1">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>Local Time</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="8" column="13">
-        <widget class="QPushButton" name="buttonSunset">
-         <property name="toolTip">
-          <string>Today's sunset</string>
-         </property>
-         <property name="text">
-          <string/>
-         </property>
-         <property name="icon">
-          <iconset resource="../../data/gui/guiRes.qrc">
-           <normaloff>:/graphicGui/bbtTime-off.png</normaloff>
-           <disabledoff>:/graphicGui/bbtTime-off.png</disabledoff>:/graphicGui/bbtTime-off.png</iconset>
-         </property>
-        </widget>
-       </item>
-       <item row="7" column="14">
-        <widget class="QLabel" name="labelDurationColumn2">
-         <property name="text">
-          <string>Duration</string>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="14">
-        <widget class="QLabel" name="labelAstronomicalTwilightDuration">
-         <property name="text">
-          <string/>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="6" rowspan="11">
-        <widget class="Line" name="lineDelimiterSections">
-         <property name="minimumSize">
-          <size>
-           <width>1</width>
-           <height>0</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>1</width>
-           <height>16777215</height>
-          </size>
-         </property>
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="5">
-        <layout class="QHBoxLayout" name="JuneSolsticeLayout">
-         <item>
-          <widget class="QLabel" name="labelJuneSolstice">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string comment="season">Summer</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QPushButton" name="buttonJuneSolsticePrevious">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="toolTip">
-            <string>Previous June Solstice</string>
-           </property>
-           <property name="icon">
-            <iconset resource="../../data/gui/guiRes.qrc">
-             <normaloff>:/graphicGui/btTimeRewind-off.png</normaloff>
-             <disabledoff>:/graphicGui/btTimeRewind-off.png</disabledoff>:/graphicGui/btTimeRewind-off.png</iconset>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QPushButton" name="buttonJuneSolsticeCurrent">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="toolTip">
-            <string>Current June Solstice</string>
-           </property>
-           <property name="icon">
-            <iconset resource="../../data/gui/guiRes.qrc">
-             <normaloff>:/graphicGui/bbtTime-off.png</normaloff>
-             <disabledoff>:/graphicGui/bbtTime-off.png</disabledoff>:/graphicGui/bbtTime-off.png</iconset>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QPushButton" name="buttonJuneSolsticeNext">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="toolTip">
-            <string>Next June Solstice</string>
-           </property>
-           <property name="icon">
-            <iconset resource="../../data/gui/guiRes.qrc">
-             <normaloff>:/graphicGui/btTimeForward-off.png</normaloff>
-             <disabledoff>:/graphicGui/btTimeForward-off.png</disabledoff>:/graphicGui/btTimeForward-off.png</iconset>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item row="10" column="5">
-        <widget class="QLabel" name="labelDecemberSolsticeDuration">
-         <property name="textInteractionFlags">
-          <set>Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item row="8" column="1">
-        <widget class="QLabel" name="labelLT2">
-         <property name="text">
-          <string>Local Time</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-         </property>
-        </widget>
-       </item>
        <item row="4" column="13">
         <widget class="QPushButton" name="buttonNauticalDusk">
          <property name="toolTip">
@@ -570,578 +1054,6 @@
           <iconset resource="../../data/gui/guiRes.qrc">
            <normaloff>:/graphicGui/bbtTime-off.png</normaloff>
            <disabledoff>:/graphicGui/bbtTime-off.png</disabledoff>:/graphicGui/bbtTime-off.png</iconset>
-         </property>
-        </widget>
-       </item>
-       <item row="10" column="7" colspan="7">
-        <widget class="QLabel" name="labelNight">
-         <property name="font">
-          <font>
-           <italic>true</italic>
-          </font>
-         </property>
-         <property name="text">
-          <string>Astronomical Night</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="10" column="14">
-        <widget class="QLabel" name="labelNightDuration">
-         <property name="font">
-          <font>
-           <italic>true</italic>
-          </font>
-         </property>
-         <property name="toolTip">
-          <string/>
-         </property>
-         <property name="text">
-          <string/>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item row="8" column="14">
-        <widget class="QLabel" name="labelDayDuration">
-         <property name="text">
-          <string/>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="10">
-        <widget class="QPushButton" name="buttonNauticalDawn">
-         <property name="toolTip">
-          <string>Morning nautical twilight</string>
-         </property>
-         <property name="text">
-          <string/>
-         </property>
-         <property name="icon">
-          <iconset resource="../../data/gui/guiRes.qrc">
-           <normaloff>:/graphicGui/bbtTime-off.png</normaloff>
-           <disabledoff>:/graphicGui/bbtTime-off.png</disabledoff>:/graphicGui/bbtTime-off.png</iconset>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="10">
-        <widget class="QPushButton" name="buttonCivilDawn">
-         <property name="toolTip">
-          <string>Morning civil twilight</string>
-         </property>
-         <property name="text">
-          <string/>
-         </property>
-         <property name="icon">
-          <iconset resource="../../data/gui/guiRes.qrc">
-           <normaloff>:/graphicGui/bbtTime-off.png</normaloff>
-           <disabledoff>:/graphicGui/bbtTime-off.png</disabledoff>:/graphicGui/bbtTime-off.png</iconset>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="3">
-        <widget class="QLabel" name="labelMarchEquinoxLT">
-         <property name="textInteractionFlags">
-          <set>Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item row="7" column="8" colspan="3">
-        <widget class="QLabel" name="labelRise">
-         <property name="text">
-          <string>Rise</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="3">
-        <widget class="QLabel" name="labelMarchEquinoxDuration">
-         <property name="textInteractionFlags">
-          <set>Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="13">
-        <widget class="QPushButton" name="buttonAstronomicalDusk">
-         <property name="toolTip">
-          <string>Evening astronomical twilight</string>
-         </property>
-         <property name="text">
-          <string/>
-         </property>
-         <property name="icon">
-          <iconset resource="../../data/gui/guiRes.qrc">
-           <normaloff>:/graphicGui/bbtTime-off.png</normaloff>
-           <disabledoff>:/graphicGui/bbtTime-off.png</disabledoff>:/graphicGui/bbtTime-off.png</iconset>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="14">
-        <widget class="QLabel" name="labelNauticalTwilightDuration">
-         <property name="text">
-          <string/>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="11" colspan="3">
-        <widget class="QLabel" name="labelDusk">
-         <property name="text">
-          <string>Dusk</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="13">
-        <widget class="QPushButton" name="buttonCivilDusk">
-         <property name="toolTip">
-          <string>Evening civil twilight</string>
-         </property>
-         <property name="text">
-          <string/>
-         </property>
-         <property name="icon">
-          <iconset resource="../../data/gui/guiRes.qrc">
-           <normaloff>:/graphicGui/bbtTime-off.png</normaloff>
-           <disabledoff>:/graphicGui/bbtTime-off.png</disabledoff>:/graphicGui/bbtTime-off.png</iconset>
-         </property>
-        </widget>
-       </item>
-       <item row="7" column="3">
-        <layout class="QHBoxLayout" name="SeptemberEquinoxLayout">
-         <item>
-          <widget class="QLabel" name="labelSeptemberEquinox">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string comment="season">Fall</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QPushButton" name="buttonSeptemberEquinoxPrevious">
-           <property name="toolTip">
-            <string>Previous September Equinox</string>
-           </property>
-           <property name="icon">
-            <iconset resource="../../data/gui/guiRes.qrc">
-             <normaloff>:/graphicGui/btTimeRewind-off.png</normaloff>
-             <disabledoff>:/graphicGui/btTimeRewind-off.png</disabledoff>:/graphicGui/btTimeRewind-off.png</iconset>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QPushButton" name="buttonSeptemberEquinoxCurrent">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="toolTip">
-            <string>Current September Equinox</string>
-           </property>
-           <property name="icon">
-            <iconset resource="../../data/gui/guiRes.qrc">
-             <normaloff>:/graphicGui/bbtTime-off.png</normaloff>
-             <disabledoff>:/graphicGui/bbtTime-off.png</disabledoff>:/graphicGui/bbtTime-off.png</iconset>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QPushButton" name="buttonSeptemberEquinoxNext">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="toolTip">
-            <string>Next September Equinox</string>
-           </property>
-           <property name="icon">
-            <iconset resource="../../data/gui/guiRes.qrc">
-             <normaloff>:/graphicGui/btTimeForward-off.png</normaloff>
-             <disabledoff>:/graphicGui/btTimeForward-off.png</disabledoff>:/graphicGui/btTimeForward-off.png</iconset>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item row="3" column="5">
-        <widget class="QLabel" name="labelJuneSolsticeLT">
-         <property name="textInteractionFlags">
-          <set>Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="7">
-        <widget class="QLabel" name="labelAstronomicalTwilight">
-         <property name="text">
-          <string comment="twilight">Astronomical</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="4" rowspan="5">
-        <widget class="Line" name="line_2">
-         <property name="minimumSize">
-          <size>
-           <width>1</width>
-           <height>0</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>1</width>
-           <height>16777215</height>
-          </size>
-         </property>
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-        </widget>
-       </item>
-       <item row="8" column="11" colspan="2">
-        <widget class="QLabel" name="labelSunset">
-         <property name="text">
-          <string/>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item row="9" column="7">
-        <widget class="QLabel" name="labelMoon">
-         <property name="text">
-          <string>Moon</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="8" column="10">
-        <widget class="QPushButton" name="buttonSunrise">
-         <property name="toolTip">
-          <string>Today's sunrise</string>
-         </property>
-         <property name="text">
-          <string/>
-         </property>
-         <property name="icon">
-          <iconset resource="../../data/gui/guiRes.qrc">
-           <normaloff>:/graphicGui/bbtTime-off.png</normaloff>
-           <disabledoff>:/graphicGui/bbtTime-off.png</disabledoff>:/graphicGui/bbtTime-off.png</iconset>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="8" colspan="2">
-        <widget class="QLabel" name="labelNauticalTwilightBegin">
-         <property name="text">
-          <string/>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="1" colspan="5">
-        <widget class="QLabel" name="labelSeasons">
-         <property name="font">
-          <font>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>Seasons</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="11" colspan="2">
-        <widget class="QLabel" name="labelAstronomicalTwilightEnd">
-         <property name="text">
-          <string/>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="8" colspan="2">
-        <widget class="QLabel" name="labelAstronomicalTwilightBegin">
-         <property name="text">
-          <string/>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item row="9" column="8" colspan="2">
-        <widget class="QLabel" name="labelMoonRise">
-         <property name="text">
-          <string/>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item row="9" column="10">
-        <widget class="QPushButton" name="buttonMoonrise">
-         <property name="toolTip">
-          <string>Today's moonrise</string>
-         </property>
-         <property name="text">
-          <string/>
-         </property>
-         <property name="icon">
-          <iconset resource="../../data/gui/guiRes.qrc">
-           <normaloff>:/graphicGui/bbtTime-off.png</normaloff>
-           <disabledoff>:/graphicGui/bbtTime-off.png</disabledoff>:/graphicGui/bbtTime-off.png</iconset>
-         </property>
-        </widget>
-       </item>
-       <item row="7" column="5">
-        <layout class="QHBoxLayout" name="DecemberSolsticeLayout">
-         <item>
-          <widget class="QLabel" name="labelDecemberSolstice">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string comment="season">Winter</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QPushButton" name="buttonDecemberSolsticePrevious">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="toolTip">
-            <string>Previous December Solstice</string>
-           </property>
-           <property name="icon">
-            <iconset resource="../../data/gui/guiRes.qrc">
-             <normaloff>:/graphicGui/btTimeRewind-off.png</normaloff>
-             <disabledoff>:/graphicGui/btTimeRewind-off.png</disabledoff>:/graphicGui/btTimeRewind-off.png</iconset>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QPushButton" name="buttonDecemberSolsticeCurrent">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="toolTip">
-            <string>Current December Solstice</string>
-           </property>
-           <property name="icon">
-            <iconset resource="../../data/gui/guiRes.qrc">
-             <normaloff>:/graphicGui/bbtTime-off.png</normaloff>
-             <disabledoff>:/graphicGui/bbtTime-off.png</disabledoff>:/graphicGui/bbtTime-off.png</iconset>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QPushButton" name="buttonDecemberSolsticeNext">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="toolTip">
-            <string>Next December Solstice</string>
-           </property>
-           <property name="icon">
-            <iconset resource="../../data/gui/guiRes.qrc">
-             <normaloff>:/graphicGui/btTimeForward-off.png</normaloff>
-             <disabledoff>:/graphicGui/btTimeForward-off.png</disabledoff>:/graphicGui/btTimeForward-off.png</iconset>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item row="3" column="10">
-        <widget class="QPushButton" name="buttonAstronomicalDawn">
-         <property name="toolTip">
-          <string>Morning astronomical twilight</string>
-         </property>
-         <property name="text">
-          <string/>
-         </property>
-         <property name="icon">
-          <iconset resource="../../data/gui/guiRes.qrc">
-           <normaloff>:/graphicGui/bbtTime-off.png</normaloff>
-           <disabledoff>:/graphicGui/bbtTime-off.png</disabledoff>:/graphicGui/bbtTime-off.png</iconset>
-         </property>
-        </widget>
-       </item>
-       <item row="9" column="1">
-        <widget class="QLabel" name="labelJD2">
-         <property name="text">
-          <string>Julian Day</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="1">
-        <widget class="QLabel" name="labelDuration1">
-         <property name="text">
-          <string>Duration</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="11" colspan="2">
-        <widget class="QLabel" name="labelNauticalTwilightEnd">
-         <property name="text">
-          <string/>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item row="9" column="11" colspan="2">
-        <widget class="QLabel" name="labelMoonSet">
-         <property name="text">
-          <string/>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="14">
-        <widget class="QLabel" name="labelDurationColumn1">
-         <property name="text">
-          <string>Duration</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="8" column="7">
-        <widget class="QLabel" name="labelSun">
-         <property name="text">
-          <string>Sun</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="5">
-        <widget class="QLabel" name="labelJuneSolsticeJD">
-         <property name="textInteractionFlags">
-          <set>Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="5">
-        <widget class="QLabel" name="labelJuneSolsticeDuration">
-         <property name="textInteractionFlags">
-          <set>Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="2" rowspan="10">
-        <widget class="Line" name="line_4">
-         <property name="minimumSize">
-          <size>
-           <width>1</width>
-           <height>0</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>1</width>
-           <height>16777215</height>
-          </size>
-         </property>
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="7">
-        <widget class="QLabel" name="labelNauticalTwilight">
-         <property name="text">
-          <string comment="twilight">Nautical</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
          </property>
         </widget>
        </item>
@@ -1205,6 +1117,191 @@
           </widget>
          </item>
         </layout>
+       </item>
+       <item row="3" column="7">
+        <widget class="QLabel" name="labelAstronomicalTwilight">
+         <property name="text">
+          <string comment="twilight">Astronomical</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="8" colspan="2">
+        <widget class="QLabel" name="labelAstronomicalTwilightBegin">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="1">
+        <widget class="QLabel" name="labelLT1">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Local Time</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="9" column="1">
+        <widget class="QLabel" name="labelJD2">
+         <property name="text">
+          <string>Julian Day</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="9" column="5">
+        <widget class="QLabel" name="labelDecemberSolsticeJD">
+         <property name="textInteractionFlags">
+          <set>Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="11" colspan="3">
+        <widget class="QLabel" name="labelDusk">
+         <property name="text">
+          <string>Dusk</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="3">
+        <widget class="QLabel" name="labelMarchEquinoxJD">
+         <property name="textInteractionFlags">
+          <set>Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="10">
+        <widget class="QPushButton" name="buttonCivilDawn">
+         <property name="toolTip">
+          <string>Morning civil twilight</string>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="icon">
+          <iconset resource="../../data/gui/guiRes.qrc">
+           <normaloff>:/graphicGui/bbtTime-off.png</normaloff>
+           <disabledoff>:/graphicGui/bbtTime-off.png</disabledoff>:/graphicGui/bbtTime-off.png</iconset>
+         </property>
+        </widget>
+       </item>
+       <item row="11" column="7">
+        <widget class="QLabel" name="labelSun2">
+         <property name="text">
+          <string>Sun</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="11" column="8">
+        <widget class="QLabel" name="labelBeforeSunrise">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="11" column="10">
+        <widget class="QPushButton" name="buttonBeforeSunrise">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Defined minutes before today's sunrise</string>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="icon">
+          <iconset resource="../../data/gui/guiRes.qrc">
+           <normaloff>:/graphicGui/bbtTime-off.png</normaloff>
+           <disabledoff>:/graphicGui/bbtTime-off.png</disabledoff>:/graphicGui/bbtTime-off.png</iconset>
+         </property>
+        </widget>
+       </item>
+       <item row="11" column="11">
+        <widget class="QLabel" name="labelAfterSunset">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="11" column="13">
+        <widget class="QPushButton" name="buttonAfterSunset">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Defined minutes after today's sunset</string>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="icon">
+          <iconset resource="../../data/gui/guiRes.qrc">
+           <normaloff>:/graphicGui/bbtTime-off.png</normaloff>
+           <disabledoff>:/graphicGui/bbtTime-off.png</disabledoff>:/graphicGui/bbtTime-off.png</iconset>
+         </property>
+        </widget>
+       </item>
+       <item row="11" column="14">
+        <widget class="QSpinBox" name="spinBoxMinutes">
+         <property name="toolTip">
+          <string>Minutes before sunrise/after sunset</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+         <property name="minimum">
+          <number>1</number>
+         </property>
+         <property name="maximum">
+          <number>120</number>
+         </property>
+         <property name="value">
+          <number>60</number>
+         </property>
+        </widget>
        </item>
       </layout>
      </widget>

--- a/src/gui/astroCalcAlmanacWidget.ui
+++ b/src/gui/astroCalcAlmanacWidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>638</width>
-    <height>314</height>
+    <height>323</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -51,138 +51,8 @@
        <string>Specific Time</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayoutSpecificTime">
-       <item row="8" column="1">
-        <widget class="QLabel" name="labelLT2">
-         <property name="text">
-          <string>Local Time</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="7" column="3">
-        <layout class="QHBoxLayout" name="SeptemberEquinoxLayout">
-         <item>
-          <widget class="QLabel" name="labelSeptemberEquinox">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string comment="season">Fall</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QPushButton" name="buttonSeptemberEquinoxPrevious">
-           <property name="toolTip">
-            <string>Previous September Equinox</string>
-           </property>
-           <property name="icon">
-            <iconset resource="../../data/gui/guiRes.qrc">
-             <normaloff>:/graphicGui/btTimeRewind-off.png</normaloff>
-             <disabledoff>:/graphicGui/btTimeRewind-off.png</disabledoff>:/graphicGui/btTimeRewind-off.png</iconset>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QPushButton" name="buttonSeptemberEquinoxCurrent">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="toolTip">
-            <string>Current September Equinox</string>
-           </property>
-           <property name="icon">
-            <iconset resource="../../data/gui/guiRes.qrc">
-             <normaloff>:/graphicGui/bbtTime-off.png</normaloff>
-             <disabledoff>:/graphicGui/bbtTime-off.png</disabledoff>:/graphicGui/bbtTime-off.png</iconset>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QPushButton" name="buttonSeptemberEquinoxNext">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="toolTip">
-            <string>Next September Equinox</string>
-           </property>
-           <property name="icon">
-            <iconset resource="../../data/gui/guiRes.qrc">
-             <normaloff>:/graphicGui/btTimeForward-off.png</normaloff>
-             <disabledoff>:/graphicGui/btTimeForward-off.png</disabledoff>:/graphicGui/btTimeForward-off.png</iconset>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item row="4" column="5">
-        <widget class="QLabel" name="labelJuneSolsticeJD">
-         <property name="textInteractionFlags">
-          <set>Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item row="10" column="3">
-        <widget class="QLabel" name="labelSeptemberEquinoxDuration">
-         <property name="textInteractionFlags">
-          <set>Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="4" rowspan="5">
-        <widget class="Line" name="line_2">
-         <property name="minimumSize">
-          <size>
-           <width>1</width>
-           <height>0</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>1</width>
-           <height>16777215</height>
-          </size>
-         </property>
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-        </widget>
-       </item>
-       <item row="8" column="14">
-        <widget class="QPushButton" name="buttonSunset">
-         <property name="toolTip">
-          <string>Today's sunset</string>
-         </property>
-         <property name="text">
-          <string/>
-         </property>
-         <property name="icon">
-          <iconset resource="../../data/gui/guiRes.qrc">
-           <normaloff>:/graphicGui/bbtTime-off.png</normaloff>
-           <disabledoff>:/graphicGui/bbtTime-off.png</disabledoff>:/graphicGui/bbtTime-off.png</iconset>
-         </property>
-        </widget>
-       </item>
-       <item row="9" column="3">
-        <widget class="QLabel" name="labelSeptemberEquinoxJD">
-         <property name="textInteractionFlags">
-          <set>Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="15">
-        <widget class="QLabel" name="labelNauticalTwilightDuration">
+       <item row="8" column="8" colspan="2">
+        <widget class="QLabel" name="labelSunrise">
          <property name="text">
           <string/>
          </property>
@@ -191,477 +61,6 @@
          </property>
          <property name="textInteractionFlags">
           <set>Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item row="7" column="5">
-        <layout class="QHBoxLayout" name="DecemberSolsticeLayout">
-         <item>
-          <widget class="QLabel" name="labelDecemberSolstice">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string comment="season">Winter</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QPushButton" name="buttonDecemberSolsticePrevious">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="toolTip">
-            <string>Previous December Solstice</string>
-           </property>
-           <property name="icon">
-            <iconset resource="../../data/gui/guiRes.qrc">
-             <normaloff>:/graphicGui/btTimeRewind-off.png</normaloff>
-             <disabledoff>:/graphicGui/btTimeRewind-off.png</disabledoff>:/graphicGui/btTimeRewind-off.png</iconset>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QPushButton" name="buttonDecemberSolsticeCurrent">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="toolTip">
-            <string>Current December Solstice</string>
-           </property>
-           <property name="icon">
-            <iconset resource="../../data/gui/guiRes.qrc">
-             <normaloff>:/graphicGui/bbtTime-off.png</normaloff>
-             <disabledoff>:/graphicGui/bbtTime-off.png</disabledoff>:/graphicGui/bbtTime-off.png</iconset>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QPushButton" name="buttonDecemberSolsticeNext">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="toolTip">
-            <string>Next December Solstice</string>
-           </property>
-           <property name="icon">
-            <iconset resource="../../data/gui/guiRes.qrc">
-             <normaloff>:/graphicGui/btTimeForward-off.png</normaloff>
-             <disabledoff>:/graphicGui/btTimeForward-off.png</disabledoff>:/graphicGui/btTimeForward-off.png</iconset>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item row="8" column="7">
-        <widget class="QLabel" name="labelSun">
-         <property name="text">
-          <string>Sun</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="3">
-        <widget class="QLabel" name="labelMarchEquinoxJD">
-         <property name="textInteractionFlags">
-          <set>Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="1">
-        <widget class="QLabel" name="labelDuration1">
-         <property name="text">
-          <string>Duration</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="14">
-        <widget class="QPushButton" name="buttonCivilDusk">
-         <property name="toolTip">
-          <string>Evening civil twilight</string>
-         </property>
-         <property name="text">
-          <string/>
-         </property>
-         <property name="icon">
-          <iconset resource="../../data/gui/guiRes.qrc">
-           <normaloff>:/graphicGui/bbtTime-off.png</normaloff>
-           <disabledoff>:/graphicGui/bbtTime-off.png</disabledoff>:/graphicGui/bbtTime-off.png</iconset>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="3">
-        <widget class="QLabel" name="labelMarchEquinoxLT">
-         <property name="textInteractionFlags">
-          <set>Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="1">
-        <widget class="QLabel" name="labelJD1">
-         <property name="text">
-          <string>Julian Day</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="12" colspan="3">
-        <widget class="QLabel" name="labelDusk">
-         <property name="text">
-          <string>Dusk</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="7" column="15">
-        <widget class="QLabel" name="labelDurationColumn2">
-         <property name="text">
-          <string>Duration</string>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="5">
-        <widget class="QLabel" name="labelJuneSolsticeLT">
-         <property name="textInteractionFlags">
-          <set>Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item row="9" column="7">
-        <widget class="QLabel" name="labelMoon">
-         <property name="text">
-          <string>Moon</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="15">
-        <widget class="QLabel" name="labelDurationColumn1">
-         <property name="text">
-          <string>Duration</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="3">
-        <widget class="QLabel" name="labelMarchEquinoxDuration">
-         <property name="textInteractionFlags">
-          <set>Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item row="8" column="3">
-        <widget class="QLabel" name="labelSeptemberEquinoxLT">
-         <property name="textInteractionFlags">
-          <set>Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="11">
-        <widget class="QPushButton" name="buttonAstronomicalDawn">
-         <property name="toolTip">
-          <string>Morning astronomical twilight</string>
-         </property>
-         <property name="text">
-          <string/>
-         </property>
-         <property name="icon">
-          <iconset resource="../../data/gui/guiRes.qrc">
-           <normaloff>:/graphicGui/bbtTime-off.png</normaloff>
-           <disabledoff>:/graphicGui/bbtTime-off.png</disabledoff>:/graphicGui/bbtTime-off.png</iconset>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="6" rowspan="11">
-        <widget class="Line" name="lineDelimiterSections">
-         <property name="minimumSize">
-          <size>
-           <width>1</width>
-           <height>0</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>1</width>
-           <height>16777215</height>
-          </size>
-         </property>
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-        </widget>
-       </item>
-       <item row="6" column="7" colspan="9">
-        <widget class="Line" name="line_5">
-         <property name="minimumSize">
-          <size>
-           <width>0</width>
-           <height>1</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>16777215</width>
-           <height>1</height>
-          </size>
-         </property>
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="14">
-        <widget class="QPushButton" name="buttonNauticalDusk">
-         <property name="toolTip">
-          <string>Evening nautical twilight</string>
-         </property>
-         <property name="text">
-          <string/>
-         </property>
-         <property name="icon">
-          <iconset resource="../../data/gui/guiRes.qrc">
-           <normaloff>:/graphicGui/bbtTime-off.png</normaloff>
-           <disabledoff>:/graphicGui/bbtTime-off.png</disabledoff>:/graphicGui/bbtTime-off.png</iconset>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="1">
-        <layout class="QHBoxLayout" name="YearLayout">
-         <item>
-          <widget class="QLabel" name="labelYear">
-           <property name="text">
-            <string>Year</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLabel" name="labelCurrentYear">
-           <property name="font">
-            <font>
-             <bold>true</bold>
-            </font>
-           </property>
-           <property name="text">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLabel" name="labelYearDuration">
-           <property name="text">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item row="9" column="11">
-        <widget class="QPushButton" name="buttonMoonrise">
-         <property name="toolTip">
-          <string>Today's moonrise</string>
-         </property>
-         <property name="text">
-          <string/>
-         </property>
-         <property name="icon">
-          <iconset resource="../../data/gui/guiRes.qrc">
-           <normaloff>:/graphicGui/bbtTime-off.png</normaloff>
-           <disabledoff>:/graphicGui/bbtTime-off.png</disabledoff>:/graphicGui/bbtTime-off.png</iconset>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="7">
-        <widget class="QLabel" name="labelTwilight">
-         <property name="text">
-          <string>Twilight</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="8" column="11">
-        <widget class="QPushButton" name="buttonSunrise">
-         <property name="toolTip">
-          <string>Today's sunrise</string>
-         </property>
-         <property name="text">
-          <string/>
-         </property>
-         <property name="icon">
-          <iconset resource="../../data/gui/guiRes.qrc">
-           <normaloff>:/graphicGui/bbtTime-off.png</normaloff>
-           <disabledoff>:/graphicGui/bbtTime-off.png</disabledoff>:/graphicGui/bbtTime-off.png</iconset>
-         </property>
-        </widget>
-       </item>
-       <item row="7" column="4" rowspan="4">
-        <widget class="Line" name="line_3">
-         <property name="minimumSize">
-          <size>
-           <width>1</width>
-           <height>0</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>1</width>
-           <height>16777215</height>
-          </size>
-         </property>
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-        </widget>
-       </item>
-       <item row="8" column="5">
-        <widget class="QLabel" name="labelDecemberSolsticeLT">
-         <property name="textInteractionFlags">
-          <set>Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="14">
-        <widget class="QPushButton" name="buttonAstronomicalDusk">
-         <property name="toolTip">
-          <string>Evening astronomical twilight</string>
-         </property>
-         <property name="text">
-          <string/>
-         </property>
-         <property name="icon">
-          <iconset resource="../../data/gui/guiRes.qrc">
-           <normaloff>:/graphicGui/bbtTime-off.png</normaloff>
-           <disabledoff>:/graphicGui/bbtTime-off.png</disabledoff>:/graphicGui/bbtTime-off.png</iconset>
-         </property>
-        </widget>
-       </item>
-       <item row="10" column="5">
-        <widget class="QLabel" name="labelDecemberSolsticeDuration">
-         <property name="textInteractionFlags">
-          <set>Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item row="10" column="7" colspan="8">
-        <widget class="QLabel" name="labelNight">
-         <property name="font">
-          <font>
-           <italic>true</italic>
-          </font>
-         </property>
-         <property name="text">
-          <string>Astronomical Night</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="8" column="15">
-        <widget class="QLabel" name="labelDayDuration">
-         <property name="text">
-          <string/>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="11">
-        <widget class="QPushButton" name="buttonCivilDawn">
-         <property name="toolTip">
-          <string>Morning civil twilight</string>
-         </property>
-         <property name="text">
-          <string/>
-         </property>
-         <property name="icon">
-          <iconset resource="../../data/gui/guiRes.qrc">
-           <normaloff>:/graphicGui/bbtTime-off.png</normaloff>
-           <disabledoff>:/graphicGui/bbtTime-off.png</disabledoff>:/graphicGui/bbtTime-off.png</iconset>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="7" colspan="9">
-        <widget class="QLabel" name="labelToday">
-         <property name="font">
-          <font>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>Today</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="10" column="1">
-        <widget class="QLabel" name="labelDuration2">
-         <property name="text">
-          <string>Duration</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="9" column="1">
-        <widget class="QLabel" name="labelJD2">
-         <property name="text">
-          <string>Julian Day</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="7" column="12" colspan="3">
-        <widget class="QLabel" name="labelSet">
-         <property name="text">
-          <string>Set</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
          </property>
         </widget>
        </item>
@@ -675,66 +74,22 @@
          </property>
         </widget>
        </item>
-       <item row="3" column="7">
-        <widget class="QLabel" name="labelAstronomicalTwilight">
+       <item row="4" column="1">
+        <widget class="QLabel" name="labelJD1">
          <property name="text">
-          <string comment="twilight">Astronomical</string>
+          <string>Julian Day</string>
          </property>
          <property name="alignment">
           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
          </property>
         </widget>
        </item>
-       <item row="1" column="2" rowspan="10">
-        <widget class="Line" name="line_4">
-         <property name="minimumSize">
-          <size>
-           <width>1</width>
-           <height>0</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>1</width>
-           <height>16777215</height>
-          </size>
-         </property>
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
+       <item row="8" column="3">
+        <widget class="QLabel" name="labelSeptemberEquinoxLT">
+         <property name="textInteractionFlags">
+          <set>Qt::TextSelectableByMouse</set>
          </property>
         </widget>
-       </item>
-       <item row="6" column="3" colspan="3">
-        <widget class="Line" name="line">
-         <property name="minimumSize">
-          <size>
-           <width>0</width>
-           <height>1</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>16777215</width>
-           <height>1</height>
-          </size>
-         </property>
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-        </widget>
-       </item>
-       <item row="11" column="1">
-        <spacer name="verticalSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
        </item>
        <item row="1" column="3">
         <layout class="QHBoxLayout" name="MarchEquinoxLayout">
@@ -807,48 +162,158 @@
          </item>
         </layout>
        </item>
-       <item row="4" column="7">
-        <widget class="QLabel" name="labelNauticalTwilight">
+       <item row="9" column="13">
+        <widget class="QPushButton" name="buttonMoonset">
+         <property name="toolTip">
+          <string>Today's moonset</string>
+         </property>
          <property name="text">
-          <string comment="twilight">Nautical</string>
+          <string/>
+         </property>
+         <property name="icon">
+          <iconset resource="../../data/gui/guiRes.qrc">
+           <normaloff>:/graphicGui/bbtTime-off.png</normaloff>
+           <disabledoff>:/graphicGui/bbtTime-off.png</disabledoff>:/graphicGui/bbtTime-off.png</iconset>
+         </property>
+        </widget>
+       </item>
+       <item row="9" column="3">
+        <widget class="QLabel" name="labelSeptemberEquinoxJD">
+         <property name="textInteractionFlags">
+          <set>Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="9" column="5">
+        <widget class="QLabel" name="labelDecemberSolsticeJD">
+         <property name="textInteractionFlags">
+          <set>Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="8" colspan="3">
+        <widget class="QLabel" name="labelDawn">
+         <property name="text">
+          <string>Dawn</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="5">
+        <widget class="QLabel" name="labelDecemberSolsticeLT">
+         <property name="textInteractionFlags">
+          <set>Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="11" colspan="3">
+        <widget class="QLabel" name="labelSet">
+         <property name="text">
+          <string>Set</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="4" rowspan="4">
+        <widget class="Line" name="line_3">
+         <property name="minimumSize">
+          <size>
+           <width>1</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>1</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="11" colspan="2">
+        <widget class="QLabel" name="labelCivilTwilightEnd">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="7" colspan="8">
+        <widget class="Line" name="line_5">
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>1</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>16777215</width>
+           <height>1</height>
+          </size>
+         </property>
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="3">
+        <widget class="QLabel" name="labelMarchEquinoxJD">
+         <property name="textInteractionFlags">
+          <set>Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="11" column="1">
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="5" column="8" colspan="2">
+        <widget class="QLabel" name="labelCivilTwilightBegin">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="10" column="1">
+        <widget class="QLabel" name="labelDuration2">
+         <property name="text">
+          <string>Duration</string>
          </property>
          <property name="alignment">
           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
          </property>
         </widget>
        </item>
-       <item row="0" column="1" colspan="5">
-        <widget class="QLabel" name="labelSeasons">
-         <property name="font">
-          <font>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>Seasons</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="5">
-        <widget class="QLabel" name="labelJuneSolsticeDuration">
-         <property name="textInteractionFlags">
-          <set>Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item row="10" column="15">
-        <widget class="QLabel" name="labelNightDuration">
-         <property name="font">
-          <font>
-           <italic>true</italic>
-          </font>
-         </property>
-         <property name="toolTip">
-          <string/>
-         </property>
+       <item row="5" column="14">
+        <widget class="QLabel" name="labelCivilTwilightDuration">
          <property name="text">
           <string/>
          </property>
@@ -859,6 +324,81 @@
           <set>Qt::TextSelectableByMouse</set>
          </property>
         </widget>
+       </item>
+       <item row="6" column="3" colspan="3">
+        <widget class="Line" name="line">
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>1</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>16777215</width>
+           <height>1</height>
+          </size>
+         </property>
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="7">
+        <widget class="QLabel" name="labelTwilight">
+         <property name="text">
+          <string>Twilight</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="10" column="3">
+        <widget class="QLabel" name="labelSeptemberEquinoxDuration">
+         <property name="textInteractionFlags">
+          <set>Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <layout class="QHBoxLayout" name="YearLayout">
+         <item>
+          <widget class="QLabel" name="labelYear">
+           <property name="text">
+            <string>Year</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="labelCurrentYear">
+           <property name="font">
+            <font>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="labelYearDuration">
+           <property name="text">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </item>
        <item row="3" column="1">
         <widget class="QLabel" name="labelLT1">
@@ -876,27 +416,10 @@
          </property>
         </widget>
        </item>
-       <item row="9" column="5">
-        <widget class="QLabel" name="labelDecemberSolsticeJD">
-         <property name="textInteractionFlags">
-          <set>Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item row="7" column="8" colspan="4">
-        <widget class="QLabel" name="labelRise">
-         <property name="text">
-          <string>Rise</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="9" column="14">
-        <widget class="QPushButton" name="buttonMoonset">
+       <item row="8" column="13">
+        <widget class="QPushButton" name="buttonSunset">
          <property name="toolTip">
-          <string>Today's moonset</string>
+          <string>Today's sunset</string>
          </property>
          <property name="text">
           <string/>
@@ -905,6 +428,45 @@
           <iconset resource="../../data/gui/guiRes.qrc">
            <normaloff>:/graphicGui/bbtTime-off.png</normaloff>
            <disabledoff>:/graphicGui/bbtTime-off.png</disabledoff>:/graphicGui/bbtTime-off.png</iconset>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="14">
+        <widget class="QLabel" name="labelDurationColumn2">
+         <property name="text">
+          <string>Duration</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="14">
+        <widget class="QLabel" name="labelAstronomicalTwilightDuration">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="6" rowspan="11">
+        <widget class="Line" name="lineDelimiterSections">
+         <property name="minimumSize">
+          <size>
+           <width>1</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>1</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
          </property>
         </widget>
        </item>
@@ -979,17 +541,88 @@
          </item>
         </layout>
        </item>
-       <item row="1" column="8" colspan="4">
-        <widget class="QLabel" name="labelDawn">
+       <item row="10" column="5">
+        <widget class="QLabel" name="labelDecemberSolsticeDuration">
+         <property name="textInteractionFlags">
+          <set>Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="1">
+        <widget class="QLabel" name="labelLT2">
          <property name="text">
-          <string>Dawn</string>
+          <string>Local Time</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="13">
+        <widget class="QPushButton" name="buttonNauticalDusk">
+         <property name="toolTip">
+          <string>Evening nautical twilight</string>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="icon">
+          <iconset resource="../../data/gui/guiRes.qrc">
+           <normaloff>:/graphicGui/bbtTime-off.png</normaloff>
+           <disabledoff>:/graphicGui/bbtTime-off.png</disabledoff>:/graphicGui/bbtTime-off.png</iconset>
+         </property>
+        </widget>
+       </item>
+       <item row="10" column="7" colspan="7">
+        <widget class="QLabel" name="labelNight">
+         <property name="font">
+          <font>
+           <italic>true</italic>
+          </font>
+         </property>
+         <property name="text">
+          <string>Astronomical Night</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="10" column="14">
+        <widget class="QLabel" name="labelNightDuration">
+         <property name="font">
+          <font>
+           <italic>true</italic>
+          </font>
+         </property>
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="text">
+          <string/>
          </property>
          <property name="alignment">
           <set>Qt::AlignCenter</set>
          </property>
+         <property name="textInteractionFlags">
+          <set>Qt::TextSelectableByMouse</set>
+         </property>
         </widget>
        </item>
-       <item row="4" column="11">
+       <item row="8" column="14">
+        <widget class="QLabel" name="labelDayDuration">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="10">
         <widget class="QPushButton" name="buttonNauticalDawn">
          <property name="toolTip">
           <string>Morning nautical twilight</string>
@@ -1004,8 +637,62 @@
          </property>
         </widget>
        </item>
-       <item row="5" column="15">
-        <widget class="QLabel" name="labelCivilTwilightDuration">
+       <item row="5" column="10">
+        <widget class="QPushButton" name="buttonCivilDawn">
+         <property name="toolTip">
+          <string>Morning civil twilight</string>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="icon">
+          <iconset resource="../../data/gui/guiRes.qrc">
+           <normaloff>:/graphicGui/bbtTime-off.png</normaloff>
+           <disabledoff>:/graphicGui/bbtTime-off.png</disabledoff>:/graphicGui/bbtTime-off.png</iconset>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="3">
+        <widget class="QLabel" name="labelMarchEquinoxLT">
+         <property name="textInteractionFlags">
+          <set>Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="8" colspan="3">
+        <widget class="QLabel" name="labelRise">
+         <property name="text">
+          <string>Rise</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="3">
+        <widget class="QLabel" name="labelMarchEquinoxDuration">
+         <property name="textInteractionFlags">
+          <set>Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="13">
+        <widget class="QPushButton" name="buttonAstronomicalDusk">
+         <property name="toolTip">
+          <string>Evening astronomical twilight</string>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="icon">
+          <iconset resource="../../data/gui/guiRes.qrc">
+           <normaloff>:/graphicGui/bbtTime-off.png</normaloff>
+           <disabledoff>:/graphicGui/bbtTime-off.png</disabledoff>:/graphicGui/bbtTime-off.png</iconset>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="14">
+        <widget class="QLabel" name="labelNauticalTwilightDuration">
          <property name="text">
           <string/>
          </property>
@@ -1017,124 +704,133 @@
          </property>
         </widget>
        </item>
-       <item row="3" column="15">
-        <widget class="QLabel" name="labelAstronomicalTwilightDuration">
+       <item row="1" column="11" colspan="3">
+        <widget class="QLabel" name="labelDusk">
          <property name="text">
-          <string/>
+          <string>Dusk</string>
          </property>
          <property name="alignment">
           <set>Qt::AlignCenter</set>
          </property>
+        </widget>
+       </item>
+       <item row="5" column="13">
+        <widget class="QPushButton" name="buttonCivilDusk">
+         <property name="toolTip">
+          <string>Evening civil twilight</string>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="icon">
+          <iconset resource="../../data/gui/guiRes.qrc">
+           <normaloff>:/graphicGui/bbtTime-off.png</normaloff>
+           <disabledoff>:/graphicGui/bbtTime-off.png</disabledoff>:/graphicGui/bbtTime-off.png</iconset>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="3">
+        <layout class="QHBoxLayout" name="SeptemberEquinoxLayout">
+         <item>
+          <widget class="QLabel" name="labelSeptemberEquinox">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string comment="season">Fall</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="buttonSeptemberEquinoxPrevious">
+           <property name="toolTip">
+            <string>Previous September Equinox</string>
+           </property>
+           <property name="icon">
+            <iconset resource="../../data/gui/guiRes.qrc">
+             <normaloff>:/graphicGui/btTimeRewind-off.png</normaloff>
+             <disabledoff>:/graphicGui/btTimeRewind-off.png</disabledoff>:/graphicGui/btTimeRewind-off.png</iconset>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="buttonSeptemberEquinoxCurrent">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>Current September Equinox</string>
+           </property>
+           <property name="icon">
+            <iconset resource="../../data/gui/guiRes.qrc">
+             <normaloff>:/graphicGui/bbtTime-off.png</normaloff>
+             <disabledoff>:/graphicGui/bbtTime-off.png</disabledoff>:/graphicGui/bbtTime-off.png</iconset>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="buttonSeptemberEquinoxNext">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>Next September Equinox</string>
+           </property>
+           <property name="icon">
+            <iconset resource="../../data/gui/guiRes.qrc">
+             <normaloff>:/graphicGui/btTimeForward-off.png</normaloff>
+             <disabledoff>:/graphicGui/btTimeForward-off.png</disabledoff>:/graphicGui/btTimeForward-off.png</iconset>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item row="3" column="5">
+        <widget class="QLabel" name="labelJuneSolsticeLT">
          <property name="textInteractionFlags">
           <set>Qt::TextSelectableByMouse</set>
          </property>
         </widget>
        </item>
-       <item row="3" column="12" colspan="2">
-        <widget class="QLabel" name="labelAstronomicalTwilightEnd">
+       <item row="3" column="7">
+        <widget class="QLabel" name="labelAstronomicalTwilight">
          <property name="text">
-          <string/>
+          <string comment="twilight">Astronomical</string>
          </property>
          <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::TextSelectableByMouse</set>
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
          </property>
         </widget>
        </item>
-       <item row="4" column="12" colspan="2">
-        <widget class="QLabel" name="labelNauticalTwilightEnd">
-         <property name="text">
-          <string/>
+       <item row="1" column="4" rowspan="5">
+        <widget class="Line" name="line_2">
+         <property name="minimumSize">
+          <size>
+           <width>1</width>
+           <height>0</height>
+          </size>
          </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
+         <property name="maximumSize">
+          <size>
+           <width>1</width>
+           <height>16777215</height>
+          </size>
          </property>
-         <property name="textInteractionFlags">
-          <set>Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="12" colspan="2">
-        <widget class="QLabel" name="labelCivilTwilightEnd">
-         <property name="text">
-          <string/>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::TextSelectableByMouse</set>
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
          </property>
         </widget>
        </item>
-       <item row="3" column="8" colspan="3">
-        <widget class="QLabel" name="labelAstronomicalTwilightBegin">
-         <property name="text">
-          <string/>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="8" colspan="3">
-        <widget class="QLabel" name="labelNauticalTwilightBegin">
-         <property name="text">
-          <string/>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="8" colspan="3">
-        <widget class="QLabel" name="labelCivilTwilightBegin">
-         <property name="text">
-          <string/>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item row="8" column="8" colspan="3">
-        <widget class="QLabel" name="labelSunrise">
-         <property name="text">
-          <string/>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item row="9" column="8" colspan="3">
-        <widget class="QLabel" name="labelMoonRise">
-         <property name="text">
-          <string/>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item row="8" column="12" colspan="2">
+       <item row="8" column="11" colspan="2">
         <widget class="QLabel" name="labelSunset">
          <property name="text">
           <string/>
@@ -1147,7 +843,233 @@
          </property>
         </widget>
        </item>
-       <item row="9" column="12" colspan="2">
+       <item row="9" column="7">
+        <widget class="QLabel" name="labelMoon">
+         <property name="text">
+          <string>Moon</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="10">
+        <widget class="QPushButton" name="buttonSunrise">
+         <property name="toolTip">
+          <string>Today's sunrise</string>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="icon">
+          <iconset resource="../../data/gui/guiRes.qrc">
+           <normaloff>:/graphicGui/bbtTime-off.png</normaloff>
+           <disabledoff>:/graphicGui/bbtTime-off.png</disabledoff>:/graphicGui/bbtTime-off.png</iconset>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="8" colspan="2">
+        <widget class="QLabel" name="labelNauticalTwilightBegin">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1" colspan="5">
+        <widget class="QLabel" name="labelSeasons">
+         <property name="font">
+          <font>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Seasons</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="11" colspan="2">
+        <widget class="QLabel" name="labelAstronomicalTwilightEnd">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="8" colspan="2">
+        <widget class="QLabel" name="labelAstronomicalTwilightBegin">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="9" column="8" colspan="2">
+        <widget class="QLabel" name="labelMoonRise">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="9" column="10">
+        <widget class="QPushButton" name="buttonMoonrise">
+         <property name="toolTip">
+          <string>Today's moonrise</string>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="icon">
+          <iconset resource="../../data/gui/guiRes.qrc">
+           <normaloff>:/graphicGui/bbtTime-off.png</normaloff>
+           <disabledoff>:/graphicGui/bbtTime-off.png</disabledoff>:/graphicGui/bbtTime-off.png</iconset>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="5">
+        <layout class="QHBoxLayout" name="DecemberSolsticeLayout">
+         <item>
+          <widget class="QLabel" name="labelDecemberSolstice">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string comment="season">Winter</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="buttonDecemberSolsticePrevious">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>Previous December Solstice</string>
+           </property>
+           <property name="icon">
+            <iconset resource="../../data/gui/guiRes.qrc">
+             <normaloff>:/graphicGui/btTimeRewind-off.png</normaloff>
+             <disabledoff>:/graphicGui/btTimeRewind-off.png</disabledoff>:/graphicGui/btTimeRewind-off.png</iconset>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="buttonDecemberSolsticeCurrent">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>Current December Solstice</string>
+           </property>
+           <property name="icon">
+            <iconset resource="../../data/gui/guiRes.qrc">
+             <normaloff>:/graphicGui/bbtTime-off.png</normaloff>
+             <disabledoff>:/graphicGui/bbtTime-off.png</disabledoff>:/graphicGui/bbtTime-off.png</iconset>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="buttonDecemberSolsticeNext">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>Next December Solstice</string>
+           </property>
+           <property name="icon">
+            <iconset resource="../../data/gui/guiRes.qrc">
+             <normaloff>:/graphicGui/btTimeForward-off.png</normaloff>
+             <disabledoff>:/graphicGui/btTimeForward-off.png</disabledoff>:/graphicGui/btTimeForward-off.png</iconset>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item row="3" column="10">
+        <widget class="QPushButton" name="buttonAstronomicalDawn">
+         <property name="toolTip">
+          <string>Morning astronomical twilight</string>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="icon">
+          <iconset resource="../../data/gui/guiRes.qrc">
+           <normaloff>:/graphicGui/bbtTime-off.png</normaloff>
+           <disabledoff>:/graphicGui/bbtTime-off.png</disabledoff>:/graphicGui/bbtTime-off.png</iconset>
+         </property>
+        </widget>
+       </item>
+       <item row="9" column="1">
+        <widget class="QLabel" name="labelJD2">
+         <property name="text">
+          <string>Julian Day</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="1">
+        <widget class="QLabel" name="labelDuration1">
+         <property name="text">
+          <string>Duration</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="11" colspan="2">
+        <widget class="QLabel" name="labelNauticalTwilightEnd">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="9" column="11" colspan="2">
         <widget class="QLabel" name="labelMoonSet">
          <property name="text">
           <string/>
@@ -1159,6 +1081,130 @@
           <set>Qt::TextSelectableByMouse</set>
          </property>
         </widget>
+       </item>
+       <item row="1" column="14">
+        <widget class="QLabel" name="labelDurationColumn1">
+         <property name="text">
+          <string>Duration</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="7">
+        <widget class="QLabel" name="labelSun">
+         <property name="text">
+          <string>Sun</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="5">
+        <widget class="QLabel" name="labelJuneSolsticeJD">
+         <property name="textInteractionFlags">
+          <set>Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="5">
+        <widget class="QLabel" name="labelJuneSolsticeDuration">
+         <property name="textInteractionFlags">
+          <set>Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="2" rowspan="10">
+        <widget class="Line" name="line_4">
+         <property name="minimumSize">
+          <size>
+           <width>1</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>1</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="7">
+        <widget class="QLabel" name="labelNauticalTwilight">
+         <property name="text">
+          <string comment="twilight">Nautical</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="7" colspan="8">
+        <layout class="QHBoxLayout" name="horizontalLayout">
+         <item>
+          <widget class="QPushButton" name="buttonYesterday">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>Yesterday</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+           <property name="icon">
+            <iconset resource="../../data/gui/guiRes.qrc">
+             <normaloff>:/graphicGui/btTimeRewind-off.png</normaloff>
+             <disabledoff>:/graphicGui/btTimeRewind-off.png</disabledoff>:/graphicGui/btTimeRewind-off.png</iconset>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="labelToday">
+           <property name="font">
+            <font>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>Today</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="buttonTomorrow">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>Tomorrow</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+           <property name="icon">
+            <iconset resource="../../data/gui/guiRes.qrc">
+             <normaloff>:/graphicGui/btTimeForward-off.png</normaloff>
+             <disabledon>:/graphicGui/btTimeForward-off.png</disabledon>:/graphicGui/btTimeForward-off.png</iconset>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </item>
       </layout>
      </widget>

--- a/src/gui/astroCalcAlmanacWidget.ui
+++ b/src/gui/astroCalcAlmanacWidget.ui
@@ -61,6 +61,16 @@
          </property>
         </widget>
        </item>
+       <item row="14" column="8" colspan="2">
+        <widget class="QLabel" name="labelCustomMoonrise">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
        <item row="3" column="11" colspan="2">
         <widget class="QLabel" name="labelAstronomicalTwilightEnd">
          <property name="text">
@@ -167,6 +177,58 @@
          </property>
         </widget>
        </item>
+       <item row="13" column="13">
+        <widget class="QPushButton" name="buttonCustomSunset">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Today's Sun at custom altitude (set)</string>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="icon">
+          <iconset resource="../../data/gui/guiRes.qrc">
+           <normaloff>:/graphicGui/bbtTime-off.png</normaloff>
+           <disabledoff>:/graphicGui/bbtTime-off.png</disabledoff>:/graphicGui/bbtTime-off.png</iconset>
+         </property>
+        </widget>
+       </item>
+       <item row="14" column="10">
+        <widget class="QPushButton" name="buttonCustomMoonrise">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Today's Moon at custom altitude (rise)</string>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="icon">
+          <iconset resource="../../data/gui/guiRes.qrc">
+           <normaloff>:/graphicGui/bbtTime-off.png</normaloff>
+           <disabledoff>:/graphicGui/bbtTime-off.png</disabledoff>:/graphicGui/bbtTime-off.png</iconset>
+         </property>
+        </widget>
+       </item>
+       <item row="14" column="11" colspan="2">
+        <widget class="QLabel" name="labelCustomMoonset">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
        <item row="3" column="14">
         <widget class="QLabel" name="labelAstronomicalTwilightDuration">
          <property name="text">
@@ -181,7 +243,7 @@
         </widget>
        </item>
        <item row="1" column="2" rowspan="10">
-        <widget class="Line" name="line_4">
+        <widget class="Line" name="lineDelimiterLeftBlock">
          <property name="minimumSize">
           <size>
            <width>1</width>
@@ -287,6 +349,25 @@
          </property>
         </widget>
        </item>
+       <item row="11" column="7" colspan="8">
+        <widget class="Line" name="lineDelimiterCustomData">
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>1</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>16777215</width>
+           <height>1</height>
+          </size>
+         </property>
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
        <item row="9" column="13">
         <widget class="QPushButton" name="buttonMoonset">
          <property name="toolTip">
@@ -339,6 +420,27 @@
          </property>
          <property name="alignment">
           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="13" column="10">
+        <widget class="QPushButton" name="buttonCustomSunrise">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Today's Sun at custom altitude (rise)</string>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="icon">
+          <iconset resource="../../data/gui/guiRes.qrc">
+           <normaloff>:/graphicGui/bbtTime-off.png</normaloff>
+           <disabledoff>:/graphicGui/bbtTime-off.png</disabledoff>:/graphicGui/bbtTime-off.png</iconset>
          </property>
         </widget>
        </item>
@@ -423,6 +525,32 @@
          </property>
         </widget>
        </item>
+       <item row="12" column="11" colspan="2">
+        <widget class="QLabel" name="labelAfterSunset">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="13" column="12">
+        <widget class="QLabel" name="labelCustomSunset">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
        <item row="1" column="8" colspan="3">
         <widget class="QLabel" name="labelDawn">
          <property name="text">
@@ -442,19 +570,6 @@
           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
          </property>
         </widget>
-       </item>
-       <item row="11" column="1">
-        <spacer name="verticalSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
        </item>
        <item row="10" column="14">
         <widget class="QLabel" name="labelNightDuration">
@@ -517,7 +632,7 @@
         </layout>
        </item>
        <item row="1" column="4" rowspan="5">
-        <widget class="Line" name="line_2">
+        <widget class="Line" name="lineDelimiterSeasonsTop">
          <property name="minimumSize">
           <size>
            <width>1</width>
@@ -550,6 +665,56 @@
          </property>
         </widget>
        </item>
+       <item row="13" column="7">
+        <widget class="QLabel" name="labelCustomSun">
+         <property name="text">
+          <string>Sun</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="13" column="14">
+        <widget class="QDoubleSpinBox" name="spinBoxCustomSunAltitude">
+         <property name="toolTip">
+          <string>Custom altitude of the Sun</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+         <property name="minimum">
+          <double>-90.000000000000000</double>
+         </property>
+         <property name="maximum">
+          <double>90.000000000000000</double>
+         </property>
+         <property name="value">
+          <double>-7.000000000000000</double>
+         </property>
+        </widget>
+       </item>
+       <item row="14" column="13">
+        <widget class="QPushButton" name="buttonCustomMoonset">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Today's Moon at custom altitude (set)</string>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="icon">
+          <iconset resource="../../data/gui/guiRes.qrc">
+           <normaloff>:/graphicGui/bbtTime-off.png</normaloff>
+           <disabledoff>:/graphicGui/bbtTime-off.png</disabledoff>:/graphicGui/bbtTime-off.png</iconset>
+         </property>
+        </widget>
+       </item>
        <item row="10" column="3">
         <widget class="QLabel" name="labelSeptemberEquinoxDuration">
          <property name="textInteractionFlags">
@@ -557,7 +722,7 @@
          </property>
         </widget>
        </item>
-       <item row="0" column="6" rowspan="11">
+       <item row="0" column="6" rowspan="15">
         <widget class="Line" name="lineDelimiterSections">
          <property name="minimumSize">
           <size>
@@ -586,6 +751,44 @@
          </property>
          <property name="textInteractionFlags">
           <set>Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="12" column="14">
+        <widget class="QSpinBox" name="spinBoxMinutes">
+         <property name="toolTip">
+          <string>Minutes before sunrise/after sunset</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+         <property name="minimum">
+          <number>1</number>
+         </property>
+         <property name="maximum">
+          <number>120</number>
+         </property>
+         <property name="value">
+          <number>60</number>
+         </property>
+        </widget>
+       </item>
+       <item row="14" column="14">
+        <widget class="QDoubleSpinBox" name="spinBoxCustomMoonAltitude">
+         <property name="toolTip">
+          <string>Custom altitude of the Moon</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+         <property name="minimum">
+          <double>-90.000000000000000</double>
+         </property>
+         <property name="maximum">
+          <double>90.000000000000000</double>
+         </property>
+         <property name="value">
+          <double>18.000000000000000</double>
          </property>
         </widget>
        </item>
@@ -757,7 +960,7 @@
         </widget>
        </item>
        <item row="6" column="7" colspan="8">
-        <widget class="Line" name="line_5">
+        <widget class="Line" name="lineDelimiterToday">
          <property name="minimumSize">
           <size>
            <width>0</width>
@@ -881,6 +1084,27 @@
          </property>
         </widget>
        </item>
+       <item row="12" column="13">
+        <widget class="QPushButton" name="buttonAfterSunset">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Defined minutes after today's sunset</string>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="icon">
+          <iconset resource="../../data/gui/guiRes.qrc">
+           <normaloff>:/graphicGui/bbtTime-off.png</normaloff>
+           <disabledoff>:/graphicGui/bbtTime-off.png</disabledoff>:/graphicGui/bbtTime-off.png</iconset>
+         </property>
+        </widget>
+       </item>
        <item row="8" column="3">
         <widget class="QLabel" name="labelSeptemberEquinoxLT">
          <property name="textInteractionFlags">
@@ -959,8 +1183,28 @@
          </item>
         </layout>
        </item>
+       <item row="13" column="8" colspan="2">
+        <widget class="QLabel" name="labelCustomSunrise">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="14" column="7">
+        <widget class="QLabel" name="labelCustomMoon">
+         <property name="text">
+          <string>Moon</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
        <item row="7" column="4" rowspan="4">
-        <widget class="Line" name="line_3">
+        <widget class="Line" name="lineDelimiterSeasonsBottom">
          <property name="minimumSize">
           <size>
            <width>1</width>
@@ -1024,7 +1268,7 @@
         </widget>
        </item>
        <item row="6" column="3" colspan="3">
-        <widget class="Line" name="line">
+        <widget class="Line" name="lineDelimiterSeasonsMiddle">
          <property name="minimumSize">
           <size>
            <width>0</width>
@@ -1054,6 +1298,37 @@
           <iconset resource="../../data/gui/guiRes.qrc">
            <normaloff>:/graphicGui/bbtTime-off.png</normaloff>
            <disabledoff>:/graphicGui/bbtTime-off.png</disabledoff>:/graphicGui/bbtTime-off.png</iconset>
+         </property>
+        </widget>
+       </item>
+       <item row="12" column="10">
+        <widget class="QPushButton" name="buttonBeforeSunrise">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Defined minutes before today's sunrise</string>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="icon">
+          <iconset resource="../../data/gui/guiRes.qrc">
+           <normaloff>:/graphicGui/bbtTime-off.png</normaloff>
+           <disabledoff>:/graphicGui/bbtTime-off.png</disabledoff>:/graphicGui/bbtTime-off.png</iconset>
+         </property>
+        </widget>
+       </item>
+       <item row="12" column="8" colspan="2">
+        <widget class="QLabel" name="labelBeforeSunrise">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
          </property>
         </widget>
        </item>
@@ -1206,102 +1481,31 @@
          </property>
         </widget>
        </item>
-       <item row="11" column="7">
-        <widget class="QLabel" name="labelSun2">
-         <property name="text">
-          <string>Sun</string>
+       <item row="15" column="7">
+        <spacer name="verticalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
          </property>
-         <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
          </property>
-        </widget>
+        </spacer>
        </item>
-       <item row="11" column="8">
-        <widget class="QLabel" name="labelBeforeSunrise">
-         <property name="text">
-          <string/>
+       <item row="11" column="1" rowspan="4">
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
          </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
          </property>
-         <property name="textInteractionFlags">
-          <set>Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item row="11" column="10">
-        <widget class="QPushButton" name="buttonBeforeSunrise">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string>Defined minutes before today's sunrise</string>
-         </property>
-         <property name="text">
-          <string/>
-         </property>
-         <property name="icon">
-          <iconset resource="../../data/gui/guiRes.qrc">
-           <normaloff>:/graphicGui/bbtTime-off.png</normaloff>
-           <disabledoff>:/graphicGui/bbtTime-off.png</disabledoff>:/graphicGui/bbtTime-off.png</iconset>
-         </property>
-        </widget>
-       </item>
-       <item row="11" column="11">
-        <widget class="QLabel" name="labelAfterSunset">
-         <property name="text">
-          <string/>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item row="11" column="13">
-        <widget class="QPushButton" name="buttonAfterSunset">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string>Defined minutes after today's sunset</string>
-         </property>
-         <property name="text">
-          <string/>
-         </property>
-         <property name="icon">
-          <iconset resource="../../data/gui/guiRes.qrc">
-           <normaloff>:/graphicGui/bbtTime-off.png</normaloff>
-           <disabledoff>:/graphicGui/bbtTime-off.png</disabledoff>:/graphicGui/bbtTime-off.png</iconset>
-         </property>
-        </widget>
-       </item>
-       <item row="11" column="14">
-        <widget class="QSpinBox" name="spinBoxMinutes">
-         <property name="toolTip">
-          <string>Minutes before sunrise/after sunset</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-         </property>
-         <property name="minimum">
-          <number>1</number>
-         </property>
-         <property name="maximum">
-          <number>120</number>
-         </property>
-         <property name="value">
-          <number>60</number>
-         </property>
-        </widget>
+        </spacer>
        </item>
       </layout>
      </widget>


### PR DESCRIPTION
### Description
The section "Today" in AstroCalc/Almanac tool has been expanded:
- Added buttons to quick jump to yesterday/tomorrow
- Added ability to set minutes before sunrise/after sunset and jump to these times (Fixes #4513)
- Added ability to compute time when Sun and Moon at custom altitude and jump to these times (Fixes #4467)

Note: twilight finder use for computation sunrise/sunset time in InfoBox and for actions to jump to these times via shortcuts 

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
