### PR TITLE
Add support for zooming of the Location dialog's map widget

### DIFF
--- a/src/core/StelApp.cpp
+++ b/src/core/StelApp.cpp
@@ -1577,6 +1577,13 @@ float StelApp::getScreenScale() const
 	return dppRatio * fontRatio;
 }
 
+float StelApp::getGuiScale() const
+{
+	const float dppRatio = StelApp::getInstance().getDevicePixelsPerPixel();
+	const float fontRatio = StelApp::getInstance().guiFontSizeRatio();
+	return dppRatio * fontRatio;
+}
+
 void StelApp::setAppFont(QFont font)
 {
 	int oldSize=QGuiApplication::font().pixelSize();

--- a/src/core/StelApp.hpp
+++ b/src/core/StelApp.hpp
@@ -237,7 +237,10 @@ public:
 	//! Set the ratio (in percent) of screen button size to the default screen scale-dependent one
 	void setScreenButtonScale(double s);
 
-	//! Combines #getDevicePixelsPerPixel and #getScreenFontSize
+	//! Combines #getDevicePixelsPerPixel and #guiFontSizeRatio
+	float getGuiScale() const;
+
+	//! Combines #getDevicePixelsPerPixel and #screenFontSizeRatio
 	float getScreenScale() const;
 
 	//! Get the GUI instance implementing the abstract GUI interface.

--- a/src/gui/MapWidget.cpp
+++ b/src/gui/MapWidget.cpp
@@ -70,14 +70,14 @@ void MapWidget::setLocationFilter(double longitude, double latitude, double newS
 	update();
 }
 
-QPointF MapWidget::mapPointToLonLat(const QPointF& mapPoint) const
+auto MapWidget::mapPointToLonLat(const QPointF& mapPoint) const -> LonLat
 {
 	const auto lat = (mapPoint.y() - mapRect.center().y()) / mapRect.height() * -180;
 	const auto lon = (mapPoint.x() - mapRect.center().x()) / mapRect.width()  * 360;
-	return {lon, lat};
+	return {std::remainder(lon, 360), std::clamp(lat, -90., 90.)};
 }
 
-QPointF MapWidget::lonLatToMapPoint(const double lon, const double lat) const
+auto MapWidget::lonLatToMapPoint(const double lon, const double lat) const -> MapPoint
 {
 	const auto x = mapRect.left() + (lon + 180) /  360. * mapRect.width();
 	const auto y = mapRect.top()  + (lat -  90) / -180. * mapRect.height();
@@ -115,7 +115,7 @@ void MapWidget::mouseReleaseEvent(QMouseEvent* event)
 		return;
 	}
 
-	if(!mapRect.contains(pos))
+	if(mapRect.top() > pos.y() || mapRect.bottom() < pos.y())
 		return;
 
 	const auto [lon, lat] = mapPointToLonLat(pos);
@@ -153,6 +153,7 @@ void MapWidget::wheelEvent(QWheelEvent* event)
 void MapWidget::setMap(const QPixmap &map)
 {
 	this->map = map;
+	scaledMap = {};
 	updateScaledMapAndRect();
 }
 
@@ -177,99 +178,64 @@ void MapWidget::makeSearchAreaOutline(const int width, const int height)
 	// included in the path if connect the points naively.
 	if (searchCenterLat + searchRadius > 90)
 	{
-		searchAreaOutline.moveTo(mapRect.topRight());
-		searchAreaOutline.lineTo(mapRect.topLeft());
+		searchAreaOutline.moveTo(mapRect.topRight() + QPointF(1,-1));
+		searchAreaOutline.lineTo(mapRect.topLeft() + QPointF(-1,-1));
 		std::sort(points.begin(), points.end(),
 		          [](auto& a, auto& b){ return a.x() < b.x(); });
-		searchAreaOutline.lineTo(mapRect.left(), points.front().y());
+		searchAreaOutline.lineTo(points.back().x() - mapRect.width(), points.back().y());
 		for (const auto& p : points)
 			searchAreaOutline.lineTo(p);
-		searchAreaOutline.lineTo(mapRect.right(), points.back().y());
+		searchAreaOutline.lineTo(points.front().x() + mapRect.width(), points.front().y());
 		searchAreaOutline.closeSubpath();
 	}
 	else if (searchCenterLat - searchRadius < -90)
 	{
-		searchAreaOutline.moveTo(mapRect.bottomRight());
-		searchAreaOutline.lineTo(mapRect.bottomLeft());
+		searchAreaOutline.moveTo(mapRect.bottomRight() + QPointF(1,1));
+		searchAreaOutline.lineTo(mapRect.bottomLeft() + QPointF(-1,1));
 		std::sort(points.begin(), points.end(),
 		          [](auto& a, auto& b){ return a.x() < b.x(); });
-		searchAreaOutline.lineTo(mapRect.left(), points.front().y());
+		searchAreaOutline.lineTo(points.back().x() - mapRect.width(), points.back().y());
 		for (const auto& p : points)
 			searchAreaOutline.lineTo(p);
-		searchAreaOutline.lineTo(mapRect.right(), points.back().y());
+		searchAreaOutline.lineTo(points.front().x() + mapRect.width(), points.front().y());
 		searchAreaOutline.closeSubpath();
 	}
 	else
 	{
-		// Handle possible split over longitude ±180°
-		std::vector<QPointF> pointsWest, pointsEast;
-		bool lastPointWasWest;
-		if (points[0].x() < mapRect.left() + width / 2.)
-		{
-			pointsWest.push_back(points[0]);
-			lastPointWasWest = true;
-		}
-		else
-		{
-			pointsEast.push_back(points[0]);
-			lastPointWasWest = false;
-		}
-
+		// Handle possible jump over longitude ±180°
+		bool needCopyOnTheLeft = false, needCopyOnTheRight = false;
 		for (size_t n = 1; n < points.size(); ++n)
 		{
-			const auto& p = points[n];
-			if (lastPointWasWest)
+			const auto& prevP = points[n-1];
+			auto& p = points[n];
+			if (std::abs(p.x() - width - prevP.x()) < std::abs(p.x() - prevP.x()))
 			{
-				const auto& prevP = pointsWest.back();
-				if (std::abs(p.x() - width - prevP.x()) < std::abs(p.x() - prevP.x()))
-				{
-					// Switching over to the east, need to make
-					// the western path cross the left side.
-					pointsWest.emplace_back(p.x() - width, p.y());
-					// Also we need to make the eastern part
-					// to continue from the right side.
-					pointsEast.emplace_back(prevP.x() + width, prevP.y());
-					lastPointWasWest = false;
-					pointsEast.emplace_back(p);
-				}
-				else
-				{
-					pointsWest.emplace_back(p);
-				}
+				p.setX(p.x() - width);
+				needCopyOnTheRight = true;
 			}
-			else
+			else if (std::abs(p.x() + width - prevP.x()) < std::abs(p.x() - prevP.x()))
 			{
-				const auto& prevP = pointsEast.back();
-				if (std::abs(p.x() + width - prevP.x()) < std::abs(p.x() - prevP.x()))
-				{
-					// Switching over to the west, need to make
-					// the eastern path cross the right side.
-					pointsEast.emplace_back(p.x() + width, p.y());
-					// Also we need to make the western part
-					// to continue from the left side.
-					pointsWest.emplace_back(prevP.x() - width, prevP.y());
-					lastPointWasWest = true;
-					pointsWest.emplace_back(p);
-				}
-				else
-				{
-					pointsEast.emplace_back(p);
-				}
+				p.setX(p.x() + width);
+				needCopyOnTheLeft = true;
 			}
 		}
 
-		if (!pointsWest.empty())
+		searchAreaOutline.moveTo(points[0]);
+		for (const auto& p : points)
+			searchAreaOutline.lineTo(p);
+		searchAreaOutline.closeSubpath();
+		if (needCopyOnTheLeft)
 		{
-			searchAreaOutline.moveTo(pointsWest[0]);
-			for (const auto& p : pointsWest)
-				searchAreaOutline.lineTo(p);
+			searchAreaOutline.moveTo(points[0].x() - width, points[0].y());
+			for (const auto& p : points)
+				searchAreaOutline.lineTo(p.x() - width, p.y());
 			searchAreaOutline.closeSubpath();
 		}
-		if (!pointsEast.empty())
+		if (needCopyOnTheRight)
 		{
-			searchAreaOutline.moveTo(pointsEast[0]);
-			for (const auto& p : pointsEast)
-				searchAreaOutline.lineTo(p);
+			searchAreaOutline.moveTo(points[0].x() + width, points[0].y());
+			for (const auto& p : points)
+				searchAreaOutline.lineTo(p.x() + width, p.y());
 			searchAreaOutline.closeSubpath();
 		}
 	}
@@ -281,8 +247,14 @@ void MapWidget::paintEvent(QPaintEvent*)
 	const double ratio = devicePixelRatioF();
 	painter.scale(1/ratio, 1/ratio); // Work in units of device pixels
 
-	painter.setClipRect(mapRect);
-	painter.drawPixmap(mapRect.toRect(), scaledMap);
+	const auto mainRect = mapRect.toRect();
+	const int windowWidth = width();
+	const int mapWidth = mainRect.width();
+	const QPoint horizShift(mapWidth, 0);
+	const int kMin = -1 - mainRect.x() / mapWidth + (mainRect.x() % mapWidth == 0);
+	const int kMax = (windowWidth - mainRect.x()) / mapWidth;
+	for (int k = kMin; k <= kMax; ++k)
+		painter.drawPixmap(QRect(mainRect.topLeft() + k * horizShift, mainRect.size()), scaledMap);
 
 	if (markerVisible)
 	{
@@ -294,27 +266,40 @@ void MapWidget::paintEvent(QPaintEvent*)
 
 		const auto [markerCenterPosX, markerCenterPosY] = lonLatToMapPoint(markerLon, markerLat);
 
-		painter.drawPixmap(std::lround(markerCenterPosX) - scaledMarker.width()/2,
-		                   std::lround(markerCenterPosY) - scaledMarker.height(),
-		                   scaledMarker);
+		for (int k = kMin; k <= kMax; ++k)
+		{
+			painter.drawPixmap(std::lround(markerCenterPosX + k * mapWidth) - scaledMarker.width()/2,
+			                   std::lround(markerCenterPosY) - scaledMarker.height(),
+			                   scaledMarker);
+		}
 	}
 
 	if (searchRadius < 180)
 	{
 		if (searchAreaOutline.isEmpty())
 			makeSearchAreaOutline(scaledMap.width(), scaledMap.height());
-		// Outline
-		painter.setPen(QColor(0, 127, 255, 255));
-		painter.setBrush(Qt::transparent);
-		painter.setRenderHint(QPainter::Antialiasing);
-		painter.drawPath(searchAreaOutline);
 
-		// Darken the areas that are filtered out
-		auto path = searchAreaOutline;
-		path.addRect(mapRect);
-		painter.setPen(Qt::transparent);
-		painter.setBrush(QColor(0,0,0,127));
-		painter.drawPath(path);
+		for (int k = kMin; k <= kMax; ++k)
+		{
+			const QRect currMapRect(mainRect.topLeft() + k * horizShift, mainRect.size());
+			painter.setClipRect(currMapRect);
+
+			auto currPath = searchAreaOutline;
+			currPath.translate(currMapRect.left() - mainRect.left(), 0);
+
+			// Outline
+			painter.setPen(QColor(0, 127, 255, 255));
+			painter.setBrush(Qt::transparent);
+			painter.setRenderHint(QPainter::Antialiasing);
+			painter.drawPath(currPath);
+
+			// Darken the areas that are filtered out
+			auto path = currPath;
+			path.addRect(currMapRect);
+			painter.setPen(Qt::transparent);
+			painter.setBrush(QColor(0,0,0,127));
+			painter.drawPath(path);
+		}
 	}
 }
 
@@ -338,6 +323,11 @@ void MapWidget::updateScaledMapAndRect()
 		// QPixmap::scaled() gives higher quality of resampling than QPainter::drawPixmap()
 		scaledMap = map.scaled(realSize, Qt::KeepAspectRatio, Qt::SmoothTransformation);
 	}
+
+	while (shift.x() + currentDragShift.x() > virtualSize.width())
+		shift.setX(shift.x() - virtualSize.width());
+	while (shift.x() + currentDragShift.x() < -virtualSize.width())
+		shift.setX(shift.x() + virtualSize.width());
 
 	auto topLeft = QPointF(std::round(( width()*ratio-virtualSize.width ()) / 2.),
 	                       std::round((height()*ratio-virtualSize.height()) / 2.));

--- a/src/gui/MapWidget.cpp
+++ b/src/gui/MapWidget.cpp
@@ -254,8 +254,11 @@ void MapWidget::paintEvent(QPaintEvent*)
 	const QPoint horizShift(mapWidth, 0);
 	const int kMin = -1 - mainRect.x() / mapWidth + (mainRect.x() % mapWidth == 0);
 	const int kMax = (windowWidth - mainRect.x()) / mapWidth;
+	if (mapRect.width() > scaledMap.width())
+		painter.setRenderHint(QPainter::SmoothPixmapTransform);
 	for (int k = kMin; k <= kMax; ++k)
 		painter.drawPixmap(QRect(mainRect.topLeft() + k * horizShift, mainRect.size()), scaledMap);
+	painter.setRenderHint(QPainter::SmoothPixmapTransform, false);
 
 	if (markerVisible)
 	{

--- a/src/gui/MapWidget.cpp
+++ b/src/gui/MapWidget.cpp
@@ -28,6 +28,16 @@
 namespace
 {
 constexpr int GUI_PIXMAPS_SCALE = 5;
+
+template<typename Event>
+QPointF position(const Event* event, const double devPixelRatio)
+{
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+	return event->position() * devPixelRatio;
+#else
+	return QPointF(event->pos()) * devPixelRatio;
+#endif
+}
 }
 
 MapWidget::MapWidget(QWidget* parent)
@@ -36,7 +46,7 @@ MapWidget::MapWidget(QWidget* parent)
 	, locationMarker(":/graphicGui/uieMapPointer.png")
 	, markerVisible(true)
 {
-	updateScaledMap();
+	updateScaledMapAndRect();
 }
 
 void MapWidget::setMarkerVisible(bool visible)
@@ -76,8 +86,34 @@ QPointF MapWidget::lonLatToMapPoint(const double lon, const double lat) const
 
 void MapWidget::mousePressEvent(QMouseEvent* event)
 {
-	const double ratio = devicePixelRatioF();
-	const auto pos = QPointF(event->pos()) * ratio;
+	if (event->button() != Qt::LeftButton) return;
+
+	dragStart = position(event, devicePixelRatioF());
+	currentDragShift = QPointF(0,0);
+}
+
+void MapWidget::mouseMoveEvent(QMouseEvent* event)
+{
+	if (!(event->buttons() & Qt::LeftButton)) return;
+
+	currentDragShift = position(event, devicePixelRatioF()) - dragStart;
+	updateScaledMapAndRect();
+}
+
+void MapWidget::mouseReleaseEvent(QMouseEvent* event)
+{
+	if (event->button() != Qt::LeftButton) return;
+
+	const auto pos = position(event, devicePixelRatioF());
+	currentDragShift = pos - dragStart;
+	shift += currentDragShift;
+	const bool moved = currentDragShift.x() != 0 || currentDragShift.y() != 0;
+	currentDragShift = QPointF(0,0);
+	if (moved)
+	{
+		updateScaledMapAndRect();
+		return;
+	}
 
 	if(!mapRect.contains(pos))
 		return;
@@ -87,14 +123,37 @@ void MapWidget::mousePressEvent(QMouseEvent* event)
 	StelLocationMgr* locationMgr = &StelApp::getInstance().getLocationMgr();
 	QColor color=locationMgr->getColorForCoordinates(lon, lat);
 
+	dragStart = QPointF(-1,-1);
+
 	emit positionChanged(lon, lat, color);
+}
+
+void MapWidget::wheelEvent(QWheelEvent* event)
+{
+	if (event->buttons() & Qt::LeftButton) return;
+
+	const double delta = event->angleDelta().y();
+	const auto pos = position(event, devicePixelRatioF());
+	const auto offset = pos - QPointF(width(), height()) / 2.;
+
+	double zoomFactor = std::pow(2., delta / 120.);
+	const auto oldZoom = zoom;
+	zoom = oldZoom * zoomFactor;
+	if (zoom < 1)
+	{
+		zoom = 1;
+		zoomFactor = zoom / oldZoom;
+	}
+
+	shift = (shift - offset) * zoomFactor + offset;
+
+	updateScaledMapAndRect();
 }
 
 void MapWidget::setMap(const QPixmap &map)
 {
 	this->map = map;
-	updateScaledMap();
-	update();
+	updateScaledMapAndRect();
 }
 
 void MapWidget::makeSearchAreaOutline(const int width, const int height)
@@ -223,7 +282,7 @@ void MapWidget::paintEvent(QPaintEvent*)
 	painter.scale(1/ratio, 1/ratio); // Work in units of device pixels
 
 	painter.setClipRect(mapRect);
-	painter.drawPixmap(mapRect.topLeft(), scaledMap);
+	painter.drawPixmap(mapRect.toRect(), scaledMap);
 
 	if (markerVisible)
 	{
@@ -261,21 +320,38 @@ void MapWidget::paintEvent(QPaintEvent*)
 
 void MapWidget::resizeEvent(QResizeEvent* event)
 {
-	updateScaledMap();
-	searchAreaOutline = {};
+	updateScaledMapAndRect();
 }
 
-void MapWidget::updateScaledMap()
+void MapWidget::updateScaledMapAndRect()
 {
 	const double ratio = devicePixelRatioF();
-	const auto newSize = size() * ratio;
-	if (scaledMap.size() != newSize)
+	const auto virtualSize = height() * QSize(2, 1) * (ratio * zoom);
+	QSize realSize;
+	if (virtualSize.width() > map.width() || virtualSize.height() > map.height())
+		realSize = map.size();
+	else
+		realSize = virtualSize;
+
+	if (scaledMap.size() != realSize)
 	{
 		// QPixmap::scaled() gives higher quality of resampling than QPainter::drawPixmap()
-		scaledMap = map.scaled(newSize, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+		scaledMap = map.scaled(realSize, Qt::KeepAspectRatio, Qt::SmoothTransformation);
 	}
 
-	mapRect = QRectF(QPointF(std::round(( width()*ratio-scaledMap.width ()) / 2.),
-	                         std::round((height()*ratio-scaledMap.height()) / 2.)),
-	                 scaledMap.size());
+	auto topLeft = QPointF(std::round(( width()*ratio-virtualSize.width ()) / 2.),
+	                       std::round((height()*ratio-virtualSize.height()) / 2.));
+	topLeft += shift + currentDragShift;
+
+	const auto topLeftBeforeFix = topLeft;
+	if (topLeft.y() > 0)
+		topLeft.setY(0);
+	else if (topLeft.y() + virtualSize.height() < height())
+		topLeft.setY(height() - virtualSize.height());
+	shift += topLeft - topLeftBeforeFix;
+
+	mapRect = QRectF(topLeft, virtualSize);
+
+	searchAreaOutline = {};
+	update();
 }

--- a/src/gui/MapWidget.cpp
+++ b/src/gui/MapWidget.cpp
@@ -28,6 +28,7 @@
 namespace
 {
 constexpr int GUI_PIXMAPS_SCALE = 5;
+constexpr int THRESHOLD_FOR_CLICK = 5;
 
 template<typename Event>
 QPointF position(const Event* event, const double devPixelRatio)
@@ -107,7 +108,7 @@ void MapWidget::mouseReleaseEvent(QMouseEvent* event)
 	const auto pos = position(event, devicePixelRatioF());
 	currentDragShift = pos - dragStart;
 	shift += currentDragShift;
-	const bool moved = currentDragShift.x() != 0 || currentDragShift.y() != 0;
+	const bool moved = currentDragShift.manhattanLength() > THRESHOLD_FOR_CLICK * StelApp::getInstance().guiFontSizeRatio();
 	currentDragShift = QPointF(0,0);
 	if (moved)
 	{

--- a/src/gui/MapWidget.cpp
+++ b/src/gui/MapWidget.cpp
@@ -60,6 +60,20 @@ void MapWidget::setLocationFilter(double longitude, double latitude, double newS
 	update();
 }
 
+QPointF MapWidget::mapPointToLonLat(const QPointF& mapPoint) const
+{
+	const auto lat = (mapPoint.y() - mapRect.center().y()) / mapRect.height() * -180;
+	const auto lon = (mapPoint.x() - mapRect.center().x()) / mapRect.width()  * 360;
+	return {lon, lat};
+}
+
+QPointF MapWidget::lonLatToMapPoint(const double lon, const double lat) const
+{
+	const auto x = mapRect.left() + (lon + 180) /  360. * mapRect.width();
+	const auto y = mapRect.top()  + (lat -  90) / -180. * mapRect.height();
+	return {x,y};
+}
+
 void MapWidget::mousePressEvent(QMouseEvent* event)
 {
 	const double ratio = devicePixelRatioF();
@@ -68,8 +82,7 @@ void MapWidget::mousePressEvent(QMouseEvent* event)
 	if(!mapRect.contains(pos))
 		return;
 
-	const auto lat = (pos.y() - mapRect.center().y()) / mapRect.height() * -180;
-	const auto lon = (pos.x() - mapRect.center().x()) / mapRect.width()  * 360;
+	const auto [lon, lat] = mapPointToLonLat(pos);
 
 	StelLocationMgr* locationMgr = &StelApp::getInstance().getLocationMgr();
 	QColor color=locationMgr->getColorForCoordinates(lon, lat);
@@ -97,8 +110,7 @@ void MapWidget::makeSearchAreaOutline(const int width, const int height)
 		lon *= M_180_PI;
 		lat *= M_180_PI;
 
-		const auto x = mapRect.left() + (lon + 180) /  360. * width;
-		const auto y = mapRect.top()  + (lat -  90) / -180. * height;
+		const auto [x, y] = lonLatToMapPoint(lon, lat);
 		points.emplace_back(x, y);
 	}
 
@@ -221,12 +233,11 @@ void MapWidget::paintEvent(QPaintEvent*)
 			++locMarkerWidth;
 		const auto scaledMarker = locationMarker.scaledToWidth(locMarkerWidth, Qt::SmoothTransformation);
 
-		const auto markerCenterPosX = std::lround(mapRect.left() + (markerLon + 180) /  360. * scaledMap.width() );
-		const auto markerCenterPosY = std::lround(mapRect.top()  + (markerLat -  90) / -180. * scaledMap.height());
+		const auto [markerCenterPosX, markerCenterPosY] = lonLatToMapPoint(markerLon, markerLat);
 
-		painter.drawPixmap(markerCenterPosX - scaledMarker.width()/2,
-				   markerCenterPosY - scaledMarker.height(),
-				   scaledMarker);
+		painter.drawPixmap(std::lround(markerCenterPosX) - scaledMarker.width()/2,
+		                   std::lround(markerCenterPosY) - scaledMarker.height(),
+		                   scaledMarker);
 	}
 
 	if (searchRadius < 180)

--- a/src/gui/MapWidget.hpp
+++ b/src/gui/MapWidget.hpp
@@ -59,6 +59,9 @@ protected:
 	void paintEvent(QPaintEvent* event) override;
 	void resizeEvent(QResizeEvent* event) override;
 
+	QPointF mapPointToLonLat(const QPointF& mapPoint) const;
+	QPointF lonLatToMapPoint(double lon, double lat) const;
+
 private:
 	void makeSearchAreaOutline(int width, int height);
 	void updateScaledMap();

--- a/src/gui/MapWidget.hpp
+++ b/src/gui/MapWidget.hpp
@@ -56,6 +56,9 @@ signals:
 
 protected:
 	void mousePressEvent(QMouseEvent* event) override;
+	void mouseMoveEvent(QMouseEvent* event) override;
+	void mouseReleaseEvent(QMouseEvent* event) override;
+	void wheelEvent(QWheelEvent* event) override;
 	void paintEvent(QPaintEvent* event) override;
 	void resizeEvent(QResizeEvent* event) override;
 
@@ -64,7 +67,7 @@ protected:
 
 private:
 	void makeSearchAreaOutline(int width, int height);
-	void updateScaledMap();
+	void updateScaledMapAndRect();
 
 private:
 	double markerLat=0, markerLon=0;
@@ -73,6 +76,10 @@ private:
 	QPixmap map, scaledMap;
 	QPixmap locationMarker;
 	QRectF mapRect; // in device pixels
+	QPointF shift;
+	QPointF dragStart;
+	QPointF currentDragShift;
+	double zoom = 1;
 	bool markerVisible;
 };
 

--- a/src/gui/MapWidget.hpp
+++ b/src/gui/MapWidget.hpp
@@ -62,8 +62,17 @@ protected:
 	void paintEvent(QPaintEvent* event) override;
 	void resizeEvent(QResizeEvent* event) override;
 
-	QPointF mapPointToLonLat(const QPointF& mapPoint) const;
-	QPointF lonLatToMapPoint(double lon, double lat) const;
+	struct LonLat
+	{
+		double longitude;
+		double latitude;
+	};
+	LonLat mapPointToLonLat(const QPointF& mapPoint) const;
+	struct MapPoint
+	{
+		double x, y;
+	};
+	MapPoint lonLatToMapPoint(double lon, double lat) const;
 
 private:
 	void makeSearchAreaOutline(int width, int height);


### PR DESCRIPTION
### Description

This lets one zoom into the map widget in the Location dialog and pan it. Infinite panning is allowed along the longitude direction. 

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?

**Test Configuration**:
* Operating system: Ubuntu 22.04
* Graphics Card: Intel UHD Graphics 620

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
