### PR TITLE
Fix/wait for keypress 4866

### DIFF
--- a/guide/ch_scripting.tex
+++ b/guide/ch_scripting.tex
@@ -155,6 +155,29 @@ still run without or with just minor modifications as described in this section.
 
 The Qt6-based builds (version 1.0 and later) do not offer a way to pause and resume a script as was available in the Qt5-based builds (0.10 to 0.22). 
 
+However, \texttt{core.waitForKeypress()}\newFeature{26.2} can be used to pause a script until a key is pressed, 
+which is particularly useful for planetarium presentations with a Bluetooth or wireless remote clicker. 
+A visual indicator \emph{``Press key to continue...''} can be displayed on screen while the script is paused.
+To advance, press  \key{SPACE} or the advance key on the remote clicker (which triggers \key{PgDn}).
+While the script is paused, you can operate all other hotkeys (except what you have configured as \key{SPACE} action).  
+
+Example usage:
+\begin{script}
+core.goToObject("Orion");
+core.waitForKeypress();
+core.goToObject("Sirius");
+core.waitForKeypress();
+\end{script}
+
+Displaying the \emph{``Press key to continue...''} message is fine for private use, but may not be wanted in a show environment. 
+You can switch it off in the Script Console (F12) or in \file{config.ini}:
+
+\begin{configfile}
+[scripts]
+flag_show_continue_message = false
+\end{configfile}
+
+
 \subsection{The Vec3f problem}
 \label{sec:scripting:differences:Vec3f}
 

--- a/landscapes/trees/landscape.ini
+++ b/landscapes/trees/landscape.ini
@@ -7,7 +7,8 @@ maptex = trees_512.png
 # Orientation: South is Top!
 maptex_illum = trees_illum_512.png
 maptex_fog = trees_fog_512.png
-texturefov = 210
+texturefov = 190
+
 
 [location]
 planet = Earth

--- a/po/stellarium/POTFILES.in
+++ b/po/stellarium/POTFILES.in
@@ -67,6 +67,7 @@ src/gui/ConfigureOrbitColorsDialog.cpp
 src/gui/DateTimeDialog.cpp
 src/gui/LightPollutionWidget.cpp
 src/scripting/StelScriptMgr.cpp
+src/scripting/StelMainScriptAPI.hpp
 src/main.cpp
 src/StelMainView.cpp
 

--- a/src/gui/ScriptConsole.cpp
+++ b/src/gui/ScriptConsole.cpp
@@ -145,6 +145,8 @@ void ScriptConsole::createDialogContent()
 	ui->allowStoreAbsoluteCheckBox->setChecked(StelApp::getInstance().getScriptMgr().getFlagAllowWriteAbsolutePaths());
 	connect(ui->allowStoreAbsoluteCheckBox, SIGNAL(clicked(bool)), &StelApp::getInstance().getScriptMgr(), SLOT(setFlagAllowWriteAbsolutePaths(bool)));
 
+	ui->showWaitMessageCheckBox->setChecked(StelApp::getInstance().getScriptMgr().getFlagShowContinueMessage());
+	connect(ui->showWaitMessageCheckBox, SIGNAL(clicked(bool)), &StelApp::getInstance().getScriptMgr(), SLOT(setFlagShowContinueMessage(bool)));
 
 	dirty = false;
 }

--- a/src/gui/scriptConsole.ui
+++ b/src/gui/scriptConsole.ui
@@ -369,6 +369,13 @@
            </widget>
           </item>
           <item>
+           <widget class="QCheckBox" name="showWaitMessageCheckBox">
+            <property name="text">
+             <string>Show screen message in WaitForKey() calls</string>
+            </property>
+           </widget>
+          </item>
+          <item>
            <spacer name="verticalSpacer">
             <property name="orientation">
              <enum>Qt::Vertical</enum>

--- a/src/scripting/StelMainScriptAPI.cpp
+++ b/src/scripting/StelMainScriptAPI.cpp
@@ -1017,17 +1017,25 @@ void StelMainScriptAPI::waitFor(const QString& dt, const QString& spec)
 	}
 }
 
-void StelMainScriptAPI::waitForKeypress()
+void StelMainScriptAPI::waitForKeypress(const QString message)
 {
 	StelScriptMgr* scriptMgr = &StelApp::getInstance().getScriptMgr();
+	LabelMgr* labelMgr = GETSTELMODULE(LabelMgr);
+	int labelId;
+
 	QCoreApplication::processEvents();
 	QEventLoop* loop = scriptMgr->getWaitEventLoop();
 	KeypressFilter filter(loop);
 	qApp->installEventFilter(&filter);
+	if (scriptMgr->getFlagShowContinueMessage())
+		labelId = labelMgr->labelScreen(message, 30, 30, true, 20, "#ffffff", false, 0);
+
 	if( loop->exec() != 0 )
 	{
 		emit requestExit();
 	}
+	if (scriptMgr->getFlagShowContinueMessage())
+		labelMgr->deleteLabel(labelId);
 	qApp->removeEventFilter(&filter);
 }
 

--- a/src/scripting/StelMainScriptAPI.hpp
+++ b/src/scripting/StelMainScriptAPI.hpp
@@ -1014,7 +1014,7 @@ public slots:
 
 	//! Pauses script until key is pressed
 	//! enables interactive control of scripts in planetarium presentations.
-	void waitForKeypress();
+	void waitForKeypress(const QString message=q_("Press key to continue..."));
 
 	//! Retrieve value of environment variable @param name.
 	//! On desktop Windows and Qt before 5.10, this call may result in data loss if the original

--- a/src/scripting/StelScriptMgr.cpp
+++ b/src/scripting/StelScriptMgr.cpp
@@ -507,6 +507,7 @@ StelScriptMgr::StelScriptMgr(QObject *parent): QObject(parent)
 	QSettings *conf=StelApp::getInstance().getSettings();
 	flagAllowExternalScreenshotDir=conf->value("scripts/flag_allow_screenshots_dir", false).toBool();
 	flagAllowWriteAbsolutePaths=conf->value("scripts/flag_allow_write_absolute_path", false).toBool();
+	flagShowContinueMessage=conf->value("scripts/flag_show_continue_message", true).toBool();
 }
 
 void StelScriptMgr::initActions()
@@ -1212,5 +1213,17 @@ void StelScriptMgr::setFlagAllowWriteAbsolutePaths(bool flag)
 		conf->setValue("scripts/flag_allow_write_absolute_path", flag);
 		conf->sync();
 		emit flagAllowWriteAbsolutePathsChanged(flag);
+	}
+}
+
+void StelScriptMgr::setFlagShowContinueMessage(bool flag)
+{
+	if (flag!=flagShowContinueMessage)
+	{
+		flagShowContinueMessage=flag;
+		QSettings* conf = StelApp::getInstance().getSettings();
+		conf->setValue("scripts/flag_show_continue_message", flag);
+		conf->sync();
+		emit flagShowContinueMessageChanged(flag);
 	}
 }

--- a/src/scripting/StelScriptMgr.hpp
+++ b/src/scripting/StelScriptMgr.hpp
@@ -25,6 +25,7 @@
 #include <QFile>
 #include <QTimer>
 #include <QEventLoop>
+#include <QKeyEvent>
 #include <QMap>
 #include <QPair>
 #include <QSet>
@@ -51,9 +52,16 @@ class KeypressFilter : public QObject {
 public:
 	KeypressFilter(QEventLoop* l) : loop(l) {}
 	bool eventFilter(QObject* obj, QEvent* event) override {
-		if (event->type() == QEvent::KeyPress) {
-			loop->quit();
-			return true;
+		// A presenter's clicker device sends PgUp/PgDn events as ShortcutOverride.
+		if((event->type() == QEvent::KeyRelease) || (event->type() == QEvent::ShortcutOverride))
+		{
+			QKeyEvent* keyEvent = static_cast<QKeyEvent*>(event);
+			if (QList<Qt::Key>({Qt::Key::Key_Space, Qt::Key::Key_PageDown, Qt::Key::Key_PageUp}).contains(static_cast<Qt::Key>(keyEvent->key())))
+			{
+				loop->quit();
+				keyEvent->accept();
+				return true;
+			}
 		}
 		return QObject::eventFilter(obj, event);
 	}
@@ -76,6 +84,7 @@ class StelScriptMgr : public QObject
 	// CAVEAT: Do not convert this class to a StelModule: The Qt properties (esp. the following 2) should not be available in the StelProperty system (and the object should not be scriptable)!
 	Q_PROPERTY(bool flagAllowExternalScreenshotDir READ getFlagAllowExternalScreenshotDir WRITE setFlagAllowExternalScreenshotDir NOTIFY flagAllowExternalScreenshotDirChanged)
 	Q_PROPERTY(bool flagAllowWriteAbsolutePaths READ getFlagAllowWriteAbsolutePaths WRITE setFlagAllowWriteAbsolutePaths NOTIFY flagAllowWriteAbsolutePathsChanged)
+	Q_PROPERTY(bool flagShowContinueMessage     READ getFlagShowContinueMessage     WRITE setFlagShowContinueMessage     NOTIFY flagShowContinueMessageChanged)
 
 #ifdef ENABLE_SCRIPT_CONSOLE
 friend class ScriptConsole;
@@ -281,6 +290,11 @@ public slots:
 	bool getFlagAllowWriteAbsolutePaths() const {return flagAllowWriteAbsolutePaths;}
 	void setFlagAllowWriteAbsolutePaths(bool flag);
 
+	//! Flag setter/getter for deciding whether to show the continue message in WaitForKey()
+	bool getFlagShowContinueMessage() const {return flagShowContinueMessage;}
+	void setFlagShowContinueMessage(bool flag);
+
+
 private slots:
 	//! Called at the end of the running threa
 	void scriptEnded();
@@ -301,6 +315,8 @@ signals:
 	void flagAllowExternalScreenshotDirChanged(bool flag);
 	//! Notification that flag to allow scripts to write to absolute paths changed
 	void flagAllowWriteAbsolutePathsChanged(bool flag);
+	//! Notification that the "press key to continue" has been toggled
+	void flagShowContinueMessageChanged(bool flag);
 
 private:
 	// Utility functions for preprocessor. DEAD CODE!
@@ -338,7 +354,8 @@ private:
 
 	//! Event filter to detect keypress for waitForKeypress()
 	QObject* keypressEventFilter;
-	
+	bool flagShowContinueMessage; // property flag deciding whether to show the continue... message in waitForKeypress()
+
 	QString scriptFileName;
 	
 

--- a/util/RESET_UI_TO_QT5.sh
+++ b/util/RESET_UI_TO_QT5.sh
@@ -51,8 +51,12 @@ sed -e 's/Qt::FocusPolicy::NoFocus/Qt::NoFocus/g' \
 	-e 's/QListView::ResizeMode::Adjust/QListView::Adjust/g' \
 	-e 's/QListView::LayoutMode::SinglePass/QListView::SinglePass/g' \
 	-e 's/QListView::ViewMode::IconMode/QListView::IconMode/g' \
+	-e 's/QPlainTextEdit::LineWrapMode::NoWrap/QPlainTextEdit::NoWrap/' \
 	-e 's/QSlider::TickPosition::NoTicks/QSlider::NoTicks/g' \
+	-e 's/Qt::ScrollBarPolicy::ScrollBarAlwaysOn/Qt::ScrollBarAlwaysOn/' \
 	-e 's/Qt::TextInteractionFlag::TextSelectableByMouse/Qt::TextSelectableByMouse/g' \
 	-e 's/Qt::TextInteractionFlag::NoTextInteraction/Qt::NoTextInteraction/g' \
+	-e 's/QTabWidget::TabPosition::North/QTabWidget::North/g' \
 	-e 's/QTabWidget::TabPosition::South/QTabWidget::South/g' \
 	   $1
+	   


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Please include a summary of the change and which issue is fixed. -->
<!--- Please also include relevant motivation and context. -->
<!--- List any dependencies that are required for this change. -->

Unfortunately original feature author @Gizmoobs gave up a step from the finish line. 

This now adds the suggested changes, make message display optional and message configurable, and adds documentation.
Works with SPACE, PgUp, PgDn and remote clicker device.

Fixes #4866 

### Screenshots (if appropriate):

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Use any script, add WaitForKey() or WaitForKey("My very own message") and run it. 
The script should pause until you press Space, PgUp, PgDn or the external clicker device.

**Test Configuration**:
* Operating system: Windows 11
* Graphics Card: irrelevant

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x]  I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (header file)
- [x] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
