### PR TITLE
Fix wrong exaggerated stellar parallax for binary stars

### DIFF
--- a/src/core/modules/Star.hpp
+++ b/src/core/modules/Star.hpp
@@ -445,6 +445,7 @@ struct Star
       pmra = sky_orbit_vel.dot(p2) * 1000.;
       pmdec = sky_orbit_vel.dot(q2) * 1000.;
       StelUtils::rectToSphe(&ra, &dec, v);
+      v.normalize();
    }
 };
 


### PR DESCRIPTION
### Description
Fix wrong exaggerated stellar parallax for binary stars.

Fixes #4498 

### Screenshots (if appropriate):

Sirius:


https://github.com/user-attachments/assets/eecfc515-b055-4941-bc83-b86d692eb3c7

Pollux:

https://github.com/user-attachments/assets/77bb4bfa-166a-42b0-bba1-264dee62b866

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?
Visual

**Test Configuration**:
* Operating system: MacOS 26
* Graphics Card: Apple M3

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
