### PR TITLE
Fixed few typos in some files in the doc directory

### DIFF
--- a/doc/fileStructure.doxygen
+++ b/doc/fileStructure.doxygen
@@ -23,7 +23,7 @@
 
 @tableofcontents
 
-@section intro_structire Introduction
+@section intro_structure Introduction
 
 This article explains the directory and file layout which Stellarium uses from a programmer's perspective, lays out the rationale behind it, and uses examples to illustrate the way things work.
 

--- a/doc/plugIns.doxygen
+++ b/doc/plugIns.doxygen
@@ -39,7 +39,7 @@ As Stellarium's plugin interface has changed over time, plugins for different ve
 
 Static plugins require changes in the core code of Stellarium (the addition of %Qt macros in several classes). This is why adding a new static plugin requires either asking the developers to add it to the main distribution, or creating and distributing a custom build.
 
-Dynamic plugin libriaries need to be installed in a proper place in Stellarium's \ref fileStructure "file tree" to function. Stellarium is looking for plugins in the <tt>/modules</tt> subdirectory of the user data directory or the installation data directory. Each plugin library must be in its own subdiretory of the <tt>/modules</tt> directory. If the plugin is called "MyPlugin", then its subdirectory should be also called <tt>/MyPlugin</tt> and the main name (without the extension) of the plugin binary file should be <tt>libMyPlugin</tt>. So, for example, the file tree should look like this on Windows XP:
+Dynamic plugin libraries need to be installed in a proper place in Stellarium's \ref fileStructure "file tree" to function. Stellarium is looking for plugins in the <tt>/modules</tt> subdirectory of the user data directory or the installation data directory. Each plugin library must be in its own subdirectory of the <tt>/modules</tt> directory. If the plugin is called "MyPlugin", then its subdirectory should be also called <tt>/MyPlugin</tt> and the main name (without the extension) of the plugin binary file should be <tt>libMyPlugin</tt>. So, for example, the file tree should look like this on Windows XP:
  - <tt>C:/Documents and Settings/User/Application Data/Stellarium/</tt> (user data directory)
   - <tt>modules/</tt>
    - <tt>MyPlugin/</tt>


### PR DESCRIPTION
While reading what is inside the `doc` directory, I found few typos that I fixed.

**Before**
```text
@section intro_structire Introduction
```
```text
Dynamic plugin `libriaries` need to be ... its own `subdiretory` of ...
```

**After**
```text
@section intro_structure Introduction
```
```text
Dynamic plugin `libraries` need to be ... its own `subdirectory` of ...
```

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] Housekeeping

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
No test is needed.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
