### PR TITLE
Fix grammar in typo reporting sentence in CONTRIBUTING.md.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ Don't report in this case.
 If you miss translations, please help us with your language and join our 
 translators at [Transifex](https://explore.transifex.com/stellarium/stellarium/).
 
-If the bug still persists, or you're find any typos, errors, or new feature suggestions 
+If the bug still persists, or you find any typos, errors, or new feature suggestions 
 feel free to open a new issue.
 
 When opening an issue to report a problem, please try and provide a minimal steps that 


### PR DESCRIPTION
Fix minor grammar issue in CONTRIBUTING.md

This keeps the contribution guide clear for first-time reporters without changing behavior.


### Description
- Corrected a small grammatical error in `CONTRIBUTING.md`:
  - `or you're find any typos` -> `or you find any typos`
- This is a documentation-only change and has no runtime impact.
- No dependencies required.

Fixes # (issue) <!-- N/A -->

### Screenshots (if appropriate):
N/A

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] This change requires a documentation update
- [x] Housekeeping

### How Has This Been Tested?
- Reviewed the diff locally and confirmed only one sentence in `CONTRIBUTING.md` was changed.
- Verified no source code or build configuration files were modified.

**Test Configuration**:
* Operating system: macOS 15.3 (darwin 25.3.0)
* Graphics Card: N/A (documentation-only change)

## Checklist:
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules