### PR TITLE
Add waitForKeypress() to support Bluetooth remote presentations (#3556)

### DIFF
--- a/src/scripting/StelMainScriptAPI.cpp
+++ b/src/scripting/StelMainScriptAPI.cpp
@@ -1017,6 +1017,19 @@ void StelMainScriptAPI::waitFor(const QString& dt, const QString& spec)
 	}
 }
 
+void StelMainScriptAPI::waitForKeypress()
+{
+	StelScriptMgr* scriptMgr = &StelApp::getInstance().getScriptMgr();
+	QCoreApplication::processEvents();
+	QEventLoop* loop = scriptMgr->getWaitEventLoop();
+	KeypressFilter filter(loop);
+	qApp->installEventFilter(&filter);
+	if( loop->exec() != 0 )
+	{
+		emit requestExit();
+	}
+	qApp->removeEventFilter(&filter);
+}
 
 void StelMainScriptAPI::selectObjectByName(const QString& name, bool pointer)
 {

--- a/src/scripting/StelMainScriptAPI.hpp
+++ b/src/scripting/StelMainScriptAPI.hpp
@@ -1012,6 +1012,10 @@ public slots:
 	//! @param spec "local" or "utc"
 	void waitFor(const QString& dt, const QString& spec="utc");
 
+	//! Pauses script until key is pressed
+	//! enables interactive control of scripts in planetarium presentations.
+	void waitForKeypress();
+
 	//! Retrieve value of environment variable @param name.
 	//! On desktop Windows and Qt before 5.10, this call may result in data loss if the original
 	//! string contains Unicode characters not representable in the ANSI encoding.

--- a/src/scripting/StelScriptMgr.hpp
+++ b/src/scripting/StelScriptMgr.hpp
@@ -45,6 +45,20 @@ class QScriptEngine;
 class ScriptConsole;
 #endif
 
+// Event filter to detect keypress for waitForKeypress()
+class KeypressFilter : public QObject {
+	QEventLoop* loop;
+public:
+	KeypressFilter(QEventLoop* 1) : loop(1) {}
+	bool eventFilter(QObject* obj, QEvent* event) override {
+		if (event->type() == QEvent::KeyPress) {
+			loop->quit();
+			return true;
+		}
+		return QObject::eventFilter(obj, event);
+	}
+};
+
 //! Manage scripting in Stellarium
 //! Notes on migration from QtScript to QJSEngine
 //! - The old engine had isEvaluating(). We must use a mutex for the same idea.
@@ -321,6 +335,9 @@ private:
 
 	//! The QEventLoop for wait and waitFor
 	QEventLoop* waitEventLoop;
+
+	//! Event filter to detect keypress for waitForKeypress()
+	QObject* keypressEventFilter;
 	
 	QString scriptFileName;
 	

--- a/src/scripting/StelScriptMgr.hpp
+++ b/src/scripting/StelScriptMgr.hpp
@@ -49,7 +49,7 @@ class ScriptConsole;
 class KeypressFilter : public QObject {
 	QEventLoop* loop;
 public:
-	KeypressFilter(QEventLoop* 1) : loop(1) {}
+	KeypressFilter(QEventLoop* l) : loop(l) {}
 	bool eventFilter(QObject* obj, QEvent* event) override {
 		if (event->type() == QEvent::KeyPress) {
 			loop->quit();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
I added "waitForKeypress()" that uses QEventLoop to block the script temporarily and uses an event filter to detect a keypress. I figure since a bluetooth remote like a presentation clicker would be read as a keyboard, that I can just treat it like a keyboard in the function.

Fixes #3556

### Screenshots (if appropriate):

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?
I have not tested this locally yet because of the build environment on NixOS.

**Test Configuration**:
* Operating system: NixOS 25.11
* Graphics Card: NVIDIA GeForce RTX 4090

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
