### PR TITLE
Simplify 'pronounce' .po entries of Chinese SCs

### DIFF
--- a/src/core/StelTranslator.cpp
+++ b/src/core/StelTranslator.cpp
@@ -110,6 +110,16 @@ QString StelTranslator::qTranslateStar(const QString& s, const QString& c) const
 	return res;
 }
 
+QString StelTranslator::qTranslateStarPronounce(const QString& s, const QString& c) const
+{
+	if (s.isEmpty())
+		return "";
+	const auto res = tryQtranslateStarPronounce(s, c);
+	if (res.isEmpty())
+		return s;
+	return res;
+}
+
 QString StelTranslator::tryTranslateChineseStar(const QString& s, const QString& c) const
 {
 	static const auto re = []{ QRegularExpression re("(.+)( [IXVLCDM]+)([*?]*)$"); re.optimize(); return re; }();
@@ -161,6 +171,20 @@ QString StelTranslator::tryTranslateChineseStar(const QString& s, const QString&
 	return translatedConstellation + translatedAdded + number + extra;
 }
 
+QString StelTranslator::tryTranslateChineseStarPronounce(const QString& s, const QString& c) const
+{
+	static const auto re = []{ QRegularExpression re("(.+)( [IXVLCDM]+)$"); re.optimize(); return re; }();
+	const auto match = re.match(s);
+	if (!match.hasMatch()) return {};
+
+	const auto constellation = match.captured(1);
+	const auto translatedConstellation = tryQtranslate(constellation, c);
+	if (translatedConstellation.isEmpty()) return {};
+
+	QString number = match.captured(2);
+	return translatedConstellation + number;
+}
+
 QString StelTranslator::tryQtranslate(const QString &s, const QString &c) const
 {
 	return translator->translate("", s.toUtf8().constData(),c.toUtf8().constData());
@@ -169,6 +193,13 @@ QString StelTranslator::tryQtranslate(const QString &s, const QString &c) const
 QString StelTranslator::tryQtranslateStar(const QString &s, const QString &c) const
 {
 	const auto translated = tryTranslateChineseStar(s, c);
+	if (!translated.isEmpty()) return translated;
+	return tryQtranslate(s, c);
+}
+
+QString StelTranslator::tryQtranslateStarPronounce(const QString &s, const QString &c) const
+{
+	const auto translated = tryTranslateChineseStarPronounce(s, c);
 	if (!translated.isEmpty()) return translated;
 	return tryQtranslate(s, c);
 }

--- a/src/core/StelTranslator.hpp
+++ b/src/core/StelTranslator.hpp
@@ -77,6 +77,9 @@ public:
 	//! Same as #qtranslate, but with additional code to handle Chinese names of stars
 	QString qTranslateStar(const QString& s, const QString& c = QString()) const;
 
+	//! Same as #qTranslateStar, but specifically for the \p pronounce entries
+	QString qTranslateStarPronounce(const QString& s, const QString& c = QString()) const;
+
 	//! Try to translate input message and return it as a QString. If no translation
 	//! exist for the current StelTranslator language, a null string is returned.
 	//! @param s input string in english.
@@ -86,7 +89,10 @@ public:
 
 	//! Same as #tryQtranslate, but with additional code to handle Chinese names of stars
 	QString tryQtranslateStar(const QString& s, const QString& c = QString()) const;
-	
+
+	//! Same as #tryQtranslateStar, but specifically for the \p pronounce entries
+	QString tryQtranslateStarPronounce(const QString& s, const QString& c = QString()) const;
+
 	//! Get true translator locale name. Actual locale, never "system".
 	//! @return Locale name e.g "fr_FR"
 	const QString& getTrueLocaleName() const
@@ -131,6 +137,7 @@ private:
 	const StelTranslator& operator=(const StelTranslator&);
 
 	QString tryTranslateChineseStar(const QString& s, const QString& c) const;
+	QString tryTranslateChineseStarPronounce(const QString& s, const QString& c) const;
 	
 	//! Initialize the languages code list from the passed file
 	//! @param fileName file containing the list of language codes

--- a/src/core/modules/StarMgr.cpp
+++ b/src/core/modules/StarMgr.cpp
@@ -800,8 +800,18 @@ void StarMgr::loadCultureSpecificNameForNamedObject(const QJsonArray& data, cons
 				continue;
 		}
 
-		StelObject::CulturalName cName{entry["native"].toString(), entry["pronounce"].toString(), trans.qTranslateStar(entry["pronounce"].toString()),
-					entry["transliteration"].toString(), entry["english"].toString(), trans.qTranslateStar(entry["english"].toString()), entry["IPA"].toString(), QString(), QString(), StelObject::CulturalNameSpecial::None};
+		const StelObject::CulturalName cName {
+			entry["native"].toString(),
+			entry["pronounce"].toString(),
+			trans.qTranslateStarPronounce(entry["pronounce"].toString()),
+			entry["transliteration"].toString(),
+			entry["english"].toString(),
+			trans.qTranslateStar(entry["english"].toString()),
+			entry["IPA"].toString(),
+			QString(),
+			QString(),
+			StelObject::CulturalNameSpecial::None
+		};
 
 		//if (culturalNamesMap.contains(HIP))
 		//	qInfo() << "Adding additional cultural name for HIP" << HIP << ":" <<  cName.native << "/" << cName.pronounceI18n << "/" << cName.translated;

--- a/util/skycultures/generate-pot.py
+++ b/util/skycultures/generate-pot.py
@@ -345,6 +345,10 @@ def update_cultures_pot(sclist, pot):
                         if entry not in pot:
                             pot.append(entry)
 
+                    # Now the pronounce entries also need a lite version of the above cleaning
+                    if pronounce:
+                        pronounce = re.sub(' [MDCLXVI]+$', '', pronounce)
+
                 comment = ''
                 if not chinese_name_cleaned or not english in cons_ast_names:
                     if native:


### PR DESCRIPTION
### Description

This PR implements the lite version of the simplification of Chinese names for use with the `pronounce` entries. (The changes to `*.po` and `*.pot` files are not included in this PR, they'll have to be done later.)

### How Has This Been Tested?

I've checked that after I run `generate-pot.py`, update `stellarium-skycultures/ru.po` using with `msgmerge`, and then add a translation of `"Guànsuǒ"` as `"Гуань суо"` indeed the screen label of `Guànsuǒ IV` is translated to `Гуань суо IV`.

I'm not completely sure this should be merged before 25.3, since this has some changes to C++ code that need to be more thoroughly tested than a few days before the release.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
