### PR TITLE
Add a filter to list only enabled surveys

### DIFF
--- a/src/gui/ViewDialog.cpp
+++ b/src/gui/ViewDialog.cpp
@@ -747,6 +747,7 @@ void ViewDialog::createDialogContent()
 	connect(ui->surveysTreeWidget, &QTreeWidget::currentItemChanged, this, &ViewDialog::updateHipsText, Qt::QueuedConnection);
 	connect(ui->surveysTreeWidget, &QTreeWidget::itemChanged, this, &ViewDialog::hipsListItemChanged);
 	connect(ui->surveysFilter, &QLineEdit::textChanged, this, &ViewDialog::filterSurveys);
+	connect(ui->listOnlyEnabledSurveys, &QCheckBox::toggled, this, &ViewDialog::filterSurveys);
 	updateHips();
 
 	updateTabBarListWidgetWidth();
@@ -1088,6 +1089,44 @@ void ViewDialog::toggleHipsDialog()
 	}
 }
 
+void ViewDialog::updateSurveyFilteredState(QTreeWidgetItem& item, const QString& filterPattern) const
+{
+	const QString text = item.text(0).simplified();
+	bool show = filterPattern.isEmpty() || text.contains(filterPattern, Qt::CaseInsensitive);
+	if (ui->listOnlyEnabledSurveys->isChecked())
+	{
+		switch (item.data(0, HipsRole::ItemType).toInt())
+		{
+		case HipsItemType::Survey:
+		{
+			if (item.checkState(0) != Qt::Checked)
+				show = false;
+			break;
+		}
+		case HipsItemType::Planet:
+		{
+			bool planetHasEnabledGroup = false;
+			for (int n = 0; n < item.childCount(); ++n)
+			{
+				const auto groupItem = item.child(n);
+				Q_ASSERT(groupItem->data(0, HipsRole::ItemType).toInt() == HipsItemType::Group);
+				if (groupItem->checkState(0) == Qt::Checked)
+				{
+					planetHasEnabledGroup = true;
+					break;
+				}
+			}
+			if (!planetHasEnabledGroup)
+				show = false;
+			break;
+		}
+		default:
+			break;
+		}
+	}
+	item.setHidden(!show);
+}
+
 void ViewDialog::filterSurveys()
 {
 	const QString pattern = ui->surveysFilter->text().simplified();
@@ -1095,9 +1134,7 @@ void ViewDialog::filterSurveys()
 	for (int row = 0; row < list.topLevelItemCount(); ++row)
 	{
 		auto& item = *list.topLevelItem(row);
-		const QString text = item.text(0).simplified();
-		const bool show = pattern.isEmpty() || text.contains(pattern, Qt::CaseInsensitive);
-		item.setHidden(!show);
+		updateSurveyFilteredState(item, pattern);
 	}
 }
 
@@ -1148,12 +1185,12 @@ void ViewDialog::hipsListItemChanged(QTreeWidgetItem* item)
 	}
 	case HipsItemType::Group:
 	{
+		const auto planetItem = item->parent();
+		Q_ASSERT(planetItem);
+		Q_ASSERT(planetItem->data(0, HipsRole::ItemType).toInt() == HipsItemType::Planet);
 		// First, uncheck all the sibling groups except the one we're enabling
 		if (item->checkState(0) == Qt::Checked)
 		{
-			const auto planetItem = item->parent();
-			Q_ASSERT(planetItem);
-			Q_ASSERT(planetItem->data(0, HipsRole::ItemType).toInt() == HipsItemType::Planet);
 			for (int n = 0; n < planetItem->childCount(); ++n)
 			{
 				const auto groupItem = planetItem->child(n);
@@ -1166,6 +1203,7 @@ void ViewDialog::hipsListItemChanged(QTreeWidgetItem* item)
 				}
 			}
 		}
+		updateSurveyFilteredState(*planetItem, ui->surveysFilter->text().simplified());
 
 		// Now configure the survey chosen
 		HipsSurveyP colors;

--- a/src/gui/ViewDialog.hpp
+++ b/src/gui/ViewDialog.hpp
@@ -126,6 +126,7 @@ private slots:
 	void setDisplayFormatForSpins(bool flagDecimalDegrees);
 
 private:
+	void updateSurveyFilteredState(QTreeWidgetItem& item, const QString& filterPattern) const;
 	void connectGroupBox(class QGroupBox* groupBox, const QString& actionId);
 	void updateSkyCultureText();
 	void initSkyCultureTime();

--- a/src/gui/viewDialog.ui
+++ b/src/gui/viewDialog.ui
@@ -6561,15 +6561,12 @@
           <property name="spacing">
            <number>3</number>
           </property>
-          <item row="0" column="1" rowspan="3">
+          <item row="0" column="2" rowspan="3">
            <widget class="QTextBrowser" name="surveysTextBrowser">
             <property name="openExternalLinks">
              <bool>true</bool>
             </property>
            </widget>
-          </item>
-          <item row="0" column="0">
-           <widget class="QComboBox" name="surveyTypeComboBox"/>
           </item>
           <item row="1" column="0">
            <widget class="QLineEdit" name="surveysFilter">
@@ -6581,7 +6578,17 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="0">
+          <item row="1" column="1">
+           <widget class="QCheckBox" name="listOnlyEnabledSurveys">
+            <property name="text">
+             <string extracomment="Short for &quot;list only enabled surveys&quot;">Enabled only</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0" colspan="2">
+           <widget class="QComboBox" name="surveyTypeComboBox"/>
+          </item>
+          <item row="2" column="0" colspan="2">
            <widget class="QTreeWidget" name="surveysTreeWidget">
             <property name="horizontalScrollBarPolicy">
              <enum>Qt::ScrollBarAlwaysOff</enum>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

Oftentimes it's hard to find a survey you had enabled on previous runs of Stellarium, and it will be still shown. To ease this, this PR adds an option to list only the surveys that are currently enabled.

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?

**Test Configuration**:
* Operating system: Ubuntu 22.04
* Graphics Card: Intel UHD Graphics 620

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
