### PR TITLE
SCM Plugin: don't exit on "Export and Exit" when export failed

### DIFF
--- a/plugins/SkyCultureMaker/CHANGELOG.md
+++ b/plugins/SkyCultureMaker/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Version 1.0.1
 
 * Fix: Drawn constellations are not reset after "Export and Exit"
+* Fix: "Export and Exit" exits even when export failed, deleting all unsaved progress
 * Fix: Stop drawing line key (Double Right Click) only works when Star/DSO is selected
 * Fix: Not all SC description input fields that are marked required are actually checked
 * Fix: No formal checks for 'Constellations' input field in SC description

--- a/plugins/SkyCultureMaker/src/gui/ScmSkyCultureExportDialog.cpp
+++ b/plugins/SkyCultureMaker/src/gui/ScmSkyCultureExportDialog.cpp
@@ -82,13 +82,13 @@ void ScmSkyCultureExportDialog::handleFontChanged()
 	ui->titleLbl->setFont(titleLblFont);
 }
 
-void ScmSkyCultureExportDialog::exportSkyCulture()
+bool ScmSkyCultureExportDialog::exportSkyCulture()
 {
 	if (maker == nullptr)
 	{
 		qWarning() << "SkyCultureMaker: maker is nullptr. Cannot export sky culture.";
 		ScmSkyCultureExportDialog::close();
-		return;
+		return false;
 	}
 
 	scm::ScmSkyCulture* currentSkyCulture = maker->getCurrentSkyCulture();
@@ -97,7 +97,7 @@ void ScmSkyCultureExportDialog::exportSkyCulture()
 		qWarning() << "SkyCultureMaker: current sky culture is nullptr. Cannot export.";
 		maker->showUserErrorMessage(this->dialog, ui->titleBar->title(), q_("No sky culture is set."));
 		ScmSkyCultureExportDialog::close();
-		return;
+		return false;
 	}
 
 	QString skyCultureId = currentSkyCulture->getId();
@@ -110,7 +110,7 @@ void ScmSkyCultureExportDialog::exportSkyCulture()
 		qWarning() << "SkyCultureMaker: Could not export sky culture. User cancelled or failed to choose "
 			      "directory.";
 		maker->showUserErrorMessage(this->dialog, ui->titleBar->title(), q_("Failed to choose export directory."));
-		return; // User cancelled or failed to choose directory
+		return false; // User cancelled or failed to choose directory
 	}
 
 	if (skyCultureDirectory.exists())
@@ -119,7 +119,7 @@ void ScmSkyCultureExportDialog::exportSkyCulture()
 			   << "already exists. Cannot export.";
 		maker->showUserErrorMessage(this->dialog, ui->titleBar->title(), q_("Sky culture with this ID already exists."));
 		// don't close the dialog here, so the user can delete the folder first
-		return;
+		return false;
 	}
 
 	// Create the sky culture directory
@@ -129,7 +129,7 @@ void ScmSkyCultureExportDialog::exportSkyCulture()
 		qWarning() << "SkyCultureMaker: Failed to create sky culture directory at"
 			   << skyCultureDirectory.absolutePath();
 		maker->showUserErrorMessage(this->dialog, ui->titleBar->title(), q_("Failed to create sky culture directory."));
-		return;
+		return false;
 	}
 
 	// save illustrations before json, because the relative illustrations path is required for the json export
@@ -142,7 +142,7 @@ void ScmSkyCultureExportDialog::exportSkyCulture()
 		// delete the created directory
 		skyCultureDirectory.removeRecursively();
 		ScmSkyCultureExportDialog::close();
-		return;
+		return false;
 	}
 
 	// Export the sky culture to the index.json file
@@ -155,7 +155,7 @@ void ScmSkyCultureExportDialog::exportSkyCulture()
 		maker->showUserErrorMessage(this->dialog, ui->titleBar->title(), q_("Failed to create JSON document for sky culture."));
 		skyCultureDirectory.removeRecursively();
 		ScmSkyCultureExportDialog::close();
-		return;
+		return false;
 	}
 	QFile scJsonFile(skyCultureDirectory.absoluteFilePath("index.json"));
 	if (!scJsonFile.open(QIODevice::WriteOnly | QIODevice::Text))
@@ -164,7 +164,7 @@ void ScmSkyCultureExportDialog::exportSkyCulture()
 		maker->showUserErrorMessage(this->dialog, ui->titleBar->title(), q_("Failed to open index.json for writing."));
 		skyCultureDirectory.removeRecursively();
 		ScmSkyCultureExportDialog::close();
-		return;
+		return false;
 	}
 	scJsonFile.write(scJsonDoc.toJson(QJsonDocument::Indented));
 	scJsonFile.close();
@@ -177,7 +177,7 @@ void ScmSkyCultureExportDialog::exportSkyCulture()
 		qWarning() << "SkyCultureMaker: Failed to export sky culture description.";
 		skyCultureDirectory.removeRecursively();
 		ScmSkyCultureExportDialog::close();
-		return;
+		return false;
 	}
 
 	// Save the CMakeLists.txt file
@@ -188,7 +188,7 @@ void ScmSkyCultureExportDialog::exportSkyCulture()
 		qWarning() << "SkyCultureMaker: Failed to export CMakeLists.txt.";
 		skyCultureDirectory.removeRecursively();
 		ScmSkyCultureExportDialog::close();
-		return;
+		return false;
 	}
 
 	maker->showUserInfoMessage(this->dialog, ui->titleBar->title(),
@@ -199,6 +199,8 @@ void ScmSkyCultureExportDialog::exportSkyCulture()
 
 	// Reload the sky cultures in Stellarium to make the new one available immediately
 	StelApp::getInstance().getSkyCultureMgr().reloadSkyCulture();
+
+	return true;
 }
 
 bool ScmSkyCultureExportDialog::chooseExportDirectory(const QString& skyCultureId, QDir& skyCultureDirectory)
@@ -224,11 +226,13 @@ bool ScmSkyCultureExportDialog::chooseExportDirectory(const QString& skyCultureI
 
 void ScmSkyCultureExportDialog::exportAndExitSkyCulture()
 {
-	exportSkyCulture();
-	maker->resetScmDialogs();
-	maker->hideAllDialogs();
-	maker->setIsScmEnabled(false);
-	maker->setNewSkyCulture();
+	if(exportSkyCulture())
+	{
+		maker->resetScmDialogs();
+		maker->hideAllDialogs();
+		maker->setIsScmEnabled(false);
+		maker->setNewSkyCulture();
+	}
 }
 
 bool ScmSkyCultureExportDialog::saveSkyCultureCMakeListsFile(const QDir& directory)

--- a/plugins/SkyCultureMaker/src/gui/ScmSkyCultureExportDialog.hpp
+++ b/plugins/SkyCultureMaker/src/gui/ScmSkyCultureExportDialog.hpp
@@ -50,7 +50,7 @@ private:
 	SkyCultureMaker *maker           = nullptr;
 	QString skyCulturesPath;
 
-	void exportSkyCulture();
+	bool exportSkyCulture();
 	bool chooseExportDirectory(const QString &skyCultureId, QDir &skyCultureDirectory);
 	void exportAndExitSkyCulture();
 	bool saveSkyCultureCMakeListsFile(const QDir &directory);


### PR DESCRIPTION
Previously when pressing "Export and Exit" and the export failed, for example when the directory already existed or the user closed the file dialog, the SCM window simply closed and all progress was lost. In my opinion, the user should get the error message and then have another try to export it, without the dialogs just closing.

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?
Manual test.

**Test Configuration**:
* Operating system: MacOS 26.0.1
* Graphics Card: Apple M3 Pro

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
