### PR TITLE
SCM: remove "test only" warning and enable translation in start dialog

### DIFF
--- a/plugins/SkyCultureMaker/src/gui/ScmStartDialog.cpp
+++ b/plugins/SkyCultureMaker/src/gui/ScmStartDialog.cpp
@@ -65,11 +65,9 @@ void ScmStartDialog::retranslate()
 void ScmStartDialog::createDialogContent()
 {
 	ui->setupUi(dialog);
+	ui->welcomeLabel->setText(q_("Welcome to the Sky Culture Maker!"));
 
-	// SCM just after merge creates misformatted description.md. For now, inform the feature testers.
-	ui->welcomeLabel->setText(QString("%1<br/><bold>%2</bold>").arg(q_("Welcome to the Sky Culture Maker!"), q_("Note: Test only. The result does not yet comply to Stellarium's formatting rules.")));
-
-	// connect(&StelApp::getInstance(), SIGNAL(languageChanged()), this, SLOT(retranslate()));
+	connect(&StelApp::getInstance(), SIGNAL(languageChanged()), this, SLOT(retranslate()));
 	connect(&StelApp::getInstance(), &StelApp::fontChanged, this, &ScmStartDialog::handleFontChanged);
 	connect(&StelApp::getInstance(), &StelApp::guiFontSizeChanged, this, &ScmStartDialog::handleFontChanged);
 


### PR DESCRIPTION
Removes the warning that the SCM is for testing only. Also enables the translation for the start dialog, which was commented out for some reason.

Whether this PR can be merged or not is discussed in #4636.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
