### PR TITLE
Re-enable INDI for windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -436,12 +436,7 @@ IF(ENABLE_XLSX)
 ENDIF()
 
 # Activate support for INDI client in Telescope Control plugin
-IF(WIN32)
-     # Disable support for INDI client in Windows
-     SET(ENABLE_INDI 0)
-ELSE()
-     SET(ENABLE_INDI 1 CACHE BOOL "Define whether to use INDI client in Telescope Control plugin.")
-ENDIF()
+SET(ENABLE_INDI 1 CACHE BOOL "Define whether to use INDI client in Telescope Control plugin.")
 IF(ENABLE_INDI)
      ADD_DEFINITIONS(-DENABLE_INDI)
 ENDIF()

--- a/src/external/CMakeLists.txt
+++ b/src/external/CMakeLists.txt
@@ -145,7 +145,7 @@ IF(USE_PLUGIN_TELESCOPECONTROL AND ENABLE_INDI)
 
         # Fix build in windows
 	file(READ ${indiclient_SOURCE_DIR}/libs/indibase/indilogger.h INDILOGGER_H)
-	string(REGEX REPLACE "#include <sys/time.h>" "#ifdef Q_OS_WIN\n#include <windows.h>\n#else\n#include <sys/time.h>\n#endif" INDILOGGER_H "${INDILOGGER_H}")
+	string(REGEX REPLACE "#include <sys/time.h>" "#ifdef Q_OS_WIN\n# include <windows.h>\n#else\n# include <sys/time.h>\n#endif" INDILOGGER_H "${INDILOGGER_H}")
 	file(WRITE ${indiclient_SOURCE_DIR}/indilogger.h.new "${INDILOGGER_H}")
 	configure_file(${indiclient_SOURCE_DIR}/indilogger.h.new ${indiclient_SOURCE_DIR}/libs/indibase/indilogger.h COPYONLY)
 

--- a/src/external/CMakeLists.txt
+++ b/src/external/CMakeLists.txt
@@ -111,6 +111,13 @@ IF(USE_PLUGIN_TELESCOPECONTROL AND ENABLE_INDI)
 		VERSION 2.1.3
 		DOWNLOAD_ONLY YES)
 
+	# remove GCCisms
+	file(READ ${indiclient_SOURCE_DIR}/libs/indibase/defaultdevice.h DEFAULTDEVICE_H)
+	string(REPLACE "__attribute__((deprecated))" "" DEFAULTDEVICE_H "${DEFAULTDEVICE_H}")
+	string(REPLACE "__attribute__((deprecated))" "" DEFAULTDEVICE_H "${DEFAULTDEVICE_H}")
+	file(WRITE ${indiclient_SOURCE_DIR}/libs/indibase/defaultdevice.h.new "${DEFAULTDEVICE_H}")
+	configure_file(${indiclient_SOURCE_DIR}/libs/indibase/defaultdevice.h.new ${indiclient_SOURCE_DIR}/libs/indibase/defaultdevice.h COPYONLY)
+
 	# remove missing definitions
 	file(READ ${indiclient_SOURCE_DIR}/libs/indicore/indicom.c INDICOM_C)
 	string(REPLACE "case 576000: bps = B576000; break;" "" INDICOM_C "${INDICOM_C}")
@@ -145,7 +152,7 @@ IF(USE_PLUGIN_TELESCOPECONTROL AND ENABLE_INDI)
 
         # Fix build in windows
 	file(READ ${indiclient_SOURCE_DIR}/libs/indibase/indilogger.h INDILOGGER_H)
-	string(REGEX REPLACE "#include <sys/time.h>" "#ifdef Q_OS_WIN\n# include <windows.h>\n#else\n# include <sys/time.h>\n#endif" INDILOGGER_H "${INDILOGGER_H}")
+	string(REGEX REPLACE "#include <sys/time.h>" "#ifdef Q_OS_WIN\nstruct timeval { long long tv_sec; long long tv_usec; };\n#else\n# include <sys/time.h>\n#endif" INDILOGGER_H "${INDILOGGER_H}")
 	file(WRITE ${indiclient_SOURCE_DIR}/indilogger.h.new "${INDILOGGER_H}")
 	configure_file(${indiclient_SOURCE_DIR}/indilogger.h.new ${indiclient_SOURCE_DIR}/libs/indibase/indilogger.h COPYONLY)
 


### PR DESCRIPTION
### Description

There was no real reason to disable INDI support for Windows. The build fixes are rather simple, and from what I checked in Wine, connection and slewing does work (though I got a crash at some moment, but this is another issue I suppose, need to check if it exists in 24.3).

Fixes #4117

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?

**Test Configuration**:
* Operating system: Ubuntu 22.04 + Wine 11.0
