### PR TITLE
Fix tracked object jumps while zooming with viewport offset

### DIFF
--- a/src/core/StelMovementMgr.cpp
+++ b/src/core/StelMovementMgr.cpp
@@ -1027,8 +1027,6 @@ void StelMovementMgr::setFOVDeg(float fov)
 // Increment/decrement smoothly the vision field and position
 void StelMovementMgr::updateMotion(double deltaTime)
 {
-	updateVisionVector(deltaTime);
-
 	const StelProjectorP proj = core->getProjection(StelCore::FrameJ2000);
 	// the more it is zoomed, the lower the moving speed is (in angle)
 	double depl=keyMoveSpeed*deltaTime*1000*currentFov;
@@ -1083,11 +1081,13 @@ void StelMovementMgr::updateMotion(double deltaTime)
 		deltaAlt = rateY*M_PI_180*deltaTime;
 	}
 
+	updateVisionVector(deltaTime);
 	panView(deltaAz, deltaAlt);
 	updateAutoZoom(deltaTime);
 }
 
-// called at begin of updateMotion()
+// Called after manual FOV changes so viewport-offset tracking uses the FOV
+// that will be rendered for this frame.
 void StelMovementMgr::updateVisionVector(double deltaTime)
 {
 	// Specialized setups cannot use this functionality!


### PR DESCRIPTION
## AI Disclosure

This pull request was generated with AI assistance and reviewed locally before submission.

## Summary

This fixes a viewport-offset tracking issue where a selected/tracked object could visibly jump during manual zoom when a non-zero vertical viewport offset was active.

The change reorders an existing `updateVisionVector(deltaTime)` call so tracking compensation runs after manual FOV changes for the frame. No extra per-frame work is added.

Fixes #4887.

## Pre-Fix Behavior

With tracking enabled and vertical viewport offset set, manual zoom could render a frame using the new FOV while the tracking aim still reflected the previous FOV. The selected object visibly shifted during zoom.

In the local scripted repro, the tracked object moved by up to 61 px during repeated zoom pulses with a 20% vertical viewport offset.

## Post-Fix Behavior

Tracking compensation uses the FOV that will be rendered for the frame. The selected object remains stable during manual zoom with the same viewport offset.

In the same local scripted repro, the tracked object stayed within normal pixel-rounding variance during zoom.

## Performance Impact

None expected. This only reorders an existing per-frame update; it does not add another call, loop, allocation, projection calculation, or render step.

## Visual Evidence

Before/after video:

https://github.com/Symmetricity/stellarium/releases/download/pr-4915-evidence/target1-viewport-offset-before-after.mp4

Preview:

![before-after preview](https://github.com/Symmetricity/stellarium/releases/download/pr-4915-evidence/target1-viewport-offset-before-after-preview.png)

## Reproduction

Also ran a local scripted Xvfb repro that:

1. selects and tracks Vega,
2. applies a 20% vertical viewport offset,
3. performs repeated manual zoom-in/zoom-out pulses,
4. logs the selected object's screen position during each pulse.

Pre-fix: max observed jump during zoom was 61 px.

Post-fix: movement stayed within pixel-rounding variance.

The local repro script is not included in this PR because it is a standalone GUI/Xvfb automation script rather than a project test. I can share it if useful.

## Testing

Ran locally:

```bash
cmake --build <build-dir> --parallel 2
ctest --test-dir <build-dir> --output-on-failure
git diff --check
```
