### PR TITLE
Fix Save List button in Observing Lists window not saving description-only changes

### DIFF
--- a/src/gui/ObsListDialog.cpp
+++ b/src/gui/ObsListDialog.cpp
@@ -469,8 +469,9 @@ void ObsListDialog::loadSelectedList()
 
 	// Display description and creation date
 	currentListName=observingListMap.value(KEY_NAME).toString();
+	currentListDescription=observingListMap.value(KEY_DESCRIPTION).toString();
 	ui->listNameLineEdit->setText(currentListName);
-	ui->descriptionLineEdit->setText(observingListMap.value(KEY_DESCRIPTION).toString());
+	ui->descriptionLineEdit->setText(currentListDescription);
 	ui->creationDateLineEdit->setText(observingListMap.value(KEY_CREATION_DATE).toString());
 	ui->lastEditLineEdit->setText(observingListMap.value(KEY_LAST_EDIT, observingListMap.value(KEY_CREATION_DATE)).toString());
 
@@ -1339,7 +1340,11 @@ void ObsListDialog::saveButtonPressed()
 		return;
 	}
 
-	// Last chance to detect any change: Just list name changed?
+	// Last chance to detect any change: Just list name or description changed?
+	QString listDescription = ui->descriptionLineEdit->text().trimmed();
+	if(currentListDescription!=listDescription)
+		tainted=true;
+
 	if (currentListName!=listName)
 		tainted=true;
 
@@ -1348,6 +1353,7 @@ void ObsListDialog::saveButtonPressed()
 
 	//OK, we save this and keep it as current list.
 	currentListName=listName;
+	currentListDescription=listDescription;
 
 	QFile jsonFile(observingListJsonPath);
 	if (!jsonFile.open(QIODevice::ReadWrite | QIODevice::Text))
@@ -1505,7 +1511,7 @@ QVariantMap ObsListDialog::prepareCurrentList(QHash<QString, observingListItem> 
 	QVariantMap currentList = {
 		// Name, description, current date for the list, current sorting
 		{KEY_NAME,          currentListName},
-		{KEY_DESCRIPTION,   ui->descriptionLineEdit->text()},
+		{KEY_DESCRIPTION,   currentListDescription},
 		{KEY_SORTING,       sorting},
 		{KEY_CREATION_DATE, ui->creationDateLineEdit->text()},
 		{KEY_LAST_EDIT,     lastEditDate }

--- a/src/gui/ObsListDialog.hpp
+++ b/src/gui/ObsListDialog.hpp
@@ -250,6 +250,7 @@ private:
 
 	QList<QString> listNames; //!< List names, used for the ComboBox
 	QString currentListName;  //!< Name of list with selectedOlud
+	QString currentListDescription; //!< Description of list with selectedOlud
 	QString sorting;	  //!< Sorting of the list ex: right ascension
 
 	bool flagUseJD;         //!< Property. Store/retrieve date


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Please include a summary of the change and which issue is fixed. -->
<!--- Please also include relevant motivation and context. -->
<!--- List any dependencies that are required for this change. -->
I added a check when the user presses the "Save List" button that checks if the description has been modified. The code already performs the same check for the list's name, so I pretty much mirrored that implementation, but for the description field. I added a `QString currentListDescription` variable to match the `QString currentListName`, and updated it in the same ways.

Fixes #3808 

### Screenshots (if appropriate):
https://github.com/user-attachments/assets/4d9e6fdc-d51e-4612-b9d0-ef9cfc4ff56c

Here's a demonstration of the fixed behavior. The list now saves with the new description, even when only the description is modified. It's a pretty small fix, so I just tested that the basic adding/removing/saving functionality still works. 



### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system: Windows 10
* Graphics Card: NVidia Geforce GTX

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [ X] I have performed a self-review of my own code
- [ X] I have commented my code, particularly in hard-to-understand areas
- [ X] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [ X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
