### PR TITLE
SCM: Use better button labels in the Close dialog

### DIFF
--- a/plugins/SkyCultureMaker/src/gui/scmHideOrAbortMakerDialog.ui
+++ b/plugins/SkyCultureMaker/src/gui/scmHideOrAbortMakerDialog.ui
@@ -87,7 +87,7 @@
            <item>
             <widget class="QLabel" name="questionLbl">
              <property name="text">
-              <string>Hide the plugin to resume later or abort the process?</string>
+              <string>Hide the plugin to resume later or close it without saving the sky culture?</string>
              </property>
              <property name="alignment">
               <set>Qt::AlignCenter</set>


### PR DESCRIPTION
The current labels in the close confirmation dialog of the SCM are quite confusing: Hide, Abort, Cancel. The "abort" and "cancel" are synonyms, and already in English they can cause confusion. And in some translations, apparently, they are even translated to the same word, as described [here](https://github.com/Stellarium/stellarium/pull/4683#issuecomment-3618957803).

This PR changes the button labels to be more explicit in what they do.