### PR TITLE
Fix observing list window displaying incorrect list name after delete

### DIFF
--- a/src/gui/ObsListDialog.cpp
+++ b/src/gui/ObsListDialog.cpp
@@ -467,6 +467,10 @@ void ObsListDialog::loadSelectedList()
 
 	QVariantList listOfObjects;
 
+	// Display selected name in combo box
+	int index = ui->obsListComboBox->findData(selectedOlud);
+	ui->obsListComboBox->setCurrentIndex(index);
+
 	// Display description and creation date
 	currentListName=observingListMap.value(KEY_NAME).toString();
 	currentListDescription=observingListMap.value(KEY_DESCRIPTION).toString();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Please include a summary of the change and which issue is fixed. -->
<!--- Please also include relevant motivation and context. -->
<!--- List any dependencies that are required for this change. -->

Fixes #3816 
I added a small fix that updates the selected list name in the dropdown combo box in the observing lists menu. The `loadSelectedList` method gets called after deleting, and reloads the UI contents for a new selected list, but doesn't set the selected list in the dropdown combo box. I added 2 lines that set the selection from the combo box based on the `selectedOlud`, which is used to set all of the other fields. 

### Screenshots (if appropriate):
<br><br>**Fixed behavior, correct list name is shown after delete:**

https://github.com/user-attachments/assets/2d1983a5-2a75-4e17-b142-ffd651850a7a

<br><br>**Previous behavior, incorrect list name is shown, while correct description and list items are shown:**

<img width="996" height="600" alt="DeleteList_BuggedBehavior" src="https://github.com/user-attachments/assets/679e8552-4100-40c7-8038-e962c038f209" />


### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system: Windows 10
* Graphics Card: Nvidia GeForce GTX

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
