### PR TITLE
Show polar distance

### DIFF
--- a/src/core/StelApp.cpp
+++ b/src/core/StelApp.cpp
@@ -699,6 +699,7 @@ void StelApp::init(QSettings* conf)
 
 	setFlagShowDecimalDegrees(confSettings->value("gui/flag_show_decimal_degrees", false).toBool());
 	setFlagSouthAzimuthUsage(confSettings->value("gui/flag_use_azimuth_from_south", false).toBool());
+	setFlagPolarDistanceUsage(confSettings->value("gui/flag_use_polar_distance", false).toBool());
 	setFlagUseFormattingOutput(confSettings->value("gui/flag_use_formatting_output", false).toBool());
 	setFlagUseCCSDesignation(confSettings->value("gui/flag_use_ccs_designations", false).toBool());
 	setFlagOverwriteInfoColor(confSettings->value("gui/flag_overwrite_info_color", false).toBool());	
@@ -1280,6 +1281,16 @@ void StelApp::setFlagSouthAzimuthUsage(bool use)
 		flagUseAzimuthFromSouth=use;
 		StelApp::immediateSave("gui/flag_use_azimuth_from_south", use);
 		emit flagUseAzimuthFromSouthChanged(use);
+	}
+}
+
+void StelApp::setFlagPolarDistanceUsage(bool use)
+{
+	if (flagUsePolarDistance!=use)
+	{
+		flagUsePolarDistance=use;
+		StelApp::immediateSave("gui/flag_use_polar_distance", use);
+		emit flagUsePolarDistanceChanged(use);
 	}
 }
 

--- a/src/core/StelApp.hpp
+++ b/src/core/StelApp.hpp
@@ -81,6 +81,7 @@ class StelApp : public QObject
 	Q_PROPERTY(bool nightMode READ getVisionModeNight WRITE setVisionModeNight NOTIFY visionNightModeChanged)
 	Q_PROPERTY(bool flagShowDecimalDegrees  READ getFlagShowDecimalDegrees  WRITE setFlagShowDecimalDegrees  NOTIFY flagShowDecimalDegreesChanged)
 	Q_PROPERTY(bool flagUseAzimuthFromSouth READ getFlagSouthAzimuthUsage   WRITE setFlagSouthAzimuthUsage   NOTIFY flagUseAzimuthFromSouthChanged)
+	Q_PROPERTY(bool flagUsePolarDistance READ getFlagPolarDistanceUsage   WRITE setFlagPolarDistanceUsage   NOTIFY flagUsePolarDistanceChanged)
 	Q_PROPERTY(bool flagUseCCSDesignation   READ getFlagUseCCSDesignation   WRITE setFlagUseCCSDesignation   NOTIFY flagUseCCSDesignationChanged)
 	Q_PROPERTY(bool flagUseFormattingOutput READ getFlagUseFormattingOutput WRITE setFlagUseFormattingOutput NOTIFY flagUseFormattingOutputChanged)
 	Q_PROPERTY(bool flagOverwriteInfoColor  READ getFlagOverwriteInfoColor  WRITE setFlagOverwriteInfoColor  NOTIFY flagOverwriteInfoColorChanged)
@@ -313,6 +314,11 @@ public slots:
 	bool getFlagSouthAzimuthUsage() const { return flagUseAzimuthFromSouth; }
 	//! Get flag for using calculation of azimuth from south towards west (instead north towards east)
 	void setFlagSouthAzimuthUsage(bool use);
+
+	//! Set flag for using calculation of polar distance for equatorial coordinates
+	bool getFlagPolarDistanceUsage() const { return flagUsePolarDistance; }
+	//! Get flag for using calculation of polar distance for equatorial coordinates
+	void setFlagPolarDistanceUsage(bool use);
 	
 	//! Set flag for using of formatting output for coordinates
 	void setFlagUseFormattingOutput(bool b);
@@ -377,6 +383,7 @@ signals:
 	void visionNightModeChanged(bool);
 	void flagShowDecimalDegreesChanged(bool);
 	void flagUseAzimuthFromSouthChanged(bool);
+	void flagUsePolarDistanceChanged(bool);
 	void flagUseCCSDesignationChanged(bool);
 	void flagUseFormattingOutputChanged(bool);
 	void flagOverwriteInfoColorChanged(bool);
@@ -549,6 +556,7 @@ private:
 	
 	bool flagShowDecimalDegrees;  // Format infotext with decimal degrees, not minutes/seconds
 	bool flagUseAzimuthFromSouth; // Display calculate azimuth from south towards west (as in some astronomical literature)
+	bool flagUsePolarDistance; // Display calculate polar distance for equatorial coordinates
 	bool flagUseFormattingOutput; // Use tabular coordinate format for infotext
 	bool flagUseCCSDesignation;   // Use symbols like alpha (RA), delta (declination) for coordinate system labels
 	bool flagOverwriteInfoColor; // Overwrite and use color for text in info panel

--- a/src/core/StelObject.cpp
+++ b/src/core/StelObject.cpp
@@ -371,6 +371,7 @@ QString StelObject::getCommonInfoString(const StelCore *core, const InfoStringGr
 	const bool withAtmosphere = core->getSkyDrawer()->getFlagHasAtmosphere();
 	const bool withDecimalDegree = app.getFlagShowDecimalDegrees();
 	const bool useSouthAzimuth = app.getFlagSouthAzimuthUsage();
+	const bool usePolarDistance = app.getFlagPolarDistanceUsage();
 	const bool withTables = app.getFlagUseFormattingOutput();
 	const bool withDesignations = app.getFlagUseCCSDesignation();
 	const QString cepoch = qc_("on date", "coordinates for current epoch");
@@ -401,13 +402,24 @@ QString StelObject::getCommonInfoString(const StelCore *core, const InfoStringGr
 	if (withTables)
 		res += "<table style='margin:0em 0em 0em -0.125em;border-spacing:0px;border:0px;'>";
 
-	// TRANSLATORS: Right ascension/Declination
-	const QString RADec = withDesignations ? QString("&alpha;/&delta;") : qc_("RA/Dec", "celestial coordinate system");
+	QString RADec;
+	if (usePolarDistance)
+	{
+		// TRANSLATORS: Right ascension/Polar Distance
+		RADec = withDesignations ? QString("&alpha;/p") : qc_("RA/PD", "celestial coordinate system");
+	}
+	else
+	{
+		// TRANSLATORS: Right ascension/Declination
+		RADec = withDesignations ? QString("&alpha;/&delta;") : qc_("RA/Dec", "celestial coordinate system");
+	}
 
 	if (flags&RaDecJ2000)
 	{
 		double dec_j2000, ra_j2000;
 		StelUtils::rectToSphe(&ra_j2000,&dec_j2000,getJ2000EquatorialPos(core));
+		if (usePolarDistance)
+			dec_j2000 = M_PI_2f - dec_j2000;
 		if (withDecimalDegree)
 		{
 			firstCoordinate  = StelUtils::radToDecDegStr(ra_j2000,5,false,true);
@@ -431,6 +443,8 @@ QString StelObject::getCommonInfoString(const StelCore *core, const InfoStringGr
 	{
 		double dec_equ, ra_equ;
 		StelUtils::rectToSphe(&ra_equ,&dec_equ,eqNow);
+		if (usePolarDistance)
+			dec_equ = M_PI_2f - dec_equ;
 		if (withDecimalDegree)
 		{
 			firstCoordinate  = StelUtils::radToDecDegStr(ra_equ,5,false,true);
@@ -455,6 +469,8 @@ QString StelObject::getCommonInfoString(const StelCore *core, const InfoStringGr
 		double dec_sidereal, ra_sidereal, ha_sidereal;
 		StelUtils::rectToSphe(&ra_sidereal,&dec_sidereal,getSiderealPosGeometric(core));
 		ra_sidereal = 2.*M_PI-ra_sidereal;
+		if (usePolarDistance)
+			dec_sidereal = M_PI_2f - dec_sidereal;
 		if (withAtmosphere && (alt_app>-2.0*M_PI/180.0)) // Don't show refracted values much below horizon where model is meaningless.
 		{
 			StelUtils::rectToSphe(&ra_sidereal,&dec_sidereal,getSiderealPosApparent(core));
@@ -490,8 +506,17 @@ QString StelObject::getCommonInfoString(const StelCore *core, const InfoStringGr
 			}
 		}
 
-		// TRANSLATORS: Hour angle/Declination
-		const QString HADec = withDesignations ? QString("h/&delta;") : qc_("HA/Dec", "celestial coordinate system");
+		QString HADec;
+		if (usePolarDistance)
+		{
+			// TRANSLATORS: Hour angle/Polar Distance
+			HADec = withDesignations ? QString("h/p") : qc_("HA/PD", "celestial coordinate system");
+		}
+		else
+		{
+			// TRANSLATORS: Hour angle/Declination
+			HADec = withDesignations ? QString("h/&delta;") : qc_("HA/Dec", "celestial coordinate system");
+		}
 
 		if (withTables)
 			res += QString("<tr><td>%1:</td><td style='text-align:right;'>%2/</td><td style='text-align:right;'>%3</td><td>%4</td></tr>").arg(HADec, firstCoordinate, secondCoordinate, apparent);

--- a/src/core/modules/GridLinesMgr.cpp
+++ b/src/core/modules/GridLinesMgr.cpp
@@ -314,6 +314,7 @@ void SkyGrid::draw(const StelCore* core) const
 
 	const StelProjectorP prj = core->getProjection(frameType, (frameType!=StelCore::FrameAltAz && frameType!=StelCore::FrameFixedEquatorial) ? StelCore::RefractionAuto : StelCore::RefractionOff);
 	const bool withDecimalDegree = StelApp::getInstance().getFlagShowDecimalDegrees();
+        const bool usePolarDistance = StelApp::getInstance().getFlagPolarDistanceUsage();
 
 	// Look for all meridians and parallels intersecting with the disk bounding the viewport
 	// Check whether the pole are in the viewport
@@ -451,6 +452,10 @@ void SkyGrid::draw(const StelCore* core) const
 	for (i=0; i<maxNbIter; ++i)
 	{
 		StelUtils::rectToSphe(&lon2, &lat2, fpt);
+
+                if (usePolarDistance && (frameType==StelCore::FrameJ2000 || frameType==StelCore::FrameEquinoxEqu || frameType==StelCore::FrameFixedEquatorial))
+                        lat2 = M_PI_2 - lat2;
+
 		if (withDecimalDegree)
 			userData.text = StelUtils::radToDecDegStr(lat2);
 		else
@@ -508,6 +513,10 @@ void SkyGrid::draw(const StelCore* core) const
 		for (int j=0; j<maxNbIter-i; ++j)
 		{
 			StelUtils::rectToSphe(&lon2, &lat2, fpt);
+
+                        if (usePolarDistance && (frameType==StelCore::FrameJ2000 || frameType==StelCore::FrameEquinoxEqu || frameType==StelCore::FrameFixedEquatorial))
+                                lat2 = M_PI_2 - lat2;
+
 			if (withDecimalDegree)
 				userData.text = StelUtils::radToDecDegStr(lat2);
 			else

--- a/src/gui/ConfigurationDialog.cpp
+++ b/src/gui/ConfigurationDialog.cpp
@@ -313,37 +313,38 @@ void ConfigurationDialog::createDialogContent()
 	connect(ui->diskViewportCheckbox, SIGNAL(toggled(bool)), this, SLOT(setDiskViewport(bool)));
 	connectBoolProperty(ui->autoZoomResetsDirectionCheckbox, "StelMovementMgr.flagAutoZoomOutResetsDirection");
 
-	connectBoolProperty(ui->showQuitButtonCheckBox,				"StelGui.flagShowQuitButton");
-	connectBoolProperty(ui->showFlipButtonsCheckbox,				"StelGui.flagShowFlipButtons");
-	connectBoolProperty(ui->showNebulaBgButtonCheckbox,			"StelGui.flagShowNebulaBackgroundButton");
+	connectBoolProperty(ui->showQuitButtonCheckBox,			"StelGui.flagShowQuitButton");
+	connectBoolProperty(ui->showFlipButtonsCheckbox,			"StelGui.flagShowFlipButtons");
+	connectBoolProperty(ui->showNebulaBgButtonCheckbox,		"StelGui.flagShowNebulaBackgroundButton");
 	
-	connectBoolProperty(ui->showObsListButtonCheckBox,	"StelGui.flagShowObsListButton");
+	connectBoolProperty(ui->showObsListButtonCheckBox,			"StelGui.flagShowObsListButton");
 	
-	connectBoolProperty(ui->showICRSGridButtonCheckBox,			"StelGui.flagShowICRSGridButton");
+	connectBoolProperty(ui->showICRSGridButtonCheckBox,		"StelGui.flagShowICRSGridButton");
 	connectBoolProperty(ui->showGalacticGridButtonCheckBox,		"StelGui.flagShowGalacticGridButton");
 	connectBoolProperty(ui->showEclipticGridButtonCheckBox,		"StelGui.flagShowEclipticGridButton");
-	connectBoolProperty(ui->showHipsButtonCheckBox,				"StelGui.flagShowHiPSButton");
-	connectBoolProperty(ui->showDSSButtonCheckbox,				"StelGui.flagShowDSSButton");
+	connectBoolProperty(ui->showHipsButtonCheckBox,			"StelGui.flagShowHiPSButton");
+	connectBoolProperty(ui->showDSSButtonCheckbox,			"StelGui.flagShowDSSButton");
 	connectBoolProperty(ui->showGotoSelectedButtonCheckBox,		"StelGui.flagShowGotoSelectedObjectButton");
 	connectBoolProperty(ui->showNightmodeButtonCheckBox,		"StelGui.flagShowNightmodeButton");
-	connectBoolProperty(ui->showFullscreenButtonCheckBox,			"StelGui.flagShowFullscreenButton");
+	connectBoolProperty(ui->showFullscreenButtonCheckBox,		"StelGui.flagShowFullscreenButton");
 	connectBoolProperty(ui->showCardinalButtonCheckBox,			"StelGui.flagShowCardinalButton");
-	connectBoolProperty(ui->showCompassButtonCheckBox,			"StelGui.flagShowCompassButton");
+	connectBoolProperty(ui->showCompassButtonCheckBox,		"StelGui.flagShowCompassButton");
 
 	connectBoolProperty(ui->showConstellationBoundariesButtonCheckBox, "StelGui.flagShowConstellationBoundariesButton");
-	connectBoolProperty(ui->showConstellationArtsButtonCheckBox, "StelGui.flagShowConstellationArtsButton");
-	connectBoolProperty(ui->showAsterismLinesButtonCheckBox,		"StelGui.flagShowAsterismLinesButton");
+	connectBoolProperty(ui->showConstellationArtsButtonCheckBox,	"StelGui.flagShowConstellationArtsButton");
+	connectBoolProperty(ui->showAsterismLinesButtonCheckBox,	"StelGui.flagShowAsterismLinesButton");
 	connectBoolProperty(ui->showAsterismLabelsButtonCheckBox,	"StelGui.flagShowAsterismLabelsButton");
 
-	connectBoolProperty(ui->decimalDegreeCheckBox,				"StelApp.flagShowDecimalDegrees");
-	connectBoolProperty(ui->azimuthFromSouthcheckBox,			"StelApp.flagUseAzimuthFromSouth");
+	connectBoolProperty(ui->checkBoxDecimalDegrees,			"StelApp.flagShowDecimalDegrees");
+	connectBoolProperty(ui->checkBoxAzimuthFromSouth,			"StelApp.flagUseAzimuthFromSouth");
+	connectBoolProperty(ui->checkBoxPolarDistance,				"StelApp.flagUsePolarDistance");
 
 	connectBoolProperty(ui->mouseTimeoutCheckbox,				"MainView.flagCursorTimeout");
-	connectDoubleProperty(ui->mouseTimeoutSpinBox,				"MainView.cursorTimeout");
-	connectIntProperty(ui->minFpsSpinBox,                                   "MainView.minFps");
-	connectIntProperty(ui->maxFpsSpinBox,                                   "MainView.maxFps");
+	connectDoubleProperty(ui->mouseTimeoutSpinBox,			"MainView.cursorTimeout");
+	connectIntProperty(ui->minFpsSpinBox,						"MainView.minFps");
+	connectIntProperty(ui->maxFpsSpinBox,						"MainView.maxFps");
 	connectBoolProperty(ui->useButtonsBackgroundCheckBox,		"StelGui.flagUseButtonsBackground");
-	connectBoolProperty(ui->indicationMountModeCheckBox,			"StelMovementMgr.flagIndicationMountMode");
+	connectBoolProperty(ui->indicationMountModeCheckBox,		"StelMovementMgr.flagIndicationMountMode");
 	connectBoolProperty(ui->kineticScrollingCheckBox,				"StelGui.flagUseKineticScrolling");
 	connectBoolProperty(ui->focusOnDaySpinnerCheckBox,			"StelGui.flagEnableFocusOnDaySpinner");
 	ui->overwriteTextColorButton->setup("StelApp.overwriteInfoColor", "color/info_text_color");
@@ -1181,7 +1182,7 @@ void ConfigurationDialog::saveAllSettings()
 
 	conf->setValue("gui/flag_show_obslist_button",			propMgr->getStelPropertyValue("StelGui.flagShowObsListButton").toBool());
 
-	conf->setValue("gui/flag_show_icrs_grid_button",		propMgr->getStelPropertyValue("StelGui.flagShowICRSGridButton").toBool());
+	conf->setValue("gui/flag_show_icrs_grid_button",			propMgr->getStelPropertyValue("StelGui.flagShowICRSGridButton").toBool());
 	conf->setValue("gui/flag_show_galactic_grid_button",		propMgr->getStelPropertyValue("StelGui.flagShowGalacticGridButton").toBool());
 	conf->setValue("gui/flag_show_ecliptic_grid_button",		propMgr->getStelPropertyValue("StelGui.flagShowEclipticGridButton").toBool());
 	conf->setValue("gui/flag_show_boundaries_button",		propMgr->getStelPropertyValue("StelGui.flagShowConstellationBoundariesButton").toBool());
@@ -1190,12 +1191,13 @@ void ConfigurationDialog::saveAllSettings()
 	conf->setValue("gui/flag_show_asterism_labels_button",		propMgr->getStelPropertyValue("StelGui.flagShowAsterismLabelsButton").toBool());
 	conf->setValue("gui/flag_show_decimal_degrees",			propMgr->getStelPropertyValue("StelApp.flagShowDecimalDegrees").toBool());
 	conf->setValue("gui/flag_use_azimuth_from_south",		propMgr->getStelPropertyValue("StelApp.flagUseAzimuthFromSouth").toBool());
-	conf->setValue("gui/flag_use_formatting_output",		propMgr->getStelPropertyValue("StelApp.flagUseFormattingOutput").toBool());
+	conf->setValue("gui/flag_use_polar_distance",				propMgr->getStelPropertyValue("StelApp.flagUsePolarDistance").toBool());
+	conf->setValue("gui/flag_use_formatting_output",			propMgr->getStelPropertyValue("StelApp.flagUseFormattingOutput").toBool());
 	conf->setValue("gui/flag_use_ccs_designations",			propMgr->getStelPropertyValue("StelApp.flagUseCCSDesignation").toBool());
 	conf->setValue("gui/flag_overwrite_info_color",			propMgr->getStelPropertyValue("StelApp.flagOverwriteInfoColor").toBool());
-	conf->setValue("gui/flag_time_jd",				gui->getButtonBar()->getFlagTimeJd());
+	conf->setValue("gui/flag_time_jd",						gui->getButtonBar()->getFlagTimeJd());
 	conf->setValue("gui/flag_show_buttons_background",		propMgr->getStelPropertyValue("StelGui.flagUseButtonsBackground").toBool());
-	conf->setValue("gui/flag_indication_mount_mode",		mvmgr->getFlagIndicationMountMode());
+	conf->setValue("gui/flag_indication_mount_mode",			mvmgr->getFlagIndicationMountMode());
 
 	// configuration dialog / navigation tab
 	conf->setValue("navigation/flag_enable_zoom_keys",		mvmgr->getFlagEnableZoomKeys());

--- a/src/gui/configurationDialog.ui
+++ b/src/gui/configurationDialog.ui
@@ -1082,10 +1082,27 @@
              <property name="bottomMargin">
               <number>0</number>
              </property>
+             <item row="2" column="0">
+              <widget class="QCheckBox" name="checkBoxUseFormattingOutput">
+               <property name="text">
+                <string>Tabular output for coordinates and time</string>
+               </property>
+              </widget>
+             </item>
              <item row="1" column="0">
               <widget class="QCheckBox" name="checkBoxUMShortNotationSurfaceBrightness">
                <property name="text">
                 <string>Short notation for units of surface brightness</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="1">
+              <widget class="QCheckBox" name="checkBoxDecimalDegrees">
+               <property name="toolTip">
+                <string>Use decimal degrees for coordinates</string>
+               </property>
+               <property name="text">
+                <string>Use decimal degrees</string>
                </property>
               </widget>
              </item>
@@ -1096,25 +1113,8 @@
                </property>
               </widget>
              </item>
-             <item row="2" column="0">
-              <widget class="QCheckBox" name="checkBoxUseFormattingOutput">
-               <property name="text">
-                <string>Tabular output for coordinates and time</string>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="1">
-              <widget class="QCheckBox" name="decimalDegreeCheckBox">
-               <property name="toolTip">
-                <string>Use decimal degrees for coordinates</string>
-               </property>
-               <property name="text">
-                <string>Use decimal degrees</string>
-               </property>
-              </widget>
-             </item>
              <item row="1" column="1">
-              <widget class="QCheckBox" name="azimuthFromSouthcheckBox">
+              <widget class="QCheckBox" name="checkBoxAzimuthFromSouth">
                <property name="toolTip">
                 <string>Activate this option to calculate azimuth from south towards west.</string>
                </property>
@@ -1123,10 +1123,20 @@
                </property>
               </widget>
              </item>
-             <item row="2" column="1">
+             <item row="4" column="1">
               <widget class="QCheckBox" name="checkBoxUseCCSDesignations">
                <property name="text">
                 <string>Designations for celestial coordinate systems</string>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="1">
+              <widget class="QCheckBox" name="checkBoxPolarDistance">
+               <property name="toolTip">
+                <string>Use polar distance instead of declination in equatorial coordinates</string>
+               </property>
+               <property name="text">
+                <string>Polar distance, not declination</string>
                </property>
               </widget>
              </item>
@@ -2745,7 +2755,7 @@
   <customwidget>
    <class>TitleBar</class>
    <extends>QFrame</extends>
-   <header>Dialog.hpp</header>
+   <header location="global">Dialog.hpp</header>
    <container>1</container>
   </customwidget>
   <customwidget>
@@ -2797,9 +2807,8 @@
   <tabstop>checkBoxUMSurfaceBrightness</tabstop>
   <tabstop>checkBoxUMShortNotationSurfaceBrightness</tabstop>
   <tabstop>checkBoxUseFormattingOutput</tabstop>
-  <tabstop>decimalDegreeCheckBox</tabstop>
-  <tabstop>azimuthFromSouthcheckBox</tabstop>
-  <tabstop>checkBoxUseCCSDesignations</tabstop>
+  <tabstop>checkBoxDecimalDegrees</tabstop>
+  <tabstop>checkBoxAzimuthFromSouth</tabstop>
   <tabstop>showConstellationBoundariesButtonCheckBox</tabstop>
   <tabstop>showConstellationArtsButtonCheckBox</tabstop>
   <tabstop>showAsterismLinesButtonCheckBox</tabstop>


### PR DESCRIPTION
### Description
Added ability to use polar distance instead of declination in equatorial coordinates

Fixes #4529 (issue)

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?
- Run Stellarium
- Enable grids or select the celestial object
- Switch to use polar distance in Configuration dialog

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
