### PR TITLE
Allow elongation-dependent name for Venus in Sardinian culture

### DIFF
--- a/skycultures/sardinian/index.json
+++ b/skycultures/sardinian/index.json
@@ -70,6 +70,7 @@
     "HIP 21421": [{"english": "The Bunch's Driver"}],
     "HIP 32349": [{"english": "Steel Star"}],
     "HIP 69673": [{"english": "The Seven Brother's Driver"}],
-    "NAME Venus": [{"english": "Evening Star / Morning Star", "native": "Isteddu Chenadorzu / S'Isteddu 'e Impuddile"}]
+    "NAME Venus": [{"english": "Evening Star", "native": "Isteddu Chenadorzu", "visible": "evening"},
+				           {"english": "Morning Star", "native": "S'Isteddu 'e Impuddile", "visible": "morning"}]
   }
 }


### PR DESCRIPTION
Since the Sardinian sky culture has two names of Venus displayed (which is ugly), I figured it made more sense to make them elongation dependent, which I find more elegant.

Fixes # (issue)

### Screenshots (if appropriate):
<img width="1323" height="1027" alt="image" src="https://github.com/user-attachments/assets/42e58f89-995e-41a0-8031-455bc554b42c" />


### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?
Modifying `index.json` of the Sardinian sky culture accordingly.

**Test Configuration**:
* Operating system: Windows 11 64-bit (although irrelevant)
* Graphics Card: Completely irrelevant

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
