### PR TITLE
Add support for proper lunar mesh instead of the ellipse

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -42,8 +42,10 @@ environment:
     VSPATH: C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\SDK\ScopeCppSDK\VC\bin
     QT_VERSION_MAJOR: 5
     QT_BASEDIR: C:\Qt\5.12\msvc2017_64
-    CMAKE_GENERATOR: Visual Studio 15 2017 Win64
-    CMAKE_ARGS: --
+    CMAKE_GENERATOR: Visual Studio 15 2017
+    CMAKE_ARGS: -A x64
+    cmakeURL: https://github.com/Kitware/CMake/releases/download/v3.18.6/cmake-3.18.6-win64-x64.zip
+    cmakeBaseName: cmake-3.18.6-win64-x64
     exiv2url: https://github.com/10110111/exiv2/releases/download/ver0.28.0-final/exiv2-0.28.0-2017msvc64.zip
     exiv2baseName: exiv2-0.28.0-2017msvc64
     scConverterEnabled: false
@@ -113,6 +115,10 @@ before_build:
 
   - ps: if($env:exiv2url -ne $null) { appveyor DownloadFile $env:exiv2url -FileName c:\$env:exiv2baseName.zip }
   - ps: if($env:exiv2url -ne $null) { 7z e c:\$env:exiv2baseName.zip -spf -oc:\ }
+  - ps: if($env:cmakeURL -ne $null) { appveyor DownloadFile $env:cmakeURL -FileName c:\$env:cmakeBaseName.zip }
+  - ps: if($env:cmakeURL -ne $null) { 7z e c:\$env:cmakeBaseName.zip -spf -oc:\ }
+  - ps: if($env:cmakeURL -ne $null) { $env:PATH="c:\$env:cmakeBaseName\bin;$env:PATH" }
+
   - if [%PUBLISH_BINARY%]==[true] appveyor DownloadFile https://github.com/Stellarium/stellarium-data/releases/download/guide/guide.pdf -FileName c:\stellarium\guide\guide.pdf
 
   - ps: if($env:INSTALL_CONVERTER_DEPS -eq "true") { appveyor DownloadFile $env:gettextURL -FileName c:\$env:gettextBaseName.zip }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-CMAKE_MINIMUM_REQUIRED(VERSION 3.16)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.18)
 # CMake 3.20+ is required if x-compiling for Windows on ARM
 MESSAGE(STATUS "Found CMake ${CMAKE_VERSION}")
 

--- a/data/shaders/planet.frag
+++ b/data/shaders/planet.frag
@@ -35,6 +35,7 @@ uniform mediump float skyBrightness;
 uniform bool hasAtmosphere;
 uniform bool hasNormalMap;
 uniform bool hasHorizonMap;
+uniform bool texCoordsFromFragment;
 
 uniform int shadowCount;
 uniform highp mat4 shadowData;
@@ -171,6 +172,15 @@ lowp float outgasFactor(in mediump vec3 normal, in highp vec3 lightDir, in mediu
     return opac;
 }
 
+vec4 sampleTexDxDy(sampler2D sampler, vec2 texCoord, vec2 texDx, vec2 texDy)
+{
+#ifdef textureGrad_SUPPORTED
+    if(texCoordsFromFragment)
+        return textureGrad(sampler, texCoord, texDx, texDy);
+#endif
+    return texture2D(sampler, texCoord);
+}
+
 void main()
 {
 #ifndef IS_MOON
@@ -288,9 +298,36 @@ void main()
     }
 
 #ifdef IS_MOON
+    mediump vec2 moonTexCoord = texc;
+    mediump vec2 texDx = vec2(0), texDy = vec2(0);
+    if(texCoordsFromFragment)
+    {
+        moonTexCoord = vec2(atan(normalZ.x, -normalZ.y)/(2.*PI)+0.5, asin(normalize(normalZ).z)/PI+0.5);
+
+#ifdef textureGrad_SUPPORTED
+        // The usual automatic computation of derivatives of texture coordinates
+        // breaks down at the discontinuity of atan, resulting in choosing the most
+        // minified mip level instead of the correct one, which looks as a seam on
+        // the screen. Thus, we need to compute them in a custom way, treating atan
+        // as a (continuous) multivalued function. We differentiate
+        // atan(normalZ.x(x,y), -normalZ.y(x,y)) with respect to x and y and yield
+        // gradLongitude vector.
+        vec2 gradNormalZX = vec2(dFdx(normalZ.x), dFdy(normalZ.x));
+        vec2 gradNormalZY = vec2(dFdx(-normalZ.y), dFdy(-normalZ.y));
+        vec2 gradLongitude = vec2(-normalZ.y*gradNormalZX.s-normalZ.x*gradNormalZY.s,
+                                  -normalZ.y*gradNormalZX.t-normalZ.x*gradNormalZY.t)
+                                                       /
+                                             dot(normalZ, normalZ);
+        float texTdx = dFdx(moonTexCoord.t);
+        float texTdy = dFdy(moonTexCoord.t);
+        texDx = vec2(gradLongitude.s/(2.*PI), texTdx);
+        texDy = vec2(gradLongitude.t/(2.*PI), texTdy);
+#endif
+    }
+
     mediump vec3 normal;
     if(hasNormalMap)
-        normal = texture2D(normalMap, texc).rgb-vec3(0.5);
+        normal = sampleTexDxDy(normalMap, moonTexCoord, texDx, texDy).rgb-vec3(0.5);
     else
         normal = vec3(0,0,1);
 
@@ -306,7 +343,7 @@ void main()
         mediump vec3 zenith = normalZ;
         mediump float sunAzimuth = atan(dot(lightDirection,lonDir), dot(lightDirection,northDir));
         mediump float sinSunElevation = dot(zenith, lightDirection);
-        mediump vec4 horizonElevSample = (texture2D(horizonMap, texc) - 0.5) * 2.;
+        mediump vec4 horizonElevSample = (sampleTexDxDy(horizonMap, moonTexCoord, texDx, texDy) - 0.5) * 2.;
         mediump vec4 sinHorizElevs = sign(horizonElevSample) * horizonElevSample * horizonElevSample;
         mediump float sinHorizElevLeft, sinHorizElevRight;
         mediump float alpha;
@@ -390,7 +427,10 @@ void main()
     //litColor.xyz = clamp( litColor.xyz + vec3(outgas), 0.0, 1.0);
 
     lowp vec4 texColor;
-#ifdef RINGS_SUPPORT
+#ifdef IS_MOON
+    texColor = sampleTexDxDy(tex, moonTexCoord, texDx, texDy);
+#else
+# ifdef RINGS_SUPPORT
     if(isRing)
     {
         float radius = length(texc);
@@ -402,10 +442,11 @@ void main()
             texColor = vec4(0);
     }
     else
-#endif
+# endif // RINGS_SUPPORT
     {
         texColor = texture2D(tex, texc);
     }
+#endif // IS_MOON
 
     texColor.rgb = srgbToLinear(texColor.rgb);
 

--- a/data/shaders/planet.vert
+++ b/data/shaders/planet.vert
@@ -23,7 +23,9 @@
 
 ATTRIBUTE highp vec4 vertex; // vertex projected by CPU
 ATTRIBUTE mediump vec2 texCoord;
+#ifndef PROJECTOR_PRESENT
 ATTRIBUTE highp vec4 unprojectedVertex; //original vertex coordinate (in km for OBJ models, in AU otherwise)
+#endif
 #ifdef IS_OBJ
     ATTRIBUTE mediump vec3 normalIn; // OBJs have pre-calculated normals
 #endif
@@ -49,9 +51,18 @@ VARYING highp vec3 P; //original unprojected position (in AU)
     uniform highp vec3 lightDirection;
 #endif
 
+#ifdef PROJECTOR_PRESENT
+uniform float sphereScale;
+#endif
+
 void main()
 {
+#ifdef PROJECTOR_PRESENT
+	highp vec4 unprojectedVertex = vertex;
+	gl_Position = projectionMatrix*vec4(project(sphereScale*vertex.xyz), 1);
+#else
     gl_Position = projectionMatrix * vertex;
+#endif
     texc = texCoord;
 
 #ifdef SHADOWMAP

--- a/models/CMakeLists.txt
+++ b/models/CMakeLists.txt
@@ -1,3 +1,4 @@
+file(ARCHIVE_EXTRACT INPUT ${CMAKE_CURRENT_SOURCE_DIR}/moon-vertices-indices.bin.7z DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
 ########### install files ###############
 
@@ -9,6 +10,7 @@ INSTALL(DIRECTORY ./ DESTINATION ${SDATALOC}/models
 	PATTERN "*.obj"
 	PATTERN "*.gz"
 	PATTERN "CMakeFiles" EXCLUDE )
+INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/moon-vertices-indices.bin DESTINATION ${SDATALOC}/models)
 
 INSTALL(DIRECTORY blender/ DESTINATION ${SDATALOC}/models/blender
 	FILES_MATCHING 

--- a/src/core/RefractionExtinction.cpp
+++ b/src/core/RefractionExtinction.cpp
@@ -282,6 +282,23 @@ QByteArray Refraction::getForwardTransformShader() const
 {
 	return QByteArray(1+R"(
 uniform float REFRACTION_press_temp_corr;
+// Workaround for Intel's unusable implementation of sin & cos, which leads to broken geometry of the Moon every 0.9° of elevation.
+float REFRACTION_sin(float x)
+{
+	const float PI = 3.14159265;
+	x = mod(x+PI, 2.0*PI)-PI;
+	return x*(0.999999599920672 + x*x*(-0.166665526354071 + x*x*(0.00833240298869917 + x*x*(-0.0001980863334175 + x*x*(2.69971463693744e-6 - 2.03622449118901e-8*x*x)))));
+}
+// Workaround for Intel's and AMD's unusable implementation of asin, which leads to time-dependent shifts of the Moon from its refracted positions.
+float REFRACTION_asin(float x)
+{
+	float sign = x < 0. ? -1. : 1.;
+	if(x < 0.) x = -x;
+	x = 2. * sqrt(1. - x) - 1.;
+	float v = 0.848061881596496 + x*(-0.755929497461161 + x*(-0.0539853235799928 + x*(-0.025701166121295 + x*(-0.00723634508887381 +
+	           x*(-0.00314276748524976 + x*(-0.00101365621070969 + x*(-0.000411380592372285 + x*(-0.000428167561924693 - 0.000213293541786718*x))))))));
+	return v * sign;
+}
 vec3 innerRefractionForward(vec3 altAzPos)
 {
 	const float PI = 3.14159265;
@@ -300,7 +317,7 @@ vec3 innerRefractionForward(vec3 altAzPos)
 	}
 
 	float sinGeo = altAzPos[2]/len;
-	float geom_alt_rad = asin(sinGeo);
+	float geom_alt_rad = REFRACTION_asin(sinGeo);
 	float geom_alt_deg = M_180_PI*geom_alt_rad;
 	if (geom_alt_deg > MIN_GEO_ALTITUDE_DEG)
 	{
@@ -321,7 +338,7 @@ vec3 innerRefractionForward(vec3 altAzPos)
 	// We have to shorten X,Y components of the vector as well by the change in cosines of altitude, or (sqrt(1-sin(alt))
 
 	float refr_alt_rad=geom_alt_deg*M_PI_180;
-	float sinRef=sin(refr_alt_rad);
+	float sinRef = REFRACTION_sin(refr_alt_rad);
 
 	// FIXME: do we really need double's mantissa length here as a comment in the C++ code says?
 	float shortenxy = abs(sinGeo)>=1.0 ? 1.0 : sqrt((1.-sinRef*sinRef)/(1.-sinGeo*sinGeo));

--- a/src/core/RefractionExtinction.cpp
+++ b/src/core/RefractionExtinction.cpp
@@ -283,14 +283,14 @@ QByteArray Refraction::getForwardTransformShader() const
 	return QByteArray(1+R"(
 uniform float REFRACTION_press_temp_corr;
 // Workaround for Intel's unusable implementation of sin & cos, which leads to broken geometry of the Moon every 0.9° of elevation.
-float REFRACTION_sin(float x)
+highp float REFRACTION_sin(highp float x)
 {
 	const float PI = 3.14159265;
 	x = mod(x+PI, 2.0*PI)-PI;
 	return x*(0.999999599920672 + x*x*(-0.166665526354071 + x*x*(0.00833240298869917 + x*x*(-0.0001980863334175 + x*x*(2.69971463693744e-6 - 2.03622449118901e-8*x*x)))));
 }
 // Workaround for Intel's and AMD's unusable implementation of asin, which leads to time-dependent shifts of the Moon from its refracted positions.
-float REFRACTION_asin(float x)
+highp float REFRACTION_asin(highp float x)
 {
 	float sign = x < 0. ? -1. : 1.;
 	if(x < 0.) x = -x;
@@ -299,13 +299,13 @@ float REFRACTION_asin(float x)
 	           x*(-0.00314276748524976 + x*(-0.00101365621070969 + x*(-0.000411380592372285 + x*(-0.000428167561924693 - 0.000213293541786718*x))))))));
 	return v * sign;
 }
-vec3 innerRefractionForward(vec3 altAzPos)
+highp vec3 innerRefractionForward(highp vec3 altAzPos)
 {
-	const float PI = 3.14159265;
-	const float M_180_PI = 180./PI;
-	const float M_PI_180 = PI/180.;
-	const float MIN_GEO_ALTITUDE_DEG=@MIN_GEO_ALTITUDE_DEG@;
-	const float TRANSITION_WIDTH_GEO_DEG=@TRANSITION_WIDTH_GEO_DEG@;
+	const highp float PI = 3.14159265;
+	const highp float M_180_PI = 180./PI;
+	const highp float M_PI_180 = PI/180.;
+	const highp float MIN_GEO_ALTITUDE_DEG=@MIN_GEO_ALTITUDE_DEG@;
+	const highp float TRANSITION_WIDTH_GEO_DEG=@TRANSITION_WIDTH_GEO_DEG@;
 
 	float press_temp_corr = REFRACTION_press_temp_corr;
 
@@ -316,13 +316,13 @@ vec3 innerRefractionForward(vec3 altAzPos)
 		return altAzPos;
 	}
 
-	float sinGeo = altAzPos[2]/len;
-	float geom_alt_rad = REFRACTION_asin(sinGeo);
-	float geom_alt_deg = M_180_PI*geom_alt_rad;
+	highp float sinGeo = altAzPos[2]/len;
+	highp float geom_alt_rad = REFRACTION_asin(sinGeo);
+	highp float geom_alt_deg = M_180_PI*geom_alt_rad;
 	if (geom_alt_deg > MIN_GEO_ALTITUDE_DEG)
 	{
 		// refraction from Saemundsson, S&T1986 p70 / in Meeus, Astr.Alg.
-		float r=press_temp_corr * ( 1.02 / tan((geom_alt_deg+10.3/(geom_alt_deg+5.11))*M_PI_180) + 0.0019279);
+		highp float r=press_temp_corr * ( 1.02 / tan((geom_alt_deg+10.3/(geom_alt_deg+5.11))*M_PI_180) + 0.0019279);
 		geom_alt_deg += r;
 		if (geom_alt_deg > 90.)
 			geom_alt_deg=90.;
@@ -330,18 +330,18 @@ vec3 innerRefractionForward(vec3 altAzPos)
 	else if(geom_alt_deg>MIN_GEO_ALTITUDE_DEG-TRANSITION_WIDTH_GEO_DEG)
 	{
 		// Avoids the jump below -5 by interpolating linearly between MIN_GEO_ALTITUDE_DEG and bottom of transition zone
-		float r_m5=press_temp_corr * ( 1.02 / tan((MIN_GEO_ALTITUDE_DEG+10.3/(MIN_GEO_ALTITUDE_DEG+5.11))*M_PI_180) + 0.0019279);
+		highp float r_m5=press_temp_corr * ( 1.02 / tan((MIN_GEO_ALTITUDE_DEG+10.3/(MIN_GEO_ALTITUDE_DEG+5.11))*M_PI_180) + 0.0019279);
 		geom_alt_deg += r_m5*(geom_alt_deg-(MIN_GEO_ALTITUDE_DEG-TRANSITION_WIDTH_GEO_DEG))/TRANSITION_WIDTH_GEO_DEG;
 	}
 	else return altAzPos;
 	// At this point we have corrected geometric altitude. Note that if we just change altAzPos[2], we would change vector length, so this would change our angles.
 	// We have to shorten X,Y components of the vector as well by the change in cosines of altitude, or (sqrt(1-sin(alt))
 
-	float refr_alt_rad=geom_alt_deg*M_PI_180;
-	float sinRef = REFRACTION_sin(refr_alt_rad);
+	highp float refr_alt_rad=geom_alt_deg*M_PI_180;
+	highp float sinRef = REFRACTION_sin(refr_alt_rad);
 
 	// FIXME: do we really need double's mantissa length here as a comment in the C++ code says?
-	float shortenxy = abs(sinGeo)>=1.0 ? 1.0 : sqrt((1.-sinRef*sinRef)/(1.-sinGeo*sinGeo));
+	highp float shortenxy = abs(sinGeo)>=1.0 ? 1.0 : sqrt((1.-sinRef*sinRef)/(1.-sinGeo*sinGeo));
 
 	altAzPos[0]*=shortenxy;
 	altAzPos[1]*=shortenxy;
@@ -350,18 +350,18 @@ vec3 innerRefractionForward(vec3 altAzPos)
 	return altAzPos;
 }
 
-uniform mat4 REFRACTION_preTransfoMat;
-uniform mat4 REFRACTION_postTransfoMat;
+uniform highp mat4 REFRACTION_preTransfoMat;
+uniform highp mat4 REFRACTION_postTransfoMat;
 
-vec3 vertexToAltAzPos(vec3 v)
+highp vec3 vertexToAltAzPos(highp vec3 v)
 {
-	vec3 altAzPosNotRefracted = (REFRACTION_preTransfoMat * vec4(v,1)).xyz;
+	highp vec3 altAzPosNotRefracted = (REFRACTION_preTransfoMat * vec4(v,1)).xyz;
 	return innerRefractionForward(altAzPosNotRefracted);
 }
 
-vec3 modelViewForwardTransform(vec3 v)
+highp vec3 modelViewForwardTransform(highp vec3 v)
 {
-	vec3 altAzPos = vertexToAltAzPos(v);
+	highp vec3 altAzPos = vertexToAltAzPos(v);
 	return (REFRACTION_postTransfoMat * vec4(altAzPos, 1)).xyz;
 }
 

--- a/src/core/StelProjector.cpp
+++ b/src/core/StelProjector.cpp
@@ -92,11 +92,11 @@ QByteArray StelProjector::Mat4dTransform::getForwardTransformShader() const
 #line 1 104
 uniform mat4 PROJECTOR_vertexToAltAzPosMatrix;
 uniform mat4 PROJECTOR_modelViewMatrix;
-vec3 modelViewForwardTransform(vec3 v)
+vec3 modelViewForwardTransform(highp vec3 v)
 {
 	return (PROJECTOR_modelViewMatrix * vec4(v,1)).xyz;
 }
-vec3 vertexToAltAzPos(vec3 v)
+vec3 vertexToAltAzPos(highp vec3 v)
 {
 	return (PROJECTOR_vertexToAltAzPosMatrix * vec4(v,1)).xyz;
 }
@@ -466,21 +466,21 @@ QByteArray StelProjector::getProjectShader() const
 {
 	static const char*const projectSrc = 1+R"(
 #line 1 106
-uniform vec2 PROJECTOR_viewportCenter;
-uniform vec2 PROJECTOR_flip;
-uniform float PROJECTOR_pixelPerRad;
-uniform float PROJECTOR_zNear;
-uniform float PROJECTOR_oneOverZNearMinusZFar;
-vec3 project(vec3 modelSpacePoint)
+uniform highp vec2 PROJECTOR_viewportCenter;
+uniform highp vec2 PROJECTOR_flip;
+uniform highp float PROJECTOR_pixelPerRad;
+uniform highp float PROJECTOR_zNear;
+uniform highp float PROJECTOR_oneOverZNearMinusZFar;
+highp vec3 project(highp vec3 modelSpacePoint)
 {
-	float flipHorz = PROJECTOR_flip.x, flipVert = PROJECTOR_flip.y;
-	vec2  viewportCenter = PROJECTOR_viewportCenter;
-	float pixelPerRad = PROJECTOR_pixelPerRad;
-	float zNear = PROJECTOR_zNear;
-	float oneOverZNearMinusZFar = PROJECTOR_oneOverZNearMinusZFar;
+	highp float flipHorz = PROJECTOR_flip.x, flipVert = PROJECTOR_flip.y;
+	highp vec2  viewportCenter = PROJECTOR_viewportCenter;
+	highp float pixelPerRad = PROJECTOR_pixelPerRad;
+	highp float zNear = PROJECTOR_zNear;
+	highp float oneOverZNearMinusZFar = PROJECTOR_oneOverZNearMinusZFar;
 
-	vec3 worldSpacePoint = modelViewForwardTransform(modelSpacePoint);
-	vec3 v = projectorForwardTransform(worldSpacePoint);
+	highp vec3 worldSpacePoint = modelViewForwardTransform(modelSpacePoint);
+	highp vec3 v = projectorForwardTransform(worldSpacePoint);
 	return vec3(viewportCenter[0] + flipHorz * pixelPerRad * v[0],
 	            viewportCenter[1] + flipVert * pixelPerRad * v[1],
 	            (v[2] - zNear) * oneOverZNearMinusZFar);
@@ -504,25 +504,25 @@ QByteArray StelProjector::getUnProjectShader() const
 {
 	static const char*const projectSrc = 1+R"(
 #line 1 107
-uniform vec2 PROJECTOR_viewportCenter;
-uniform vec2 PROJECTOR_flip;
-uniform float PROJECTOR_pixelPerRad;
-vec3 winPosToWorldPos(float x, float y, out bool ok)
+uniform highp vec2 PROJECTOR_viewportCenter;
+uniform highp vec2 PROJECTOR_flip;
+uniform highp float PROJECTOR_pixelPerRad;
+highp vec3 winPosToWorldPos(highp float x, highp float y, out bool ok)
 {
-	float flipHorz = PROJECTOR_flip.x, flipVert = PROJECTOR_flip.y;
-	vec2  viewportCenter = PROJECTOR_viewportCenter;
-	float pixelPerRad = PROJECTOR_pixelPerRad;
+	highp float flipHorz = PROJECTOR_flip.x, flipVert = PROJECTOR_flip.y;
+	highp vec2  viewportCenter = PROJECTOR_viewportCenter;
+	highp float pixelPerRad = PROJECTOR_pixelPerRad;
 
-	vec3 v;
+	highp vec3 v;
 	v[0] = flipHorz * (x - viewportCenter[0]) / pixelPerRad;
 	v[1] = flipVert * (y - viewportCenter[1]) / pixelPerRad;
 	v[2] = 0.;
 	return projectorBackwardTransform(v, ok);
 }
 
-vec3 unProject(float x, float y, out bool ok)
+highp vec3 unProject(highp float x, highp float y, out bool ok)
 {
-	vec3 worldPos = winPosToWorldPos(x, y, ok);
+	highp vec3 worldPos = winPosToWorldPos(x, y, ok);
 	// Even when the reprojected point comes from a region of the screen,
 	// where nothing is projected to (rval=false), we finish reprojecting.
 	// This looks good for atmosphere rendering, and it helps avoiding

--- a/src/core/modules/Planet.cpp
+++ b/src/core/modules/Planet.cpp
@@ -3963,6 +3963,7 @@ void Planet::PlanetShaderVars::initLocations(QOpenGLShaderProgram* p)
 	GL(hasAtmosphere = p->uniformLocation("hasAtmosphere"));
 	GL(hasNormalMap = p->uniformLocation("hasNormalMap"));
 	GL(hasHorizonMap = p->uniformLocation("hasHorizonMap"));
+	GL(texCoordsFromFragment = p->uniformLocation("texCoordsFromFragment"));
 
 	// Moon-specific variables
 	GL(earthShadow = p->uniformLocation("earthShadow"));
@@ -4786,8 +4787,9 @@ void Planet::computeModelMatrix(Mat4d &result, bool solarEclipseCase) const
 	}
 }
 
-Planet::RenderData Planet::setCommonShaderUniforms(const StelPainter& painter, QOpenGLShaderProgram* shader, const PlanetShaderVars& shaderVars,
-                                                   const StelPainterLight& light, const bool hasNormalMap, const bool hasHorizonMap)
+Planet::RenderData Planet::setCommonShaderUniforms(const StelPainter& painter, QOpenGLShaderProgram* shader,
+                                                   const PlanetShaderVars& shaderVars, const StelPainterLight& light, 
+                                                   const bool hasNormalMap, const bool hasHorizonMap, const bool texCoordsFromFragment)
 {
 	RenderData data;
 
@@ -4837,6 +4839,7 @@ Planet::RenderData Planet::setCommonShaderUniforms(const StelPainter& painter, Q
 
 	GL(shader->setUniformValue(shaderVars.hasNormalMap, GLint(hasNormalMap)));
 	GL(shader->setUniformValue(shaderVars.hasHorizonMap, GLint(hasHorizonMap)));
+	GL(shader->setUniformValue(shaderVars.texCoordsFromFragment, GLint(texCoordsFromFragment)));
 
 	GL(shader->setUniformValue(shaderVars.projectionMatrix, qMat));
 	GL(shader->setUniformValue(shaderVars.hasAtmosphere, GLint(atmosphere)));
@@ -4967,7 +4970,7 @@ void Planet::drawSphere(const StelPainterLight& light, StelPainter* painter, flo
 
 	GL(shader->bind());
 
-	RenderData rData = setCommonShaderUniforms(*painter,shader,*shaderVars,light, isMoon,isMoon);
+	RenderData rData = setCommonShaderUniforms(*painter,shader,*shaderVars,light, isMoon,isMoon,isMoon);
 	if(this==ssm->getSun())
 	{
 		const auto color = painter->getColor();
@@ -5217,7 +5220,7 @@ void Planet::drawSurvey(const StelPainterLight& light, StelCore* core, StelPaint
 	}
 
 	GL(shader->bind());
-	RenderData rData = setCommonShaderUniforms(*painter, shader, *shaderVars, light, !!survey.normals, !!survey.horizons);
+	RenderData rData = setCommonShaderUniforms(*painter, shader, *shaderVars, light, !!survey.normals, !!survey.horizons, false);
 	QVector<Vec3f> projectedVertsArray;
 	QVector<Vec3f> vertsArray;
 	const double angle = 2 * getSpheroidAngularRadius(core) * M_PI_180;
@@ -5511,7 +5514,7 @@ bool Planet::drawObjModel(const StelPainterLight& light, StelPainter *painter, f
 	GL(shd->enableAttributeArray("vertex"));
 	objModel->projPosBuffer->release();
 
-	setCommonShaderUniforms(*painter,shd,*shdVars,light,false,false);
+	setCommonShaderUniforms(*painter,shd,*shdVars,light,false,false,false);
 
 	//draw that model using the array wrapper
 	objModel->arr->draw();

--- a/src/core/modules/Planet.cpp
+++ b/src/core/modules/Planet.cpp
@@ -116,6 +116,8 @@ QOpenGLShaderProgram* Planet::ringPlanetShaderProgram=Q_NULLPTR;
 Planet::PlanetShaderVars Planet::ringPlanetShaderVars;
 QOpenGLShaderProgram* Planet::moonShaderProgram=Q_NULLPTR;
 Planet::PlanetShaderVars Planet::moonShaderVars;
+QOpenGLShaderProgram* Planet::sphereMoonShaderProgram=Q_NULLPTR;
+Planet::PlanetShaderVars Planet::sphereMoonShaderVars;
 QOpenGLShaderProgram* Planet::objShaderProgram=Q_NULLPTR;
 Planet::PlanetShaderVars Planet::objShaderVars;
 QOpenGLShaderProgram* Planet::objShadowShaderProgram=Q_NULLPTR;
@@ -364,8 +366,12 @@ Planet::~Planet()
 			gl->glDeleteBuffers(1, &sphereVBO);
 		if(ringsVAO)
 			gl->glDeleteBuffers(1, &ringsVBO);
+		if(moonVAO)
+			gl->glDeleteBuffers(1, &moonVBO);
 		if(surveyVBO)
 			gl->glDeleteBuffers(1, &surveyVBO);
+		if(moonVBO)
+			gl->glDeleteBuffers(1, &moonVBO);
 	}
 }
 
@@ -3964,6 +3970,7 @@ void Planet::PlanetShaderVars::initLocations(QOpenGLShaderProgram* p)
 	GL(hasNormalMap = p->uniformLocation("hasNormalMap"));
 	GL(hasHorizonMap = p->uniformLocation("hasHorizonMap"));
 	GL(texCoordsFromFragment = p->uniformLocation("texCoordsFromFragment"));
+	GL(sphereScale = p->uniformLocation("sphereScale"));
 
 	// Moon-specific variables
 	GL(earthShadow = p->uniformLocation("earthShadow"));
@@ -4116,8 +4123,8 @@ bool Planet::initShader()
 	ringPlanetShaderProgram = createShader("ringPlanetShaderProgram",ringPlanetShaderVars,vsrc,
 	                                       makeSRGBUtilsShader()+fsrc,"#define RINGS_SUPPORT\n\n");
 	// Moon shader program
-	moonShaderProgram = createShader("moonShaderProgram",moonShaderVars,vsrc,
-	                                 makeSRGBUtilsShader()+fsrc,"#define IS_MOON\n\n");
+	sphereMoonShaderProgram = createShader("sphereMoonShaderProgram",sphereMoonShaderVars,vsrc,
+	                                       makeSRGBUtilsShader()+fsrc,"#define IS_MOON\n\n");
 	// OBJ model shader program
 	// we REQUIRE some fixed attribute locations here
 	QMap<QByteArray,int> attrLoc;
@@ -4252,7 +4259,7 @@ bool Planet::initShader()
 	//check if ALL shaders have been created correctly
 	shaderError = !(planetShaderProgram&&
 	                ringPlanetShaderProgram&&
-	                moonShaderProgram&&
+	                sphereMoonShaderProgram&&
 	                objShaderProgram&&
 	                objShadowShaderProgram&&
 	                transformShaderProgram);
@@ -4266,8 +4273,8 @@ void Planet::deinitShader()
 	planetShaderProgram = Q_NULLPTR;
 	delete ringPlanetShaderProgram;
 	ringPlanetShaderProgram = Q_NULLPTR;
-	delete moonShaderProgram;
-	moonShaderProgram = Q_NULLPTR;
+	delete sphereMoonShaderProgram;
+	sphereMoonShaderProgram = Q_NULLPTR;
 	delete objShaderProgram;
 	objShaderProgram = Q_NULLPTR;
 	delete objShadowShaderProgram;
@@ -4948,6 +4955,37 @@ Planet::RenderData Planet::setCommonShaderUniforms(const StelPainter& painter, Q
 	return data;
 }
 
+void Planet::setupMoonVAO()
+{
+	auto& gl = *QOpenGLContext::currentContext()->functions();
+	gl.glBindBuffer(GL_ARRAY_BUFFER, moonVBO);
+	gl.glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, moonVBO);
+	moonShaderProgram->setAttributeBuffer(moonShaderVars.vertex, GL_FLOAT, 0, 3);
+	moonShaderProgram->enableAttributeArray(moonShaderVars.vertex);
+	gl.glBindBuffer(GL_ARRAY_BUFFER, 0);
+}
+
+void Planet::bindMoonVAO()
+{
+	if(moonVAO->isCreated())
+		moonVAO->bind();
+	else
+		setupMoonVAO();
+}
+
+void Planet::releaseMoonVAO()
+{
+	if(moonVAO->isCreated())
+	{
+		moonVAO->release();
+	}
+	else
+	{
+		moonShaderProgram->disableAttributeArray(moonShaderVars.vertex);
+		gl->glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+	}
+}
+
 float Planet::computeEclipsePush() const
 {
 	const SolarSystem* ssm = GETSTELMODULE(SolarSystem);
@@ -5003,30 +5041,76 @@ bool Planet::drawMoon(const StelPainterLight& light, StelPainter& painter)
 	if (normalMap && !normalMap->bind(normalTexUnit)) return false;
 	if (texMap && !texMap->bind(colorTexUnit)) return false;
 
-	QVector<float> projectedVertexArr(model.vertexArr.size());
-	const auto sphereScaleF=static_cast<float>(sphereScale);
-	for (int i=0;i<model.vertexArr.size()/3;++i)
+	const auto projector = painter.getProjector();
+	if(!moonShaderProgram || !prevProjector || !projector->isSameProjection(*prevProjector))
 	{
-		Vec3f p = *(reinterpret_cast<const Vec3f*>(model.vertexArr.constData()+i*3));
-		p *= sphereScaleF;
-		painter.getProjector()->project(p, *(reinterpret_cast<Vec3f*>(projectedVertexArr.data()+i*3)));
-	}
+		moonShaderProgram = new QOpenGLShaderProgram;
+		prevProjector = projector;
 
-	const PlanetShaderVars* shaderVars = &moonShaderVars;
-	//check if shaders are loaded
-	if(!moonShaderProgram)
-	{
-		Planet::initShader();
-		if(shaderError)
+		const auto vFileName = StelFileMgr::findFile("data/shaders/planet.vert",StelFileMgr::File);
+		const auto fFileName = StelFileMgr::findFile("data/shaders/planet.frag",StelFileMgr::File);
+
+		if(vFileName.isEmpty())
 		{
-			qCritical() << "Can't use planet drawing, shaders invalid!";
+			qCritical() << "Cannot find 'data/shaders/planet.vert', can't use planet rendering!";
 			return false;
 		}
+		if(fFileName.isEmpty())
+		{
+			qCritical() << "Cannot find 'data/shaders/planet.frag', can't use planet rendering!";
+			return false;
+		}
+
+		QFile vFile(vFileName);
+		if(!vFile.open(QIODevice::ReadOnly | QIODevice::Text))
+		{
+			qCritical() << "Cannot load planet vertex shader file" << vFileName << vFile.errorString();
+			return false;
+		}
+		const auto vsrc = StelOpenGL::globalShaderPrefix(StelOpenGL::VERTEX_SHADER) +
+							projector->getProjectShader() +
+							"#define PROJECTOR_PRESENT\n"
+							"#define IS_MOON\n\n" +
+							vFile.readAll();
+		bool ok = moonShaderProgram->addShaderFromSourceCode(QOpenGLShader::Vertex, vsrc);
+		if(!moonShaderProgram->log().isEmpty())
+		{
+			qWarning().noquote() << "Planet::drawMoon: warnings while compiling vertex shader:\n"
+								 << moonShaderProgram->log();
+		}
+		if(!ok) return false;
+
+		QFile fFile(fFileName);
+		if(!fFile.open(QIODevice::ReadOnly | QIODevice::Text))
+		{
+			qCritical() << "Cannot load planet fragment shader file" << fFileName << fFile.errorString();
+			return false;
+		}
+		const auto fsrc = StelOpenGL::globalShaderPrefix(StelOpenGL::FRAGMENT_SHADER) +
+							makeSRGBUtilsShader()+
+							"#define IS_MOON\n\n" +
+							fFile.readAll();
+		ok = moonShaderProgram->addShaderFromSourceCode(QOpenGLShader::Fragment, fsrc);
+		if(!moonShaderProgram->log().isEmpty())
+		{
+			qWarning().noquote() << "Planet::drawMoon: warnings while compiling fragment shader:\n"
+								 << moonShaderProgram->log();
+		}
+		if(!ok) return false;
+
+		if(!StelPainter::linkProg(moonShaderProgram, "Moon render program"))
+			return false;
+
+		moonShaderVars.initLocations(moonShaderProgram);
 	}
+	if(!moonShaderProgram || !moonShaderProgram->isLinked())
+		return false;
 
 	GL(moonShaderProgram->bind());
 
-	RenderData rData = setCommonShaderUniforms(painter,moonShaderProgram,*shaderVars,light,true,true,true);
+	moonShaderProgram->setUniformValue(moonShaderVars.sphereScale, static_cast<GLfloat>(sphereScale));
+	projector->setProjectUniforms(*moonShaderProgram);
+	RenderData rData = setCommonShaderUniforms(painter,moonShaderProgram,moonShaderVars,light,true,true,true);
 
 	GL(moonShaderProgram->setUniformValue(moonShaderVars.tex, colorTexUnit));
 	GL(moonShaderProgram->setUniformValue(moonShaderVars.normalMap, normalTexUnit));
@@ -5039,37 +5123,25 @@ bool Planet::drawMoon(const StelPainterLight& light, StelPainter& painter)
 	}
 	GL(moonShaderProgram->setUniformValue(moonShaderVars.horizonMap, horizonTexUnit));
 
-	if(!sphereVAO)
-	{
-		sphereVAO.reset(new QOpenGLVertexArrayObject);
-		sphereVAO->create();
-		gl->glGenBuffers(1, &sphereVBO);
-	}
-
-	sphereVAO->bind();
-	gl->glBindBuffer(GL_ARRAY_BUFFER, sphereVBO);
-	gl->glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, sphereVBO);
-
-	const auto projectedVertArrSize = projectedVertexArr.size() * GLsizeiptr(sizeof projectedVertexArr[0]);
-
-	const auto modelVertArrOffset = projectedVertArrSize;
-	const auto modelVertArrSize = model.vertexArr.size() * GLsizeiptr(sizeof model.vertexArr[0]);
-
-	const auto indicesOffset = modelVertArrOffset + modelVertArrSize;
+	const auto vertArrSize = model.vertexArr.size() * GLsizeiptr(sizeof model.vertexArr[0]);
+	const auto indicesOffset = vertArrSize;
 	const auto indicesSize = model.indexArr.size() * GLsizeiptr(sizeof model.indexArr[0]);
 
-	gl->glBufferData(GL_ARRAY_BUFFER, projectedVertArrSize+modelVertArrSize+indicesSize, nullptr, GL_STREAM_DRAW);
-	gl->glBufferSubData(GL_ARRAY_BUFFER, 0, projectedVertArrSize, projectedVertexArr.constData());
-	gl->glBufferSubData(GL_ARRAY_BUFFER, modelVertArrOffset, modelVertArrSize, model.vertexArr.constData());
-	gl->glBufferSubData(GL_ARRAY_BUFFER, indicesOffset, indicesSize, model.indexArr.constData());
+	if(!moonVAO)
+	{
+		moonVAO.reset(new QOpenGLVertexArrayObject);
+		moonVAO->create();
+		gl->glGenBuffers(1, &moonVBO);
 
-	GL(moonShaderProgram->setAttributeBuffer(shaderVars->vertex, GL_FLOAT, 0, 3));
-	GL(moonShaderProgram->enableAttributeArray(shaderVars->vertex));
-	GL(moonShaderProgram->setAttributeBuffer(shaderVars->unprojectedVertex, GL_FLOAT, modelVertArrOffset, 3));
-	GL(moonShaderProgram->enableAttributeArray(shaderVars->unprojectedVertex));
-	// This may have been enabled by drawSphere() if the Moon has been rendered by it due to user toggling settings,
-	// so disable the array explicitly. Maybe it's drawSphere who should actually take care of this.
-	GL(moonShaderProgram->disableAttributeArray(shaderVars->texCoord));
+		gl->glBindBuffer(GL_ARRAY_BUFFER, moonVBO);
+		gl->glBufferData(GL_ARRAY_BUFFER, vertArrSize+indicesSize, nullptr, GL_STATIC_DRAW);
+		gl->glBufferSubData(GL_ARRAY_BUFFER, 0, vertArrSize, model.vertexArr.constData());
+		gl->glBufferSubData(GL_ARRAY_BUFFER, indicesOffset, indicesSize, model.indexArr.constData());
+
+		bindMoonVAO();
+		setupMoonVAO();
+		releaseMoonVAO();
+	}
 
 	painter.setCullFace(true);
 	gl->glCullFace(GL_BACK);
@@ -5077,11 +5149,9 @@ bool Planet::drawMoon(const StelPainterLight& light, StelPainter& painter)
 	painter.setDepthTest(true);
 	gl->glClear(GL_DEPTH_BUFFER_BIT);
 
+	bindMoonVAO();
 	GL(gl->glDrawElements(GL_TRIANGLES, model.indexArr.size(), GL_UNSIGNED_INT, reinterpret_cast<void*>(indicesOffset)));
-
-	gl->glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
-	gl->glBindBuffer(GL_ARRAY_BUFFER, 0);
-	sphereVAO->release();
+	releaseMoonVAO();
 
 	GL(moonShaderProgram->release());
 
@@ -5152,8 +5222,8 @@ void Planet::drawSphere(const StelPainterLight& light, StelPainter* painter, flo
 	}
 	if (isMoon)
 	{
-		shader = moonShaderProgram;
-		shaderVars = &moonShaderVars;
+		shader = sphereMoonShaderProgram;
+		shaderVars = &sphereMoonShaderVars;
 	}
 	//check if shaders are loaded
 	if(!shader)
@@ -5173,7 +5243,7 @@ void Planet::drawSphere(const StelPainterLight& light, StelPainter* painter, flo
 		}
 		if (isMoon)
 		{
-			shader = moonShaderProgram;
+			shader = sphereMoonShaderProgram;
 		}
 	}
 
@@ -5199,16 +5269,16 @@ void Planet::drawSphere(const StelPainterLight& light, StelPainter* painter, flo
 	if (isMoon)
 	{
 		GL(normalMap->bind(2));
-		GL(moonShaderProgram->setUniformValue(moonShaderVars.normalMap, 2));
+		GL(sphereMoonShaderProgram->setUniformValue(sphereMoonShaderVars.normalMap, 2));
 		if (!rData.shadowCandidates.isEmpty())
 		{
 			GL(texEarthShadow->bind(3));
-			GL(moonShaderProgram->setUniformValue(moonShaderVars.earthShadow, 3));
+			GL(sphereMoonShaderProgram->setUniformValue(sphereMoonShaderVars.earthShadow, 3));
 			const auto push = computeEclipsePush();
-			GL(moonShaderProgram->setUniformValue(moonShaderVars.eclipsePush, push)); // constant for now...
+			GL(sphereMoonShaderProgram->setUniformValue(sphereMoonShaderVars.eclipsePush, push)); // constant for now...
 		}
 		GL(horizonMap->bind(4));
-		GL(moonShaderProgram->setUniformValue(moonShaderVars.horizonMap, 4));
+		GL(sphereMoonShaderProgram->setUniformValue(sphereMoonShaderVars.horizonMap, 4));
 	}
 
 	if (englishName==L1S("Mars"))
@@ -5399,8 +5469,8 @@ void Planet::drawSurvey(const StelPainterLight& light, StelCore* core, StelPaint
 	}
 	if (isMoon)
 	{
-		shader = moonShaderProgram;
-		shaderVars = &moonShaderVars;
+		shader = sphereMoonShaderProgram;
+		shaderVars = &sphereMoonShaderVars;
 	}
 
 	GL(shader->bind());
@@ -5421,12 +5491,15 @@ void Planet::drawSurvey(const StelPainterLight& light, StelCore* core, StelPaint
 
 	if (isMoon)
 	{
-		GL(moonShaderProgram->setUniformValue(moonShaderVars.normalMap, 2));
+		GL(sphereMoonShaderProgram->setUniformValue(sphereMoonShaderVars.normalMap, 2));
 		if (!rData.shadowCandidates.isEmpty())
 		{
 			GL(texEarthShadow->bind(3));
-			GL(moonShaderProgram->setUniformValue(moonShaderVars.earthShadow, 3));
+			GL(sphereMoonShaderProgram->setUniformValue(sphereMoonShaderVars.earthShadow, 3));
+			const auto push = computeEclipsePush();
+			GL(sphereMoonShaderProgram->setUniformValue(sphereMoonShaderVars.eclipsePush, push)); // constant for now...
 		}
+		GL(sphereMoonShaderProgram->setUniformValue(sphereMoonShaderVars.horizonMap, 4));
 	}
 
 	// Apply a rotation otherwise the hips surveys don't get rendered at the

--- a/src/core/modules/Planet.cpp
+++ b/src/core/modules/Planet.cpp
@@ -4569,16 +4569,13 @@ void Planet::draw3dModel(StelCore* core, StelProjector::ModelViewTranformP trans
 			sPainter.setColor(overbright, powf(0.75f, extinctedMag)*overbright, powf(0.42f, 0.9f*extinctedMag)*overbright);
 		}
 
-		if(ssm->getFlagUseObjModels() && (!objModelPath.isEmpty() || isMoon))
+		if (!survey || survey.colors->getInterstate() < 1.0f)
 		{
-			if(!drawObjModel(light, &sPainter, isMoon, screenRd))
-			{
+			bool drawingModel = ssm->getFlagUseObjModels() && (!objModelPath.isEmpty() || isMoon);
+			if (drawingModel)
+				drawingModel = drawObjModel(light, &sPainter, isMoon, screenRd);
+			if (!drawingModel)
 				drawSphere(light, &sPainter, screenRd, drawOnlyRing);
-			}
-		}
-		else if (!survey || survey.colors->getInterstate() < 1.0f)
-		{
-			drawSphere(light, &sPainter, screenRd, drawOnlyRing);
 		}
 
 		if (survey && survey.colors->getInterstate() > 0.0f)

--- a/src/core/modules/Planet.cpp
+++ b/src/core/modules/Planet.cpp
@@ -4562,9 +4562,9 @@ void Planet::draw3dModel(StelCore* core, StelProjector::ModelViewTranformP trans
 			sPainter.setColor(overbright, powf(0.75f, extinctedMag)*overbright, powf(0.42f, 0.9f*extinctedMag)*overbright);
 		}
 
-		if(ssm->getFlagUseObjModels() && !objModelPath.isEmpty())
+		if(ssm->getFlagUseObjModels() && (!objModelPath.isEmpty() || isMoon))
 		{
-			if(!drawObjModel(light, &sPainter, screenRd))
+			if(!drawObjModel(light, &sPainter, isMoon, screenRd))
 			{
 				drawSphere(light, &sPainter, screenRd, drawOnlyRing);
 			}
@@ -4701,6 +4701,74 @@ void sSphere(Planet3DModel* model, const float radius, const float oneMinusOblat
 		}
 		t -= dt;
 	}
+}
+
+bool sMoon(Moon3DModel& model, const double equatorialRadius, const double oneMinusOblateness)
+{
+	try
+	{
+		const auto path = StelFileMgr::findFile("models/moon-vertices-indices.bin", StelFileMgr::File);
+		if(path.isEmpty())
+			throw std::runtime_error("cannot find the model file");
+
+		QFile file(path);
+		if(!file.open(QFile::ReadOnly))
+			throw std::runtime_error("cannot open file: "+file.errorString().toStdString());
+		const auto data = file.readAll();
+		if(data.isEmpty())
+			throw std::runtime_error("cannot read Moon model file: "+file.errorString().toStdString());
+
+		uint32_t vertexCount, indexCount;
+		float rMin, rMax;
+		if(size_t(data.size()) < sizeof vertexCount + sizeof indexCount + sizeof rMin + sizeof rMax)
+			throw std::runtime_error("cannot read header");
+		qsizetype pos = 0;
+		std::memcpy(&vertexCount, data.data() + pos, sizeof vertexCount);
+		pos += sizeof vertexCount;
+		std::memcpy(&indexCount, data.data() + pos, sizeof indexCount);
+		pos += sizeof indexCount;
+		std::memcpy(&rMin, data.data() + pos, sizeof rMin);
+		pos += sizeof rMin;
+		std::memcpy(&rMax, data.data() + pos, sizeof rMax);
+		pos += sizeof rMax;
+
+		model.vertexArr.resize(3 * vertexCount);
+		using VType = uint16_t;
+		constexpr double vTypeMax = std::numeric_limits<VType>::max();
+		const qint64 vertSize = model.vertexArr.size()*sizeof(VType);
+		if(data.size() < pos + vertSize)
+			throw std::runtime_error("cannot read vertices");
+		for(size_t n = 0; n < vertexCount; ++n)
+		{
+			uint16_t coords[3];
+			std::memcpy(coords, data.data() + pos, sizeof coords);
+			pos += sizeof coords;
+			const auto r     = coords[0] / vTypeMax * (rMax - rMin) + rMin;
+			const auto theta = coords[1] / vTypeMax * M_PI - M_PI/2;
+			const auto phi   = coords[2] / vTypeMax * (2*M_PI) - M_PI;
+			model.vertexArr[n * 3 + 0] = r * std::cos(theta) * std::cos(phi);
+			model.vertexArr[n * 3 + 1] = r * std::cos(theta) * std::sin(phi);
+			model.vertexArr[n * 3 + 2] = r * std::sin(theta);
+		}
+
+		model.indexArr.resize(indexCount);
+		const qint64 indSize = model.indexArr.size()*sizeof model.indexArr[0];
+		if(data.size() < pos + indSize)
+			throw std::runtime_error("cannot read indices");
+		std::memcpy(model.indexArr.data(), data.data() + pos, indSize);
+		pos += indSize;
+
+		qDebug() << "The Moon: read" << model.vertexArr.size()/3
+		         << "vertices and" << model.indexArr.size() << "indices";
+	}
+	catch(std::exception const& ex)
+	{
+		qCritical().noquote() << "Failed to load model of the Moon:" << ex.what();
+		model.indexArr.clear();
+		model.vertexArr.clear();
+		return false;
+	}
+	return true;
 }
 
 struct Ring3DModel
@@ -4880,6 +4948,147 @@ Planet::RenderData Planet::setCommonShaderUniforms(const StelPainter& painter, Q
 	return data;
 }
 
+float Planet::computeEclipsePush() const
+{
+	const SolarSystem* ssm = GETSTELMODULE(SolarSystem);
+
+	// Ad-hoc visibility improvement during lunar eclipses:
+	// During partial umbra phase, make moon brighter so that the bright limb and umbra border has more visibility.
+	// When the moon is half in umbra, we start to raise its brightness. Near edge of totality we try to simulate the apparent super-bright edge.
+	static const double tweak=1.015; // 1.00 to have maximum push only in full umbra. 1.01 or even 1.02 looks better to show a brilliant last/first edge
+	GLfloat push=1.0f;
+
+	// Like in getVMagnitude() we must compute an elongation from the aberrated sun.
+	PlanetP sun=ssm->getSun();
+	const Vec3d obsPos=parent->eclipticPos-sun->getAberrationPush();
+	const double observerRq = obsPos.normSquared();
+	const Vec3d& planetHelioPos = getHeliocentricEclipticPos() - sun->getAberrationPush();
+	const double planetRq = planetHelioPos.normSquared();
+	const double observerPlanetRq = (obsPos - planetHelioPos).normSquared();
+	double aberratedElongation = std::acos((observerPlanetRq  + observerRq - planetRq)/(2.0*std::sqrt(observerPlanetRq*observerRq)));
+	const double od = 180. - aberratedElongation * (180.0/M_PI); // opposition distance [degrees]
+
+	// Compute umbra radius at lunar distance.
+	const double Lambda=getEclipticPos().norm();                             // Lunar distance [AU]
+	const double sigma=ssm->getEarthShadowRadiiAtLunarDistance().first[0]/3600.;
+	const double tau=atan(getEquatorialRadius()/Lambda) * M_180_PI; // geocentric angle of Lunar radius [degrees]
+
+	if (od<tweak*sigma-tau)     // if the Moon is fully immersed in the shadow
+		push=4.0f;
+	else if (od<tweak*sigma)    // If the Moon is half immersed, start pushing with a strong power function that make it apparent only in the last few percents.
+		push+=3.f*(1.f-pow(static_cast<float>((od-tweak*sigma+tau)/tau), 1.f/6.f));
+
+	return push;
+}
+
+bool Planet::drawMoon(const StelPainterLight& light, StelPainter& painter)
+{
+	if(shaderError) return false;
+
+	if(model.indexArr.isEmpty() && !model.attemptedToLoad)
+	{
+		model.attemptedToLoad = true;
+		if(!sMoon(model, equatorialRadius, oneMinusOblateness))
+			return false;
+	}
+	if(model.vertexArr.isEmpty()) return false;
+
+	constexpr int colorTexUnit = 0;
+	constexpr int normalTexUnit = 2;
+	constexpr int earthShadowTexUnit = 3;
+	constexpr int horizonTexUnit = 4;
+
+	// For lazy loading, return if texture is not yet loaded
+	if (horizonMap && !horizonMap->bind(horizonTexUnit)) return false;
+	if (normalMap && !normalMap->bind(normalTexUnit)) return false;
+	if (texMap && !texMap->bind(colorTexUnit)) return false;
+
+	QVector<float> projectedVertexArr(model.vertexArr.size());
+	const auto sphereScaleF=static_cast<float>(sphereScale);
+	for (int i=0;i<model.vertexArr.size()/3;++i)
+	{
+		Vec3f p = *(reinterpret_cast<const Vec3f*>(model.vertexArr.constData()+i*3));
+		p *= sphereScaleF;
+		painter.getProjector()->project(p, *(reinterpret_cast<Vec3f*>(projectedVertexArr.data()+i*3)));
+	}
+
+	const PlanetShaderVars* shaderVars = &moonShaderVars;
+	//check if shaders are loaded
+	if(!moonShaderProgram)
+	{
+		Planet::initShader();
+		if(shaderError)
+		{
+			qCritical() << "Can't use planet drawing, shaders invalid!";
+			return false;
+		}
+	}
+
+	GL(moonShaderProgram->bind());
+
+	RenderData rData = setCommonShaderUniforms(painter,moonShaderProgram,*shaderVars,light,true,true,true);
+
+	GL(moonShaderProgram->setUniformValue(moonShaderVars.tex, colorTexUnit));
+	GL(moonShaderProgram->setUniformValue(moonShaderVars.normalMap, normalTexUnit));
+	if (!rData.shadowCandidates.isEmpty())
+	{
+		GL(texEarthShadow->bind(earthShadowTexUnit));
+		GL(moonShaderProgram->setUniformValue(moonShaderVars.earthShadow, earthShadowTexUnit));
+		const auto push = computeEclipsePush();
+		GL(moonShaderProgram->setUniformValue(moonShaderVars.eclipsePush, push)); // constant for now...
+	}
+	GL(moonShaderProgram->setUniformValue(moonShaderVars.horizonMap, horizonTexUnit));
+
+	if(!sphereVAO)
+	{
+		sphereVAO.reset(new QOpenGLVertexArrayObject);
+		sphereVAO->create();
+		gl->glGenBuffers(1, &sphereVBO);
+	}
+
+	sphereVAO->bind();
+	gl->glBindBuffer(GL_ARRAY_BUFFER, sphereVBO);
+	gl->glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, sphereVBO);
+
+	const auto projectedVertArrSize = projectedVertexArr.size() * GLsizeiptr(sizeof projectedVertexArr[0]);
+
+	const auto modelVertArrOffset = projectedVertArrSize;
+	const auto modelVertArrSize = model.vertexArr.size() * GLsizeiptr(sizeof model.vertexArr[0]);
+
+	const auto indicesOffset = modelVertArrOffset + modelVertArrSize;
+	const auto indicesSize = model.indexArr.size() * GLsizeiptr(sizeof model.indexArr[0]);
+
+	gl->glBufferData(GL_ARRAY_BUFFER, projectedVertArrSize+modelVertArrSize+indicesSize, nullptr, GL_STREAM_DRAW);
+	gl->glBufferSubData(GL_ARRAY_BUFFER, 0, projectedVertArrSize, projectedVertexArr.constData());
+	gl->glBufferSubData(GL_ARRAY_BUFFER, modelVertArrOffset, modelVertArrSize, model.vertexArr.constData());
+	gl->glBufferSubData(GL_ARRAY_BUFFER, indicesOffset, indicesSize, model.indexArr.constData());
+
+	GL(moonShaderProgram->setAttributeBuffer(shaderVars->vertex, GL_FLOAT, 0, 3));
+	GL(moonShaderProgram->enableAttributeArray(shaderVars->vertex));
+	GL(moonShaderProgram->setAttributeBuffer(shaderVars->unprojectedVertex, GL_FLOAT, modelVertArrOffset, 3));
+	GL(moonShaderProgram->enableAttributeArray(shaderVars->unprojectedVertex));
+	// This may have been enabled by drawSphere() if the Moon has been rendered by it due to user toggling settings,
+	// so disable the array explicitly. Maybe it's drawSphere who should actually take care of this.
+	GL(moonShaderProgram->disableAttributeArray(shaderVars->texCoord));
+
+	painter.setCullFace(true);
+	gl->glCullFace(GL_BACK);
+	painter.setDepthMask(true);
+	painter.setDepthTest(true);
+	gl->glClear(GL_DEPTH_BUFFER_BIT);
+
+	GL(gl->glDrawElements(GL_TRIANGLES, model.indexArr.size(), GL_UNSIGNED_INT, reinterpret_cast<void*>(indicesOffset)));
+
+	gl->glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+	gl->glBindBuffer(GL_ARRAY_BUFFER, 0);
+	sphereVAO->release();
+
+	GL(moonShaderProgram->release());
+
+	painter.setCullFace(false);
+	return true;
+}
+
 void Planet::drawSphere(const StelPainterLight& light, StelPainter* painter, float screenRd, bool drawOnlyRing)
 {
 	const float sphereScaleF=static_cast<float>(sphereScale);
@@ -4995,32 +5204,7 @@ void Planet::drawSphere(const StelPainterLight& light, StelPainter* painter, flo
 		{
 			GL(texEarthShadow->bind(3));
 			GL(moonShaderProgram->setUniformValue(moonShaderVars.earthShadow, 3));
-			// Ad-hoc visibility improvement during lunar eclipses:
-			// During partial umbra phase, make moon brighter so that the bright limb and umbra border has more visibility.
-			// When the moon is half in umbra, we start to raise its brightness. Near edge of totality we try to simulate the apparent super-bright edge.
-			static const double tweak=1.015; // 1.00 to have maximum push only in full umbra. 1.01 or even 1.02 looks better to show a brilliant last/first edge
-			GLfloat push=1.0f;
-
-			// Like in getVMagnitude() we must compute an elongation from the aberrated sun.
-			PlanetP sun=ssm->getSun();
-			const Vec3d obsPos=parent->eclipticPos-sun->getAberrationPush();
-			const double observerRq = obsPos.normSquared();
-			const Vec3d& planetHelioPos = getHeliocentricEclipticPos() - sun->getAberrationPush();
-			const double planetRq = planetHelioPos.normSquared();
-			const double observerPlanetRq = (obsPos - planetHelioPos).normSquared();
-			double aberratedElongation = std::acos((observerPlanetRq  + observerRq - planetRq)/(2.0*std::sqrt(observerPlanetRq*observerRq)));
-			const double od = 180. - aberratedElongation * (180.0/M_PI); // opposition distance [degrees]
-
-			// Compute umbra radius at lunar distance.
-			const double Lambda=getEclipticPos().norm();                             // Lunar distance [AU]
-			const double sigma=ssm->getEarthShadowRadiiAtLunarDistance().first[0]/3600.;
-			const double tau=atan(getEquatorialRadius()/Lambda) * M_180_PI; // geocentric angle of Lunar radius [degrees]
-
-			if (od<tweak*sigma-tau)     // if the Moon is fully immersed in the shadow
-				push=4.0f;
-			else if (od<tweak*sigma)    // If the Moon is half immersed, start pushing with a strong power function that make it apparent only in the last few percents.
-				push+=3.f*(1.f-pow(static_cast<float>((od-tweak*sigma+tau)/tau), 1.f/6.f));
-
+			const auto push = computeEclipsePush();
 			GL(moonShaderProgram->setUniformValue(moonShaderVars.eclipsePush, push)); // constant for now...
 		}
 		GL(horizonMap->bind(4));
@@ -5402,9 +5586,11 @@ bool Planet::ensureObjLoaded()
 	return true;
 }
 
-bool Planet::drawObjModel(const StelPainterLight& light, StelPainter *painter, float screenRd)
+bool Planet::drawObjModel(const StelPainterLight& light, StelPainter *painter, const bool isMoon, float screenRd)
 {
 	Q_UNUSED(screenRd) //screen size unused for now, use it for LOD or something?
+
+	if(isMoon) return drawMoon(light, *painter);
 
 	//make sure the OBJ is loaded, or start loading it
 	if(!ensureObjLoaded())

--- a/src/core/modules/Planet.hpp
+++ b/src/core/modules/Planet.hpp
@@ -63,6 +63,13 @@ class QOpenGLFramebufferObject;
 
 typedef QSharedPointer<class HipsSurvey> HipsSurveyP;
 
+struct Moon3DModel
+{
+	QVector<float> vertexArr;
+	QVector<uint32_t> indexArr;
+	bool attemptedToLoad = false;
+};
+
 // Class to manage rings for planets like Saturn
 class Ring
 {
@@ -769,7 +776,7 @@ protected:
 	//! Draws the OBJ model, assuming it is available
 	//! @param screenRd radius in screen pixels.
 	//! @return false if the model can currently not be drawn (not loaded)
-	bool drawObjModel(const StelPainterLight& light, StelPainter* painter, float screenRd);
+	bool drawObjModel(const StelPainterLight& light, StelPainter* painter, bool isMoon, float screenRd);
 
 	bool drawObjShadowMap(const Vec3d& lightPosition, StelPainter *painter, QMatrix4x4& shadowMatrix);
 
@@ -780,11 +787,16 @@ protected:
 	//! Draw the 3D sphere
 	void drawSphere(const StelPainterLight& light, StelPainter* painter, float screenRd, bool drawOnlyRing=false);
 
+	//! Draw the Moon
+	bool drawMoon(const StelPainterLight& light, StelPainter& painter);
+
 	//! Draw the Hips survey.
 	void drawSurvey(const StelPainterLight& light, StelCore* core, StelPainter* painter);
 
 	//! Draw the circle and name of the Planet
 	void drawHints(const StelCore* core, StelPainter &sPainter, const QFont& planetNameFont);
+
+	float computeEclipsePush() const;
 
 	PlanetOBJModel* loadObjModel() const;
 
@@ -891,6 +903,7 @@ private:
 
 	QList<StelObject::CulturalName> culturalNames; //!< names loaded from non-modern Skycultures. Usually just one, but there may be more!
 
+	Moon3DModel model;
 
 	QString texMapFileOrig;     //!< File path for texture; used for saving original filename
 	QString normalMapFileOrig;  //!< File path for normal map; used for saving original filename

--- a/src/core/modules/Planet.hpp
+++ b/src/core/modules/Planet.hpp
@@ -24,6 +24,7 @@
 #include <qopengl.h>
 #include "StelObject.hpp"
 #include "StelProjector.hpp"
+#include "StelProjectorType.hpp"
 #include "StelPropertyMgr.hpp"
 #include "StelTranslator.hpp"
 #include "VecMath.hpp"
@@ -911,11 +912,19 @@ private:
 
 	std::unique_ptr<QOpenGLVertexArrayObject> sphereVAO;
 	std::unique_ptr<QOpenGLVertexArrayObject> ringsVAO;
+	std::unique_ptr<QOpenGLVertexArrayObject> moonVAO;
 	GLuint sphereVBO=0;
 	GLuint ringsVBO=0;
+	GLuint moonVBO=0;
 
 	std::unique_ptr<QOpenGLVertexArrayObject> surveyVAO;
 	GLuint surveyVBO=0;
+
+	StelProjectorP prevProjector;
+
+	void setupMoonVAO();
+	void bindMoonVAO();
+	void releaseMoonVAO();
 
 	const QString getContextString() const;
 	QPair<double, double> getLunarEclipseMagnitudes() const;
@@ -942,6 +951,7 @@ private:
 		int skyBrightness;
 		int orenNayarParameters;
 		int outgasParameters;
+		int sphereScale;
 
 		// For Mars poles
 		int poleLat; // latitudes of edges of northern (x) and southern (y) polar cap [texture y, moving from 0 (S) to 1 (N)]. Only used for Mars, use [1, 0] for other objects.
@@ -990,6 +1000,9 @@ private:
 	static PlanetShaderVars ringPlanetShaderVars;
 	static QOpenGLShaderProgram* ringPlanetShaderProgram;
 	
+	static PlanetShaderVars sphereMoonShaderVars;
+	static QOpenGLShaderProgram* sphereMoonShaderProgram;
+
 	static PlanetShaderVars moonShaderVars;
 	static QOpenGLShaderProgram* moonShaderProgram;
 

--- a/src/core/modules/Planet.hpp
+++ b/src/core/modules/Planet.hpp
@@ -940,6 +940,7 @@ private:
 		int horizonMap;
 		int hasNormalMap;
 		int hasHorizonMap;
+		int texCoordsFromFragment;
 
 		// Rings-specific variables
 		int isRing;
@@ -967,8 +968,8 @@ private:
 	};
 
 	//! Calculates and uploads the common shader uniforms (projection matrix, texture, lighting&shadow data)
-	RenderData setCommonShaderUniforms(const StelPainter& painter, QOpenGLShaderProgram* shader, const PlanetShaderVars& shaderVars,
-	                                   const StelPainterLight& light, bool hasNormalMap, bool hasHorizonMap);
+	RenderData setCommonShaderUniforms(const StelPainter &painter, QOpenGLShaderProgram* shader, const PlanetShaderVars& shaderVars,
+                                           const StelPainterLight& light, bool hasNormalMap, bool hasHorizonMap, bool texCoordsFromFragment);
 
 	static PlanetShaderVars planetShaderVars;
 	static QOpenGLShaderProgram* planetShaderProgram;


### PR DESCRIPTION
This is a WIP implementation of the lunar mesh, which helps us get

1. The proper silhouette of the Moon, and
2. Better look of the rim during full Moon due to the back-faced parts of craters and mountains not being visible.

What's currently missing:

1. ~~This should obey `flagUseObjModels` and resort to the old sphere-based rendering when it's disabled. Or maybe add a separate feature flag, since the other models are much more lightweight?~~
2. Surveys are still rendered as spheres (and I don't think this will be changed in this PR).

This implementation includes a 44 MiB lunar mesh in a custom binary format optimized for compressibility, so its 7zip archive is only 7 MiB. This archive is what's contained in the repo, and it gets extracted on installation, so the installers will get the 44 MiB input. I hope that in particular Inno Setup will be able to achieve a similar compression. Of all compressors only 7zip and lzma/xz achieve about 7 MiB size, others (bzip2, gzip) appear to be much less efficient (13 MiB and 21 MiB, respectively). I chose 7zip because CMake supports it out of the box.

The worst-case performance of displaying only the Moon fullscreen at 0.3° FoV on my ASUS ProArt PX13 (with AMD Radeon 890M) dropped from 42 FPS to 33 FPS, which seems fair for the improvement achieved. On Zenbook UX333F with Intel UHD Graphics 620 the drop is from 16 FPS to 4.4 FPS, which is why it's desirable to fix the ability to turn the feature off.

I don't intend for this to get into 26.1, since it's likely to break some other aspect of planet rendering, so I suppose it should aim at 26.2.