### PR TITLE
SCM Plugin: bug fixes

### DIFF
--- a/plugins/SkyCultureMaker/CHANGELOG.md
+++ b/plugins/SkyCultureMaker/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Sky Culture Maker Plugin - Changelog
 
+## Version 1.0.1
+
+* Fix: Drawn constellations are not reset after "Export and Exit"
+* Fix: Stop drawing line key (Double Right Click) only works when Star/DSO is selected
+* Fix: Not all SC description input fields that are marked required are actually checked
+* Fix: No formal checks for 'Constellations' input field in SC description
+
 ## Version 1.0.0
 
 * Initial release of the Sky Culture Maker Plugin

--- a/plugins/SkyCultureMaker/CMakeLists.txt
+++ b/plugins/SkyCultureMaker/CMakeLists.txt
@@ -1,5 +1,5 @@
 # This is the cmake config file for the Sky Culture Maker plugin
-SET(SCM_VERSION "1.0.0")
+SET(SCM_VERSION "1.0.1")
 
 # Option to manually control converter, defaults to FALSE
 OPTION(SCM_SHOULD_ENABLE_CONVERTER "Attempt to enable Sky Culture Converter" FALSE)

--- a/plugins/SkyCultureMaker/src/CMakeLists.txt
+++ b/plugins/SkyCultureMaker/src/CMakeLists.txt
@@ -8,49 +8,53 @@ INCLUDE_DIRECTORIES(
 LINK_DIRECTORIES(${CMAKE_BINARY_DIR}/src)
 
 SET( SkyCultureMaker_SRCS
-     SkyCultureMaker.hpp
-     SkyCultureMaker.cpp
 
-     ScmDraw.hpp
-     ScmDraw.cpp
+     enumBitops.hpp
      ScmConstellation.hpp
      ScmConstellation.cpp
      ScmConstellationArtwork.hpp
      ScmConstellationArtwork.cpp
+     ScmDraw.hpp
+     ScmDraw.cpp
      ScmSkyCulture.hpp
      ScmSkyCulture.cpp
+     SkyCultureMaker.hpp
+     SkyCultureMaker.cpp
 
-     gui/ScmStartDialog.hpp
-     gui/ScmStartDialog.cpp
      gui/ScmConstellationDialog.hpp
      gui/ScmConstellationDialog.cpp
-     gui/ScmSkyCultureDialog.hpp
-     gui/ScmSkyCultureDialog.cpp
-     gui/ScmConstellationImageAnchor.hpp
-     gui/ScmConstellationImageAnchor.cpp
      gui/ScmConstellationImage.hpp
      gui/ScmConstellationImage.cpp
-     gui/ScmSkyCultureExportDialog.hpp
-     gui/ScmSkyCultureExportDialog.cpp
+     gui/ScmConstellationImageAnchor.hpp
+     gui/ScmConstellationImageAnchor.cpp
      gui/ScmHideOrAbortMakerDialog.hpp
      gui/ScmHideOrAbortMakerDialog.cpp
+     gui/ScmSkyCultureDialog.hpp
+     gui/ScmSkyCultureDialog.cpp
+     gui/ScmSkyCultureExportDialog.hpp
+     gui/ScmSkyCultureExportDialog.cpp
+     gui/ScmStartDialog.hpp
+     gui/ScmStartDialog.cpp
 
+     types/Anchor.hpp
+     types/Classification.hpp
      types/CoordinateLine.hpp
      types/Description.hpp
-     types/Drawing.hpp
      types/DialogID.hpp
+     types/Drawing.hpp
+     types/DrawingMode.hpp
      types/DrawTools.hpp
+     types/License.hpp
      types/Lines.hpp
-     types/StarLine.hpp
      types/SkyPoint.hpp
-     types/Anchor.hpp
+     types/StarLine.hpp
 )
 
 SET( SCM_UIS
      gui/scmConstellationDialog.ui
+     gui/scmHideOrAbortMakerDialog.ui
      gui/scmSkyCultureDialog.ui
      gui/scmSkyCultureExportDialog.ui
-     gui/scmHideOrAbortMakerDialog.ui
      gui/scmStartDialog.ui
 )
 

--- a/plugins/SkyCultureMaker/src/ScmDraw.cpp
+++ b/plugins/SkyCultureMaker/src/ScmDraw.cpp
@@ -38,7 +38,7 @@ void scm::ScmDraw::setSearchMode(bool active)
 	if (inSearchMode == true && active == false)
 	{
 		// only allow search and find for normal constellations
-		if(drawingMode == DrawingMode::StarsAndDSO)
+		if (drawingMode == DrawingMode::StarsAndDSO)
 		{
 			selectedStarIsSearched = true;
 		}
@@ -246,15 +246,27 @@ void scm::ScmDraw::handleMouseClicks(class QMouseEvent *event)
 		}
 
 		// Reset line drawing
-		if (event->button() == Qt::RightButton && event->type() == QEvent::MouseButtonDblClick &&
-		    hasFlag(drawState, Drawing::hasEnd))
+		if (event->button() == Qt::RightButton && event->type() == QEvent::MouseButtonDblClick)
 		{
-			if (!drawnLines.coordinates.empty())
+			// this allows the double click to cancel drawing even if hovering over a star
+			if (hasFlag(drawState, Drawing::hasEnd))
 			{
-				drawnLines.coordinates.pop_back();
-				drawnLines.stars.pop_back();
+				if (!drawnLines.coordinates.empty())
+				{
+					drawnLines.coordinates.pop_back();
+					drawnLines.stars.pop_back();
+				}
+				drawState = Drawing::None;
 			}
-			drawState = Drawing::None;
+			else if (hasFlag(drawState, Drawing::hasFloatingEnd))
+			{
+				std::get<CoordinateLine>(currentLine).start.set(0, 0, 0);
+				std::get<CoordinateLine>(currentLine).end.set(0, 0, 0);
+				std::get<StarLine>(currentLine).start.reset();
+				std::get<StarLine>(currentLine).end.reset();
+				drawState = Drawing::None;
+			}
+
 			event->accept();
 			return;
 		}

--- a/plugins/SkyCultureMaker/src/ScmDraw.cpp
+++ b/plugins/SkyCultureMaker/src/ScmDraw.cpp
@@ -249,6 +249,7 @@ void scm::ScmDraw::handleMouseClicks(class QMouseEvent *event)
 		if (event->button() == Qt::RightButton && event->type() == QEvent::MouseButtonDblClick)
 		{
 			// this allows the double click to cancel drawing even if hovering over a star
+			// or when in coordinate mode
 			if (hasFlag(drawState, Drawing::hasEnd))
 			{
 				if (!drawnLines.coordinates.empty())

--- a/plugins/SkyCultureMaker/src/gui/ScmSkyCultureDialog.cpp
+++ b/plugins/SkyCultureMaker/src/gui/ScmSkyCultureDialog.cpp
@@ -182,7 +182,7 @@ void ScmSkyCultureDialog::saveSkyCulture()
 	// check if description is complete
 	if (!desc.isComplete())
 	{
-		maker->showUserWarningMessage(dialog, ui->titleBar->title(), q_("The sky culture description is not complete. Please fill in all required fields."));
+		maker->showUserWarningMessage(dialog, ui->titleBar->title(), q_("The sky culture description is not complete. Please fill in all required fields correctly."));
 		return;
 	}
 

--- a/plugins/SkyCultureMaker/src/gui/ScmSkyCultureExportDialog.cpp
+++ b/plugins/SkyCultureMaker/src/gui/ScmSkyCultureExportDialog.cpp
@@ -228,6 +228,7 @@ void ScmSkyCultureExportDialog::exportAndExitSkyCulture()
 	maker->resetScmDialogs();
 	maker->hideAllDialogs();
 	maker->setIsScmEnabled(false);
+	maker->setNewSkyCulture();
 }
 
 bool ScmSkyCultureExportDialog::saveSkyCultureCMakeListsFile(const QDir& directory)

--- a/plugins/SkyCultureMaker/src/gui/scmSkyCultureDialog.ui
+++ b/plugins/SkyCultureMaker/src/gui/scmSkyCultureDialog.ui
@@ -66,7 +66,7 @@
       <item>
        <widget class="QTabWidget" name="tabs">
         <property name="currentIndex">
-         <number>1</number>
+         <number>0</number>
         </property>
         <property name="iconSize">
          <size>

--- a/plugins/SkyCultureMaker/src/types/Description.hpp
+++ b/plugins/SkyCultureMaker/src/types/Description.hpp
@@ -66,7 +66,8 @@ struct Description
 			   !introduction.trimmed().isEmpty() &&
 			   !cultureDescription.trimmed().isEmpty() &&
 			   !constellations.trimmed().isEmpty() &&
-			   constellations.contains("##### ") && // at least one constellation description
+			   // at least one constellation name. this is a very basic check but at least makes the user aware of the markdown sections
+			   constellations.contains("##### ") &&
 			   !references.trimmed().isEmpty() &&
 			   !authors.trimmed().isEmpty() &&
 			   !about.trimmed().isEmpty() &&

--- a/plugins/SkyCultureMaker/src/types/Description.hpp
+++ b/plugins/SkyCultureMaker/src/types/Description.hpp
@@ -58,16 +58,19 @@ struct Description
 
 	/**
 	 * @brief Check if the description is complete.
-	 * @return true if all required fields are filled, false otherwise.
+	 * @return true if all required fields are correctly filled, false otherwise.
 	 */
 	bool isComplete() const
 	{
 		return !name.trimmed().isEmpty() &&
-			   !authors.trimmed().isEmpty() &&
-			   license != scm::LicenseType::NONE &&
+			   !introduction.trimmed().isEmpty() &&
 			   !cultureDescription.trimmed().isEmpty() &&
-			   !about.trimmed().isEmpty() &&
+			   !constellations.trimmed().isEmpty() &&
+			   constellations.contains("##### ") && // at least one constellation description
 			   !references.trimmed().isEmpty() &&
+			   !authors.trimmed().isEmpty() &&
+			   !about.trimmed().isEmpty() &&
+			   license != scm::LicenseType::NONE &&
 			   classification != scm::ClassificationType::NONE;
 	}
 };


### PR DESCRIPTION
While using the plugin, I have noticed a few small things that did not seem to work as intended. Instead of creating separate issues for each bug, I decided to fix them in one batch. Specifically:

* Fix: Drawn constellations are not reset after "Export and Exit"
* Fix: Stop drawing line key (Double Right Click) only works when Star/DSO is selected
* Fix: Not all SC description input fields that are marked required are actually checked
* Fix: No formal checks for 'Constellations' input field in SC description

For reasons of transparency, I have also updated the changelog. I suppose version 1.0.1 of the plugin will contain all changes up to the 25.4 release.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] Housekeeping

### How Has This Been Tested?
Manual tests.

**Test Configuration**:
* Operating system: MacOS 26.0.1
* Graphics Card: Apple M3 Pro

## Checklist:
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
