### PR TITLE
Fix problems with zooming in SkyCultureExplorer on first use

### DIFF
--- a/src/gui/SkyCultureMapGraphicsView.cpp
+++ b/src/gui/SkyCultureMapGraphicsView.cpp
@@ -332,10 +332,25 @@ void SkyCultureMapGraphicsView::showEvent(QShowEvent *e)
 void SkyCultureMapGraphicsView::scaleView(double factor)
 {
 	// calculate requested zoom before executing the zoom operation to limit the min / max zoom level
-	const double scaling = transform().scale(factor, factor).mapRect(QRectF(0, 0, 1, 1)).width();
+	QRectF viewRect = viewport()->rect().adjusted(2, 2, - 2, - 2);
+	QRectF sceneRect = transform().scale(factor, factor).mapRect(QRectF(2, 2, defaultRect.width() * 1.3, defaultRect.height() * 1.3));
+	const double currentTransform = transform().mapRect(QRectF(0, 0, 1, 1)).width();
+	const double scaledTransform = transform().scale(factor, factor).mapRect(QRectF(0, 0, 1, 1)).width();
+	const double windowMapRatio = calculateScaleRatio(defaultRect.width() * 1.3, defaultRect.height() * 1.3);
+	const double scaledWindowMapRatio = std::min(viewRect.width() / sceneRect.width(), viewRect.height() / sceneRect.height());
 
-	if (scaling < 0.16 || scaling > 500.0) // scaling < min or scaling > max zoom level
-		return;
+	if (factor < 1) // zoom out operation
+	{
+		if (scaledWindowMapRatio > 1.0)
+		{
+			factor = windowMapRatio;
+		}
+	}
+	else // zoom in operation
+	{
+		if (scaledTransform > 500.0)
+			factor = 500.0 / currentTransform;
+	}
 
 	scale(factor, factor);
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
Previously, there was an issue where, when Stellarium was launched for the very first time, users could neither zoom in nor zoom out on the map. This issue has been resolved, and the logic behind the zoom limits has been revised.

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I reset my config.ini file to simulate a fresh stellarium installation. (OS: Windows 11)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
