### PR TITLE
Fix GravityLabels with mixed-directional labels (and higher-level Unicode)

### DIFF
--- a/src/core/StelPainter.cpp
+++ b/src/core/StelPainter.cpp
@@ -574,18 +574,24 @@ void StelPainter::sSphereMap(double radius, unsigned int slices, unsigned int st
 	}
 }
 
-void StelPainter::drawTextGravity180(const float x, const float y, const QString& ws, const float xshift, const float yshift)
+// Draw the string starting at the given position x/y with the current font.
+// The string is split into single characters and rotated against the view center for planetarium dome use.
+// @param x horizontal position of the lower left corner of the first character of the text in pixel.
+// @param y vertical position of the lower left corner of the first character of the text in pixel.
+// @param str the text to print.
+// @param xshift shift in pixel in the rotated x direction.
+// @param yshift shift in pixel in the rotated y direction.
+void StelPainter::drawTextGravity180(const float x, const float y, const QString& str, const float xshift, const float yshift)
 {
 	const float dx = x - static_cast<float>(prj->viewportCenter[0]);
 	const float dy = y - static_cast<float>(prj->viewportCenter[1]);
 	float d = std::sqrt(dx*dx + dy*dy);
 
 	// If the text is too far away to be visible in the screen return
-	if (d>qMax(prj->viewportXywh[3], prj->viewportXywh[2])*2 || ws.isEmpty())
+	if (d>qMax(prj->viewportXywh[3], prj->viewportXywh[2])*2 || str.isEmpty())
 		return;
 
 	const auto fm = getFontMetrics();
-	const bool rtl = StelApp::getInstance().getLocaleMgr().isSkyRTL();
 
 	const float ppx = static_cast<float>(prj->getDevicePixelsPerPixel());
 	float anglePerUnitWidth = ppx / d;
@@ -609,17 +615,87 @@ void StelPainter::drawTextGravity180(const float x, const float y, const QString
 		yVc = y0 - d * std::sin(theta);
 	}
 
-	const int slen = ws.length();
-	const int startI = rtl ? slen - 1 : 0;
-	const int endI = rtl ? -1 : slen;
-	const int inc = rtl ? -1 : 1;
-	for (int i = startI; i != endI; i += inc)
+	std::u32string label32=str.toStdU32String();
+
+	// TODO: Move these and the same from St4elSkyCultureMgr to a common place.
+	static const uint32_t FSI32=U'\U00002068'; // First strong isolate: Treat following text as isolated and in the direction of its first strong directional character.
+						   // ASSUMPTION: Can be used as autodetect feature? Mark all parts inside embeddings?
+	static const uint32_t PDI32=U'\U00002069'; // Pop directional isolate: terminate scope of last LRI/RLI/FSI
+	static const uint32_t LRM32=U'\U0000200e';
+
+	// We have two types: regular one-script strings and cultural labels with several segments enclosed in Unicode FSI/PDI isolators.
+	if (label32.find(FSI32) == std::u32string::npos)
 	{
-		const QChar c = ws[i];
-		const float x = d * std::cos(theta) + xVc;
-		const float y = d * std::sin(theta) + yVc;
-		drawText(x, y, c, 90.f + theta*M_180_PIf, 0., 0.);
-		theta += fm.horizontalAdvance(c) * anglePerUnitWidth;
+		// rtl tracks the right-to-left status of the text in the current position.
+		const bool rtl = StelApp::getInstance().getLocaleMgr().isSkyRTL();
+		const int slen = label32.length();
+		const int startI = rtl ? slen - 1 : 0;
+		const int endI = rtl ? -1 : slen;
+		const int inc = rtl ? -1 : 1;
+		for (int i = startI; i != endI; i += inc)
+		{
+			const QString c = QString::fromUcs4(&label32[i], 1);
+			const float x = d * std::cos(theta) + xVc;
+			const float y = d * std::sin(theta) + yVc;
+			drawText(x, y, c, 90.f + theta*M_180_PIf, 0., 0.);
+			theta += fm.horizontalAdvance(c) * anglePerUnitWidth;
+		}
+	}
+	else
+	{
+		// We manage our RTL by ourselves.
+		for (int i = 0; i < label32.length(); ++i)
+		{
+			uint32_t chr32=label32[i];
+			if (chr32==FSI32)
+			{
+				// cut out substring
+				const uint32_t posBegin = label32.find(FSI32, i);
+				const uint32_t posEnd   = label32.find(PDI32, i);
+				const int isolatedLength=posEnd-posBegin-1;
+				std::u32string isolatedGroup=label32.substr(posBegin+1, isolatedLength); // The string between FSI and PDI
+				// find out ltr or rtl?
+				// An Arab user's translated Arab string is bracketed in \u200e (LRM) marks. Build a cleaned string.
+				std::u32string cleanedIsolated;
+				foreach(uint32_t ch, isolatedGroup)
+				{
+					if (ch!=LRM32)
+						cleanedIsolated.append(1, ch);
+				}
+
+				// For now, we just use QString::isRightToLeft() on the back-converted inner string.
+				// TODO: If that is not enough, we will have to manually analyze the string until the first strong character tells us its direction.
+				const QString isolatedString=QString::fromUcs4(cleanedIsolated.data(), cleanedIsolated.length());
+				const bool isoRtl=isolatedString.isRightToLeft();
+				const int isoLength=cleanedIsolated.length();
+
+				//qDebug() << "From" << posBegin << "to" << posEnd << ", length" << isoLength;
+				//qDebug() << ( subrtl ?  "RTL: " : "NOT RTL: " ) << isolatedString;
+
+				const int startI = isoRtl ? isoLength - 1 : 0;
+				const int endI = isoRtl ? -1 : isoLength;
+				const int inc = isoRtl ? -1 : 1;
+				for (int i = startI; i != endI; i += inc)
+				{
+					const QString c = QString::fromUcs4(&cleanedIsolated[i], 1);
+					//qDebug() << "inner char at pos " << i << ":" << c;
+					const float x = d * std::cos(theta) + xVc;
+					const float y = d * std::sin(theta) + yVc;
+					drawText(x, y, c, 90.f + theta*M_180_PIf, 0., 0.);
+					theta += fm.horizontalAdvance(c) * anglePerUnitWidth;
+				}
+				i+=isolatedLength+1;
+			}
+			else
+			{
+				const QString c = QString::fromUcs4(&label32[i], 1);
+				//qDebug() << "continuing at pos " << i << ":" << c;
+				const float x = d * std::cos(theta) + xVc;
+				const float y = d * std::sin(theta) + yVc;
+				drawText(x, y, c, 90.f + theta*M_180_PIf, 0., 0.);
+				theta += fm.horizontalAdvance(c) * anglePerUnitWidth;
+			}
+		}
 	}
 }
 

--- a/src/core/StelPainter.hpp
+++ b/src/core/StelPainter.hpp
@@ -90,9 +90,14 @@ public:
 	//! @param xshift shift in pixel in the rotated x direction.
 	//! @param yshift shift in pixel in the rotated y direction.
 	//! @param noGravity don't take into account the fact that the text should be written with gravity.
-	//! @param v direction vector of object to draw. GZ20120826: Will draw only if this is in the visible hemisphere.
 	void drawText(float x, float y, const QString& str, float angleDeg=0.f,
               float xshift=0.f, float yshift=0.f, bool noGravity=true);
+	//! @param v direction vector of object to draw. Will draw only if this is in the visible hemisphere.
+	//! @param str the text to print.
+	//! @param angleDeg rotation angle in degree. Rotation is around x,y. Only used if noGravity=true
+	//! @param xshift shift in pixel in the rotated x direction.
+	//! @param yshift shift in pixel in the rotated y direction.
+	//! @param noGravity don't take into account the fact that the text should be written with gravity.
 	void drawText(const Vec3d& v, const QString& str, float angleDeg=0.f,
               float xshift=0.f, float yshift=0.f, bool noGravity=true);
 
@@ -396,6 +401,12 @@ private:
             double maxSqDistortion=5., int nbI=0,
             bool checkDisc1=true, bool checkDisc2=true, bool checkDisc3=true) const;
 
+	//! Draw the string starting at the given position x/y with the current font. The string is split into single characters and rotated against the view center for planetarium dome use.
+	//! @param x horizontal position of the lower left corner of the first character of the text in pixel.
+	//! @param y vertical position of the lower left corner of the first character of the text in pixel.
+	//! @param str the text to print.
+	//! @param xshift shift in pixel in the rotated x direction.
+	//! @param yshift shift in pixel in the rotated y direction.
 	void drawTextGravity180(float x, float y, const QString& str, float xshift = 0, float yshift = 0);
 
 	// Used by the method below.

--- a/src/core/StelSkyCultureMgr.cpp
+++ b/src/core/StelSkyCultureMgr.cpp
@@ -985,8 +985,8 @@ QString StelSkyCultureMgr::createCulturalLabel(const StelObject::CulturalName &c
 	//static const QString LRO{"\u202d"}; // Left-to-right override: Force following characters to be treated as strong left-to-right chars.
 	//static const QString RLO{"\u202e"}; // Right-to-left override: Force following characters to be treated as strong right-to-left chars.
 	//static const QString PDF{"\u202c"}; // Pop directional formatting: terminate scope of last LRE/RLE/LRO/RLO
-	static const QString LRI{"\u2066"}; // left-to-right isolate: Treat following text as isolated and left-to-right
-	static const QString RLI{"\u2067"}; // right-to-left isolate: Treat following text as isolated and right-to-left
+	//static const QString LRI{"\u2066"}; // left-to-right isolate: Treat following text as isolated and left-to-right
+	//static const QString RLI{"\u2067"}; // right-to-left isolate: Treat following text as isolated and right-to-left
 	static const QString FSI{"\u2068"}; // First strong isolate: Treat following text as isolated and in the direction of its first strong directional character.
 					    // ASSUMPTION: Can be used as autodetect feature? Mark all parts inside embeddings?
 	static const QString PDI{"\u2069"}; // Pop directional isolate: terminate scope of last LRI/RLI/FSI

--- a/src/core/StelSkyCultureMgr.hpp
+++ b/src/core/StelSkyCultureMgr.hpp
@@ -301,6 +301,10 @@ public slots:
 	//! Returns whether current skyculture uses (incorporates) common names.
 	bool currentSkycultureUsesCommonNames() const;
 
+#if QT_VERSION_MAJOR >= 6
+	//! Debugging/developing function. Call via scripting.
+	void analyzeScreenLabel() const;
+#endif
 signals:
 	//! Emitted whenever the default sky culture changed.
 	//! @see setDefaultSkyCultureID


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Please include a summary of the change and which issue is fixed. -->
<!--- Please also include relevant motivation and context. -->
<!--- List any dependencies that are required for this change. -->

The multipart cultural label causes problems with gravityLabels when 
- it contains characters not covered in 16-bit strings (e.g. Cuneiform): characters missing.
- it mixes Latin and right-to-left script like Arab: Arab characters are shown reversed

TODO:
- [x] split string into the isolated Unicode strings, handle each part separately. 
- [x] Convert to u32string and process from there
- [x] make sure multi-part labels are RTL-fit


Fixes # (issue)

### Screenshots (if appropriate):

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system: Windows 11
* Graphics Card: irrelevant

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
