### PR TITLE
Replace deprecated constructor for QMouseEvent and avoid unnecessary …

### DIFF
--- a/src/core/StelApp.cpp
+++ b/src/core/StelApp.cpp
@@ -1170,8 +1170,13 @@ void StelApp::handleClick(QMouseEvent* inputEvent)
 	if (viewportEffect)
 		viewportEffect->distortXY(x, y);
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 	QMouseEvent event(inputEvent->type(), QPointF(x*devicePixelsPerPixel, y*devicePixelsPerPixel), inputEvent->globalPosition(), inputEvent->button(), inputEvent->buttons(), inputEvent->modifiers());
 	event.setAccepted(false);
+#else
+    QMouseEvent event(inputEvent->type(), QPoint(qRound(x*devicePixelsPerPixel), qRound(y*devicePixelsPerPixel)), inputEvent->button(), inputEvent->buttons(), inputEvent->modifiers());
+	event.setAccepted(false);
+#endif
 	
 	// Send the event to every StelModule
 	for (auto* i : moduleMgr->getCallOrders(StelModule::ActionHandleMouseClicks))

--- a/src/core/StelApp.cpp
+++ b/src/core/StelApp.cpp
@@ -1172,11 +1172,10 @@ void StelApp::handleClick(QMouseEvent* inputEvent)
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 	QMouseEvent event(inputEvent->type(), QPointF(x*devicePixelsPerPixel, y*devicePixelsPerPixel), inputEvent->globalPosition(), inputEvent->button(), inputEvent->buttons(), inputEvent->modifiers());
-	event.setAccepted(false);
 #else
-    QMouseEvent event(inputEvent->type(), QPoint(qRound(x*devicePixelsPerPixel), qRound(y*devicePixelsPerPixel)), inputEvent->button(), inputEvent->buttons(), inputEvent->modifiers());
-	event.setAccepted(false);
+	QMouseEvent event(inputEvent->type(), QPoint(qRound(x*devicePixelsPerPixel), qRound(y*devicePixelsPerPixel)), inputEvent->button(), inputEvent->buttons(), inputEvent->modifiers());
 #endif
+	event.setAccepted(false);
 	
 	// Send the event to every StelModule
 	for (auto* i : moduleMgr->getCallOrders(StelModule::ActionHandleMouseClicks))

--- a/src/core/StelApp.cpp
+++ b/src/core/StelApp.cpp
@@ -1171,7 +1171,7 @@ void StelApp::handleClick(QMouseEvent* inputEvent)
 		viewportEffect->distortXY(x, y);
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-	QMouseEvent event(inputEvent->type(), QPointF(x*devicePixelsPerPixel, y*devicePixelsPerPixel), inputEvent->globalPosition(), inputEvent->button(), inputEvent->buttons(), inputEvent->modifiers());
+	QMouseEvent event(inputEvent->type(), QPointF(x,y) * devicePixelsPerPixel, inputEvent->globalPosition() * devicePixelsPerPixel, inputEvent->button(), inputEvent->buttons(), inputEvent->modifiers());
 #else
 	QMouseEvent event(inputEvent->type(), QPoint(qRound(x*devicePixelsPerPixel), qRound(y*devicePixelsPerPixel)), inputEvent->button(), inputEvent->buttons(), inputEvent->modifiers());
 #endif

--- a/src/core/StelApp.cpp
+++ b/src/core/StelApp.cpp
@@ -1170,7 +1170,7 @@ void StelApp::handleClick(QMouseEvent* inputEvent)
 	if (viewportEffect)
 		viewportEffect->distortXY(x, y);
 
-	QMouseEvent event(inputEvent->type(), QPoint(qRound(x*devicePixelsPerPixel), qRound(y*devicePixelsPerPixel)), inputEvent->button(), inputEvent->buttons(), inputEvent->modifiers());
+	QMouseEvent event(inputEvent->type(), QPointF(x*devicePixelsPerPixel, y*devicePixelsPerPixel), inputEvent->globalPosition(), inputEvent->button(), inputEvent->buttons(), inputEvent->modifiers());
 	event.setAccepted(false);
 	
 	// Send the event to every StelModule


### PR DESCRIPTION
…implicit conversion from QPoint to QPointF

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Please include a summary of the change and which issue is fixed. -->
<!--- Please also include relevant motivation and context. -->
<!--- List any dependencies that are required for this change. -->

Fixes # (issue)

### Screenshots (if appropriate):

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system: <Name, version number>
* Graphics Card: <Manufacturer (likely Intel, NVidia, AMD?), Model (HD, Geforce, Radeon..., with model number), driver version?>

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
