### PR TITLE
Fix InfoString with RTL components

### DIFF
--- a/src/core/StelObject.cpp
+++ b/src/core/StelObject.cpp
@@ -1009,6 +1009,16 @@ QString StelObject::getCommonInfoString(const StelCore *core, const InfoStringGr
 // Apply post processing on the info string
 void StelObject::postProcessInfoString(QString& str, const InfoStringGroup& flags) const
 {
+	static const QString FSI{"\u2068"}; // First strong isolate: Treat following text as isolated and in the direction of its first strong directional character.
+					    // ASSUMPTION: Can be used as autodetect feature? Mark all parts inside embeddings?
+	static const QString PDI{"\u2069"}; // Pop directional isolate: terminate scope of last LRI/RLI/FSI
+	static const QString LRM{"\u200e"}; // left-right-mark which may be present in Arab strings from translations.
+
+	str.replace(LRM, "");
+	str.replace(FSI, "<span dir=\"auto\">");
+	//str.replace(FSI, "<span dir=\"ltr\">");
+	str.replace(PDI, "</span>");
+
 	StelObjectMgr* omgr;
 	omgr=GETSTELMODULE(StelObjectMgr);
 	str.append(getExtraInfoStrings(Script).join(' '));

--- a/src/core/StelObject.cpp
+++ b/src/core/StelObject.cpp
@@ -1039,6 +1039,7 @@ void StelObject::postProcessInfoString(QString& str, const InfoStringGroup& flag
 
 	if (flags&PlainText)
 	{
+		static const QRegularExpression h2Re("<h2[^>]*>");
 		static const QRegularExpression brRe2("<br(\\s*/)?>\\s*");
 		static const QRegularExpression tdRe1("<td\\s*>");
 		static const QRegularExpression tdRe2("<td \\w+='[^']*'>"); // Seen: style, align, colspan, rowspan. Always only one expression.
@@ -1048,7 +1049,7 @@ void StelObject::postProcessInfoString(QString& str, const InfoStringGroup& flag
 		static const QRegularExpression tableRe4("<table style=\"[^\"]*\">");
 		str.replace("<b>", "");
 		str.replace("</b>", "");
-		str.replace("<h2>", "");
+		str.replace(h2Re, "");
 		str.replace("</h2>", "\n");
 		str.replace(brRe2, "\n");
 		str.replace("<tr>", "");

--- a/src/core/StelPainter.cpp
+++ b/src/core/StelPainter.cpp
@@ -617,7 +617,7 @@ void StelPainter::drawTextGravity180(const float x, const float y, const QString
 
 	std::u32string label32=str.toStdU32String();
 
-	// TODO: Move these and the same from St4elSkyCultureMgr to a common place.
+	// TODO: Move these and the same from StelSkyCultureMgr to a common place.
 	static const uint32_t FSI32=U'\U00002068'; // First strong isolate: Treat following text as isolated and in the direction of its first strong directional character.
 						   // ASSUMPTION: Can be used as autodetect feature? Mark all parts inside embeddings?
 	static const uint32_t PDI32=U'\U00002069'; // Pop directional isolate: terminate scope of last LRI/RLI/FSI

--- a/src/core/StelSkyCultureMgr.cpp
+++ b/src/core/StelSkyCultureMgr.cpp
@@ -977,8 +977,6 @@ QString StelSkyCultureMgr::createCulturalLabel(const StelObject::CulturalName &c
 					       const QString &commonNameI18n,
 					       const QString &abbrevI18n) const
 {
-	// rtl tracks the right-to-left status of the text in the current position.
-	const bool rtl = StelApp::getInstance().getLocaleMgr().isSkyRTL();
 	// Each element may be in an RTL language (e.g. Arab). However,
 	// - for most (left-to-right) languages we want a canonical order of left to right elements.
 	// - for Arab and other right-to-left user languages, we set a canonical order of right-to-left elements.
@@ -1016,7 +1014,7 @@ QString StelSkyCultureMgr::createCulturalLabel(const StelObject::CulturalName &c
 	// If native contains non-Latin glyphs, pronounce or transliteration is mandatory.
 	QString pronounceStr=(lName.pronounceI18n.isEmpty() ? lName.pronounce : lName.pronounceI18n);
 	QString nativeOrPronounce = (lName.native.isEmpty() ? lName.pronounceI18n : lName.native);
-	QString pronounceOrNative = (lName.pronounceI18n.isEmpty() ? lName.native : lName.pronounceI18n);
+	QString pronounceOrNative = (pronounceStr.isEmpty() ? lName.native : pronounceStr);
 	QString translitOrPronounce = (lName.transliteration.isEmpty() ? pronounceStr : lName.transliteration);
 
 	// If you call this with an actual argument abbrevI18n, you really only want a short label.
@@ -1090,9 +1088,6 @@ QString StelSkyCultureMgr::createCulturalLabel(const StelObject::CulturalName &c
 	if (!braced.isEmpty())
 	{
 		QString pronTrans=QString(" %1%3%2").arg(QChar(0x2997), QChar(0x2998), braced.join(", "+ZWS));
-		if (rtl)
-			label.prepend(pronTrans+ZWS);
-		else
 			label.append(pronTrans+ZWS);
 	}
 
@@ -1100,9 +1095,6 @@ QString StelSkyCultureMgr::createCulturalLabel(const StelObject::CulturalName &c
 	if ((styleInt & int(StelObject::CulturalDisplayStyle::IPA)) && (!lName.IPA.isEmpty()) && (label != lName.IPA))
 	{
 		QString ipa=QString(" [%1]").arg(lName.IPA);
-		if (rtl)
-			label.prepend(ipa+ZWS);
-		else
 			label.append(ipa+ZWS);
 	}
 
@@ -1124,9 +1116,6 @@ QString StelSkyCultureMgr::createCulturalLabel(const StelObject::CulturalName &c
 	if (!bracketed.isEmpty())
 	{
 		QString transBy=QString(" (%1)").arg(bracketed.join(", "+ZWS));
-		if (rtl)
-			label.prepend(transBy+ZWS);
-		else
 			label.append(transBy+ZWS);
 	}
 
@@ -1135,9 +1124,6 @@ QString StelSkyCultureMgr::createCulturalLabel(const StelObject::CulturalName &c
 	if ((styleInt & int(StelObject::CulturalDisplayStyle::Modern)) && (!commonNameI18n.isEmpty()) && (!label.startsWith(lCommonNameI18n)) && (lCommonNameI18n!=lName.translatedI18n))
 	{
 		QString modern=QString(" %1%3%2").arg(QChar(0x29FC), QChar(0x29FD), lCommonNameI18n);
-		if (rtl)
-			label.prepend(modern+ZWS);
-		else
 			label.append(modern+ZWS);
 	}
 	if ((styleInt & int(StelObject::CulturalDisplayStyle::Modern)) && label.isEmpty()) // if something went wrong?

--- a/src/core/StelSkyCultureMgr.cpp
+++ b/src/core/StelSkyCultureMgr.cpp
@@ -997,6 +997,7 @@ QString StelSkyCultureMgr::createCulturalLabel(const StelObject::CulturalName &c
 	//static const QString LRM{"\u200e"}; // left-to-right mark: zero-width char
 	//static const QString RLM{"\u200f"}; // right-to-left mark: right to left zero-width non-Arabic char
 	//static const QString ALM{"\u061c"}; // right-to-left mark: right to left zero-width Arabic char
+	static const QString ZWS{"\u200b"}; // zero-width space (we use them to combine cultural label groups)
 
 	StelObject::CulturalName lName;
 	// copy over filled elements from cName, but enclose each with Unicode isolation markers.
@@ -1058,7 +1059,7 @@ QString StelSkyCultureMgr::createCulturalLabel(const StelObject::CulturalName &c
 	QStringList braced; // the contents of the secondary term, i.e. pronunciation and transliteration
 	if (styleInt & int(StelObject::CulturalDisplayStyle::Native))
 	{
-		label=nativeOrPronounce;
+		label=nativeOrPronounce+ZWS;
 		// Add pronounciation and Translit in braces
 		if (styleInt & int(StelObject::CulturalDisplayStyle::Pronounce))
 			braced.append(pronounceStr);
@@ -1070,14 +1071,14 @@ QString StelSkyCultureMgr::createCulturalLabel(const StelObject::CulturalName &c
 		// Use the first valid of pronunciation or transliteration as main name (fallback to native), add the others in braces if applicable
 		if (styleInt & int(StelObject::CulturalDisplayStyle::Pronounce))
 		{
-			label=pronounceOrNative;
+			label=pronounceOrNative+ZWS;
 			if (styleInt & int(StelObject::CulturalDisplayStyle::Translit))
 				braced.append(lName.transliteration);
 		}
 
 		else if (styleInt & int(StelObject::CulturalDisplayStyle::Translit))
 		{
-			label=translitOrPronounce;
+			label=translitOrPronounce+ZWS;
 		}
 	}
 
@@ -1088,11 +1089,11 @@ QString StelSkyCultureMgr::createCulturalLabel(const StelObject::CulturalName &c
 
 	if (!braced.isEmpty())
 	{
-		QString pronTrans=QString(" %1%3%2").arg(QChar(0x2997), QChar(0x2998), braced.join(", "));
+		QString pronTrans=QString(" %1%3%2").arg(QChar(0x2997), QChar(0x2998), braced.join(", "+ZWS));
 		if (rtl)
-			label.prepend(pronTrans);
+			label.prepend(pronTrans+ZWS);
 		else
-			label.append(pronTrans);
+			label.append(pronTrans+ZWS);
 	}
 
 	// Add IPA (where possible)
@@ -1100,9 +1101,9 @@ QString StelSkyCultureMgr::createCulturalLabel(const StelObject::CulturalName &c
 	{
 		QString ipa=QString(" [%1]").arg(lName.IPA);
 		if (rtl)
-			label.prepend(ipa);
+			label.prepend(ipa+ZWS);
 		else
-			label.append(ipa);
+			label.append(ipa+ZWS);
 	}
 
 	// Add translation and optional byname in brackets
@@ -1115,18 +1116,18 @@ QString StelSkyCultureMgr::createCulturalLabel(const StelObject::CulturalName &c
 		else if (!label.startsWith(lName.translatedI18n, Qt::CaseInsensitive)) // seems useless to add translation into same string
 
 			//label.append(QString(" (%1)").arg(lName.translatedI18n));
-			bracketed.append(lName.translatedI18n);
+			bracketed.append(lName.translatedI18n+ZWS);
 	}
 
 	if ( (styleInt & int(StelObject::CulturalDisplayStyle::Byname)) && (!lName.bynameI18n.isEmpty()))
-		bracketed.append(lName.bynameI18n);
+		bracketed.append(lName.bynameI18n+ZWS);
 	if (!bracketed.isEmpty())
 	{
-		QString transBy=QString(" (%1)").arg(bracketed.join(", "));
+		QString transBy=QString(" (%1)").arg(bracketed.join(", "+ZWS));
 		if (rtl)
-			label.prepend(transBy);
+			label.prepend(transBy+ZWS);
 		else
-			label.append(transBy);
+			label.append(transBy+ZWS);
 	}
 
 
@@ -1135,9 +1136,9 @@ QString StelSkyCultureMgr::createCulturalLabel(const StelObject::CulturalName &c
 	{
 		QString modern=QString(" %1%3%2").arg(QChar(0x29FC), QChar(0x29FD), lCommonNameI18n);
 		if (rtl)
-			label.prepend(modern);
+			label.prepend(modern+ZWS);
 		else
-			label.append(modern);
+			label.append(modern+ZWS);
 	}
 	if ((styleInt & int(StelObject::CulturalDisplayStyle::Modern)) && label.isEmpty()) // if something went wrong?
 		label=lCommonNameI18n;

--- a/src/core/StelUtils.cpp
+++ b/src/core/StelUtils.cpp
@@ -1377,13 +1377,21 @@ QString hoursToHmsStr(const float hours, const bool minutesOnly, const bool colo
 //! The method to splitting the text by substrings by some limit of string length
 QString wrapText(const QString& s, const int limit)
 {
+	static const uint32_t RLM32=U'\U0000200f'; // Right-Left-marker (starting Arab/Hebrew)
+	static const uint32_t LRM32=U'\U0000200e'; // Left-right-marker
+	static const uint32_t ZWS32=U'\U0000200b'; // Zero-width space
+	//static const QString LRM{"\u200e"}; // left-to-right mark: zero-width char
+	//static const QString RLM{"\u200f"}; // right-to-left mark: right to left zero-width non-Arabic char
+	static const QString ZWS{"\u200b"}; // zero-width space (we use them to combine cultural label groups)
+
+
 	QString result = "";
 	if (s.length()<=limit)
 		result = s;
 	else
 	{
 		QString prepare = "";
-		QStringList data = s.split(" ");
+		const QStringList data = s.contains(ZWS) ? s.split(ZWS) : s.split(" ");
 		for (int i = 0; i<data.size(); i++)
 		{
 			prepare.append(QString(" %1").arg(data.at(i)));

--- a/src/core/modules/MinorPlanet.cpp
+++ b/src/core/modules/MinorPlanet.cpp
@@ -22,6 +22,7 @@
 #include "MinorPlanet.hpp"
 #include "Orbit.hpp"
 #include "StelCore.hpp"
+#include "StelLocaleMgr.hpp"
 #include "StelTranslator.hpp"
 
 #include <QRegularExpression>
@@ -169,10 +170,12 @@ QString MinorPlanet::getNameI18n() const
 QString MinorPlanet::getInfoStringName(const StelCore *core, const InfoStringGroup& flags) const
 {
 	Q_UNUSED(core) Q_UNUSED(flags)
+	// rtl tracks the right-to-left status of the text in the current position.
+	const bool rtl = StelApp::getInstance().getLocaleMgr().isSkyRTL();
 	QString str;
 	QTextStream oss(&str);
 
-	oss << "<h2>";
+	oss << (rtl ? "<h2 dir=\"rtl\">" : "<h2 dir=\"ltr\">");
 	if (nameIsIAUDesignation)
 	{
 		if (minorPlanetNumber)

--- a/src/core/modules/Nebula.cpp
+++ b/src/core/modules/Nebula.cpp
@@ -22,6 +22,7 @@
 #include "Nebula.hpp"
 #include "NebulaMgr.hpp"
 #include "Planet.hpp"
+#include "StelLocaleMgr.hpp"
 #include "StelTexture.hpp"
 
 #include "StelUtils.hpp"
@@ -240,12 +241,14 @@ QStringList Nebula::getCultureLabels(StelObject::CulturalDisplayStyle style) con
 
 QString Nebula::getInfoString(const StelCore *core, const InfoStringGroup& flags) const
 {
+	// rtl tracks the right-to-left status of the text in the current position.
+	const bool rtl = StelApp::getInstance().getLocaleMgr().isSkyRTL();
 	QString str;
 	QTextStream oss(&str);
 	bool withDecimalDegree = StelApp::getInstance().getFlagShowDecimalDegrees();
 
 	if ((flags&Name) || (flags&CatalogNumber))
-		oss << "<h2>";
+		oss << (rtl ? "<h2 dir=\"rtl\">" : "<h2 dir=\"ltr\">");
 
 	if (!culturalNames.isEmpty() && flags&Name)
 		oss << getInfoLabel() << "<br/>";

--- a/src/core/modules/Planet.cpp
+++ b/src/core/modules/Planet.cpp
@@ -501,9 +501,10 @@ QString Planet::getScreenLabel() const
 }
 QString Planet::getInfoLabel() const
 {
+	static const QString ZWS{"\u200b"}; // zero-width space (we use them to combine cultural label groups)
 	static StelSkyCultureMgr *scMgr=GETSTELMODULE(StelSkyCultureMgr);
 	QStringList list=getCultureLabels(scMgr->getInfoLabelStyle());
-	return list.isEmpty() ? getNameI18n() : list.join(" - ");
+	return list.isEmpty() ? getNameI18n() : list.join(ZWS + " - " + ZWS);
 }
 
 QStringList Planet::getCultureLabels(StelObject::CulturalDisplayStyle style) const
@@ -532,9 +533,11 @@ QStringList Planet::getCultureLabels(StelObject::CulturalDisplayStyle style) con
 QString Planet::getInfoStringName(const StelCore *core, const InfoStringGroup& flags) const
 {
 	Q_UNUSED(core) Q_UNUSED(flags)
+	// rtl tracks the right-to-left status of the text in the current position.
+	const bool rtl = StelApp::getInstance().getLocaleMgr().isSkyRTL();
 	QString str;
 	QTextStream oss(&str);
-	oss << "<h2 dir=\"ltr\">";
+	oss << (rtl ? "<h2 dir=\"rtl\">" : "<h2 dir=\"ltr\">");
 
 	// NOTE: currently only moons have an IAU designation
 	if (!iauMoonNumber.isEmpty())

--- a/src/core/modules/Planet.cpp
+++ b/src/core/modules/Planet.cpp
@@ -534,7 +534,7 @@ QString Planet::getInfoStringName(const StelCore *core, const InfoStringGroup& f
 	Q_UNUSED(core) Q_UNUSED(flags)
 	QString str;
 	QTextStream oss(&str);
-	oss << "<h2>";
+	oss << "<h2 dir=\"ltr\">";
 
 	// NOTE: currently only moons have an IAU designation
 	if (!iauMoonNumber.isEmpty())

--- a/src/core/modules/StarMgr.cpp
+++ b/src/core/modules/StarMgr.cpp
@@ -2501,9 +2501,10 @@ QString StarMgr::getCulturalScreenLabel(StarId hip)
 //! When dealing with foreign skycultures, many users will want this to be longer, with more name components.
 QString StarMgr::getCulturalInfoLabel(StarId hip)
 {
+	static const QString ZWS{"\u200b"}; // zero-width space (we use them to combine cultural label groups)
 	static StelSkyCultureMgr *scMgr=GETSTELMODULE(StelSkyCultureMgr);
 	QStringList list=getCultureLabels(hip, scMgr->getInfoLabelStyle());
-	return list.isEmpty() ? "" : list.join(" - ");
+	return list.isEmpty() ? "" : list.join(ZWS + " - " + ZWS);
 }
 
 QStringList StarMgr::getCultureLabels(StarId hip, StelObject::CulturalDisplayStyle style)

--- a/src/core/modules/StarWrapper.cpp
+++ b/src/core/modules/StarWrapper.cpp
@@ -22,6 +22,7 @@
  */
 
 #include "StarWrapper.hpp"
+#include "StelLocaleMgr.hpp"
 #include "ZoneArray.hpp"
 
 #include "StelUtils.hpp"
@@ -149,6 +150,8 @@ QString StarWrapper1::getObjectTypeI18n() const
 
 QString StarWrapper1::getInfoString(const StelCore *core, const InfoStringGroup& flags) const
 {
+	// rtl tracks the right-to-left status of the text in the current position.
+	const bool rtl = StelApp::getInstance().getLocaleMgr().isSkyRTL();
 	QString str;
 	QTextStream oss(&str);
 	double az_app, alt_app;
@@ -172,7 +175,7 @@ QString StarWrapper1::getInfoString(const StelCore *core, const InfoStringGroup&
 	const int vMm = StarMgr::getGcvsMM(star_id);
 
 	if ((flags&Name) || (flags&CatalogNumber))
-		oss << "<h2 dir=\"ltr\">";
+		oss << (rtl ? "<h2 dir=\"rtl\">" : "<h2 dir=\"ltr\">");
 
 	const QString commonNameI18 = StarMgr::getCommonNameI18n(star_id);
 	const QString culturalInfoName=StarMgr::getCulturalInfoLabel(star_id);

--- a/src/core/modules/StarWrapper.cpp
+++ b/src/core/modules/StarWrapper.cpp
@@ -172,7 +172,7 @@ QString StarWrapper1::getInfoString(const StelCore *core, const InfoStringGroup&
 	const int vMm = StarMgr::getGcvsMM(star_id);
 
 	if ((flags&Name) || (flags&CatalogNumber))
-		oss << "<h2>";
+		oss << "<h2 dir=\"ltr\">";
 
 	const QString commonNameI18 = StarMgr::getCommonNameI18n(star_id);
 	const QString culturalInfoName=StarMgr::getCulturalInfoLabel(star_id);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Please include a summary of the change and which issue is fixed. -->
<!--- Please also include relevant motivation and context. -->
<!--- List any dependencies that are required for this change. -->

InfoStrings with Cultural Names containing right-to-left components (e.g. Arab) have problematic wrapping points. 
This fix adds zero-width space into the multipart names, and the splitting is modified to break lines only at those points. 
In addition, Unicode FSI/PDI groups are replaced by spans with auto dir, and the dir of the h2 headings (names) is set to ltr. 

I admit this looks like extending a kludge with another kludge, and some things can hopefully be cleaned up later (25.4?).  

Don't merge yet, though. Currently I think I have fixed RTL groups in LTR locales. I have not yet checked LTR groups in RTL program language (here likely h2 must be forced to dir=rtl). 

Fixes #4541 (issue)

### Screenshots (if appropriate):

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system: Windows 11
* Graphics Card: irrelevant

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
