### PR TITLE
SCM: Automate formatting of references

### DIFF
--- a/plugins/SkyCultureMaker/src/gui/ScmSkyCultureDialog.hpp
+++ b/plugins/SkyCultureMaker/src/gui/ScmSkyCultureDialog.hpp
@@ -119,11 +119,51 @@ private:
 	QString makeConstellationsSection() const;
 
 	/**
+	 * @brief Clears the references list and resets the helper buttons.
+	 */
+	void resetReferences();
+
+	/**
+	 * @brief Adds a new reference to the list and initiates editing it.
+	 */
+	void addNewReference();
+
+	/**
+	 * @brief Removes selected reference from the list.
+	 */
+	void removeReference();
+
+	/**
+	 * @brief Updates states of the buttons controlling the references list.
+	 */
+	void updateReferencesButtons();
+
+	/**
+	 * @brief Moves the selected reference above the previous reference, renumerating all references.
+	 */
+	void moveCurrentReferenceUp();
+
+	/**
+	 * @brief Moves the selected reference below the next reference, renumerating all references.
+	 */
+	void moveCurrentReferenceDown();
+
+	/**
+	 * @brief Updates reference numbers as shown in the list.
+	 */
+	void updateReferencesNumeration();
+
+	/**
 	 * @brief Gets the description from the text edit.
 	 *
 	 * @return The description from the text edit.
 	 */
 	scm::Description getDescriptionFromTextEdit() const;
+
+	/**
+	 * @brief Compiles the References section from all the references in the list.
+	 */
+	QString makeReferencesSection() const;
 
 	/**
 	 * @brief Opens the constellation dialog with data for a given constellation.

--- a/plugins/SkyCultureMaker/src/gui/scmSkyCultureDialog.ui
+++ b/plugins/SkyCultureMaker/src/gui/scmSkyCultureDialog.ui
@@ -237,9 +237,9 @@
              <property name="geometry">
               <rect>
                <x>0</x>
-               <y>-1317</y>
+               <y>-1481</y>
                <width>800</width>
-               <height>2235</height>
+               <height>2342</height>
               </rect>
              </property>
              <layout class="QVBoxLayout" name="descriptionLayout">
@@ -526,17 +526,69 @@
                   </widget>
                  </item>
                  <item>
-                  <widget class="QTextEdit" name="referencesTE">
-                   <property name="sizeAdjustPolicy">
-                    <enum>QAbstractScrollArea::AdjustToContents</enum>
-                   </property>
-                   <property name="acceptRichText">
-                    <bool>false</bool>
-                   </property>
-                   <property name="placeholderText">
-                    <string notr="true"> - [#1]: Author: Title, (Journal, ...), Publisher, Location, Year</string>
-                   </property>
-                  </widget>
+                  <layout class="QGridLayout" name="referencesLayout">
+                   <item row="2" column="0">
+                    <widget class="QPushButton" name="addRefBtn">
+                     <property name="text">
+                      <string>Add</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="2" column="1">
+                    <widget class="QPushButton" name="moveRefUpBtn">
+                     <property name="text">
+                      <string/>
+                     </property>
+                     <property name="icon">
+                      <iconset resource="../../../../data/gui/guiRes.qrc">
+                       <normaloff>:/graphicGui/uibtUp.png</normaloff>
+                       <disabledoff>:/graphicGui/uibtUp-disabled.png</disabledoff>:/graphicGui/uibtUp.png</iconset>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="2" column="2">
+                    <widget class="QPushButton" name="moveRefDownBtn">
+                     <property name="text">
+                      <string/>
+                     </property>
+                     <property name="icon">
+                      <iconset resource="../../../../data/gui/guiRes.qrc">
+                       <normaloff>:/graphicGui/uibtDown.png</normaloff>
+                       <disabledoff>:/graphicGui/uibtDown-disabled.png</disabledoff>:/graphicGui/uibtDown.png</iconset>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="2" column="3">
+                    <widget class="QPushButton" name="removeRefBtn">
+                     <property name="text">
+                      <string>Remove</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="0" column="0" colspan="4">
+                    <widget class="QTreeWidget" name="referencesList">
+                     <property name="rootIsDecorated">
+                      <bool>false</bool>
+                     </property>
+                     <property name="uniformRowHeights">
+                      <bool>true</bool>
+                     </property>
+                     <property name="headerHidden">
+                      <bool>true</bool>
+                     </property>
+                     <column>
+                      <property name="text">
+                       <string/>
+                      </property>
+                     </column>
+                     <column>
+                      <property name="text">
+                       <string/>
+                      </property>
+                     </column>
+                    </widget>
+                   </item>
+                  </layout>
                  </item>
                  <item>
                   <widget class="QLabel" name="authorsLbl">
@@ -635,6 +687,8 @@
    <container>1</container>
   </customwidget>
  </customwidgets>
- <resources/>
+ <resources>
+  <include location="../../../../data/gui/guiRes.qrc"/>
+ </resources>
  <connections/>
 </ui>


### PR DESCRIPTION
### Description

Now users will edit an actual list of references: a `QTreeWidget`, not having to deal with the Markdown syntax we use. This way we'll hopefully get a higher rate of syntactically correct SCs in new PRs.

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?

**Test Configuration**:
* Operating system: Ubuntu 20.04

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
