### PR TITLE
Prevent occasional race condition in SolarSystem::computePositions()

### DIFF
--- a/src/core/modules/SolarSystem.cpp
+++ b/src/core/modules/SolarSystem.cpp
@@ -806,6 +806,33 @@ void SolarSystem::loadPlanets()
 	else
 		qInfo() << "ExtendedElements: asteroid_elements.json not found"
 		        << "— asteroids using standard single-epoch orbits.";
+
+	// Build the level-bucketed view of systemPlanets used by computePositions()
+	// to drive race-free parallelism (parent levels are processed before child
+	// levels; siblings within a level are processed in parallel).
+	rebuildDependencyLevels();
+}
+
+void SolarSystem::rebuildDependencyLevels()
+{
+	systemPlanetsByLevel.clear();
+	for (const auto& p : std::as_const(systemPlanets))
+	{
+		// Walk up the parent chain to determine this body's depth.  The Sun
+		// has parent == null and lives at level 0; planets are level 1;
+		// moons of planets are level 2; sub-moons (none in stock data, but
+		// the algorithm should not assume it) would be level 3; etc.
+		int level = 0;
+		PlanetP ancestor = p->parent;
+		while (!ancestor.isNull())
+		{
+			++level;
+			ancestor = ancestor->parent;
+		}
+		if (systemPlanetsByLevel.size() <= level)
+			systemPlanetsByLevel.resize(level + 1);
+		systemPlanetsByLevel[level].append(p);
+	}
 }
 
 unsigned char SolarSystem::BvToColorIndex(double bV)
@@ -1609,7 +1636,10 @@ void SolarSystem::computePositions(StelCore *core, double dateJDE, PlanetP obser
 
 		switch (computePositionsAlgorithm)
 		{
-		case 3: // Ruslan's 1-loop solution. This would be faster, but has problems with moons when the respective planet has not been computed yet.
+		case 3: // Ruslan's 1-loop solution, made race-free by walking the
+			// dependency-level buckets in order and parallelising only across
+			// siblings of one level (so a child never reads a parent's
+			// heliocentric position concurrently with that parent's write).
 		{
 			// Position of this planet will be used in the subsequent computations
 			observerPlanet->computePosition(obs, dateJDE, Vec3d(0.));
@@ -1661,138 +1691,178 @@ void SolarSystem::computePositions(StelCore *core, double dateJDE, PlanetP obser
 				}
 			};
 
-			// This will be used for computation of transformation matrices
+			// This will be used for computation of transformation matrices.
+			// Process the observer planet first so its transMatrix and final
+			// position are valid before any other body might want to consult
+			// them.  It will be visited again by the level walk below, which
+			// is fine: processPlanet is idempotent on its input.
 			processPlanet(observerPlanet, Vec3d(0.));
 			observerPlanet->computeTransMatrix(dateJD, dateJDE);
 			const Vec3d observerPosFinal = observerPlanet->getHeliocentricEclipticPos();
 
-			// Threadable loop function for self-set number of additional worker threads
-			const auto loop = [&planets=std::as_const(systemPlanets),processPlanet,
-					  observerPosFinal](const int indexMin, const int indexMax)
+			// Defensive: rebuild the level cache if it has fallen out of sync
+			// with systemPlanets (e.g. the Solar System Editor plugin added or
+			// removed bodies without us being notified).
+			int cachedCount = 0;
+			for (const auto& lvl : std::as_const(systemPlanetsByLevel))
+				cachedCount += lvl.size();
+			if (cachedCount != systemPlanets.size())
+				rebuildDependencyLevels();
+
+			const int totalThreads = extraThreads + 1;
+			const int extras = extraThreads;
+
+			// Run `bodyOp` on every body of `level` in parallel and return
+			// only once all workers have finished.  The barrier is what makes
+			// the algorithm race-free: by the time we begin the next level,
+			// every parent at this level has been written exactly once, and
+			// the write is happens-before the children's reads.
+			const auto runLevelParallel = [totalThreads, extras]
+				(const QVector<PlanetP>& level, auto bodyOp)
 			{
-				for(int i = indexMin; i <= indexMax; ++i)
-					processPlanet(planets[i], observerPosFinal);
+				if (level.isEmpty()) return;
+				const auto stripe = [&level, totalThreads, &bodyOp](int offset)
+				{
+					for (int i = offset; i < level.size(); i += totalThreads)
+						bodyOp(level[i]);
+				};
+				QList<QFuture<void>> futures;
+				futures.reserve(extras);
+				for (int t = 0; t < extras; ++t)
+					futures.append(QtConcurrent::run(stripe, t));
+				stripe(extras);                            // main thread's share
+				for (auto& f : futures) f.waitForFinished();
 			};
 
-			QList<QFuture<void>> futures;
-			const int totalThreads = extraThreads+1;
-			const auto blockSize = systemPlanets.size() / totalThreads;
-			for(int threadN=0; threadN<totalThreads-1; ++threadN)
+			for (const auto& level : std::as_const(systemPlanetsByLevel))
 			{
-				const int indexMin = blockSize*threadN;
-				const int indexMax = blockSize*(threadN+1)-1;
-				futures.append(QtConcurrent::run(loop, indexMin,indexMax));
+				runLevelParallel(level, [&processPlanet, &observerPosFinal](const PlanetP& p)
+				{
+					processPlanet(p, observerPosFinal);
+				});
 			}
-			// and the last thread is the current one
-			loop(blockSize*(totalThreads-1), systemPlanets.size()-1);
-			for(auto& f : futures)
-
-				f.waitForFinished();
 		}
 		break;
 		case 2:
 		{
-			// Better 3-loop solution. This is still following the original solution:
-			// First, compute approximate positions at JDE.
-			// Then for each object, compute light time and repeat light-time corrected.
-			// Third, check new light time, and recompute once more if needed.
+			// Race-free 3-pass solution.  This is structurally still the
+			// original "first approx, then light-time correct, then refine"
+			// schedule -- the change is that within each pass we walk the
+			// systemPlanetsByLevel buckets in order and parallelise only
+			// across the siblings of one level, with a `waitForFinished()`
+			// barrier between levels.  That barrier is what makes the
+			// algorithm race-free: by the time we start processing a moon,
+			// its parent planet's write of `eclipticPos` is happens-before
+			// the moon's read of `Moon->getHeliocentricEclipticPos()` (which
+			// walks the parent chain).  The flat-striped version this
+			// replaces could put e.g. Earth on one worker and the Moon on
+			// another, leading to a concurrent read/write of Earth's state.
+			//
+			// Pass 1: positions at JDE (no light-time correction).
+			// Pass 2: light-time + aberration correction.
+			// Pass 3: one more refinement iteration; also updates rotation
+			//         element corrections for the major bodies that have
+			//         them.
 
-			// 1. First approximation.
-			QList<QFuture<void>> futures;
-			// This defines a function to be thrown onto a pool thread that computes every 'incr'th element.
-			auto plCompLoopZero = [=](int offset){
-				for (auto it=systemPlanets.cbegin()+offset, end=systemPlanets.cend(); it<end; it+=(extraThreads+1))
+			// Defensive: rebuild the level cache if it has fallen out of
+			// sync with systemPlanets (the Solar System Editor plugin can
+			// mutate systemPlanets at runtime).
+			int cachedCount = 0;
+			for (const auto& lvl : std::as_const(systemPlanetsByLevel))
+				cachedCount += lvl.size();
+			if (cachedCount != systemPlanets.size())
+				rebuildDependencyLevels();
+
+			const int totalThreads = extraThreads + 1;
+			const int extras = extraThreads;
+
+			// Run `bodyOp` on every body of `level` in parallel and return
+			// only once all workers have finished.
+			const auto runLevelParallel = [totalThreads, extras]
+				(const QVector<PlanetP>& level, auto bodyOp)
+			{
+				if (level.isEmpty()) return;
+				const auto stripe = [&level, totalThreads, &bodyOp](int offset)
 				{
-					it->data()->computePosition(obs, dateJDE, Vec3d(0.));
-				}
+					for (int i = offset; i < level.size(); i += totalThreads)
+						bodyOp(level[i]);
+				};
+				QList<QFuture<void>> futures;
+				futures.reserve(extras);
+				for (int t = 0; t < extras; ++t)
+					futures.append(QtConcurrent::run(stripe, t));
+				stripe(extras);                            // main thread's share
+				for (auto& f : futures) f.waitForFinished();
 			};
 
-			// Move to external threads, but also run a part in the main thread. The index 'availableThreads' is just the last group of objects.
-			for (int stride=0; stride<extraThreads; stride++)
+			// ---- Pass 1: first approximation at dateJDE -----------------
+			for (const auto& level : std::as_const(systemPlanetsByLevel))
 			{
-				auto future=QtConcurrent::run(plCompLoopZero, stride);
-				futures.append(future);
-			}
-			plCompLoopZero(extraThreads);
-
-			// Now the list is being computed by other threads. we can just wait sequentially for completion.
-			for(auto f: futures)
-				f.waitForFinished();
-			futures.clear();
-
-			const Vec3d &obsPosJDE=observerPlanet->getHeliocentricEclipticPos();
-
-			// 2.&3.: For higher accuracy, we now make two iterations of light time and aberration correction. In the final
-			// round, we also compute rotation data.  May fix sub-arcsecond inaccuracies, and optionally apply
-			// aberration in the way described in Explanatory Supplement (2013), 7.55.  For reasons unknown (See
-			// discussion in GH:#1626) we do not add anything for the Moon when observed from Earth!  Presumably the
-			// used ephemerides already provide aberration-corrected positions for the Moon?
-			const Vec3d aberrationPushSpeed=observerPlanet->getHeliocentricEclipticVelocity() * core->getAberrationFactor();
-
-			auto plCompLoopOne = [=](int offset){
-				for (auto it=systemPlanets.cbegin()+offset, end=systemPlanets.cend(); it<end; it+=extraThreads+1)
+				runLevelParallel(level, [obs, dateJDE](const PlanetP& p)
 				{
-					const auto planetPos = it->data()->getHeliocentricEclipticPos();
-					const double lightTimeDays = (planetPos-obsPosJDE).norm() * (AU / (SPEED_OF_LIGHT * 86400.));
-					Vec3d aberrationPush(0.);
-					if (withAberration && (!observerPlanetIsEarth || it->data() != getMoon()))
-						aberrationPush=lightTimeDays*aberrationPushSpeed;
-					it->data()->computePosition(obs, dateJDE-lightTimeDays, aberrationPush);
-				}
-			};
-			for (int stride=0; stride<extraThreads; stride++)
-			{
-				auto future=QtConcurrent::run(plCompLoopOne, stride);
-				futures.append(future);
+					p->computePosition(obs, dateJDE, Vec3d(0.));
+				});
 			}
-			plCompLoopOne(extraThreads); // main thread's share of the computation task
-			// Now the list is being computed by other threads. we can just wait sequentially for completion.
-			for(auto f: futures)
-				f.waitForFinished();
-			futures.clear();
 
-			// 3. Extra accuracy with another round. Not sure if useful. Maybe hide behind a new property flag?
-			auto plCompLoopTwo = [=](int offset){
-				for (auto it=systemPlanets.cbegin()+offset, end=systemPlanets.cend(); it<end; it+=extraThreads+1)
-				{
-					const auto planetPos = it->data()->getHeliocentricEclipticPos();
-					const double lightTimeDays = (planetPos-obsPosJDE).norm() * (AU / (SPEED_OF_LIGHT * 86400.));
-					Vec3d aberrationPush(0.);
-					if (withAberration && (!observerPlanetIsEarth || it->data() != getMoon()))
-						aberrationPush=lightTimeDays*aberrationPushSpeed;
-					// The next call may already do nothing if the time difference to the previous round is not large enough.
-					it->data()->computePosition(obs, dateJDE-lightTimeDays, aberrationPush);
-					//it->data()->setExtraInfoString(StelObject::DebugAid, QString("LightTime %1d; obsSpeed %2/%3/%4 AU/d")
-					//							.arg(QString::number(lightTimeDays, 'f', 3))
-					//							.arg(QString::number(aberrationPushSpeed[0], 'f', 3))
-					//							.arg(QString::number(aberrationPushSpeed[1], 'f', 3))
-					//							.arg(QString::number(aberrationPushSpeed[2], 'f', 3)));
+			// Snapshot the observer's heliocentric state *by value* (NOT by
+			// reference, as the previous implementation did).  The observer
+			// planet is itself one of the bodies recomputed in passes 2 and
+			// 3, so a reference into its members would shift under our feet
+			// halfway through those passes.
+			const Vec3d obsPosJDE           = observerPlanet->getHeliocentricEclipticPos();
+			const Vec3d aberrationPushSpeed = observerPlanet->getHeliocentricEclipticVelocity()
+			                                  * core->getAberrationFactor();
 
-					const auto update = &RotationElements::updatePlanetCorrections;
-					if      (it->data()->englishName==L1S("Moon"))    update(dateJDE-lightTimeDays, RotationElements::EarthMoon);
-					else if (it->data()->englishName==L1S("Mars"))    update(dateJDE-lightTimeDays, RotationElements::Mars);
-					else if (it->data()->englishName==L1S("Jupiter")) update(dateJDE-lightTimeDays, RotationElements::Jupiter);
-					else if (it->data()->englishName==L1S("Saturn"))  update(dateJDE-lightTimeDays, RotationElements::Saturn);
-					else if (it->data()->englishName==L1S("Uranus"))  update(dateJDE-lightTimeDays, RotationElements::Uranus);
-					else if (it->data()->englishName==L1S("Neptune")) update(dateJDE-lightTimeDays, RotationElements::Neptune);
-				}
-			};
-			for (int stride=0; stride<extraThreads; stride++)
+			// For higher accuracy, we now make two iterations of light time
+			// and aberration correction.  May fix sub-arcsecond inaccuracies,
+			// and optionally apply aberration in the way described in
+			// Explanatory Supplement (2013), 7.55.  For reasons unknown (see
+			// discussion in GH:#1626) we do not add anything for the Moon
+			// when observed from Earth -- presumably the used ephemerides
+			// already provide aberration-corrected positions for the Moon.
+			const auto lightTimeStep =
+				[obs, dateJDE, obsPosJDE, aberrationPushSpeed,
+				 withAberration, observerPlanetIsEarth, this](const PlanetP& p)
 			{
-				auto future=QtConcurrent::run(plCompLoopTwo, stride);
-				futures.append(future);
-			}
-			// At this point all available threads from the global ThreadPool should be active:
-			//omgr->addToExtraInfoString(StelObject::DebugAid, QString("Threads: Ideal: %1, Pool max %2/active %3, SolarSystem using %4<br/>").
-			//			   arg(QString::number(QThread::idealThreadCount()),
-			//			       QString::number(QThreadPool::globalInstance()->maxThreadCount()),
-			//			       QString::number(QThreadPool::globalInstance()->activeThreadCount()),
-			//			       QString::number(extraThreads)));
-			// and we still run the last stride in the main thread.
-			plCompLoopTwo(extraThreads);
-			// Now the list is being computed by other threads. we can just wait sequentially for completion.
-			for(auto f: futures)
-				f.waitForFinished();
+				const Vec3d planetPos      = p->getHeliocentricEclipticPos();
+				const double lightTimeDays = (planetPos - obsPosJDE).norm()
+				                             * (AU / (SPEED_OF_LIGHT * 86400.));
+				Vec3d aberrationPush(0.);
+				if (withAberration && (!observerPlanetIsEarth || p != getMoon()))
+					aberrationPush = lightTimeDays * aberrationPushSpeed;
+				p->computePosition(obs, dateJDE - lightTimeDays, aberrationPush);
+			};
+
+			// ---- Pass 2: light-time + aberration correction -------------
+			for (const auto& level : std::as_const(systemPlanetsByLevel))
+				runLevelParallel(level, lightTimeStep);
+
+			// ---- Pass 3: refinement (and rotation element corrections) --
+			// The next call may already do nothing if the time difference to
+			// the previous round is not large enough.
+			const auto lightTimeStepWithRotation =
+				[obs, dateJDE, obsPosJDE, aberrationPushSpeed,
+				 withAberration, observerPlanetIsEarth, this](const PlanetP& p)
+			{
+				const Vec3d planetPos      = p->getHeliocentricEclipticPos();
+				const double lightTimeDays = (planetPos - obsPosJDE).norm()
+				                             * (AU / (SPEED_OF_LIGHT * 86400.));
+				Vec3d aberrationPush(0.);
+				if (withAberration && (!observerPlanetIsEarth || p != getMoon()))
+					aberrationPush = lightTimeDays * aberrationPushSpeed;
+				p->computePosition(obs, dateJDE - lightTimeDays, aberrationPush);
+
+				const auto update = &RotationElements::updatePlanetCorrections;
+				if      (p->englishName==L1S("Moon"))    update(dateJDE-lightTimeDays, RotationElements::EarthMoon);
+				else if (p->englishName==L1S("Mars"))    update(dateJDE-lightTimeDays, RotationElements::Mars);
+				else if (p->englishName==L1S("Jupiter")) update(dateJDE-lightTimeDays, RotationElements::Jupiter);
+				else if (p->englishName==L1S("Saturn"))  update(dateJDE-lightTimeDays, RotationElements::Saturn);
+				else if (p->englishName==L1S("Uranus"))  update(dateJDE-lightTimeDays, RotationElements::Uranus);
+				else if (p->englishName==L1S("Neptune")) update(dateJDE-lightTimeDays, RotationElements::Neptune);
+			};
+			for (const auto& level : std::as_const(systemPlanetsByLevel))
+				runLevelParallel(level, lightTimeStepWithRotation);
+
 			computeTransMatrices(dateJDE, observerPlanet->getHeliocentricEclipticPos());
 		}
 		break;

--- a/src/core/modules/SolarSystem.hpp
+++ b/src/core/modules/SolarSystem.hpp
@@ -1189,6 +1189,21 @@ private:
 	//! @returns true if at least one asteroid received an epoch table.
 	bool loadExtendedAsteroidElements(const QString& filePath);
 
+	//! (Re)build systemPlanetsByLevel from the parent pointers of every body
+	//! in systemPlanets.  Level 0 is the Sun, level 1 is every body whose
+	//! parent is the Sun, level 2 is every body whose parent is a level-1
+	//! body, and so on.  computePositions() walks these levels sequentially
+	//! and parallelises only across the siblings of one level, which makes
+	//! the read of a parent's heliocentric position happen-before any child
+	//! reads it -- removing the data race that existed when the parallel
+	//! work was striped across the flat systemPlanets list.
+	//!
+	//! Cheap (O(N * avgDepth), no allocations beyond the level buckets).
+	//! Must be kept in sync with systemPlanets; called from loadPlanets()
+	//! and re-run defensively from computePositions() if the cache size
+	//! ever disagrees with systemPlanets.size().
+	void rebuildDependencyLevels();
+
 	Vec3f getEphemerisMarkerColor(int index) const;
 
 	//! Calculate a color of Solar system bodies
@@ -1240,6 +1255,12 @@ private:
 	QList<PlanetP> systemPlanets;
 	//! List of all the minor bodies of the solar system.
 	QList<PlanetP> systemMinorBodies;
+	//! Bodies of systemPlanets bucketed by their depth in the parent chain.
+	//! Index = depth (0 = Sun, 1 = Sun's children, 2 = moons of planets, ...).
+	//! Used by computePositions() to drive race-free parallelisation: each
+	//! bucket is processed in parallel; buckets are processed in order.
+	//! Maintained by rebuildDependencyLevels(); do not edit by hand.
+	QVector<QVector<PlanetP>> systemPlanetsByLevel;
 
 	// Master settings
 	bool flagOrbits;

--- a/src/core/planetsephems/gust86.c
+++ b/src/core/planetsephems/gust86.c
@@ -92,7 +92,7 @@ const double phi[5] = {5.702313,
                        1.746237,
                        4.206896};
 
-void CalcGust86Elem(double t,double elem[5*6],void *user) {
+void CalcGust86Elem(const double t,double elem[5*6],void *user) {
   double an[5],ae[5],ai[5];
   int i;
   for (i=0;i<5;i++) {

--- a/src/core/planetsephems/htc20b.c
+++ b/src/core/planetsephems/htc20b.c
@@ -171,7 +171,6 @@ int htc20( const double jd, const int sat_no, double *xyz, double *vxyz)
    int i, n_terms = (sat_no == HTC2_TELESTO ? 6 : 12);
    const int8_t *iptr;
    const int16_t *rptr;
-   double arg1, arg2, arg3, arg4;
    const double t = jd - 2451545.;
 
    switch( sat_no)
@@ -196,10 +195,10 @@ int htc20( const double jd, const int sat_no, double *xyz, double *vxyz)
    if(vxyz)
         memset(vxyz, 0, 3*sizeof(double));
 
-   arg1 = rnu1[sat_no] * t + phi1[sat_no];
-   arg2 = rnu2[sat_no] * t + phi2[sat_no];
-   arg3 = rnu3[sat_no] * t + phi3[sat_no];
-   arg4 = rlamda[sat_no] * t + theta[sat_no];
+   const double arg1 = rnu1[sat_no] * t + phi1[sat_no];
+   const double arg2 = rnu2[sat_no] * t + phi2[sat_no];
+   const double arg3 = rnu3[sat_no] * t + phi3[sat_no];
+   const double arg4 = rlamda[sat_no] * t + theta[sat_no];
 
    while( n_terms--)
       {

--- a/src/core/planetsephems/l12.c
+++ b/src/core/planetsephems/l12.c
@@ -49,21 +49,19 @@ struct sat {
 static struct sat SATS[4];
 
 
-static int elem2pv(double mu, const double elem[6], double xv[2][3])
+static int elem2pv(const double mu, const double elem[6], double xv[2][3])
 {
-    double k, h, q, p, a, al, an, ee, ce, se, de, dle, rsam1, asr, phi, psi,
-           x1, y1, vx1, vy1, f2, p2, q2, pq;
+    const double k  = elem[2];
+    const double h  = elem[3];
+    const double q  = elem[4];
+    const double p  = elem[5];
+    const double a  = elem[0];
+    const double al = elem[1];
 
-    k  = elem[2];
-    h  = elem[3];
-    q  = elem[4];
-    p  = elem[5];
-    a  = elem[0];
-    al = elem[1];
+    const double an = sqrt(mu / pow(a, 3.0));
+    double ee = al + k * sin(al) - h * cos(al);
 
-    an = sqrt(mu / pow(a, 3.0));
-    ee = al + k * sin(al) - h * cos(al);
-
+    double ce, se, de;
     do {
       ce = cos(ee);
       se = sin(ee);
@@ -73,19 +71,19 @@ static int elem2pv(double mu, const double elem[6], double xv[2][3])
 
     ce = cos(ee);
     se = sin(ee);
-    dle = h * ce - k * se;
-    rsam1 = -k * ce - h * se;
-    asr =1.0 / (1.0 + rsam1);
-    phi = sqrt(1.0 - k*k - h*h);
-    psi = 1.0 / (1.0 + phi);
-    x1 = a * (ce - k - psi * h * dle);
-    y1 = a * (se - h + psi * k * dle);
-    vx1 = an * asr * a * (-se - psi * h * rsam1);
-    vy1 = an * asr * a * ( ce + psi * k * rsam1);
-    f2 = 2.0 * sqrt(1.0 - q*q - p*p);
-    p2 = 1.0 -2.0 * p*p;
-    q2 = 1.0 -2.0 * q*q;
-    pq = 2.0 * p * q;
+    const double dle = h * ce - k * se;
+    const double rsam1 = -k * ce - h * se;
+    const double asr =1.0 / (1.0 + rsam1);
+    const double phi = sqrt(1.0 - k*k - h*h);
+    const double psi = 1.0 / (1.0 + phi);
+    const double x1 = a * (ce - k - psi * h * dle);
+    const double y1 = a * (se - h + psi * k * dle);
+    const double vx1 = an * asr * a * (-se - psi * h * rsam1);
+    const double vy1 = an * asr * a * ( ce + psi * k * rsam1);
+    const double f2 = 2.0 * sqrt(1.0 - q*q - p*p);
+    const double p2 = 1.0 -2.0 * p*p;
+    const double q2 = 1.0 -2.0 * q*q;
+    const double pq = 2.0 * p * q;
     xv[0][0] = x1 * p2 + y1 * pq;
     xv[0][1] = x1 * pq + y1 * q2;
     xv[0][2] = (q * y1 - x1 * p) * f2;
@@ -101,16 +99,16 @@ static const double L1toVsop87[9] = {
    1.339578739122566807e-02, 3.619798764705610479e-02, 9.992548516622136737e-01
 };
 
-void GetL12Coor(double jd, int ks, double p[3], double v[3])
+void GetL12Coor(const double jd, const int body, double p[3], double v[3])
 {
-    const struct sat *sat = &SATS[ks];
-    double t, arg, s, s1, s2;
+    const struct sat *sat = &SATS[body];
+    double arg, s, s1, s2;
     double elem[6];
     double val[5] = {0.0};
     double xv[2][3];
     int k;
 
-    t = jd - 2433282.5;
+    const double t = jd - 2433282.5;
     s = 0.0;
     for (k = 0; k < sat->a_len; k++) {
         arg = sat->a[k].phas + sat->a[k].freq * t;

--- a/src/core/planetsephems/l12.h
+++ b/src/core/planetsephems/l12.h
@@ -38,18 +38,18 @@ extern "C" {
 #define L12_CALLISTO      3
 
 /*
- * Galilean satellites positions using l1.2 semi-analytic theory by
+ * Galilean satellites positions using l1.2 semi-analytic theory
  * by Valery LAINEY, Alain VIENNE and Luc DURIEZ.
  * ftp://ftp.imcce.fr/pub/ephem/satel/galilean/L1/L1.2/
  *
  * @param jd Input time in TT JD.
  * @param body Moon index from 0 (Io) to 3 (Callisto).
  * @param p Get the position of the body in Cartesian coordinates with origin the center of Jupiter
- *          and in the VSOP87 plan, in AU.
+ *          and in the VSOP87 frame, in AU.
  * @param v Get the speed of the body in Cartesian coordinates with origin the center of Jupiter
- *          and in the VSOP87 plan. in AU/d.
+ *          and in the VSOP87 frame. in AU/d.
  */
-void GetL12Coor(double jd, int body, double p[3], double v[3]);
+void GetL12Coor(const double jd, const int body, double p[3], double v[3]);
 
 #ifdef __cplusplus
 }

--- a/src/core/planetsephems/marssat.c
+++ b/src/core/planetsephems/marssat.c
@@ -379,15 +379,15 @@ static const double J2000_to_VSOP87[9] = {
    4.403598133110236e-07, 9.174821370868568e-01, 3.977769829016507e-01,
   -1.909192461077750e-07,-3.977769829016049e-01, 9.174821370869625e-01};
 
-static const double ome0 = 47.68143;
-static const double inc0 = 37.1135;
-static const double dome = -0.1061;
-static const double dinc =  0.0609;
 
 static
 void GenerateMarsSatToVSOP87(double t,double mat_mars_sat_to_vsop87[9]) {
   t -= 6491.5;
   {
+    static const double ome0 = 47.68143;
+    static const double inc0 = 37.1135;
+    static const double dome = -0.1061;
+    static const double dinc =  0.0609;
     const double ome = (ome0 + dome * t / 36525.) * (M_PI/180.0);
     const double inc = (inc0 + dinc * t / 36525.) * (M_PI/180.0);
     const double co = cos(ome);
@@ -408,25 +408,26 @@ void GenerateMarsSatToVSOP87(double t,double mat_mars_sat_to_vsop87[9]) {
   }
 }
 
-static double t_0 = -1e100;
-static double t_1 = -1e100;
-static double t_2 = -1e100;
-static double marssat_elem_0[2*6];
-static double marssat_elem_1[2*6];
-static double marssat_elem_2[2*6];
+// Duplicate memory for thread safety
+static double t_0[MARS_SAT_COUNT] = {-1e100, -1e100};
+static double t_1[MARS_SAT_COUNT] = {-1e100, -1e100};
+static double t_2[MARS_SAT_COUNT] = {-1e100, -1e100};
+static double marssat_elem_0[MARS_SAT_COUNT][2*6];
+static double marssat_elem_1[MARS_SAT_COUNT][2*6];
+static double marssat_elem_2[MARS_SAT_COUNT][2*6];
 
 /* 1 day: */
 #define DELTA_T 1.0
 
-static double marssat_jd0 = -1e100;
-static double marssat_elem[2*6];
+static double marssat_jd0[MARS_SAT_COUNT] = {-1e100, -1e100};
+static double marssat_elem[MARS_SAT_COUNT][2*6];
 
 static void CalcAllMarsSatElem(double t,double elem[12], void *user) {
   CalcMarsSatElem(t,0,elem+(0*6));
   CalcMarsSatElem(t,1,elem+(1*6));
 }
 
-static double mars_sat_to_vsop87[9];
+static double mars_sat_to_vsop87[MARS_SAT_COUNT][9];
 
 void GetMarsSatCoor(double jd,int body,double *xyz, double *xyzdot) {
 	double xyz6[6];
@@ -438,37 +439,37 @@ void GetMarsSatCoor(double jd,int body,double *xyz, double *xyzdot) {
 void GetMarsSatOsculatingCoor(const double jd0,const double jd,
                               const int body,double *xyz) {
   double x[6];
-  if (jd0 != marssat_jd0) {
+  if (jd0 != marssat_jd0[body]) {
     const double t0 = jd0 - 2451545.0 + 6491.5;
-    marssat_jd0 = jd0;
-    CalcInterpolatedElements(t0,marssat_elem,12,
+    marssat_jd0[body] = jd0;
+    CalcInterpolatedElements(t0,marssat_elem[body],12,
                              &CalcAllMarsSatElem,DELTA_T,
-                             &t_0,marssat_elem_0,
-                             &t_1,marssat_elem_1,
-                             &t_2,marssat_elem_2,
+                             &t_0[body],marssat_elem_0[body],
+                             &t_1[body],marssat_elem_1[body],
+                             &t_2[body],marssat_elem_2[body],
                              NULL);
-    GenerateMarsSatToVSOP87(t0,mars_sat_to_vsop87);
+    GenerateMarsSatToVSOP87(t0,mars_sat_to_vsop87[body]);
   }
-  EllipticToRectangularA(mars_sat_bodies[body].mu,marssat_elem+(body*6),jd-jd0,x);
-  xyz[0] = mars_sat_to_vsop87[0]*x[0]
-         + mars_sat_to_vsop87[1]*x[1]
-         + mars_sat_to_vsop87[2]*x[2];
-  xyz[1] = mars_sat_to_vsop87[3]*x[0]
-         + mars_sat_to_vsop87[4]*x[1]
-         + mars_sat_to_vsop87[5]*x[2];
-  xyz[2] = mars_sat_to_vsop87[6]*x[0]
-         + mars_sat_to_vsop87[7]*x[1]
-         + mars_sat_to_vsop87[8]*x[2];
+  EllipticToRectangularA(mars_sat_bodies[body].mu,marssat_elem[body]+(body*6),jd-jd0,x);
+  xyz[0] = mars_sat_to_vsop87[body][0]*x[0]
+         + mars_sat_to_vsop87[body][1]*x[1]
+         + mars_sat_to_vsop87[body][2]*x[2];
+  xyz[1] = mars_sat_to_vsop87[body][3]*x[0]
+         + mars_sat_to_vsop87[body][4]*x[1]
+         + mars_sat_to_vsop87[body][5]*x[2];
+  xyz[2] = mars_sat_to_vsop87[body][6]*x[0]
+         + mars_sat_to_vsop87[body][7]*x[1]
+         + mars_sat_to_vsop87[body][8]*x[2];
   // GZ This is a guess, based on the structure of other operations...
-  xyz[3] = mars_sat_to_vsop87[0]*x[3]
-	 + mars_sat_to_vsop87[1]*x[4]
-	 + mars_sat_to_vsop87[2]*x[5];
-  xyz[4] = mars_sat_to_vsop87[3]*x[3]
-	 + mars_sat_to_vsop87[4]*x[4]
-	 + mars_sat_to_vsop87[5]*x[5];
-  xyz[5] = mars_sat_to_vsop87[6]*x[3]
-	 + mars_sat_to_vsop87[7]*x[4]
-	 + mars_sat_to_vsop87[8]*x[5];
+  xyz[3] = mars_sat_to_vsop87[body][0]*x[3]
+	 + mars_sat_to_vsop87[body][1]*x[4]
+	 + mars_sat_to_vsop87[body][2]*x[5];
+  xyz[4] = mars_sat_to_vsop87[body][3]*x[3]
+	 + mars_sat_to_vsop87[body][4]*x[4]
+	 + mars_sat_to_vsop87[body][5]*x[5];
+  xyz[5] = mars_sat_to_vsop87[body][6]*x[3]
+	 + mars_sat_to_vsop87[body][7]*x[4]
+	 + mars_sat_to_vsop87[body][8]*x[5];
 /*
   printf("%d %18.9lf %15.12lf %15.12lf %15.12lf\n",
          body,jd,xyz[0],xyz[1],xyz[2]);

--- a/src/core/planetsephems/marssat.h
+++ b/src/core/planetsephems/marssat.h
@@ -57,6 +57,7 @@ extern "C" {
 
 #define MARS_SAT_PHOBOS 0
 #define MARS_SAT_DEIMOS 1
+#define MARS_SAT_COUNT 2
 
 void GetMarsSatCoor(double jd, int body, double *xyz, double *xyzdot);
   /* Return the rectangular coordinates and speed of the given satellite

--- a/src/core/planetsephems/tass17.c
+++ b/src/core/planetsephems/tass17.c
@@ -3057,7 +3057,7 @@ static void CalcLon(double t,double lon[7])
 	}
 }
 
-static void CalcTass17Elem(double t,const double lon[7],int body,double elem[6])
+static void CalcTass17Elem(const double t, const double lon[7],const int body, double elem[6])
 {
 	const struct Tass17MultiTerm *tmt_begin,*tmt;
 	int i;
@@ -3143,24 +3143,23 @@ const double TASS17toJ2000[9] = {
 */
 
 #define TASS17_DIM (8*6)
-static double t_0 = -1e100;
-static double t_1 = -1e100;
-static double t_2 = -1e100;
-static double tass17_elem_0[TASS17_DIM];
-static double tass17_elem_1[TASS17_DIM];
-static double tass17_elem_2[TASS17_DIM];
+static double t_0[TASS17_NMOONS] = {-1e100, -1e100, -1e100, -1e100, -1e100, -1e100, -1e100, -1e100};
+static double t_1[TASS17_NMOONS] = {-1e100, -1e100, -1e100, -1e100, -1e100, -1e100, -1e100, -1e100};
+static double t_2[TASS17_NMOONS] = {-1e100, -1e100, -1e100, -1e100, -1e100, -1e100, -1e100, -1e100};
+static double tass17_elem_0[TASS17_NMOONS][TASS17_DIM];
+static double tass17_elem_1[TASS17_NMOONS][TASS17_DIM];
+static double tass17_elem_2[TASS17_NMOONS][TASS17_DIM];
 /* 1 day: */
 #define DELTA_T 1.0
 
-static double tass17_jd0 = -1e100;
-static double tass17_elem[TASS17_DIM];
+static double tass17_jd0[TASS17_NMOONS] = {-1e100, -1e100, -1e100, -1e100, -1e100, -1e100, -1e100, -1e100};
+static double tass17_elem[TASS17_NMOONS][TASS17_DIM];
 
 void CalcAllTass17Elem(const double t,double elem[TASS17_DIM], void *user)
 {
-	int body;
 	double lon[8];
 	CalcLon(t,lon);
-	for (body=0;body<=7;body++) CalcTass17Elem(t,lon,body,elem+(body*6));
+	for (int body=0;body<=7;body++) CalcTass17Elem(t,lon,body,elem+(body*6));
 }
 
 void GetTass17Coor(double jd,int body,double *xyz, double *xyzdot)
@@ -3174,25 +3173,25 @@ void GetTass17Coor(double jd,int body,double *xyz, double *xyzdot)
 void GetTass17OsculatingCoor(const double jd0,const double jd, const int body,double *xyz)
 {
 	double x[6];
-	if (jd0 != tass17_jd0)
+	if (jd0 != tass17_jd0[body])
 	{
 		const double t0 = jd0 - 2444240.0;
-		tass17_jd0 = jd0;
-		CalcInterpolatedElements(t0,tass17_elem,
+		tass17_jd0[body] = jd0;
+		CalcInterpolatedElements(t0,tass17_elem[body],
 					 TASS17_DIM,
 					 &CalcAllTass17Elem,DELTA_T,
-					 &t_0,tass17_elem_0,
-					 &t_1,tass17_elem_1,
-					 &t_2,tass17_elem_2,
+					 &t_0[body],tass17_elem_0[body],
+					 &t_1[body],tass17_elem_1[body],
+					 &t_2[body],tass17_elem_2[body],
 					 0);
 		/*
 		printf("GetTass17Coor(%d): %f %f  %f %f  %f %f\n",
 			body,
-			tass17_elem[body*6+0],tass17_elem[body*6+1],tass17_elem[body*6+2],
-			tass17_elem[body*6+3],tass17_elem[body*6+4],tass17_elem[body*6+5]);
+			tass17_elem[body][body*6+0],tass17_elem[body][body*6+1],tass17_elem[body][body*6+2],
+			tass17_elem[body][body*6+3],tass17_elem[body][body*6+4],tass17_elem[body][body*6+5]);
 		*/
 	}
-	EllipticToRectangularN(tass17bodies[body].mu,tass17_elem+(body*6),jd-jd0,x);
+	EllipticToRectangularN(tass17bodies[body].mu,tass17_elem[body]+(body*6),jd-jd0,x);
 	xyz[0] = TASS17toVSOP87[0]*x[0]+TASS17toVSOP87[1]*x[1]+TASS17toVSOP87[2]*x[2];
 	xyz[1] = TASS17toVSOP87[3]*x[0]+TASS17toVSOP87[4]*x[1]+TASS17toVSOP87[5]*x[2];
 	xyz[2] = TASS17toVSOP87[6]*x[0]+TASS17toVSOP87[7]*x[1]+TASS17toVSOP87[8]*x[2];

--- a/src/core/planetsephems/tass17.h
+++ b/src/core/planetsephems/tass17.h
@@ -65,6 +65,8 @@ extern "C" {
 #define TASS17_TITAN     5
 #define TASS17_HYPERION  7
 #define TASS17_IAPETUS   6
+// need to multiply various data arrays for multithreaded solutions.
+#define TASS17_NMOONS 8
 
 // xyz and xyzdot are 3-vectors (position&speed)
 void GetTass17Coor(double jd, int body, double *xyz, double *xyzdot);


### PR DESCRIPTION
I was already pretty sure where to investigate: Moons needing their planets' positions, after all, access of which may collide with writing them in another thread. This solution was proposed by Claude Code: Segment solar system into "buckets" (systemPlanetsByLevel: Sun; Planets/Minorbodies/Comets; Moons; [theoretical moons of moons]; ...)), and process the buckets in sequence. This should guarantee correct execution sequence.

In addition, it turned out some moon systems were not as independent as previously thought and needed to be made threadsafe. Now each moon has its own data set and as long as not the same computation is run in parallel for the same moon, all should be OK. Given their even higher importance with the bucket-wise processing, I have sorted the commits before the actual threading magic.

The fourth commit is as-is from Claude Code (including extensive comments discussing the changes), but needs testing, and yes, some comments can be even shortened.

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Please include a summary of the change and which issue is fixed. -->
<!--- Please also include relevant motivation and context. -->
<!--- List any dependencies that are required for this change. -->

Fixes # (issue)

### Screenshots (if appropriate):

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system: Windows 11
* Graphics Card: irrelevant

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
