### PR TITLE
Fix comet tail extinction

### DIFF
--- a/src/core/modules/Comet.cpp
+++ b/src/core/modules/Comet.cpp
@@ -491,7 +491,7 @@ void Comet::update(int deltaTime)
 		const float brightnessDecreasePerVertexFromHead=1.0f/(COMET_TAIL_SLICES*COMET_TAIL_STACKS)  * avgAtmLum;
 		float brightnessPerVertexFromHead=1.0f;
                 
-                const Vec3d tailEclOffset = eclipticPos + aberrationPush;
+        const Vec3d tailEclOffset = eclipticPos + aberrationPush;
                 
 		gastailColorArr.clear();
 		dusttailColorArr.clear();


### PR DESCRIPTION
### Description
Comet tails were using j2000ToAltAz for dust and gas tail vertices, this fix instead uses heliocentricEclipticToAltAz, which brings correct extinction WRT the horizon.

Fixes #617 

### Screenshots (if appropriate):
Comet Donati with correct extinction:
<img width="1426" height="1118" alt="bild" src="https://github.com/user-attachments/assets/97321d31-17db-4aa6-829b-d23c1cf23b6d" />


### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

**Test Configuration**:
Ubuntu 24.04.4 LTS
Qt 6.4.2

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
