### PR TITLE
Location dialog: show location filter circle

### DIFF
--- a/src/core/StelLocation.cpp
+++ b/src/core/StelLocation.cpp
@@ -229,6 +229,18 @@ StelLocation StelLocation::createFromLine(const QString& rawline)
 	return loc;
 }
 
+Vec3d StelLocation::pointAtDistanceDegrees(const double centerLon, const double centerLat, const double distDeg, const double bearing)
+{
+	Vec3d centerPoint;
+	StelUtils::spheToRect(centerLon * M_PI_180, centerLat * M_PI_180, centerPoint);
+	const Mat3d R = Mat4d::rotation(centerPoint, -bearing * M_PI_180).upper3x3();
+
+	Vec3d pointNorthOfCenter;
+	StelUtils::spheToRect(centerLon * M_PI_180, (centerLat + distDeg) * M_PI_180, pointNorthOfCenter);
+
+	return R * pointNorthOfCenter;
+}
+
 // Compute great-circle distance between two locations
 float StelLocation::distanceDegrees(const float long1, const float lat1, const float long2, const float lat2)
 {

--- a/src/core/StelLocation.hpp
+++ b/src/core/StelLocation.hpp
@@ -22,6 +22,7 @@
 #include <QString>
 #include <QVariant>
 #include <QMetaType>
+#include "VecMath.hpp"
 
 class Planet;
 
@@ -120,6 +121,10 @@ public:
 	//! Parse a location from a line serialization
 	static StelLocation createFromLine(const QString& line);
 
+	//! \brief Compute a point at \p distDeg degrees away from the center along the great circle with the given \p bearing
+	//!
+	//! To compute latitude and longitude from this Cartesian point, use #StelUtils::rectToSphe.
+	static Vec3d pointAtDistanceDegrees(const double centerLon, const double centerLat, const double distDeg, const double bearing);
 	//! Compute great-circle distance between two locations on a spherical body
 	//! arguments given in decimal degrees
 	static float distanceDegrees(const float long1, const float lat1, const float long2, const float lat2);

--- a/src/gui/LocationDialog.cpp
+++ b/src/gui/LocationDialog.cpp
@@ -640,10 +640,12 @@ void LocationDialog::setLocationFromMap(double longitude, double latitude, const
 		ui->timeZoneNameComboBox->setCurrentIndex(ui->timeZoneNameComboBox->findData("LMST", Qt::UserRole, Qt::MatchCaseSensitive));
 
 	// Filter location list for nearby sites. I assume Earth locations are better known. With only few locations on other planets in the list, 30 degrees seem OK.
-	LocationMap results = StelApp::getInstance().getLocationMgr().pickLocationsNearby(loc.planetName, longitude, latitude, loc.planetName=="Earth" ? 5.0f: 30.0f);
+	const auto searchRadius = loc.planetName=="Earth" ? 5.0f: 30.0f;
+	LocationMap results = StelApp::getInstance().getLocationMgr().pickLocationsNearby(loc.planetName, longitude, latitude, searchRadius);
 	pickedModel->setStringList(results.keys());
 	proxyModel->setSourceModel(pickedModel);
 	proxyModel->sort(0, Qt::AscendingOrder);
+	ui->mapWidget->setLocationFilter(longitude, latitude, searchRadius);
 	ui->citySearchLineEdit->setText(""); // https://wiki.qt.io/Technical_FAQ#Why_does_the_memory_keep_increasing_when_repeatedly_pasting_text_and_calling_clear.28.29_in_a_QLineEdit.3F
 }
 
@@ -686,6 +688,7 @@ void LocationDialog::moveToAnotherPlanet()
 			//	ui->timeZoneNameComboBox->setCurrentIndex(ui->timeZoneNameComboBox->findData("LMST", Qt::UserRole, Qt::MatchCaseSensitive));
 		}
 		proxyModel->sort(0, Qt::AscendingOrder);
+		ui->mapWidget->setLocationFilter(0, 0, 180);
 		ui->citySearchLineEdit->setText(""); // https://wiki.qt.io/Technical_FAQ#Why_does_the_memory_keep_increasing_when_repeatedly_pasting_text_and_calling_clear.28.29_in_a_QLineEdit.3F
 		ui->citySearchLineEdit->setFocus();
 
@@ -1000,6 +1003,7 @@ void LocationDialog::resetLocationList()
 	}
 
 	proxyModel->sort(0, Qt::AscendingOrder);
+	ui->mapWidget->setLocationFilter(0, 0, 180);
 }
 
 // called when user clicks in the region combobox and selects a region. The locations in the list are updated to select only sites in that region.

--- a/src/gui/MapWidget.cpp
+++ b/src/gui/MapWidget.cpp
@@ -50,6 +50,15 @@ void MapWidget::setMarkerPos(double longitude, double latitude)
 	update();
 }
 
+void MapWidget::setLocationFilter(double longitude, double latitude, double newSearchRadius)
+{
+	searchCenterLon = longitude;
+	searchCenterLat = latitude;
+	searchRadius = newSearchRadius;
+	searchAreaOutline = {};
+	update();
+}
+
 void MapWidget::mousePressEvent(QMouseEvent* event)
 {
 	const double ratio = devicePixelRatioF();
@@ -73,6 +82,126 @@ void MapWidget::setMap(const QPixmap &map)
 	update();
 }
 
+void MapWidget::makeSearchAreaOutline(const int width, const int height)
+{
+	constexpr double nMax = 128;
+	std::vector<QPointF> points;
+	for (double n = 0; n < nMax; ++n)
+	{
+		const auto bearing = n / nMax * 360;
+		const auto point3d = StelLocation::pointAtDistanceDegrees(searchCenterLon, searchCenterLat, searchRadius, bearing);
+		double lon, lat;
+		StelUtils::rectToSphe(&lon, &lat, point3d);
+		lon *= M_180_PI;
+		lat *= M_180_PI;
+
+		const auto x = mapRect.left() + (lon + 180) /  360. * width;
+		const auto y = mapRect.top()  + (lat -  90) / -180. * height;
+		points.emplace_back(x, y);
+	}
+
+	// Special handling for poles, because they won't be
+	// included in the path if connect the points naively.
+	if (searchCenterLat + searchRadius > 90)
+	{
+		searchAreaOutline.moveTo(mapRect.topRight());
+		searchAreaOutline.lineTo(mapRect.topLeft());
+		std::sort(points.begin(), points.end(),
+		          [](auto& a, auto& b){ return a.x() < b.x(); });
+		searchAreaOutline.lineTo(mapRect.left(), points.front().y());
+		for (const auto& p : points)
+			searchAreaOutline.lineTo(p);
+		searchAreaOutline.lineTo(mapRect.right(), points.back().y());
+		searchAreaOutline.closeSubpath();
+	}
+	else if (searchCenterLat - searchRadius < -90)
+	{
+		searchAreaOutline.moveTo(mapRect.bottomRight());
+		searchAreaOutline.lineTo(mapRect.bottomLeft());
+		std::sort(points.begin(), points.end(),
+		          [](auto& a, auto& b){ return a.x() < b.x(); });
+		searchAreaOutline.lineTo(mapRect.left(), points.front().y());
+		for (const auto& p : points)
+			searchAreaOutline.lineTo(p);
+		searchAreaOutline.lineTo(mapRect.right(), points.back().y());
+		searchAreaOutline.closeSubpath();
+	}
+	else
+	{
+		// Handle possible split over longitude ±180°
+		std::vector<QPointF> pointsWest, pointsEast;
+		bool lastPointWasWest;
+		if (points[0].x() < mapRect.left() + width / 2.)
+		{
+			pointsWest.push_back(points[0]);
+			lastPointWasWest = true;
+		}
+		else
+		{
+			pointsEast.push_back(points[0]);
+			lastPointWasWest = false;
+		}
+
+		for (size_t n = 1; n < points.size(); ++n)
+		{
+			const auto& p = points[n];
+			if (lastPointWasWest)
+			{
+				const auto& prevP = pointsWest.back();
+				if (std::abs(p.x() - width - prevP.x()) < std::abs(p.x() - prevP.x()))
+				{
+					// Switching over to the east, need to make
+					// the western path cross the left side.
+					pointsWest.emplace_back(p.x() - width, p.y());
+					// Also we need to make the eastern part
+					// to continue from the right side.
+					pointsEast.emplace_back(prevP.x() + width, prevP.y());
+					lastPointWasWest = false;
+					pointsEast.emplace_back(p);
+				}
+				else
+				{
+					pointsWest.emplace_back(p);
+				}
+			}
+			else
+			{
+				const auto& prevP = pointsEast.back();
+				if (std::abs(p.x() + width - prevP.x()) < std::abs(p.x() - prevP.x()))
+				{
+					// Switching over to the west, need to make
+					// the eastern path cross the right side.
+					pointsEast.emplace_back(p.x() + width, p.y());
+					// Also we need to make the western part
+					// to continue from the left side.
+					pointsWest.emplace_back(prevP.x() - width, prevP.y());
+					lastPointWasWest = true;
+					pointsWest.emplace_back(p);
+				}
+				else
+				{
+					pointsEast.emplace_back(p);
+				}
+			}
+		}
+
+		if (!pointsWest.empty())
+		{
+			searchAreaOutline.moveTo(pointsWest[0]);
+			for (const auto& p : pointsWest)
+				searchAreaOutline.lineTo(p);
+			searchAreaOutline.closeSubpath();
+		}
+		if (!pointsEast.empty())
+		{
+			searchAreaOutline.moveTo(pointsEast[0]);
+			for (const auto& p : pointsEast)
+				searchAreaOutline.lineTo(p);
+			searchAreaOutline.closeSubpath();
+		}
+	}
+}
+
 void MapWidget::paintEvent(QPaintEvent*)
 {
 	QPainter painter(this);
@@ -86,6 +215,7 @@ void MapWidget::paintEvent(QPaintEvent*)
 							 std::round((height()*ratio-scaledMap.height()) / 2.)),
 					 scaledMap.size());
 
+	painter.setClipRect(mapRect);
 	painter.drawPixmap(mapRect.topLeft(), scaledMap);
 
 	if (markerVisible)
@@ -103,4 +233,27 @@ void MapWidget::paintEvent(QPaintEvent*)
 				   markerCenterPosY - scaledMarker.height(),
 				   scaledMarker);
 	}
+
+	if (searchRadius < 180)
+	{
+		if (searchAreaOutline.isEmpty())
+			makeSearchAreaOutline(scaledMap.width(), scaledMap.height());
+		// Outline
+		painter.setPen(QColor(0, 127, 255, 255));
+		painter.setBrush(Qt::transparent);
+		painter.setRenderHint(QPainter::Antialiasing);
+		painter.drawPath(searchAreaOutline);
+
+		// Darken the areas that are filtered out
+		auto path = searchAreaOutline;
+		path.addRect(mapRect);
+		painter.setPen(Qt::transparent);
+		painter.setBrush(QColor(0,0,0,127));
+		painter.drawPath(path);
+	}
+}
+
+void MapWidget::resizeEvent(QResizeEvent* event)
+{
+	searchAreaOutline = {};
 }

--- a/src/gui/MapWidget.hpp
+++ b/src/gui/MapWidget.hpp
@@ -25,6 +25,7 @@
 #include <QRect>
 #include <QWidget>
 #include <QPixmap>
+#include <QPainterPath>
 
 //! @class MapWidget
 //! Special widget that shows a world map
@@ -40,6 +41,12 @@ public:
 	void setMarkerPos(double longitude, double latitude);
 	//! allow hiding the location arrow (if sitting on an observer)
 	void setMarkerVisible(bool visible);
+	//! Set the search circle to mark the locations available
+	//! @param longitude longitude in degrees in the range [-180;180[
+	//! @param latitude latitude in degrees in the range [-90;90]
+	//! @param searchRadius search radius in degrees in the range ]0;180].
+	//! If \p searchRadius is set to 180, filtering is considered disabled.
+	void setLocationFilter(double longitude, double latitude, double searchRadius);
 
 	void setMap(const QPixmap &map);
 	
@@ -50,9 +57,15 @@ signals:
 protected:
 	void mousePressEvent(QMouseEvent* event) override;
 	void paintEvent(QPaintEvent* event) override;
+	void resizeEvent(QResizeEvent* event) override;
+
+private:
+	void makeSearchAreaOutline(int width, int height);
 
 private:
 	double markerLat=0, markerLon=0;
+	double searchCenterLon=0, searchCenterLat=0, searchRadius=180;
+	QPainterPath searchAreaOutline;
 	QPixmap map;
 	QPixmap locationMarker;
 	QRectF mapRect; // in device pixels


### PR DESCRIPTION
Currently it's quite unintuitive that when one clicks in the map, the location list gets filtered. This patch gives some feedback on this, darkening the area that is filtered out and showing an outline around the remaining area.

## Screenshots

### Default look

<img width="1920" height="1044" alt="stellarium-022" src="https://github.com/user-attachments/assets/1ab27b1e-c173-4f5f-af91-976d52d91d26" />

### After a click

<img width="1920" height="1044" alt="stellarium-021" src="https://github.com/user-attachments/assets/30690687-ecf5-4f06-8bce-02cd9a612a27" />
