### PR TITLE
SCM: Tell what fields are incomplete on export error

### DIFF
--- a/plugins/SkyCultureMaker/src/gui/ScmSkyCultureDialog.cpp
+++ b/plugins/SkyCultureMaker/src/gui/ScmSkyCultureDialog.cpp
@@ -223,9 +223,13 @@ void ScmSkyCultureDialog::saveSkyCulture()
 		return;
 	}
 	// check if description is complete
-	if (!desc.isComplete())
+	const auto incompFieldsList = desc.getIncompleteFieldsList();
+	if (!incompFieldsList.isEmpty())
 	{
-		maker->showUserWarningMessage(dialog, ui->titleBar->title(), q_("The sky culture description is not complete. Please fill in all required fields correctly."));
+		auto msg = q_("The sky culture description is not complete. The following fields are not filled correctly:\n");
+		for (const auto& field : incompFieldsList)
+			msg += u8" \u2022 " + field + "\n";
+		maker->showUserWarningMessage(dialog, ui->titleBar->title(), msg);
 		return;
 	}
 

--- a/plugins/SkyCultureMaker/src/gui/scmSkyCultureDialog.ui
+++ b/plugins/SkyCultureMaker/src/gui/scmSkyCultureDialog.ui
@@ -613,7 +613,7 @@
                  <item>
                   <widget class="QLabel" name="aboutLbl">
                    <property name="text">
-                    <string>About:*</string>
+                    <string>About the sky culture:*</string>
                    </property>
                   </widget>
                  </item>

--- a/plugins/SkyCultureMaker/src/types/Description.hpp
+++ b/plugins/SkyCultureMaker/src/types/Description.hpp
@@ -56,20 +56,18 @@ struct Description
 	scm::LicenseType license;                // license code
 	scm::ClassificationType classification;  // classification code
 
-	/**
-	 * @brief Check if the description is complete.
-	 * @return true if all required fields are correctly filled, false otherwise.
-	 */
-	bool isComplete() const
+	QStringList getIncompleteFieldsList() const
 	{
-		return !name.trimmed().isEmpty() &&
-			   !introduction.trimmed().isEmpty() &&
-			   !cultureDescription.trimmed().isEmpty() &&
-			   !references.trimmed().isEmpty() &&
-			   !authors.trimmed().isEmpty() &&
-			   !about.trimmed().isEmpty() &&
-			   license != scm::LicenseType::NONE &&
-			   classification != scm::ClassificationType::NONE;
+		QStringList list;
+		if (name.trimmed().isEmpty())               list.append(q_("Name of the Sky Culture"));
+		if (introduction.trimmed().isEmpty())       list.append(qc_("Introduction", "Name of a section in sky culture description"));
+		if (cultureDescription.trimmed().isEmpty()) list.append(q_("Culture Description"));
+		if (references.trimmed().isEmpty())         list.append(qc_("References", "Name of a section in sky culture description"));
+		if (authors.trimmed().isEmpty())            list.append(qc_("Authors", "Name of a section in sky culture description"));
+		if (about.trimmed().isEmpty())              list.append(q_("About the sky culture"));
+		if (license == scm::LicenseType::NONE)      list.append(qc_("License", "Name of a section in sky culture description"));
+		if (classification == scm::ClassificationType::NONE) list.append(q_("Classification"));
+		return list;
 	}
 };
 } // namespace scm


### PR DESCRIPTION
The current message about incompleteness of the SC being exported is very generic and not very user-friendly. This PR adds an explicit list of the fields missing. This adds/changes a few translatable strings, but since they are in the SCM, I guess the few people who are going to use it will not be too upset even if the translations don't appear before the upcoming release.

I also changed the "About:*" label to be less ambiguous, because otherwise the corresponding entry in the list ("About") gets translated as "About the program" e.g. in the Russian locale.