### PR TITLE
SCM: add common_names tab (#4657)

### DIFF
--- a/data/gui/normalStyle.css
+++ b/data/gui/normalStyle.css
@@ -56,6 +56,7 @@ QTextEdit,
 QPlainTextEdit,
 QListWidget,
 QTreeWidget,
+QTableWidget,
 QLineEdit {
 	background: rgb(30, 30, 31);
 	selection-background-color: rgb(253, 216, 134);
@@ -75,6 +76,7 @@ QLineEdit {
 QTextEdit:disabled,
 QListWidget:disabled,
 QTreeWidget:disabled,
+QTableWidget:disabled,
 QLineEdit:disabled {
 	background: rgb(90, 90, 90);
 }

--- a/plugins/SkyCultureMaker/src/ScmSkyCulture.cpp
+++ b/plugins/SkyCultureMaker/src/ScmSkyCulture.cpp
@@ -126,7 +126,9 @@ QJsonObject scm::ScmSkyCulture::toJson(const bool mergeLines) const
 		{
 			QJsonArray namesArray;
 			for (const auto &name : it.value())
+			{
 				namesArray.append(name.toJson());
+			}
 			commonNamesObj[it.key()] = namesArray;
 		}
 		scJsonObj["common_names"] = commonNamesObj;

--- a/plugins/SkyCultureMaker/src/ScmSkyCulture.cpp
+++ b/plugins/SkyCultureMaker/src/ScmSkyCulture.cpp
@@ -119,6 +119,19 @@ QJsonObject scm::ScmSkyCulture::toJson(const bool mergeLines) const
 	}
 	scJsonObj["constellations"] = constellationsArray;
 
+	if (!culturalNames.isEmpty())
+	{
+		QJsonObject commonNamesObj;
+		for (auto it = culturalNames.constBegin(); it != culturalNames.constEnd(); ++it)
+		{
+			QJsonArray namesArray;
+			for (const auto &name : it.value())
+				namesArray.append(name.toJson());
+			commonNamesObj[it.key()] = namesArray;
+		}
+		scJsonObj["common_names"] = commonNamesObj;
+	}
+
 	return scJsonObj;
 }
 
@@ -154,6 +167,11 @@ void scm::ScmSkyCulture::draw(StelCore *core) const
 void scm::ScmSkyCulture::setDescription(const scm::Description &description)
 {
 	ScmSkyCulture::description = description;
+}
+
+void scm::ScmSkyCulture::setCulturalNames(const QMap<QString, QList<ScmCulturalName>> &names)
+{
+	ScmSkyCulture::culturalNames = names;
 }
 
 bool scm::ScmSkyCulture::saveDescriptionAsMarkdown(QFile &file)

--- a/plugins/SkyCultureMaker/src/ScmSkyCulture.hpp
+++ b/plugins/SkyCultureMaker/src/ScmSkyCulture.hpp
@@ -25,6 +25,7 @@
 #define SCM_SKYCULTURE_HPP
 
 #include "ScmConstellation.hpp"
+#include "types/ScmCulturalName.hpp"
 #include "StelCore.hpp"
 #include "StelSkyCultureMgr.hpp"
 #include "types/Classification.hpp"
@@ -36,6 +37,8 @@
 #include <vector>
 #include <QFile>
 #include <QJsonObject>
+#include <QList>
+#include <QMap>
 #include <QObject>
 #include <QString>
 
@@ -108,6 +111,13 @@ public:
 	void setDescription(const scm::Description &description);
 
 	/**
+	 * @brief Sets the cultural names of stars, planets DSOs of the sky culture.
+	 * The map key is the object identifier (e.g. "HIP 1234", "NAME Venus", "M 31").
+	 * @param culturalNames Map of cultural names to set.
+	 */
+	void setCulturalNames(const QMap<QString, QList<ScmCulturalName>> &culturalNames);
+
+	/**
 	 * @brief Saves the current sky culture description as markdown text.
 	 * @param file The file to save the description to.
 	 * @return true if the description was saved successfully, false otherwise.
@@ -140,6 +150,10 @@ private:
 
 	/// The description of the sky culture
 	scm::Description description;
+
+	/// The cultural names of stars, planets DSOs of the sky culture.
+	/// Key: object identifier (e.g. "HIP 1234", "NAME Venus", "M 31").
+	QMap<QString, QList<ScmCulturalName>> culturalNames;
 
 	/// The geographical location (as polygons) of the sky culture
 	QList<CulturePolygon> locations;

--- a/plugins/SkyCultureMaker/src/gui/ScmSkyCultureDialog.cpp
+++ b/plugins/SkyCultureMaker/src/gui/ScmSkyCultureDialog.cpp
@@ -1242,9 +1242,8 @@ void ScmSkyCultureDialog::cnAddNew()
 	if (!cnCheckObjectExists(key)) return;
 
 	cnEntries.append({key, name});
-	const int newRow = cnEntries.size() - 1;
 	cnRefreshTable();
-	ui->cnEntriesTable->selectRow(newRow);
+	cnClearForm();
 }
 
 void ScmSkyCultureDialog::cnSaveChanges()

--- a/plugins/SkyCultureMaker/src/gui/ScmSkyCultureDialog.cpp
+++ b/plugins/SkyCultureMaker/src/gui/ScmSkyCultureDialog.cpp
@@ -292,7 +292,7 @@ void ScmSkyCultureDialog::createDialogContent()
 	ui->cnVisibleLbl->setEnabled(false);
 	ui->cnRemoveEntryBtn->setEnabled(false);
 	connect(ui->cnObjectTypeCB, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
-	        &ScmSkyCultureDialog::cnUpdateVisibleField);
+	        [this](int i) { cnUpdateVisibleField(static_cast<CnObjectType>(i)); });
 	connect(ui->cnRemoveEntryBtn, &QPushButton::clicked, this, &ScmSkyCultureDialog::cnRemoveEntry);
 	connect(ui->cnUseSelectionBtn, &QPushButton::clicked, this, &ScmSkyCultureDialog::cnUseSelectedObject);
 	connect(ui->cnAddNewBtn, &QPushButton::clicked, this, &ScmSkyCultureDialog::cnAddNew);
@@ -303,7 +303,8 @@ void ScmSkyCultureDialog::createDialogContent()
 	{
 		if (cnEditingRow >= 0) ui->cnSaveChangesBtn->setEnabled(true);
 	};
-	connect(ui->cnObjectTypeCB, QOverload<int>::of(&QComboBox::currentIndexChanged), this, onFormEdited);
+	connect(ui->cnObjectTypeCB, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
+	        [onFormEdited](int) { onFormEdited(); });
 	connect(ui->cnObjectIdLE, &QLineEdit::textChanged, this, onFormEdited);
 	connect(ui->cnEnglishLE, &QLineEdit::textChanged, this, onFormEdited);
 	connect(ui->cnNativeLE, &QLineEdit::textChanged, this, onFormEdited);
@@ -315,7 +316,7 @@ void ScmSkyCultureDialog::createDialogContent()
 	connect(ui->cnVisibleCB, QOverload<int>::of(&QComboBox::currentIndexChanged), this, onFormEdited);
 	connect(ui->cnEntriesTable, &QTableWidget::itemSelectionChanged, this,
 	        &ScmSkyCultureDialog::cnOnTableSelectionChanged);
-	cnUpdateVisibleField(0); // initial placeholder text
+	cnUpdateVisibleField(CnObjectType::Star); // initial placeholder text
 }
 
 void ScmSkyCultureDialog::handleFontChanged()
@@ -969,35 +970,36 @@ void ScmSkyCultureDialog::cancelAddPolygon()
 	hideAddPolygon();
 }
 
-void ScmSkyCultureDialog::cnUpdateVisibleField(int typeIndex)
+void ScmSkyCultureDialog::cnUpdateVisibleField(CnObjectType type)
 {
-	// typeIndex: 0=Star, 1=Planet, 2=DSO
-	const bool isPlanet = (typeIndex == 1);
+	const bool isPlanet = (type == CnObjectType::Planet);
 	ui->cnVisibleCB->setEnabled(isPlanet);
-	if(!isPlanet) ui->cnVisibleCB->setCurrentIndex(0); // disabling the CB should reset the value
+	if (!isPlanet) ui->cnVisibleCB->setCurrentIndex(0); // disabling the CB should reset the value
 	ui->cnVisibleLbl->setEnabled(isPlanet);
 
-	switch (typeIndex)
+	switch (type)
 	{
-	case 0: ui->cnObjectIdLE->setPlaceholderText(q_("HIP or Gaia DR3 ID (e.g. HIP 1234 or Gaia DR3 1234567890)")); break;
-	case 1: ui->cnObjectIdLE->setPlaceholderText(q_("Planet name (e.g. Venus)")); break;
-	case 2: ui->cnObjectIdLE->setPlaceholderText(q_("Catalog designation (e.g. M31)")); break;
+	case CnObjectType::Star:
+		ui->cnObjectIdLE->setPlaceholderText(q_("HIP or Gaia DR3 ID (e.g. HIP 1234 or Gaia DR3 1234567890)"));
+		break;
+	case CnObjectType::Planet: ui->cnObjectIdLE->setPlaceholderText(q_("Planet name (e.g. Venus)")); break;
+	case CnObjectType::DSO: ui->cnObjectIdLE->setPlaceholderText(q_("Catalog designation (e.g. M31)")); break;
 	}
 }
 
 QString ScmSkyCultureDialog::cnBuildKey() const
 {
 	QString id = ui->cnObjectIdLE->text().trimmed();
-	switch (ui->cnObjectTypeCB->currentIndex())
+	switch (static_cast<CnObjectType>(ui->cnObjectTypeCB->currentIndex()))
 	{
 	// removal and re-addition of prefix to ensure correct casing and spacing
-	case 0:
+	case CnObjectType::Star:
 		if (id.startsWith(QLatin1String("HIP"), Qt::CaseInsensitive)) id = id.mid(3).trimmed();
 		// Normalize Gaia DR3 prefix casing; keep the numeric part as-is
 		if (id.startsWith(QLatin1String("Gaia DR3"), Qt::CaseInsensitive))
 			return QLatin1String("Gaia DR3 ") + id.mid(8).trimmed();
 		return QLatin1String("HIP ") + id;
-	case 1:
+	case CnObjectType::Planet:
 		if (id.startsWith(QLatin1String("NAME"), Qt::CaseInsensitive)) id = id.mid(4).trimmed();
 		return QLatin1String("NAME ") + id;
 	default: return id;
@@ -1006,7 +1008,7 @@ QString ScmSkyCultureDialog::cnBuildKey() const
 
 void ScmSkyCultureDialog::cnClearForm()
 {
-	ui->cnObjectTypeCB->setCurrentIndex(0);
+	ui->cnObjectTypeCB->setCurrentIndex(static_cast<int>(CnObjectType::Star));
 	ui->cnObjectIdLE->clear();
 	ui->cnEnglishLE->clear();
 	ui->cnNativeLE->clear();
@@ -1016,7 +1018,7 @@ void ScmSkyCultureDialog::cnClearForm()
 	ui->cnBynameLE->clear();
 	ui->cnReferencesLE->clear();
 	ui->cnVisibleCB->setCurrentIndex(0);
-	cnUpdateVisibleField(0);
+	cnUpdateVisibleField(CnObjectType::Star);
 }
 
 scm::ScmCulturalName ScmSkyCultureDialog::cnReadForm() const
@@ -1058,15 +1060,15 @@ void ScmSkyCultureDialog::cnPopulateForm(const QString &key, const scm::ScmCultu
 	if (key.startsWith(QLatin1String("HIP "), Qt::CaseInsensitive) ||
 	    key.startsWith(QLatin1String("Gaia DR3 "), Qt::CaseInsensitive))
 	{
-		ui->cnObjectTypeCB->setCurrentIndex(0);
+		ui->cnObjectTypeCB->setCurrentIndex(static_cast<int>(CnObjectType::Star));
 	}
 	else if (key.startsWith(QLatin1String("NAME "), Qt::CaseInsensitive))
 	{
-		ui->cnObjectTypeCB->setCurrentIndex(1);
+		ui->cnObjectTypeCB->setCurrentIndex(static_cast<int>(CnObjectType::Planet));
 	}
 	else
 	{
-		ui->cnObjectTypeCB->setCurrentIndex(2);
+		ui->cnObjectTypeCB->setCurrentIndex(static_cast<int>(CnObjectType::DSO));
 	}
 	ui->cnObjectIdLE->setText(key);
 	ui->cnEnglishLE->setText(name.translated);
@@ -1120,13 +1122,13 @@ void ScmSkyCultureDialog::cnRefreshTable()
 	}
 }
 
-bool ScmSkyCultureDialog::cnIsDuplicate(const QString &key, StelObject::CulturalNameSpecial special, int excludeRow) const
+bool ScmSkyCultureDialog::cnIsDuplicate(const QString &key, StelObject::CulturalNameSpecial special,
+                                        int excludeRow) const
 {
 	for (int i = 0; i < cnEntries.size(); ++i)
 	{
 		if (i == excludeRow) continue;
-		if (cnEntries[i].first == key && cnEntries[i].second.special == special)
-			return true;
+		if (cnEntries[i].first == key && cnEntries[i].second.special == special) return true;
 	}
 	return false;
 }
@@ -1143,7 +1145,7 @@ bool ScmSkyCultureDialog::cnValidateForm(QString &outKey, scm::ScmCulturalName &
 		            "planet name, DSO catalog designation)"));
 		return false;
 	}
-	if (ui->cnObjectTypeCB->currentIndex() == 0)
+	if (ui->cnObjectTypeCB->currentIndex() == static_cast<int>(CnObjectType::Star))
 	{
 		if (!id.startsWith(QLatin1String("Gaia DR3 "), Qt::CaseInsensitive))
 		{
@@ -1156,9 +1158,10 @@ bool ScmSkyCultureDialog::cnValidateForm(QString &outKey, scm::ScmCulturalName &
 			numStr.split(' ').first().toInt(&ok);
 			if (!ok)
 			{
-				maker->showUserWarningMessage(dialog, ui->titleBar->title(),
-				                              q_("The star identifier must be a HIP number (e.g. 1234 or HIP 1234 A) "
-				                                 "or a Gaia DR3 ID (e.g. Gaia DR3 1234567890)."));
+				maker->showUserWarningMessage(
+					dialog, ui->titleBar->title(),
+					q_("The star identifier must be a HIP number (e.g. 1234 or HIP 1234 A) "
+				           "or a Gaia DR3 ID (e.g. Gaia DR3 1234567890)."));
 				return false;
 			}
 		}
@@ -1252,18 +1255,18 @@ void ScmSkyCultureDialog::cnUseSelectedObject()
 
 	if (type == QLatin1String("Star"))
 	{
-		ui->cnObjectTypeCB->setCurrentIndex(0);
+		ui->cnObjectTypeCB->setCurrentIndex(static_cast<int>(CnObjectType::Star));
 		ui->cnObjectIdLE->setText(obj->getID());
 	}
 	else if (type == QLatin1String("Planet"))
 	{
-		ui->cnObjectTypeCB->setCurrentIndex(1);
+		ui->cnObjectTypeCB->setCurrentIndex(static_cast<int>(CnObjectType::Planet));
 		ui->cnObjectIdLE->setText(QLatin1String("NAME ") + obj->getEnglishName());
 		ui->cnEnglishLE->setText(obj->getEnglishName());
 	}
 	else
 	{
-		ui->cnObjectTypeCB->setCurrentIndex(2);
+		ui->cnObjectTypeCB->setCurrentIndex(static_cast<int>(CnObjectType::DSO));
 		QString id = GETSTELMODULE(NebulaMgr)->getLatestSelectedDSODesignationWIC();
 		if (id.isEmpty()) id = obj->getEnglishName();
 		ui->cnObjectIdLE->setText(id);

--- a/plugins/SkyCultureMaker/src/gui/ScmSkyCultureDialog.cpp
+++ b/plugins/SkyCultureMaker/src/gui/ScmSkyCultureDialog.cpp
@@ -1160,7 +1160,7 @@ void ScmSkyCultureDialog::cnUpdateEntryButtons()
 	ui->cnSaveEntryBtn->setEnabled(hasSelection);
 }
 
-bool isValidHIPIdentifier(const QString &id)
+bool ScmSkyCultureDialog::isValidHIPIdentifier(const QString &id) const
 {
 	QString hipId = id;
 	if (hipId.startsWith(QLatin1String("HIP"), Qt::CaseInsensitive))

--- a/plugins/SkyCultureMaker/src/gui/ScmSkyCultureDialog.cpp
+++ b/plugins/SkyCultureMaker/src/gui/ScmSkyCultureDialog.cpp
@@ -22,14 +22,16 @@
  */
 
 #include "ScmSkyCultureDialog.hpp"
+#include "NebulaMgr.hpp"
 #include "ScmPolygonInfoTreeItem.hpp"
+#include "StelObjectMgr.hpp"
 #include "ui_scmSkyCultureDialog.h"
 #include <cassert>
+#include <QDebug>
 #include <QHeaderView>
 #include <QMap>
 #include <QStyledItemDelegate>
 #include <QTableWidgetItem>
-#include <QDebug>
 
 namespace
 {
@@ -288,16 +290,31 @@ void ScmSkyCultureDialog::createDialogContent()
 	cnRefreshTable();
 	ui->cnVisibleCB->setEnabled(false);
 	ui->cnVisibleLbl->setEnabled(false);
-	ui->cnLoadEntryBtn->setEnabled(false);
 	ui->cnRemoveEntryBtn->setEnabled(false);
-	ui->cnSaveEntryBtn->setEnabled(false);
-	connect(ui->cnObjectTypeCB, QOverload<int>::of(&QComboBox::currentIndexChanged),
-	        this, &ScmSkyCultureDialog::cnUpdateVisibleField);
-	connect(ui->cnAddEntryBtn, &QPushButton::clicked, this, &ScmSkyCultureDialog::cnAddEntry);
-	connect(ui->cnLoadEntryBtn, &QPushButton::clicked, this, &ScmSkyCultureDialog::cnLoadEntry);
+	connect(ui->cnObjectTypeCB, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
+	        &ScmSkyCultureDialog::cnUpdateVisibleField);
 	connect(ui->cnRemoveEntryBtn, &QPushButton::clicked, this, &ScmSkyCultureDialog::cnRemoveEntry);
-	connect(ui->cnSaveEntryBtn, &QPushButton::clicked, this, &ScmSkyCultureDialog::cnSaveEntry);
-	connect(ui->cnEntriesTable, &QTableWidget::itemSelectionChanged, this, &ScmSkyCultureDialog::cnUpdateEntryButtons);
+	connect(ui->cnUseSelectionBtn, &QPushButton::clicked, this, &ScmSkyCultureDialog::cnUseSelectedObject);
+	connect(ui->cnAddNewBtn, &QPushButton::clicked, this, &ScmSkyCultureDialog::cnAddNew);
+	connect(ui->cnSaveChangesBtn, &QPushButton::clicked, this, &ScmSkyCultureDialog::cnSaveChanges);
+	ui->cnSaveChangesBtn->setEnabled(false);
+	// Enable Save Changes when the user edits any form field while a row is selected
+	const auto onFormEdited = [this]()
+	{
+		if (cnEditingRow >= 0) ui->cnSaveChangesBtn->setEnabled(true);
+	};
+	connect(ui->cnObjectTypeCB, QOverload<int>::of(&QComboBox::currentIndexChanged), this, onFormEdited);
+	connect(ui->cnObjectIdLE, &QLineEdit::textChanged, this, onFormEdited);
+	connect(ui->cnEnglishLE, &QLineEdit::textChanged, this, onFormEdited);
+	connect(ui->cnNativeLE, &QLineEdit::textChanged, this, onFormEdited);
+	connect(ui->cnPronounceLE, &QLineEdit::textChanged, this, onFormEdited);
+	connect(ui->cnTransliterationLE, &QLineEdit::textChanged, this, onFormEdited);
+	connect(ui->cnIpaLE, &QLineEdit::textChanged, this, onFormEdited);
+	connect(ui->cnBynameLE, &QLineEdit::textChanged, this, onFormEdited);
+	connect(ui->cnReferencesLE, &QLineEdit::textChanged, this, onFormEdited);
+	connect(ui->cnVisibleCB, QOverload<int>::of(&QComboBox::currentIndexChanged), this, onFormEdited);
+	connect(ui->cnEntriesTable, &QTableWidget::itemSelectionChanged, this,
+	        &ScmSkyCultureDialog::cnOnTableSelectionChanged);
 	cnUpdateVisibleField(0); // initial placeholder text
 }
 
@@ -720,6 +737,7 @@ void ScmSkyCultureDialog::resetDialog()
 		updateRemovePolygonButton();
 
 		cnEntries.clear();
+		cnEditingRow = -1;
 		cnClearForm();
 		cnRefreshTable();
 	}
@@ -956,11 +974,12 @@ void ScmSkyCultureDialog::cnUpdateVisibleField(int typeIndex)
 	// typeIndex: 0=Star, 1=Planet, 2=DSO
 	const bool isPlanet = (typeIndex == 1);
 	ui->cnVisibleCB->setEnabled(isPlanet);
+	if(!isPlanet) ui->cnVisibleCB->setCurrentIndex(0); // disabling the CB should reset the value
 	ui->cnVisibleLbl->setEnabled(isPlanet);
 
 	switch (typeIndex)
 	{
-	case 0: ui->cnObjectIdLE->setPlaceholderText(q_("HIP number (e.g. 1234)")); break;
+	case 0: ui->cnObjectIdLE->setPlaceholderText(q_("HIP or Gaia DR3 ID (e.g. HIP 1234 or Gaia DR3 1234567890)")); break;
 	case 1: ui->cnObjectIdLE->setPlaceholderText(q_("Planet name (e.g. Venus)")); break;
 	case 2: ui->cnObjectIdLE->setPlaceholderText(q_("Catalog designation (e.g. M31)")); break;
 	}
@@ -974,6 +993,9 @@ QString ScmSkyCultureDialog::cnBuildKey() const
 	// removal and re-addition of prefix to ensure correct casing and spacing
 	case 0:
 		if (id.startsWith(QLatin1String("HIP"), Qt::CaseInsensitive)) id = id.mid(3).trimmed();
+		// Normalize Gaia DR3 prefix casing; keep the numeric part as-is
+		if (id.startsWith(QLatin1String("Gaia DR3"), Qt::CaseInsensitive))
+			return QLatin1String("Gaia DR3 ") + id.mid(8).trimmed();
 		return QLatin1String("HIP ") + id;
 	case 1:
 		if (id.startsWith(QLatin1String("NAME"), Qt::CaseInsensitive)) id = id.mid(4).trimmed();
@@ -984,6 +1006,7 @@ QString ScmSkyCultureDialog::cnBuildKey() const
 
 void ScmSkyCultureDialog::cnClearForm()
 {
+	ui->cnObjectTypeCB->setCurrentIndex(0);
 	ui->cnObjectIdLE->clear();
 	ui->cnEnglishLE->clear();
 	ui->cnNativeLE->clear();
@@ -993,7 +1016,7 @@ void ScmSkyCultureDialog::cnClearForm()
 	ui->cnBynameLE->clear();
 	ui->cnReferencesLE->clear();
 	ui->cnVisibleCB->setCurrentIndex(0);
-	ui->cnSaveEntryBtn->setEnabled(false);
+	cnUpdateVisibleField(0);
 }
 
 scm::ScmCulturalName ScmSkyCultureDialog::cnReadForm() const
@@ -1031,6 +1054,20 @@ scm::ScmCulturalName ScmSkyCultureDialog::cnReadForm() const
 
 void ScmSkyCultureDialog::cnPopulateForm(const QString &key, const scm::ScmCulturalName &name)
 {
+	// Determine type from key
+	if (key.startsWith(QLatin1String("HIP "), Qt::CaseInsensitive) ||
+	    key.startsWith(QLatin1String("Gaia DR3 "), Qt::CaseInsensitive))
+	{
+		ui->cnObjectTypeCB->setCurrentIndex(0);
+	}
+	else if (key.startsWith(QLatin1String("NAME "), Qt::CaseInsensitive))
+	{
+		ui->cnObjectTypeCB->setCurrentIndex(1);
+	}
+	else
+	{
+		ui->cnObjectTypeCB->setCurrentIndex(2);
+	}
 	ui->cnObjectIdLE->setText(key);
 	ui->cnEnglishLE->setText(name.translated);
 	ui->cnNativeLE->setText(name.native);
@@ -1083,28 +1120,47 @@ void ScmSkyCultureDialog::cnRefreshTable()
 	}
 }
 
+bool ScmSkyCultureDialog::cnIsDuplicate(const QString &key, StelObject::CulturalNameSpecial special, int excludeRow) const
+{
+	for (int i = 0; i < cnEntries.size(); ++i)
+	{
+		if (i == excludeRow) continue;
+		if (cnEntries[i].first == key && cnEntries[i].second.special == special)
+			return true;
+	}
+	return false;
+}
+
 bool ScmSkyCultureDialog::cnValidateForm(QString &outKey, scm::ScmCulturalName &outName)
 {
 	const QString id = ui->cnObjectIdLE->text().trimmed();
 	if (id.isEmpty())
 	{
-		maker->showUserWarningMessage(dialog, ui->titleBar->title(),
-		                              qc_("Please enter an object identifier.",
-		                                  "Prompt for missing celestial object identifier (e.g. HIP number, "
-		                                  "planet name, DSO catalog designation)"));
+		maker->showUserWarningMessage(
+			dialog, ui->titleBar->title(),
+			qc_("Please enter an object identifier.",
+		            "Prompt for missing celestial object identifier (e.g. HIP number, Gaia DR3 ID, or"
+		            "planet name, DSO catalog designation)"));
 		return false;
 	}
 	if (ui->cnObjectTypeCB->currentIndex() == 0)
 	{
-		QString hipId = id;
-		if (hipId.startsWith(QLatin1String("HIP"), Qt::CaseInsensitive)) hipId = hipId.mid(3).trimmed();
-		bool ok = false;
-		hipId.toInt(&ok);
-		if (!ok)
+		if (!id.startsWith(QLatin1String("Gaia DR3 "), Qt::CaseInsensitive))
 		{
-			maker->showUserWarningMessage(dialog, ui->titleBar->title(),
-			                              q_("The HIP identifier must be a valid integer (e.g. 1234)."));
-			return false;
+			// HIP: strip optional prefix, then validate the numeric part
+			// Component letter suffixes are allowed (e.g. "32349 A" for multiple-star systems)
+			QString numStr = id;
+			if (numStr.startsWith(QLatin1String("HIP"), Qt::CaseInsensitive))
+				numStr = numStr.mid(3).trimmed();
+			bool ok = false;
+			numStr.split(' ').first().toInt(&ok);
+			if (!ok)
+			{
+				maker->showUserWarningMessage(dialog, ui->titleBar->title(),
+				                              q_("The star identifier must be a HIP number (e.g. 1234 or HIP 1234 A) "
+				                                 "or a Gaia DR3 ID (e.g. Gaia DR3 1234567890)."));
+				return false;
+			}
 		}
 	}
 	outKey  = cnBuildKey();
@@ -1118,24 +1174,45 @@ bool ScmSkyCultureDialog::cnValidateForm(QString &outKey, scm::ScmCulturalName &
 	return true;
 }
 
-void ScmSkyCultureDialog::cnAddEntry()
+void ScmSkyCultureDialog::cnAddNew()
 {
 	QString key;
 	scm::ScmCulturalName name;
 	if (!cnValidateForm(key, name)) return;
+
+	if (cnIsDuplicate(key, name.special))
+	{
+		maker->showUserWarningMessage(dialog, ui->titleBar->title(),
+		                              q_("An entry for this object already exists."));
+		return;
+	}
+
 	cnEntries.append({key, name});
+	const int newRow = cnEntries.size() - 1;
 	cnRefreshTable();
-	cnClearForm();
+	ui->cnEntriesTable->selectRow(newRow);
 }
 
-void ScmSkyCultureDialog::cnLoadEntry()
+void ScmSkyCultureDialog::cnSaveChanges()
 {
-	const auto selectedRows = ui->cnEntriesTable->selectionModel()->selectedRows();
-	if (selectedRows.isEmpty()) return;
-	const int row = selectedRows.first().row();
-	Q_ASSERT(row >= 0 && row < cnEntries.size());
-	cnPopulateForm(cnEntries[row].first, cnEntries[row].second);
-	ui->cnSaveEntryBtn->setEnabled(true);
+	if (cnEditingRow < 0 || cnEditingRow >= cnEntries.size()) return;
+
+	QString key;
+	scm::ScmCulturalName name;
+	if (!cnValidateForm(key, name)) return;
+
+	if (cnIsDuplicate(key, name.special, cnEditingRow))
+	{
+		maker->showUserWarningMessage(dialog, ui->titleBar->title(),
+		                              q_("An entry for this object already exists."));
+		return;
+	}
+
+	cnEntries[cnEditingRow] = {key, name};
+	// capture before cnRefreshTable resets selection
+	const int savedRow = cnEditingRow;
+	cnRefreshTable();
+	ui->cnEntriesTable->selectRow(savedRow);
 }
 
 void ScmSkyCultureDialog::cnRemoveEntry()
@@ -1145,29 +1222,72 @@ void ScmSkyCultureDialog::cnRemoveEntry()
 	const int row = selectedRows.first().row();
 	Q_ASSERT(row >= 0 && row < cnEntries.size());
 	cnEntries.removeAt(row);
+	cnEditingRow = -1;
 	cnRefreshTable();
-	cnClearForm();
-	cnUpdateEntryButtons();
+	// Select the next entry if possible, otherwise clear the form
+	if (!cnEntries.isEmpty())
+	{
+		ui->cnEntriesTable->selectRow(qMin(row, static_cast<int>(cnEntries.size()) - 1));
+	}
+	else
+	{
+		cnClearForm();
+	}
 }
 
-void ScmSkyCultureDialog::cnSaveEntry()
+void ScmSkyCultureDialog::cnUseSelectedObject()
+{
+	StelObjectMgr *objMgr              = GETSTELMODULE(StelObjectMgr);
+	const QList<StelObjectP> &selected = objMgr->getSelectedObject();
+	if (selected.isEmpty())
+	{
+		maker->showUserWarningMessage(dialog, ui->titleBar->title(),
+		                              q_("No object is currently selected in Stellarium."));
+		return;
+	}
+
+	cnClearForm();
+	const StelObjectP &obj = selected.first();
+	const QString type     = obj->getType();
+
+	if (type == QLatin1String("Star"))
+	{
+		ui->cnObjectTypeCB->setCurrentIndex(0);
+		ui->cnObjectIdLE->setText(obj->getID());
+	}
+	else if (type == QLatin1String("Planet"))
+	{
+		ui->cnObjectTypeCB->setCurrentIndex(1);
+		ui->cnObjectIdLE->setText(QLatin1String("NAME ") + obj->getEnglishName());
+		ui->cnEnglishLE->setText(obj->getEnglishName());
+	}
+	else
+	{
+		ui->cnObjectTypeCB->setCurrentIndex(2);
+		QString id = GETSTELMODULE(NebulaMgr)->getLatestSelectedDSODesignationWIC();
+		if (id.isEmpty()) id = obj->getEnglishName();
+		ui->cnObjectIdLE->setText(id);
+	}
+}
+
+void ScmSkyCultureDialog::cnOnTableSelectionChanged()
 {
 	const auto selectedRows = ui->cnEntriesTable->selectionModel()->selectedRows();
-	if (selectedRows.isEmpty()) return;
-	const int row = selectedRows.first().row();
-	Q_ASSERT(row >= 0 && row < cnEntries.size());
-	QString key;
-	scm::ScmCulturalName name;
-	if (!cnValidateForm(key, name)) return;
-	cnEntries[row] = {key, name};
-	cnRefreshTable();
-	ui->cnEntriesTable->selectRow(row);
-}
+	const bool hasSelection = !selectedRows.isEmpty();
 
-void ScmSkyCultureDialog::cnUpdateEntryButtons()
-{
-	const bool hasSelection = !ui->cnEntriesTable->selectionModel()->selectedRows().isEmpty();
-	ui->cnLoadEntryBtn->setEnabled(hasSelection);
 	ui->cnRemoveEntryBtn->setEnabled(hasSelection);
-	ui->cnSaveEntryBtn->setEnabled(hasSelection);
+	ui->cnSaveChangesBtn->setEnabled(false);
+
+	if (hasSelection)
+	{
+		const int row = selectedRows.first().row();
+		Q_ASSERT(row >= 0 && row < cnEntries.size());
+		cnEditingRow = -1; // suppress form-change signals during populate
+		cnPopulateForm(cnEntries[row].first, cnEntries[row].second);
+		cnEditingRow = row;
+	}
+	else
+	{
+		cnEditingRow = -1; // no row selected, so edits should not enable Save Changes
+	}
 }

--- a/plugins/SkyCultureMaker/src/gui/ScmSkyCultureDialog.cpp
+++ b/plugins/SkyCultureMaker/src/gui/ScmSkyCultureDialog.cpp
@@ -1065,8 +1065,14 @@ void ScmSkyCultureDialog::cnRefreshTable()
 		QString displayKey = pair.first;
 		switch (pair.second.special)
 		{
-		case StelObject::CulturalNameSpecial::Morning: displayKey += QLatin1String(" (") + q_("morning") + QLatin1String(")"); break;
-		case StelObject::CulturalNameSpecial::Evening: displayKey += QLatin1String(" (") + q_("evening") + QLatin1String(")"); break;
+		case StelObject::CulturalNameSpecial::Morning:
+			displayKey += QLatin1String(" (") + qc_("morning", "celestial object visibility period") +
+			              QLatin1String(")");
+			break;
+		case StelObject::CulturalNameSpecial::Evening:
+			displayKey += QLatin1String(" (") + qc_("evening", "celestial object visibility period") +
+			              QLatin1String(")");
+			break;
 		default: break;
 		}
 
@@ -1077,27 +1083,46 @@ void ScmSkyCultureDialog::cnRefreshTable()
 	}
 }
 
-void ScmSkyCultureDialog::cnAddEntry()
+bool ScmSkyCultureDialog::cnValidateForm(QString &outKey, scm::ScmCulturalName &outName)
 {
 	const QString id = ui->cnObjectIdLE->text().trimmed();
 	if (id.isEmpty())
 	{
-		maker->showUserWarningMessage(dialog, ui->titleBar->title(), q_("Please enter an object identifier."));
-		return;
-	}
-	if (ui->cnObjectTypeCB->currentIndex() == 0 && !isValidHIPIdentifier(id))
-	{
 		maker->showUserWarningMessage(dialog, ui->titleBar->title(),
-		                              q_("The HIP identifier must be a valid integer (e.g. 1234)."));
-		return;
+		                              qc_("Please enter an object identifier.",
+		                                  "Prompt for missing celestial object identifier (e.g. HIP number, "
+		                                  "planet name, DSO catalog designation)"));
+		return false;
 	}
-	const QString key               = cnBuildKey();
-	const scm::ScmCulturalName name = cnReadForm();
-	if (name.translated.isEmpty())
+	if (ui->cnObjectTypeCB->currentIndex() == 0)
+	{
+		QString hipId = id;
+		if (hipId.startsWith(QLatin1String("HIP"), Qt::CaseInsensitive)) hipId = hipId.mid(3).trimmed();
+		bool ok = false;
+		hipId.toInt(&ok);
+		if (!ok)
+		{
+			maker->showUserWarningMessage(dialog, ui->titleBar->title(),
+			                              q_("The HIP identifier must be a valid integer (e.g. 1234)."));
+			return false;
+		}
+	}
+	outKey  = cnBuildKey();
+	outName = cnReadForm();
+	if (outName.translated.isEmpty())
 	{
 		maker->showUserWarningMessage(dialog, ui->titleBar->title(), q_("The \"English\" field is required."));
-		return;
+		return false;
 	}
+
+	return true;
+}
+
+void ScmSkyCultureDialog::cnAddEntry()
+{
+	QString key;
+	scm::ScmCulturalName name;
+	if (!cnValidateForm(key, name)) return;
 	cnEntries.append({key, name});
 	cnRefreshTable();
 	cnClearForm();
@@ -1127,26 +1152,10 @@ void ScmSkyCultureDialog::cnSaveEntry()
 {
 	const auto selectedRows = ui->cnEntriesTable->selectionModel()->selectedRows();
 	if (selectedRows.isEmpty()) return;
-	const int row    = selectedRows.first().row();
-	const QString id = ui->cnObjectIdLE->text().trimmed();
-	if (id.isEmpty())
-	{
-		maker->showUserWarningMessage(dialog, ui->titleBar->title(), q_("Please enter an object identifier."));
-		return;
-	}
-	if (ui->cnObjectTypeCB->currentIndex() == 0 && !isValidHIPIdentifier(id))
-	{
-		maker->showUserWarningMessage(dialog, ui->titleBar->title(),
-		                              q_("The HIP identifier must be a valid integer (e.g. 1234)."));
-		return;
-	}
-	const QString key               = cnBuildKey();
-	const scm::ScmCulturalName name = cnReadForm();
-	if (name.translated.isEmpty())
-	{
-		maker->showUserWarningMessage(dialog, ui->titleBar->title(), q_("The \"English\" field is required."));
-		return;
-	}
+	const int row = selectedRows.first().row();
+	QString key;
+	scm::ScmCulturalName name;
+	if (!cnValidateForm(key, name)) return;
 	cnEntries[row] = {key, name};
 	cnRefreshTable();
 	ui->cnEntriesTable->selectRow(row);
@@ -1158,16 +1167,4 @@ void ScmSkyCultureDialog::cnUpdateEntryButtons()
 	ui->cnLoadEntryBtn->setEnabled(hasSelection);
 	ui->cnRemoveEntryBtn->setEnabled(hasSelection);
 	ui->cnSaveEntryBtn->setEnabled(hasSelection);
-}
-
-bool ScmSkyCultureDialog::isValidHIPIdentifier(const QString &id) const
-{
-	QString hipId = id;
-	if (hipId.startsWith(QLatin1String("HIP"), Qt::CaseInsensitive))
-	{
-		hipId = hipId.mid(3).trimmed();
-	}
-	bool ok = false;
-	hipId.toInt(&ok);
-	return ok;
 }

--- a/plugins/SkyCultureMaker/src/gui/ScmSkyCultureDialog.cpp
+++ b/plugins/SkyCultureMaker/src/gui/ScmSkyCultureDialog.cpp
@@ -1065,8 +1065,8 @@ void ScmSkyCultureDialog::cnRefreshTable()
 		QString displayKey = pair.first;
 		switch (pair.second.special)
 		{
-		case StelObject::CulturalNameSpecial::Morning: displayKey += QLatin1String(" (morning)"); break;
-		case StelObject::CulturalNameSpecial::Evening: displayKey += QLatin1String(" (evening)"); break;
+		case StelObject::CulturalNameSpecial::Morning: displayKey += QLatin1String(" (") + q_("morning") + QLatin1String(")"); break;
+		case StelObject::CulturalNameSpecial::Evening: displayKey += QLatin1String(" (") + q_("evening") + QLatin1String(")"); break;
 		default: break;
 		}
 

--- a/plugins/SkyCultureMaker/src/gui/ScmSkyCultureDialog.cpp
+++ b/plugins/SkyCultureMaker/src/gui/ScmSkyCultureDialog.cpp
@@ -960,15 +960,25 @@ void ScmSkyCultureDialog::cnUpdateVisibleField(int typeIndex)
 
 	switch (typeIndex)
 	{
-		case 0:
-			ui->cnObjectIdLE->setPlaceholderText(q_("HIP number (e.g. 1234)"));
-			break;
-		case 1:
-			ui->cnObjectIdLE->setPlaceholderText(q_("Planet name (e.g. Venus)"));
-			break;
-		case 2:
-			ui->cnObjectIdLE->setPlaceholderText(q_("Catalog designation (e.g. M 31)"));
-			break;
+	case 0: ui->cnObjectIdLE->setPlaceholderText(q_("HIP number (e.g. 1234)")); break;
+	case 1: ui->cnObjectIdLE->setPlaceholderText(q_("Planet name (e.g. Venus)")); break;
+	case 2: ui->cnObjectIdLE->setPlaceholderText(q_("Catalog designation (e.g. M31)")); break;
+	}
+}
+
+QString ScmSkyCultureDialog::cnBuildKey() const
+{
+	QString id = ui->cnObjectIdLE->text().trimmed();
+	switch (ui->cnObjectTypeCB->currentIndex())
+	{
+	// removal and re-addition of prefix to ensure correct casing and spacing
+	case 0:
+		if (id.startsWith(QLatin1String("HIP"), Qt::CaseInsensitive)) id = id.mid(3).trimmed();
+		return QLatin1String("HIP ") + id;
+	case 1:
+		if (id.startsWith(QLatin1String("NAME"), Qt::CaseInsensitive)) id = id.mid(4).trimmed();
+		return QLatin1String("NAME ") + id;
+	default: return id;
 	}
 }
 
@@ -989,19 +999,19 @@ void ScmSkyCultureDialog::cnClearForm()
 scm::ScmCulturalName ScmSkyCultureDialog::cnReadForm() const
 {
 	scm::ScmCulturalName name;
-	name.translated       = ui->cnEnglishLE->text().trimmed();
-	name.native           = ui->cnNativeLE->text().trimmed();
-	name.pronounce        = ui->cnPronounceLE->text().trimmed();
-	name.transliteration  = ui->cnTransliterationLE->text().trimmed();
-	name.IPA              = ui->cnIpaLE->text().trimmed();
-	name.byname           = ui->cnBynameLE->text().trimmed();
+	name.translated      = ui->cnEnglishLE->text().trimmed();
+	name.native          = ui->cnNativeLE->text().trimmed();
+	name.pronounce       = ui->cnPronounceLE->text().trimmed();
+	name.transliteration = ui->cnTransliterationLE->text().trimmed();
+	name.IPA             = ui->cnIpaLE->text().trimmed();
+	name.byname          = ui->cnBynameLE->text().trimmed();
 
 	const QString refsText = ui->cnReferencesLE->text().trimmed();
 	if (!refsText.isEmpty())
 	{
 		for (const auto &part : refsText.split(','))
 		{
-			bool ok = false;
+			bool ok       = false;
 			const int ref = part.trimmed().toInt(&ok);
 			if (ok)
 			{
@@ -1012,9 +1022,9 @@ scm::ScmCulturalName ScmSkyCultureDialog::cnReadForm() const
 
 	switch (ui->cnVisibleCB->currentIndex())
 	{
-		case 1: name.special = StelObject::CulturalNameSpecial::Morning; break;
-		case 2: name.special = StelObject::CulturalNameSpecial::Evening; break;
-		default: name.special = StelObject::CulturalNameSpecial::None;   break;
+	case 1: name.special = StelObject::CulturalNameSpecial::Morning; break;
+	case 2: name.special = StelObject::CulturalNameSpecial::Evening; break;
+	default: name.special = StelObject::CulturalNameSpecial::None; break;
 	}
 	return name;
 }
@@ -1036,9 +1046,9 @@ void ScmSkyCultureDialog::cnPopulateForm(const QString &key, const scm::ScmCultu
 
 	switch (name.special)
 	{
-		case StelObject::CulturalNameSpecial::Morning: ui->cnVisibleCB->setCurrentIndex(1); break;
-		case StelObject::CulturalNameSpecial::Evening: ui->cnVisibleCB->setCurrentIndex(2); break;
-		default:                                       ui->cnVisibleCB->setCurrentIndex(0); break;
+	case StelObject::CulturalNameSpecial::Morning: ui->cnVisibleCB->setCurrentIndex(1); break;
+	case StelObject::CulturalNameSpecial::Evening: ui->cnVisibleCB->setCurrentIndex(2); break;
+	default: ui->cnVisibleCB->setCurrentIndex(0); break;
 	}
 }
 
@@ -1053,14 +1063,9 @@ void ScmSkyCultureDialog::cnRefreshTable()
 		QString displayKey = pair.first;
 		switch (pair.second.special)
 		{
-			case StelObject::CulturalNameSpecial::Morning:
-				displayKey += QLatin1String(" (morning)");
-				break;
-			case StelObject::CulturalNameSpecial::Evening:
-				displayKey += QLatin1String(" (evening)");
-				break;
-			default:
-				break;
+		case StelObject::CulturalNameSpecial::Morning: displayKey += QLatin1String(" (morning)"); break;
+		case StelObject::CulturalNameSpecial::Evening: displayKey += QLatin1String(" (evening)"); break;
+		default: break;
 		}
 
 		ui->cnEntriesTable->setItem(row, 0, new QTableWidgetItem(displayKey));
@@ -1072,12 +1077,26 @@ void ScmSkyCultureDialog::cnRefreshTable()
 
 void ScmSkyCultureDialog::cnAddEntry()
 {
-	const QString key = ui->cnObjectIdLE->text().trimmed();
-	if (key.isEmpty())
+	const QString id = ui->cnObjectIdLE->text().trimmed();
+	if (id.isEmpty())
 	{
 		maker->showUserWarningMessage(dialog, ui->titleBar->title(), q_("Please enter an object identifier."));
 		return;
 	}
+	if (ui->cnObjectTypeCB->currentIndex() == 0)
+	{
+		QString hipId = id;
+		if (hipId.startsWith(QLatin1String("HIP"), Qt::CaseInsensitive)) hipId = hipId.mid(3).trimmed();
+		bool ok = false;
+		hipId.toInt(&ok);
+		if (!ok)
+		{
+			maker->showUserWarningMessage(dialog, ui->titleBar->title(),
+			                              q_("The HIP identifier must be a valid integer (e.g. 1234)."));
+			return;
+		}
+	}
+	const QString key               = cnBuildKey();
 	const scm::ScmCulturalName name = cnReadForm();
 	if (name.translated.isEmpty())
 	{
@@ -1113,13 +1132,27 @@ void ScmSkyCultureDialog::cnSaveEntry()
 {
 	const auto selectedRows = ui->cnEntriesTable->selectionModel()->selectedRows();
 	if (selectedRows.isEmpty()) return;
-	const int row     = selectedRows.first().row();
-	const QString key = ui->cnObjectIdLE->text().trimmed();
-	if (key.isEmpty())
+	const int row    = selectedRows.first().row();
+	const QString id = ui->cnObjectIdLE->text().trimmed();
+	if (id.isEmpty())
 	{
 		maker->showUserWarningMessage(dialog, ui->titleBar->title(), q_("Please enter an object identifier."));
 		return;
 	}
+	if (ui->cnObjectTypeCB->currentIndex() == 0)
+	{
+		QString hipId = id;
+		if (hipId.startsWith(QLatin1String("HIP"), Qt::CaseInsensitive)) hipId = hipId.mid(3).trimmed();
+		bool ok = false;
+		hipId.toInt(&ok);
+		if (!ok)
+		{
+			maker->showUserWarningMessage(dialog, ui->titleBar->title(),
+			                              q_("The HIP identifier must be a valid integer (e.g. 1234)."));
+			return;
+		}
+	}
+	const QString key               = cnBuildKey();
 	const scm::ScmCulturalName name = cnReadForm();
 	if (name.translated.isEmpty())
 	{

--- a/plugins/SkyCultureMaker/src/gui/ScmSkyCultureDialog.cpp
+++ b/plugins/SkyCultureMaker/src/gui/ScmSkyCultureDialog.cpp
@@ -27,9 +27,12 @@
 #include "StelObjectMgr.hpp"
 #include "ui_scmSkyCultureDialog.h"
 #include <cassert>
+#include <QCheckBox>
 #include <QDebug>
 #include <QHeaderView>
 #include <QMap>
+#include <QMessageBox>
+#include <QPushButton>
 #include <QStyledItemDelegate>
 #include <QTableWidgetItem>
 
@@ -739,6 +742,7 @@ void ScmSkyCultureDialog::resetDialog()
 
 		cnEntries.clear();
 		cnEditingRow = -1;
+		cnSkipObjectExistCheck = false;
 		cnClearForm();
 		cnRefreshTable();
 	}
@@ -1177,6 +1181,50 @@ bool ScmSkyCultureDialog::cnValidateForm(QString &outKey, scm::ScmCulturalName &
 	return true;
 }
 
+bool ScmSkyCultureDialog::cnCheckObjectExists(const QString &key)
+{
+	if (cnSkipObjectExistCheck) return true;
+
+	StelObjectMgr *objMgr = GETSTELMODULE(StelObjectMgr);
+	StelObjectP obj;
+
+	if (key.startsWith(QLatin1String("HIP "), Qt::CaseInsensitive) ||
+	    key.startsWith(QLatin1String("Gaia DR3 "), Qt::CaseInsensitive))
+	{
+		obj = objMgr->searchByID(QLatin1String("Star"), key);
+	}
+	else if (key.startsWith(QLatin1String("NAME "), Qt::CaseInsensitive))
+	{
+		obj = objMgr->searchByID(QLatin1String("Planet"), key.mid(5).trimmed());
+	}
+	else
+	{
+		obj = objMgr->searchByID(QLatin1String("Nebula"), key);
+	}
+
+	// the object was found
+	if (obj) return true;
+
+	QMessageBox msgBox(dialog);
+	msgBox.setIcon(QMessageBox::Warning);
+	msgBox.setText(q_("The object \"%1\" could not be found in the current Stellarium database.").arg(key));
+	msgBox.setInformativeText(q_("Do you still want to save this entry?"));
+
+	auto *dontShowAgainCB = new QCheckBox(q_("Don't show this warning again"), &msgBox);
+	msgBox.setCheckBox(dontShowAgainCB);
+
+	QPushButton *saveAnywayBtn = msgBox.addButton(q_("Save Anyway"), QMessageBox::AcceptRole);
+	QPushButton *dontSaveBtn   = msgBox.addButton(q_("Don't Save"), QMessageBox::RejectRole);
+	msgBox.setDefaultButton(dontSaveBtn);
+
+	msgBox.exec();
+
+	// deactivate this check in the current session
+	if (dontShowAgainCB->isChecked()) cnSkipObjectExistCheck = true;
+
+	return msgBox.clickedButton() == saveAnywayBtn;
+}
+
 void ScmSkyCultureDialog::cnAddNew()
 {
 	QString key;
@@ -1189,6 +1237,8 @@ void ScmSkyCultureDialog::cnAddNew()
 		                              q_("An entry for this object already exists."));
 		return;
 	}
+
+	if (!cnCheckObjectExists(key)) return;
 
 	cnEntries.append({key, name});
 	const int newRow = cnEntries.size() - 1;
@@ -1210,6 +1260,8 @@ void ScmSkyCultureDialog::cnSaveChanges()
 		                              q_("An entry for this object already exists."));
 		return;
 	}
+
+	if (!cnCheckObjectExists(key)) return;
 
 	cnEntries[cnEditingRow] = {key, name};
 	// capture before cnRefreshTable resets selection

--- a/plugins/SkyCultureMaker/src/gui/ScmSkyCultureDialog.cpp
+++ b/plugins/SkyCultureMaker/src/gui/ScmSkyCultureDialog.cpp
@@ -24,6 +24,7 @@
 #include "ScmSkyCultureDialog.hpp"
 #include "NebulaMgr.hpp"
 #include "ScmPolygonInfoTreeItem.hpp"
+#include "StarMgr.hpp"
 #include "StelObjectMgr.hpp"
 #include "ui_scmSkyCultureDialog.h"
 #include <cassert>
@@ -297,7 +298,7 @@ void ScmSkyCultureDialog::createDialogContent()
 	connect(ui->cnObjectTypeCB, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
 	        [this](int i) { cnUpdateVisibleField(static_cast<CnObjectType>(i)); });
 	connect(ui->cnRemoveEntryBtn, &QPushButton::clicked, this, &ScmSkyCultureDialog::cnRemoveEntry);
-	connect(ui->cnUseSelectionBtn, &QPushButton::clicked, this, &ScmSkyCultureDialog::cnUseSelectedObject);
+	connect(ui->cnUseFromSelectionBtn, &QPushButton::clicked, this, &ScmSkyCultureDialog::cnUseSelectedObject);
 	connect(ui->cnAddNewBtn, &QPushButton::clicked, this, &ScmSkyCultureDialog::cnAddNew);
 	connect(ui->cnSaveChangesBtn, &QPushButton::clicked, this, &ScmSkyCultureDialog::cnSaveChanges);
 	ui->cnSaveChangesBtn->setEnabled(false);
@@ -1301,20 +1302,30 @@ void ScmSkyCultureDialog::cnUseSelectedObject()
 		return;
 	}
 
-	cnClearForm();
 	const StelObjectP &obj = selected.first();
 	const QString type     = obj->getType();
 
+	QString englishName;
 	if (type == QLatin1String("Star"))
 	{
 		ui->cnObjectTypeCB->setCurrentIndex(static_cast<int>(CnObjectType::Star));
 		ui->cnObjectIdLE->setText(obj->getID());
+		// StarWrapper1::getEnglishName() returns the catalog designation ("HIP XXXXX"),
+		// not the common proper name. Use StarMgr to look it up from the HIP number.
+		const QString engId = obj->getEnglishName();
+		if (engId.startsWith(QLatin1String("HIP "), Qt::CaseInsensitive))
+		{
+			bool ok = false;
+			const StarId hip = engId.mid(4).toULongLong(&ok);
+			if (ok)
+				englishName = StarMgr::getCommonEnglishName(hip);
+		}
 	}
 	else if (type == QLatin1String("Planet"))
 	{
 		ui->cnObjectTypeCB->setCurrentIndex(static_cast<int>(CnObjectType::Planet));
 		ui->cnObjectIdLE->setText(QLatin1String("NAME ") + obj->getEnglishName());
-		ui->cnEnglishLE->setText(obj->getEnglishName());
+		englishName = obj->getEnglishName();
 	}
 	else
 	{
@@ -1322,7 +1333,9 @@ void ScmSkyCultureDialog::cnUseSelectedObject()
 		QString id = GETSTELMODULE(NebulaMgr)->getLatestSelectedDSODesignationWIC();
 		if (id.isEmpty()) id = obj->getEnglishName();
 		ui->cnObjectIdLE->setText(id);
+		englishName = obj->getEnglishName();
 	}
+	ui->cnEnglishLE->setText(englishName);
 }
 
 void ScmSkyCultureDialog::cnOnTableSelectionChanged()

--- a/plugins/SkyCultureMaker/src/gui/ScmSkyCultureDialog.cpp
+++ b/plugins/SkyCultureMaker/src/gui/ScmSkyCultureDialog.cpp
@@ -1133,6 +1133,7 @@ void ScmSkyCultureDialog::cnLoadEntry()
 	const auto selectedRows = ui->cnEntriesTable->selectionModel()->selectedRows();
 	if (selectedRows.isEmpty()) return;
 	const int row = selectedRows.first().row();
+	Q_ASSERT(row >= 0 && row < cnEntries.size());
 	cnPopulateForm(cnEntries[row].first, cnEntries[row].second);
 	ui->cnSaveEntryBtn->setEnabled(true);
 }
@@ -1142,6 +1143,7 @@ void ScmSkyCultureDialog::cnRemoveEntry()
 	const auto selectedRows = ui->cnEntriesTable->selectionModel()->selectedRows();
 	if (selectedRows.isEmpty()) return;
 	const int row = selectedRows.first().row();
+	Q_ASSERT(row >= 0 && row < cnEntries.size());
 	cnEntries.removeAt(row);
 	cnRefreshTable();
 	cnClearForm();
@@ -1153,6 +1155,7 @@ void ScmSkyCultureDialog::cnSaveEntry()
 	const auto selectedRows = ui->cnEntriesTable->selectionModel()->selectedRows();
 	if (selectedRows.isEmpty()) return;
 	const int row = selectedRows.first().row();
+	Q_ASSERT(row >= 0 && row < cnEntries.size());
 	QString key;
 	scm::ScmCulturalName name;
 	if (!cnValidateForm(key, name)) return;

--- a/plugins/SkyCultureMaker/src/gui/ScmSkyCultureDialog.cpp
+++ b/plugins/SkyCultureMaker/src/gui/ScmSkyCultureDialog.cpp
@@ -25,7 +25,10 @@
 #include "ScmPolygonInfoTreeItem.hpp"
 #include "ui_scmSkyCultureDialog.h"
 #include <cassert>
+#include <QHeaderView>
+#include <QMap>
 #include <QStyledItemDelegate>
+#include <QTableWidgetItem>
 #include <QDebug>
 
 namespace
@@ -274,6 +277,28 @@ void ScmSkyCultureDialog::createDialogContent()
 	connect(ui->moveRefUpBtn, &QPushButton::clicked, this, &ScmSkyCultureDialog::moveCurrentReferenceUp);
 	connect(ui->moveRefDownBtn, &QPushButton::clicked, this, &ScmSkyCultureDialog::moveCurrentReferenceDown);
 	connect(ui->referencesList, &QTreeWidget::currentItemChanged, this, &ScmSkyCultureDialog::updateReferencesButtons);
+
+	// Common Names Tab
+	ui->cnEntriesTable->horizontalHeader()->setStretchLastSection(false);
+	ui->cnEntriesTable->horizontalHeader()->setSectionResizeMode(0, QHeaderView::Stretch);
+	ui->cnEntriesTable->horizontalHeader()->setSectionResizeMode(1, QHeaderView::Stretch);
+	ui->cnEntriesTable->horizontalHeader()->setSectionResizeMode(2, QHeaderView::ResizeToContents);
+	ui->cnEntriesTable->horizontalHeader()->setSectionResizeMode(3, QHeaderView::ResizeToContents);
+	ui->cnEntriesTable->setItemDelegate(new NoEditDelegate(ui->cnEntriesTable));
+	cnRefreshTable();
+	ui->cnVisibleCB->setEnabled(false);
+	ui->cnVisibleLbl->setEnabled(false);
+	ui->cnLoadEntryBtn->setEnabled(false);
+	ui->cnRemoveEntryBtn->setEnabled(false);
+	ui->cnSaveEntryBtn->setEnabled(false);
+	connect(ui->cnObjectTypeCB, QOverload<int>::of(&QComboBox::currentIndexChanged),
+	        this, &ScmSkyCultureDialog::cnUpdateVisibleField);
+	connect(ui->cnAddEntryBtn, &QPushButton::clicked, this, &ScmSkyCultureDialog::cnAddEntry);
+	connect(ui->cnLoadEntryBtn, &QPushButton::clicked, this, &ScmSkyCultureDialog::cnLoadEntry);
+	connect(ui->cnRemoveEntryBtn, &QPushButton::clicked, this, &ScmSkyCultureDialog::cnRemoveEntry);
+	connect(ui->cnSaveEntryBtn, &QPushButton::clicked, this, &ScmSkyCultureDialog::cnSaveEntry);
+	connect(ui->cnEntriesTable, &QTableWidget::itemSelectionChanged, this, &ScmSkyCultureDialog::cnUpdateEntryButtons);
+	cnUpdateVisibleField(0); // initial placeholder text
 }
 
 void ScmSkyCultureDialog::handleFontChanged()
@@ -306,13 +331,20 @@ void ScmSkyCultureDialog::saveSkyCulture()
 	{
 		auto msg = q_("The sky culture description is not complete. The following fields are not filled correctly:\n");
 		for (const auto& field : incompFieldsList)
-			msg += u8" \u2022 " + field + "\n";
+			msg += QString(" \u2022 ") + field + "\n";
 		maker->showUserWarningMessage(dialog, ui->titleBar->title(), msg);
 		return;
 	}
 
 	// If valid, set the sky culture description
 	maker->setSkyCultureDescription(desc);
+
+	// Push common names into the sky culture object
+	QMap<QString, QList<scm::ScmCulturalName>> culturalNamesMap;
+	for (const auto &pair : cnEntries) {
+		culturalNamesMap[pair.first].append(pair.second);
+	}
+	maker->getCurrentSkyCulture()->setCulturalNames(culturalNamesMap);
 
 	// check wether at least 1 polygon was digitized
 	if (ui->polygonInfoTreeWidget->topLevelItemCount() < 1)
@@ -686,6 +718,10 @@ void ScmSkyCultureDialog::resetDialog()
 		ui->polygonInfoTreeWidget->clear(); // reset the location list
 		ui->scmGeoLocGraphicsView->reset(); // reset the map used for digitizing
 		updateRemovePolygonButton();
+
+		cnEntries.clear();
+		cnClearForm();
+		cnRefreshTable();
 	}
 }
 
@@ -913,4 +949,192 @@ void ScmSkyCultureDialog::confirmAddPolygon()
 void ScmSkyCultureDialog::cancelAddPolygon()
 {
 	hideAddPolygon();
+}
+
+void ScmSkyCultureDialog::cnUpdateVisibleField(int typeIndex)
+{
+	// typeIndex: 0=Star, 1=Planet, 2=DSO
+	const bool isPlanet = (typeIndex == 1);
+	ui->cnVisibleCB->setEnabled(isPlanet);
+	ui->cnVisibleLbl->setEnabled(isPlanet);
+
+	switch (typeIndex)
+	{
+		case 0:
+			ui->cnObjectIdLE->setPlaceholderText(q_("HIP number (e.g. 1234)"));
+			break;
+		case 1:
+			ui->cnObjectIdLE->setPlaceholderText(q_("Planet name (e.g. Venus)"));
+			break;
+		case 2:
+			ui->cnObjectIdLE->setPlaceholderText(q_("Catalog designation (e.g. M 31)"));
+			break;
+	}
+}
+
+void ScmSkyCultureDialog::cnClearForm()
+{
+	ui->cnObjectIdLE->clear();
+	ui->cnEnglishLE->clear();
+	ui->cnNativeLE->clear();
+	ui->cnPronounceLE->clear();
+	ui->cnTransliterationLE->clear();
+	ui->cnIpaLE->clear();
+	ui->cnBynameLE->clear();
+	ui->cnReferencesLE->clear();
+	ui->cnVisibleCB->setCurrentIndex(0);
+	ui->cnSaveEntryBtn->setEnabled(false);
+}
+
+scm::ScmCulturalName ScmSkyCultureDialog::cnReadForm() const
+{
+	scm::ScmCulturalName name;
+	name.translated       = ui->cnEnglishLE->text().trimmed();
+	name.native           = ui->cnNativeLE->text().trimmed();
+	name.pronounce        = ui->cnPronounceLE->text().trimmed();
+	name.transliteration  = ui->cnTransliterationLE->text().trimmed();
+	name.IPA              = ui->cnIpaLE->text().trimmed();
+	name.byname           = ui->cnBynameLE->text().trimmed();
+
+	const QString refsText = ui->cnReferencesLE->text().trimmed();
+	if (!refsText.isEmpty())
+	{
+		for (const auto &part : refsText.split(','))
+		{
+			bool ok = false;
+			const int ref = part.trimmed().toInt(&ok);
+			if (ok)
+			{
+				name.references.append(ref);
+			}
+		}
+	}
+
+	switch (ui->cnVisibleCB->currentIndex())
+	{
+		case 1: name.special = StelObject::CulturalNameSpecial::Morning; break;
+		case 2: name.special = StelObject::CulturalNameSpecial::Evening; break;
+		default: name.special = StelObject::CulturalNameSpecial::None;   break;
+	}
+	return name;
+}
+
+void ScmSkyCultureDialog::cnPopulateForm(const QString &key, const scm::ScmCulturalName &name)
+{
+	ui->cnObjectIdLE->setText(key);
+	ui->cnEnglishLE->setText(name.translated);
+	ui->cnNativeLE->setText(name.native);
+	ui->cnPronounceLE->setText(name.pronounce);
+	ui->cnTransliterationLE->setText(name.transliteration);
+	ui->cnIpaLE->setText(name.IPA);
+	ui->cnBynameLE->setText(name.byname);
+
+	QStringList refStrings;
+	for (int r : name.references)
+		refStrings.append(QString::number(r));
+	ui->cnReferencesLE->setText(refStrings.join(", "));
+
+	switch (name.special)
+	{
+		case StelObject::CulturalNameSpecial::Morning: ui->cnVisibleCB->setCurrentIndex(1); break;
+		case StelObject::CulturalNameSpecial::Evening: ui->cnVisibleCB->setCurrentIndex(2); break;
+		default:                                       ui->cnVisibleCB->setCurrentIndex(0); break;
+	}
+}
+
+void ScmSkyCultureDialog::cnRefreshTable()
+{
+	ui->cnEntriesTable->setRowCount(0);
+	for (const auto &pair : cnEntries)
+	{
+		const int row = ui->cnEntriesTable->rowCount();
+		ui->cnEntriesTable->insertRow(row);
+
+		QString displayKey = pair.first;
+		switch (pair.second.special)
+		{
+			case StelObject::CulturalNameSpecial::Morning:
+				displayKey += QLatin1String(" (morning)");
+				break;
+			case StelObject::CulturalNameSpecial::Evening:
+				displayKey += QLatin1String(" (evening)");
+				break;
+			default:
+				break;
+		}
+
+		ui->cnEntriesTable->setItem(row, 0, new QTableWidgetItem(displayKey));
+		ui->cnEntriesTable->setItem(row, 1, new QTableWidgetItem(pair.second.translated));
+		ui->cnEntriesTable->setItem(row, 2, new QTableWidgetItem(pair.second.native));
+		ui->cnEntriesTable->setItem(row, 3, new QTableWidgetItem(pair.second.pronounce));
+	}
+}
+
+void ScmSkyCultureDialog::cnAddEntry()
+{
+	const QString key = ui->cnObjectIdLE->text().trimmed();
+	if (key.isEmpty())
+	{
+		maker->showUserWarningMessage(dialog, ui->titleBar->title(), q_("Please enter an object identifier."));
+		return;
+	}
+	const scm::ScmCulturalName name = cnReadForm();
+	if (name.translated.isEmpty())
+	{
+		maker->showUserWarningMessage(dialog, ui->titleBar->title(), q_("The \"English\" field is required."));
+		return;
+	}
+	cnEntries.append({key, name});
+	cnRefreshTable();
+	cnClearForm();
+}
+
+void ScmSkyCultureDialog::cnLoadEntry()
+{
+	const auto selectedRows = ui->cnEntriesTable->selectionModel()->selectedRows();
+	if (selectedRows.isEmpty()) return;
+	const int row = selectedRows.first().row();
+	cnPopulateForm(cnEntries[row].first, cnEntries[row].second);
+	ui->cnSaveEntryBtn->setEnabled(true);
+}
+
+void ScmSkyCultureDialog::cnRemoveEntry()
+{
+	const auto selectedRows = ui->cnEntriesTable->selectionModel()->selectedRows();
+	if (selectedRows.isEmpty()) return;
+	const int row = selectedRows.first().row();
+	cnEntries.removeAt(row);
+	cnRefreshTable();
+	cnClearForm();
+	cnUpdateEntryButtons();
+}
+
+void ScmSkyCultureDialog::cnSaveEntry()
+{
+	const auto selectedRows = ui->cnEntriesTable->selectionModel()->selectedRows();
+	if (selectedRows.isEmpty()) return;
+	const int row     = selectedRows.first().row();
+	const QString key = ui->cnObjectIdLE->text().trimmed();
+	if (key.isEmpty())
+	{
+		maker->showUserWarningMessage(dialog, ui->titleBar->title(), q_("Please enter an object identifier."));
+		return;
+	}
+	const scm::ScmCulturalName name = cnReadForm();
+	if (name.translated.isEmpty())
+	{
+		maker->showUserWarningMessage(dialog, ui->titleBar->title(), q_("The \"English\" field is required."));
+		return;
+	}
+	cnEntries[row] = {key, name};
+	cnRefreshTable();
+	ui->cnEntriesTable->selectRow(row);
+}
+
+void ScmSkyCultureDialog::cnUpdateEntryButtons()
+{
+	const bool hasSelection = !ui->cnEntriesTable->selectionModel()->selectedRows().isEmpty();
+	ui->cnLoadEntryBtn->setEnabled(hasSelection);
+	ui->cnRemoveEntryBtn->setEnabled(hasSelection);
+	ui->cnSaveEntryBtn->setEnabled(hasSelection);
 }

--- a/plugins/SkyCultureMaker/src/gui/ScmSkyCultureDialog.cpp
+++ b/plugins/SkyCultureMaker/src/gui/ScmSkyCultureDialog.cpp
@@ -1041,7 +1041,9 @@ void ScmSkyCultureDialog::cnPopulateForm(const QString &key, const scm::ScmCultu
 
 	QStringList refStrings;
 	for (int r : name.references)
+	{
 		refStrings.append(QString::number(r));
+	}
 	ui->cnReferencesLE->setText(refStrings.join(", "));
 
 	switch (name.special)
@@ -1083,18 +1085,11 @@ void ScmSkyCultureDialog::cnAddEntry()
 		maker->showUserWarningMessage(dialog, ui->titleBar->title(), q_("Please enter an object identifier."));
 		return;
 	}
-	if (ui->cnObjectTypeCB->currentIndex() == 0)
+	if (ui->cnObjectTypeCB->currentIndex() == 0 && !isValidHIPIdentifier(id))
 	{
-		QString hipId = id;
-		if (hipId.startsWith(QLatin1String("HIP"), Qt::CaseInsensitive)) hipId = hipId.mid(3).trimmed();
-		bool ok = false;
-		hipId.toInt(&ok);
-		if (!ok)
-		{
-			maker->showUserWarningMessage(dialog, ui->titleBar->title(),
-			                              q_("The HIP identifier must be a valid integer (e.g. 1234)."));
-			return;
-		}
+		maker->showUserWarningMessage(dialog, ui->titleBar->title(),
+		                              q_("The HIP identifier must be a valid integer (e.g. 1234)."));
+		return;
 	}
 	const QString key               = cnBuildKey();
 	const scm::ScmCulturalName name = cnReadForm();
@@ -1139,18 +1134,11 @@ void ScmSkyCultureDialog::cnSaveEntry()
 		maker->showUserWarningMessage(dialog, ui->titleBar->title(), q_("Please enter an object identifier."));
 		return;
 	}
-	if (ui->cnObjectTypeCB->currentIndex() == 0)
+	if (ui->cnObjectTypeCB->currentIndex() == 0 && !isValidHIPIdentifier(id))
 	{
-		QString hipId = id;
-		if (hipId.startsWith(QLatin1String("HIP"), Qt::CaseInsensitive)) hipId = hipId.mid(3).trimmed();
-		bool ok = false;
-		hipId.toInt(&ok);
-		if (!ok)
-		{
-			maker->showUserWarningMessage(dialog, ui->titleBar->title(),
-			                              q_("The HIP identifier must be a valid integer (e.g. 1234)."));
-			return;
-		}
+		maker->showUserWarningMessage(dialog, ui->titleBar->title(),
+		                              q_("The HIP identifier must be a valid integer (e.g. 1234)."));
+		return;
 	}
 	const QString key               = cnBuildKey();
 	const scm::ScmCulturalName name = cnReadForm();
@@ -1170,4 +1158,16 @@ void ScmSkyCultureDialog::cnUpdateEntryButtons()
 	ui->cnLoadEntryBtn->setEnabled(hasSelection);
 	ui->cnRemoveEntryBtn->setEnabled(hasSelection);
 	ui->cnSaveEntryBtn->setEnabled(hasSelection);
+}
+
+bool isValidHIPIdentifier(const QString &id)
+{
+	QString hipId = id;
+	if (hipId.startsWith(QLatin1String("HIP"), Qt::CaseInsensitive))
+	{
+		hipId = hipId.mid(3).trimmed();
+	}
+	bool ok = false;
+	hipId.toInt(&ok);
+	return ok;
 }

--- a/plugins/SkyCultureMaker/src/gui/ScmSkyCultureDialog.cpp
+++ b/plugins/SkyCultureMaker/src/gui/ScmSkyCultureDialog.cpp
@@ -1314,10 +1314,9 @@ void ScmSkyCultureDialog::cnUseSelectedObject()
 		const QString engId = obj->getEnglishName();
 		if (engId.startsWith(QLatin1String("HIP "), Qt::CaseInsensitive))
 		{
-			bool ok = false;
+			bool ok          = false;
 			const StarId hip = engId.mid(4).toULongLong(&ok);
-			if (ok)
-				englishName = StarMgr::getCommonEnglishName(hip);
+			if (ok) englishName = StarMgr::getCommonEnglishName(hip);
 		}
 	}
 	else if (type == QLatin1String("Planet"))

--- a/plugins/SkyCultureMaker/src/gui/ScmSkyCultureDialog.hpp
+++ b/plugins/SkyCultureMaker/src/gui/ScmSkyCultureDialog.hpp
@@ -102,11 +102,11 @@ private slots:
 	// (uncomment when multiple regions are used)
 	//void checkMutExRegions(const QStringList checkedItems);
 	void cnUpdateVisibleField(int typeIndex);
-	void cnAddEntry();
-	void cnLoadEntry();
+	void cnAddNew();
+	void cnSaveChanges();
 	void cnRemoveEntry();
-	void cnSaveEntry();
-	void cnUpdateEntryButtons();
+	void cnUseSelectedObject();
+	void cnOnTableSelectionChanged();
 
 private:
 	Ui_scmSkyCultureDialog *ui = nullptr;
@@ -238,6 +238,9 @@ private:
 	/// Common names entries stored as (object key, name data) pairs.
 	QList<QPair<QString, scm::ScmCulturalName>> cnEntries;
 
+	/// Index of the entry currently loaded in the form (-1 = new entry).
+	int cnEditingRow = -1;
+
 	/**
 	 * @brief Validates the common names form and builds the key and name if valid.
 	 *        Shows a warning message and returns false on the first validation failure.
@@ -246,6 +249,12 @@ private:
 	 * @return true if all validation checks pass, false otherwise.
 	 */
 	bool cnValidateForm(QString &outKey, scm::ScmCulturalName &outName);
+
+	/**
+	 * @brief Returns true if cnEntries already contains an entry with the given key and special value.
+	 * @param excludeRow Row index to skip during the search (-1 to check all rows).
+	 */
+	bool cnIsDuplicate(const QString &key, StelObject::CulturalNameSpecial special, int excludeRow = -1) const;
 };
 
 #endif // SCM_SKY_CULTURE_DIALOG_HPP

--- a/plugins/SkyCultureMaker/src/gui/ScmSkyCultureDialog.hpp
+++ b/plugins/SkyCultureMaker/src/gui/ScmSkyCultureDialog.hpp
@@ -82,6 +82,9 @@ public slots:
 protected slots:
 	void handleFontChanged();
 
+private:
+	enum class CnObjectType { Star = 0, Planet = 1, DSO = 2 };
+
 private slots:
 	void saveSkyCulture();
 	void openConstellationDialog(bool isDarkConstellation);
@@ -101,7 +104,7 @@ private slots:
 	void cancelAddPolygon();
 	// (uncomment when multiple regions are used)
 	//void checkMutExRegions(const QStringList checkedItems);
-	void cnUpdateVisibleField(int typeIndex);
+	void cnUpdateVisibleField(CnObjectType type);
 	void cnAddNew();
 	void cnSaveChanges();
 	void cnRemoveEntry();

--- a/plugins/SkyCultureMaker/src/gui/ScmSkyCultureDialog.hpp
+++ b/plugins/SkyCultureMaker/src/gui/ScmSkyCultureDialog.hpp
@@ -237,6 +237,11 @@ private:
 
 	/// Common names entries stored as (object key, name data) pairs.
 	QList<QPair<QString, scm::ScmCulturalName>> cnEntries;
+
+	/**
+	 * @brief Validates the HIP identifier.
+	 */
+	bool isValidHIPIdentifier(const QString &id) const;
 };
 
 #endif // SCM_SKY_CULTURE_DIALOG_HPP

--- a/plugins/SkyCultureMaker/src/gui/ScmSkyCultureDialog.hpp
+++ b/plugins/SkyCultureMaker/src/gui/ScmSkyCultureDialog.hpp
@@ -239,9 +239,13 @@ private:
 	QList<QPair<QString, scm::ScmCulturalName>> cnEntries;
 
 	/**
-	 * @brief Validates the HIP identifier.
+	 * @brief Validates the common names form and builds the key and name if valid.
+	 *        Shows a warning message and returns false on the first validation failure.
+	 * @param outKey   Receives the normalized object key on success.
+	 * @param outName  Receives the cultural name data on success.
+	 * @return true if all validation checks pass, false otherwise.
 	 */
-	bool isValidHIPIdentifier(const QString &id) const;
+	bool cnValidateForm(QString &outKey, scm::ScmCulturalName &outName);
 };
 
 #endif // SCM_SKY_CULTURE_DIALOG_HPP

--- a/plugins/SkyCultureMaker/src/gui/ScmSkyCultureDialog.hpp
+++ b/plugins/SkyCultureMaker/src/gui/ScmSkyCultureDialog.hpp
@@ -101,6 +101,12 @@ private slots:
 	void cancelAddPolygon();
 	// (uncomment when multiple regions are used)
 	//void checkMutExRegions(const QStringList checkedItems);
+	void cnUpdateVisibleField(int typeIndex);
+	void cnAddEntry();
+	void cnLoadEntry();
+	void cnRemoveEntry();
+	void cnSaveEntry();
+	void cnUpdateEntryButtons();
 
 private:
 	Ui_scmSkyCultureDialog *ui = nullptr;
@@ -202,6 +208,29 @@ private:
 	 *
 	 */
 	void initSkyCultureTime();
+
+	/**
+	 * @brief Clears the common names form.
+	 */
+	void cnClearForm();
+
+	/**
+	 * @brief Refreshes the common names table.
+	 */
+	void cnRefreshTable();
+
+	/**
+	 * @brief Reads the common name data from the form and returns it as a ScmCulturalName object.
+	 */
+	scm::ScmCulturalName cnReadForm() const;
+
+	/**
+	 * @brief Populates the common names form with data from a given ScmCulturalName object.
+	 */
+	void cnPopulateForm(const QString &key, const scm::ScmCulturalName &name);
+
+	/// Common names entries stored as (object key, name data) pairs.
+	QList<QPair<QString, scm::ScmCulturalName>> cnEntries;
 };
 
 #endif // SCM_SKY_CULTURE_DIALOG_HPP

--- a/plugins/SkyCultureMaker/src/gui/ScmSkyCultureDialog.hpp
+++ b/plugins/SkyCultureMaker/src/gui/ScmSkyCultureDialog.hpp
@@ -229,6 +229,12 @@ private:
 	 */
 	void cnPopulateForm(const QString &key, const scm::ScmCulturalName &name);
 
+	/**
+	 * @brief Builds the normalized object key from the type combo box and the identifier line edit.
+	 *        Stars: "HIP <id>", Planets: "NAME <id>", DSOs: "<id>".
+	 */
+	QString cnBuildKey() const;
+
 	/// Common names entries stored as (object key, name data) pairs.
 	QList<QPair<QString, scm::ScmCulturalName>> cnEntries;
 };

--- a/plugins/SkyCultureMaker/src/gui/ScmSkyCultureDialog.hpp
+++ b/plugins/SkyCultureMaker/src/gui/ScmSkyCultureDialog.hpp
@@ -258,6 +258,16 @@ private:
 	 * @param excludeRow Row index to skip during the search (-1 to check all rows).
 	 */
 	bool cnIsDuplicate(const QString &key, StelObject::CulturalNameSpecial special, int excludeRow = -1) const;
+
+	/**
+	 * @brief Checks whether the object identified by the key exists in the current Stellarium database.
+	 *        If not found, a warning dialog is shown to the user, allowing them to either proceed with 
+	 * 		  saving the entry or cancel and fix the key.
+	 */
+	bool cnCheckObjectExists(const QString &key);
+
+	/// When true, the warning for objects that don't exist is suppressed for the rest of the session.
+	bool cnSkipObjectExistCheck = false;
 };
 
 #endif // SCM_SKY_CULTURE_DIALOG_HPP

--- a/plugins/SkyCultureMaker/src/gui/scmSkyCultureDialog.ui
+++ b/plugins/SkyCultureMaker/src/gui/scmSkyCultureDialog.ui
@@ -846,7 +846,7 @@
              <item row="0" column="1">
               <widget class="QLineEdit" name="cnEnglishLE">
                <property name="placeholderText">
-                <string>Name translated to English (required)</string>
+                <string>Name translated to English</string>
                </property>
               </widget>
              </item>
@@ -860,7 +860,7 @@
              <item row="1" column="1">
               <widget class="QLineEdit" name="cnNativeLE">
                <property name="placeholderText">
-                <string>Name in original script</string>
+                <string>Name in the original language</string>
                </property>
               </widget>
              </item>

--- a/plugins/SkyCultureMaker/src/gui/scmSkyCultureDialog.ui
+++ b/plugins/SkyCultureMaker/src/gui/scmSkyCultureDialog.ui
@@ -755,14 +755,14 @@
              <string>Entry Fields</string>
             </property>
             <layout class="QGridLayout" name="cnFormGridLayout">
-             <item row="0" column="0">
+             <item row="1" column="0">
               <widget class="QLabel" name="cnObjectTypeLbl">
                <property name="text">
                 <string>Type:*</string>
                </property>
               </widget>
              </item>
-             <item row="0" column="1">
+             <item row="1" column="1">
               <widget class="QComboBox" name="cnObjectTypeCB">
                <item>
                 <property name="text">
@@ -781,126 +781,141 @@
                </item>
               </widget>
              </item>
-             <item row="1" column="0">
+             <item row="2" column="0">
               <widget class="QLabel" name="cnObjectIdLbl">
                <property name="text">
                 <string>Identifier:*</string>
                </property>
               </widget>
              </item>
-             <item row="1" column="1">
+             <item row="2" column="1">
               <widget class="QLineEdit" name="cnObjectIdLE">
                <property name="placeholderText">
                 <string>HIP number (e.g. 1234)</string>
                </property>
               </widget>
              </item>
-             <item row="2" column="0">
+             <item row="0" column="0" colspan="2">
+              <widget class="QPushButton" name="cnUseFromSelectionBtn">
+               <property name="text">
+                <string>Copy Data From Selected Object</string>
+               </property>
+               <property name="toolTip">
+                <string>Fill Type, Identifier and English name from the currently selected object</string>
+               </property>
+               <property name="icon">
+                <iconset resource="../../data/gui/guiRes.qrc">
+                 <normaloff>:/graphicGui/btGotoSelectedObject-on.png</normaloff>
+                 <disabledoff>:/graphicGui/btGotoSelectedObject-off.png</disabledoff>:/graphicGui/btGotoSelectedObject-on.png</iconset>
+               </property>
+              </widget>
+             </item>
+             <item row="3" column="0">
               <widget class="QLabel" name="cnEnglishLbl">
                <property name="text">
                 <string>English:*</string>
                </property>
               </widget>
              </item>
-             <item row="2" column="1">
+             <item row="3" column="1">
               <widget class="QLineEdit" name="cnEnglishLE">
                <property name="placeholderText">
                 <string>Name translated to English</string>
                </property>
               </widget>
              </item>
-             <item row="3" column="0">
+             <item row="4" column="0">
               <widget class="QLabel" name="cnNativeLbl">
                <property name="text">
                 <string>Native:</string>
                </property>
               </widget>
              </item>
-             <item row="3" column="1">
+             <item row="4" column="1">
               <widget class="QLineEdit" name="cnNativeLE">
                <property name="placeholderText">
                 <string>Name in the original language</string>
                </property>
               </widget>
              </item>
-             <item row="4" column="0">
+             <item row="5" column="0">
               <widget class="QLabel" name="cnPronounceLbl">
                <property name="text">
                 <string>Pronounce:</string>
                </property>
               </widget>
              </item>
-             <item row="4" column="1">
+             <item row="5" column="1">
               <widget class="QLineEdit" name="cnPronounceLE">
                <property name="placeholderText">
                 <string>Latin-character pronunciation guide (e.g. Pinyin)</string>
                </property>
               </widget>
              </item>
-             <item row="5" column="0">
+             <item row="6" column="0">
               <widget class="QLabel" name="cnTransliterationLbl">
                <property name="text">
                 <string>Transliteration:</string>
                </property>
               </widget>
              </item>
-             <item row="5" column="1">
+             <item row="6" column="1">
               <widget class="QLineEdit" name="cnTransliterationLE">
                <property name="placeholderText">
                 <string>Scientific transliteration (e.g. Wylie for Tibetan)</string>
                </property>
               </widget>
              </item>
-             <item row="6" column="0">
+             <item row="7" column="0">
               <widget class="QLabel" name="cnIpaLbl">
                <property name="text">
                 <string>IPA:</string>
                </property>
               </widget>
              </item>
-             <item row="6" column="1">
+             <item row="7" column="1">
               <widget class="QLineEdit" name="cnIpaLE">
                <property name="placeholderText">
                 <string>International Phonetic Alphabet</string>
                </property>
               </widget>
              </item>
-             <item row="7" column="0">
+             <item row="8" column="0">
               <widget class="QLabel" name="cnBynameLbl">
                <property name="text">
                 <string>Byname:</string>
                </property>
               </widget>
              </item>
-             <item row="7" column="1">
+             <item row="8" column="1">
               <widget class="QLineEdit" name="cnBynameLE">
                <property name="placeholderText">
                 <string>Explanatory addition to the name (e.g. mythological role)</string>
                </property>
               </widget>
              </item>
-             <item row="8" column="0">
+             <item row="9" column="0">
               <widget class="QLabel" name="cnReferencesLbl">
                <property name="text">
                 <string>References:</string>
                </property>
               </widget>
              </item>
-             <item row="8" column="1">
+             <item row="9" column="1">
               <widget class="QLineEdit" name="cnReferencesLE">
                <property name="placeholderText">
                 <string>Comma-separated reference numbers (e.g. 1, 3, 5)</string>
                </property>
               </widget>
              </item>
-             <item row="9" column="0">
+             <item row="10" column="0">
               <widget class="QLabel" name="cnVisibleLbl">
                <property name="text">
                 <string>Visible:</string>
                </property>
               </widget>
              </item>
-             <item row="9" column="1">
+             <item row="10" column="1">
               <widget class="QComboBox" name="cnVisibleCB">
                <item>
                 <property name="text">
@@ -963,16 +978,6 @@
                </size>
               </property>
              </spacer>
-            </item>
-            <item>
-             <widget class="QPushButton" name="cnUseSelectionBtn">
-              <property name="text">
-               <string>Use Selected Object</string>
-              </property>
-              <property name="toolTip">
-               <string>Fill the identifier fields from the object currently selected in Stellarium</string>
-              </property>
-             </widget>
             </item>
            </layout>
           </item>

--- a/plugins/SkyCultureMaker/src/gui/scmSkyCultureDialog.ui
+++ b/plugins/SkyCultureMaker/src/gui/scmSkyCultureDialog.ui
@@ -703,50 +703,6 @@
            <number>6</number>
           </property>
           <item>
-           <layout class="QHBoxLayout" name="cnObjectSelectionLayout">
-            <item>
-             <widget class="QLabel" name="cnObjectTypeLbl">
-              <property name="text">
-               <string>Type:</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QComboBox" name="cnObjectTypeCB">
-              <item>
-               <property name="text">
-                <string>Star</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string>Planet</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string>Deep-Sky Object</string>
-               </property>
-              </item>
-             </widget>
-            </item>
-            <item>
-             <widget class="QLabel" name="cnObjectIdLbl">
-              <property name="text">
-               <string>Identifier:</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QLineEdit" name="cnObjectIdLE">
-              <property name="placeholderText">
-               <string>HIP number, planet name, or catalog designation</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item>
            <widget class="QLabel" name="cnEntriesLbl">
             <property name="text">
              <string>Name Entries:</string>
@@ -792,44 +748,7 @@
             </column>
            </widget>
           </item>
-          <item>
-           <layout class="QHBoxLayout" name="cnEntriesBtnLayout">
-            <item>
-             <widget class="QPushButton" name="cnAddEntryBtn">
-              <property name="text">
-               <string>Add Entry</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QPushButton" name="cnLoadEntryBtn">
-              <property name="text">
-               <string>Load Selected</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QPushButton" name="cnRemoveEntryBtn">
-              <property name="text">
-               <string>Remove Selected</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <spacer name="cnEntriesBtnSpacer">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
-          </item>
+
           <item>
            <widget class="QGroupBox" name="cnFormGroup">
             <property name="title">
@@ -837,111 +756,151 @@
             </property>
             <layout class="QGridLayout" name="cnFormGridLayout">
              <item row="0" column="0">
+              <widget class="QLabel" name="cnObjectTypeLbl">
+               <property name="text">
+                <string>Type:*</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="1">
+              <widget class="QComboBox" name="cnObjectTypeCB">
+               <item>
+                <property name="text">
+                 <string>Star</string>
+                </property>
+               </item>
+               <item>
+                <property name="text">
+                 <string>Planet</string>
+                </property>
+               </item>
+               <item>
+                <property name="text">
+                 <string>Deep-Sky Object</string>
+                </property>
+               </item>
+              </widget>
+             </item>
+             <item row="1" column="0">
+              <widget class="QLabel" name="cnObjectIdLbl">
+               <property name="text">
+                <string>Identifier:*</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="1">
+              <widget class="QLineEdit" name="cnObjectIdLE">
+               <property name="placeholderText">
+                <string>HIP number (e.g. 1234)</string>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="0">
               <widget class="QLabel" name="cnEnglishLbl">
                <property name="text">
                 <string>English:*</string>
                </property>
               </widget>
              </item>
-             <item row="0" column="1">
+             <item row="2" column="1">
               <widget class="QLineEdit" name="cnEnglishLE">
                <property name="placeholderText">
                 <string>Name translated to English</string>
                </property>
               </widget>
              </item>
-             <item row="1" column="0">
+             <item row="3" column="0">
               <widget class="QLabel" name="cnNativeLbl">
                <property name="text">
                 <string>Native:</string>
                </property>
               </widget>
              </item>
-             <item row="1" column="1">
+             <item row="3" column="1">
               <widget class="QLineEdit" name="cnNativeLE">
                <property name="placeholderText">
                 <string>Name in the original language</string>
                </property>
               </widget>
              </item>
-             <item row="2" column="0">
+             <item row="4" column="0">
               <widget class="QLabel" name="cnPronounceLbl">
                <property name="text">
                 <string>Pronounce:</string>
                </property>
               </widget>
              </item>
-             <item row="2" column="1">
+             <item row="4" column="1">
               <widget class="QLineEdit" name="cnPronounceLE">
                <property name="placeholderText">
                 <string>Latin-character pronunciation guide (e.g. Pinyin)</string>
                </property>
               </widget>
              </item>
-             <item row="3" column="0">
+             <item row="5" column="0">
               <widget class="QLabel" name="cnTransliterationLbl">
                <property name="text">
                 <string>Transliteration:</string>
                </property>
               </widget>
              </item>
-             <item row="3" column="1">
+             <item row="5" column="1">
               <widget class="QLineEdit" name="cnTransliterationLE">
                <property name="placeholderText">
                 <string>Scientific transliteration (e.g. Wylie for Tibetan)</string>
                </property>
               </widget>
              </item>
-             <item row="4" column="0">
+             <item row="6" column="0">
               <widget class="QLabel" name="cnIpaLbl">
                <property name="text">
                 <string>IPA:</string>
                </property>
               </widget>
              </item>
-             <item row="4" column="1">
+             <item row="6" column="1">
               <widget class="QLineEdit" name="cnIpaLE">
                <property name="placeholderText">
                 <string>International Phonetic Alphabet</string>
                </property>
               </widget>
              </item>
-             <item row="5" column="0">
+             <item row="7" column="0">
               <widget class="QLabel" name="cnBynameLbl">
                <property name="text">
                 <string>Byname:</string>
                </property>
               </widget>
              </item>
-             <item row="5" column="1">
+             <item row="7" column="1">
               <widget class="QLineEdit" name="cnBynameLE">
                <property name="placeholderText">
                 <string>Explanatory addition to the name (e.g. mythological role)</string>
                </property>
               </widget>
              </item>
-             <item row="7" column="0">
+             <item row="8" column="0">
               <widget class="QLabel" name="cnReferencesLbl">
                <property name="text">
                 <string>References:</string>
                </property>
               </widget>
              </item>
-             <item row="7" column="1">
+             <item row="8" column="1">
               <widget class="QLineEdit" name="cnReferencesLE">
                <property name="placeholderText">
                 <string>Comma-separated reference numbers (e.g. 1, 3, 5)</string>
                </property>
               </widget>
              </item>
-             <item row="8" column="0">
+             <item row="9" column="0">
               <widget class="QLabel" name="cnVisibleLbl">
                <property name="text">
                 <string>Visible:</string>
                </property>
               </widget>
              </item>
-             <item row="8" column="1">
+             <item row="9" column="1">
               <widget class="QComboBox" name="cnVisibleCB">
                <item>
                 <property name="text">
@@ -964,11 +923,58 @@
            </widget>
           </item>
           <item>
-           <widget class="QPushButton" name="cnSaveEntryBtn">
-            <property name="text">
-             <string>Save Entry</string>
-            </property>
-           </widget>
+           <layout class="QHBoxLayout" name="cnActionBtnLayout">
+            <item>
+             <widget class="QPushButton" name="cnAddNewBtn">
+              <property name="text">
+               <string>Add New</string>
+              </property>
+              <property name="toolTip">
+               <string>Add the current form as a new entry</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="cnSaveChangesBtn">
+              <property name="text">
+               <string>Save Changes</string>
+              </property>
+              <property name="toolTip">
+               <string>Save the edited fields back to the selected entry</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="cnRemoveEntryBtn">
+              <property name="text">
+               <string>Remove</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="cnActionBtnSpacer">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <widget class="QPushButton" name="cnUseSelectionBtn">
+              <property name="text">
+               <string>Use Selected Object</string>
+              </property>
+              <property name="toolTip">
+               <string>Fill the identifier fields from the object currently selected in Stellarium</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
          </layout>
         </widget>

--- a/plugins/SkyCultureMaker/src/gui/scmSkyCultureDialog.ui
+++ b/plugins/SkyCultureMaker/src/gui/scmSkyCultureDialog.ui
@@ -911,7 +911,7 @@
              <item row="10" column="0">
               <widget class="QLabel" name="cnVisibleLbl">
                <property name="text">
-                <string>Visible:</string>
+                <string>Visible (planets only):</string>
                </property>
               </widget>
              </item>

--- a/plugins/SkyCultureMaker/src/gui/scmSkyCultureDialog.ui
+++ b/plugins/SkyCultureMaker/src/gui/scmSkyCultureDialog.ui
@@ -798,7 +798,7 @@
              <item row="0" column="0" colspan="2">
               <widget class="QPushButton" name="cnUseFromSelectionBtn">
                <property name="text">
-                <string>Copy Data From Selected Object</string>
+                <string>Use Selected Object</string>
                </property>
                <property name="toolTip">
                 <string>Fill Type, Identifier and English name from the currently selected object</string>
@@ -942,7 +942,7 @@
             <item>
              <widget class="QPushButton" name="cnAddNewBtn">
               <property name="text">
-               <string>Add New</string>
+               <string>Add As New Entry</string>
               </property>
               <property name="toolTip">
                <string>Add the current form as a new entry</string>
@@ -952,7 +952,7 @@
             <item>
              <widget class="QPushButton" name="cnSaveChangesBtn">
               <property name="text">
-               <string>Save Changes</string>
+               <string>Update Selected Entry</string>
               </property>
               <property name="toolTip">
                <string>Save the edited fields back to the selected entry</string>
@@ -962,7 +962,7 @@
             <item>
              <widget class="QPushButton" name="cnRemoveEntryBtn">
               <property name="text">
-               <string>Remove</string>
+               <string>Remove Selected Entry</string>
               </property>
              </widget>
             </item>

--- a/plugins/SkyCultureMaker/src/gui/scmSkyCultureDialog.ui
+++ b/plugins/SkyCultureMaker/src/gui/scmSkyCultureDialog.ui
@@ -798,7 +798,7 @@
              <item row="0" column="0" colspan="2">
               <widget class="QPushButton" name="cnUseFromSelectionBtn">
                <property name="text">
-                <string>Use Selected Object</string>
+                <string>Copy Data From Selected Object</string>
                </property>
                <property name="toolTip">
                 <string>Fill Type, Identifier and English name from the currently selected object</string>
@@ -942,7 +942,7 @@
             <item>
              <widget class="QPushButton" name="cnAddNewBtn">
               <property name="text">
-               <string>Add As New Entry</string>
+               <string>Save As New Entry</string>
               </property>
               <property name="toolTip">
                <string>Add the current form as a new entry</string>

--- a/plugins/SkyCultureMaker/src/gui/scmSkyCultureDialog.ui
+++ b/plugins/SkyCultureMaker/src/gui/scmSkyCultureDialog.ui
@@ -682,6 +682,296 @@
           </item>
          </layout>
         </widget>
+        <widget class="QWidget" name="commonNamesTab">
+         <attribute name="title">
+          <string>Common Names</string>
+         </attribute>
+         <layout class="QVBoxLayout" name="cnTabLayout">
+          <property name="spacing">
+           <number>6</number>
+          </property>
+          <property name="leftMargin">
+           <number>6</number>
+          </property>
+          <property name="topMargin">
+           <number>6</number>
+          </property>
+          <property name="rightMargin">
+           <number>6</number>
+          </property>
+          <property name="bottomMargin">
+           <number>6</number>
+          </property>
+          <item>
+           <layout class="QHBoxLayout" name="cnObjectSelectionLayout">
+            <item>
+             <widget class="QLabel" name="cnObjectTypeLbl">
+              <property name="text">
+               <string>Type:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QComboBox" name="cnObjectTypeCB">
+              <item>
+               <property name="text">
+                <string>Star</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Planet</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Deep-Sky Object</string>
+               </property>
+              </item>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="cnObjectIdLbl">
+              <property name="text">
+               <string>Identifier:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLineEdit" name="cnObjectIdLE">
+              <property name="placeholderText">
+               <string>HIP number, planet name, or catalog designation</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QLabel" name="cnEntriesLbl">
+            <property name="text">
+             <string>Name Entries:</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QTableWidget" name="cnEntriesTable">
+            <property name="selectionBehavior">
+             <enum>QAbstractItemView::SelectionBehavior::SelectRows</enum>
+            </property>
+            <property name="selectionMode">
+             <enum>QAbstractItemView::SelectionMode::SingleSelection</enum>
+            </property>
+            <property name="editTriggers">
+             <set>QAbstractItemView::EditTrigger::NoEditTriggers</set>
+            </property>
+            <property name="showGrid">
+             <bool>true</bool>
+            </property>
+            <attribute name="verticalHeaderVisible">
+             <bool>false</bool>
+            </attribute>
+            <column>
+             <property name="text">
+              <string>Object</string>
+             </property>
+            </column>
+            <column>
+             <property name="text">
+              <string>English</string>
+             </property>
+            </column>
+            <column>
+             <property name="text">
+              <string>Native</string>
+             </property>
+            </column>
+            <column>
+             <property name="text">
+              <string>Pronounce</string>
+             </property>
+            </column>
+           </widget>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="cnEntriesBtnLayout">
+            <item>
+             <widget class="QPushButton" name="cnAddEntryBtn">
+              <property name="text">
+               <string>Add Entry</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="cnLoadEntryBtn">
+              <property name="text">
+               <string>Load Selected</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="cnRemoveEntryBtn">
+              <property name="text">
+               <string>Remove Selected</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="cnEntriesBtnSpacer">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QGroupBox" name="cnFormGroup">
+            <property name="title">
+             <string>Entry Fields</string>
+            </property>
+            <layout class="QGridLayout" name="cnFormGridLayout">
+             <item row="0" column="0">
+              <widget class="QLabel" name="cnEnglishLbl">
+               <property name="text">
+                <string>English:*</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="1">
+              <widget class="QLineEdit" name="cnEnglishLE">
+               <property name="placeholderText">
+                <string>Name translated to English (required)</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="0">
+              <widget class="QLabel" name="cnNativeLbl">
+               <property name="text">
+                <string>Native:</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="1">
+              <widget class="QLineEdit" name="cnNativeLE">
+               <property name="placeholderText">
+                <string>Name in original script</string>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="0">
+              <widget class="QLabel" name="cnPronounceLbl">
+               <property name="text">
+                <string>Pronounce:</string>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="1">
+              <widget class="QLineEdit" name="cnPronounceLE">
+               <property name="placeholderText">
+                <string>Latin-character pronunciation guide (e.g. Pinyin)</string>
+               </property>
+              </widget>
+             </item>
+             <item row="3" column="0">
+              <widget class="QLabel" name="cnTransliterationLbl">
+               <property name="text">
+                <string>Transliteration:</string>
+               </property>
+              </widget>
+             </item>
+             <item row="3" column="1">
+              <widget class="QLineEdit" name="cnTransliterationLE">
+               <property name="placeholderText">
+                <string>Scientific transliteration (e.g. Wylie for Tibetan)</string>
+               </property>
+              </widget>
+             </item>
+             <item row="4" column="0">
+              <widget class="QLabel" name="cnIpaLbl">
+               <property name="text">
+                <string>IPA:</string>
+               </property>
+              </widget>
+             </item>
+             <item row="4" column="1">
+              <widget class="QLineEdit" name="cnIpaLE">
+               <property name="placeholderText">
+                <string>International Phonetic Alphabet</string>
+               </property>
+              </widget>
+             </item>
+             <item row="5" column="0">
+              <widget class="QLabel" name="cnBynameLbl">
+               <property name="text">
+                <string>Byname:</string>
+               </property>
+              </widget>
+             </item>
+             <item row="5" column="1">
+              <widget class="QLineEdit" name="cnBynameLE">
+               <property name="placeholderText">
+                <string>Explanatory addition to the name (e.g. mythological role)</string>
+               </property>
+              </widget>
+             </item>
+             <item row="7" column="0">
+              <widget class="QLabel" name="cnReferencesLbl">
+               <property name="text">
+                <string>References:</string>
+               </property>
+              </widget>
+             </item>
+             <item row="7" column="1">
+              <widget class="QLineEdit" name="cnReferencesLE">
+               <property name="placeholderText">
+                <string>Comma-separated reference numbers (e.g. 1, 3, 5)</string>
+               </property>
+              </widget>
+             </item>
+             <item row="8" column="0">
+              <widget class="QLabel" name="cnVisibleLbl">
+               <property name="text">
+                <string>Visible:</string>
+               </property>
+              </widget>
+             </item>
+             <item row="8" column="1">
+              <widget class="QComboBox" name="cnVisibleCB">
+               <item>
+                <property name="text">
+                 <string>Always visible</string>
+                </property>
+               </item>
+               <item>
+                <property name="text">
+                 <string>Morning only</string>
+                </property>
+               </item>
+               <item>
+                <property name="text">
+                 <string>Evening only</string>
+                </property>
+               </item>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="cnSaveEntryBtn">
+            <property name="text">
+             <string>Save Entry</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
         <widget class="QWidget" name="geoLocTab">
          <attribute name="title">
           <string>Location</string>


### PR DESCRIPTION
This PR adds a "Common Names" tab to the sky culture editor, which lets the user insert cultural names of stars, plansts and DSOs

Fixes #4657 

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?
Created different sky cultures on my macbook.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
