### PR TITLE
Add VS2026 multi-config section and fix VS2022 statement in BUILDING.md

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -473,7 +473,7 @@ example and may not apply to your setup.
 on your main system drive. Add the path to your user/system environment variables PATH to allow Stellarium to 
 discover them during runtime.
 
-Open Visual Studio 2022. Continue wihtout code.
+Open Visual Studio 2022. Continue without code.
 
 If you want to use a specific cmake.exe go to Tools -> Options, navigate to Cmake -> General and fill the appropriate
 checkbox and path. Otherwise VS 2022 will use it own cmake.exe tool. The path of an external cmake should be included
@@ -499,7 +499,7 @@ Then build by typing this command in the Developer Command Prompt:
 
 cmake --build --preset Release
 
-Redo the same process for the last build, ie. RelWithDebInfo.
+Redo the same process for the last build, i.e. RelWithDebInfo.
 
 cmake --build --preset RelWithDebInfo
 
@@ -526,7 +526,7 @@ Note: To work on the Release or RelWithDebInfo configuration first select it fro
 
 You can also used this newly released version of Visual Studio (November 2025) to build and develop Stellarium. This release fixes the bug 
 of VS 2022 for the building steps and in a sense simplify the building process of Stellarium. Here are the changes to the process described
-above for Visual Studio 2022 (multi-configuraiton)
+above for Visual Studio 2022 (multi-configuration)
 
 Use a slightly different CMakePresets.json file, and adapt it to your development environment.
 
@@ -585,7 +585,7 @@ Use a slightly different CMakePresets.json file, and adapt it to your developmen
   ]
 }
 
-Note: To use 'Visual Studio 18 2026' generator, you need the lastest version of CMake, version 4.2.0
+Note: To use 'Visual Studio 18 2026' generator, you need the latest version of CMake, version 4.2.0
 
 Open Visual Studio 2026. Open the Stellarium folder.
 


### PR DESCRIPTION
Instructions to build Stellarium with Visual Studio 2022 were revised. Instructions to build Stellarium with Visual Studio 2026 were added.

### Description

Instructions with VS 2022 that claim we could not use the solution file of Stellarium (Stellarium.sln) was erroneous. It has been corrected in this newly version of BUILDING.md. Instructions on how to build Stellarium with Visual Studio 2026 (released November 2025), have been added.

The main motivation of this Pull Request is to make the documentation up-to-date. There are no dependencies required for this change. Moreover it is not linked to any issue #.

### Screenshots (if appropriate):
None

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?
I successfully run the procedure for building and testing Stellarium with Visual Studio 2022 and 2026 on my local Windows-based PC.

**Test Configuration**:
• Operating system : Windows 11 Pro, 25H2, OS build 26200.7171
• Processor : 13th Gen Intel(R) Core(TM) i7-13700K (3.40 GHz)
• Graphic Card : NVIDIA GeForce RTX 5050 Ti
• Driver : 581.80
• Display : ASUS PA329CV, 3840x2160 | 60 Hz | Highest (32-bit) | HDCP

## Checklist:
- [ ] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
