### PR TITLE
Fix Observing List Remove-Object button removes objects not highlighted

### DIFF
--- a/src/gui/ObsListDialog.cpp
+++ b/src/gui/ObsListDialog.cpp
@@ -1307,9 +1307,13 @@ void ObsListDialog::removeObjectButtonPressed()
 {
 	Q_ASSERT(isEditMode);
 
-	int number = ui->treeView->currentIndex().row();
-	QString uuid = itemModel->index(number, ColumnUUID).data().toString();
-	itemModel->removeRow(number);
+	//Convert selected UI row (potentially sorted) into itemModel row (unsorted)
+	QModelIndex index = ui->treeView->currentIndex();
+	QSortFilterProxyModel* proxy = qobject_cast<QSortFilterProxyModel*>(ui->treeView->model());
+	int sourceRow = proxy ? proxy->mapToSource(index).row() : index.row();
+
+	QString uuid = itemModel->index(sourceRow, ColumnUUID).data().toString();
+	itemModel->removeRow(sourceRow);
 	currentItemCollection.remove(uuid);
 	tainted=true;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Please include a summary of the change and which issue is fixed. -->
<!--- Please also include relevant motivation and context. -->
<!--- List any dependencies that are required for this change. -->

Fixes #4303 

Fixes an issue in the `removeObjectButtonPressed` method of the Observing Lists window causing the remove object button to delete random objects from the list instead of the selected one. The row number of the selected element in the sorted UI list was being used directly to remove the same row of the internal, unsorted list of objects, leading to the behavior. I added the correct conversion from UI indices to internal itemModel indices before removing the object. 

The UI Tree View object that gets the selection from the potentially-sorted list on screen has a method `mapToSource()` that does this conversion, so my implementation simply calls that before removing the object.

### Screenshots (if appropriate):
https://github.com/user-attachments/assets/8fc93ed3-cff9-49ec-88c5-020939601082


### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I included a screen recording above of the fixed behavior. It's from the same list file as in the video under issue #4303, where initially, deleting Moon would actually remove M39. Now it removes the selected Moon from the list properly. The video demonstrates removing elements from the list while the ui is sorted in various different ways, saving, discarding changes, and adding/removing new items. (Looking at the .sol file, the first Moon was the 18th UI row, but M39 was the 18th object loaded in from the .sol file, and so was getting deleted. Now it converts the 18th UI row into whatever the Moon's actual internal row number is first)

**Test Configuration**:
* Operating system: Windows 10
* Graphics Card: NVidia Geforce GTX

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
