### PR TITLE
Make RTS independent from scaling

### DIFF
--- a/src/core/modules/Planet.cpp
+++ b/src/core/modules/Planet.cpp
@@ -3776,6 +3776,11 @@ double Planet::getAngularRadius(const StelCore* core) const
 	return std::atan2(rad*sphereScale,getJ2000EquatorialPos(core).norm()) * M_180_PI;
 }
 
+double Planet::getAngularRadiusNoScale(const StelCore* core) const
+{
+	const double rad = (rings ? rings->getSize() : equatorialRadius);
+	return std::atan2(rad, getJ2000EquatorialPos(core).norm()) * M_180_PI;
+}
 
 double Planet::getSpheroidAngularRadius(const StelCore* core) const
 {
@@ -6228,7 +6233,7 @@ Vec4d Planet::getClosestRTSTime(const StelCore *core, const double altitude) con
 	{
 		StelCore* core1 = StelApp::getInstance().getCore();
 		static SolarSystem* ssystem = GETSTELMODULE(SolarSystem);
-		double ho = - getAngularRadius(core1) * M_PI_180; // semidiameter;
+		double ho = - getAngularRadiusNoScale(core1) * M_PI_180; // semidiameter;
 		double hoRefraction = 0.; 
 
 		if (core1->getSkyDrawer()->getFlagHasAtmosphere())
@@ -6292,7 +6297,7 @@ Vec4d Planet::getClosestRTSTime(const StelCore *core, const double altitude) con
 		{
 			core1->setJD(currentJD+mr);
 			core1->update(0);
-			ho = - getAngularRadius(core1) * M_PI_180; // semidiameter;
+			ho = - getAngularRadiusNoScale(core1) * M_PI_180; // semidiameter;
 			ho += hoRefraction;
 			if (altitude != 0.)
 				ho = altitude*M_PI_180; // Not sure if we use refraction for off-zero settings?
@@ -6322,7 +6327,7 @@ Vec4d Planet::getClosestRTSTime(const StelCore *core, const double altitude) con
 		{
 			core1->setJD(currentJD+ms);
 			core1->update(0);
-			ho = - getAngularRadius(core1) * M_PI_180; // semidiameter;
+			ho = - getAngularRadiusNoScale(core1) * M_PI_180; // semidiameter;
 			if (core1->getSkyDrawer()->getFlagHasAtmosphere())
 			ho += hoRefraction;
 			if (altitude != 0.)
@@ -6356,7 +6361,7 @@ Vec4d Planet::getClosestRTSTime(const StelCore *core, const double altitude) con
 		//StelObjectMgr* omgr=GETSTELMODULE(StelObjectMgr);
 		double ho = 0.;
 		if (getEnglishName()==L1S("Sun"))
-			ho = - getAngularRadius(core) * M_PI_180; // semidiameter; Canonical value 16', but this is accurate even from other planets...
+			ho = - getAngularRadiusNoScale(core) * M_PI_180; // semidiameter; Canonical value 16', but this is accurate even from other planets...
 
 		if (core->getSkyDrawer()->getFlagHasAtmosphere())
 		{

--- a/src/core/modules/Planet.hpp
+++ b/src/core/modules/Planet.hpp
@@ -289,6 +289,8 @@ public:
 
 	//! Get angular semidiameter, degrees. If planet display is artificially enlarged (e.g. Moon upscale), value will also be increased.
 	double getAngularRadius(const StelCore* core) const override;
+	//! Get angular semidiameter, degrees. If planet display is artificially enlarged (e.g. Moon upscale), upscale factor is ignored.
+	double getAngularRadiusNoScale(const StelCore* core) const;
 	virtual bool hasAtmosphere(void) {return atmosphere;}
 	virtual bool hasHalo(void) {return halo;}
 	//! Returns whether planet positions are valid and useful for the current simulation time.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

RTS times of sun and moon are defined to occur when the object's upper limb touches the mathematical horizon. 
The current implementation uses apparent diameter delivered by a function that takes artificial scaling into account. This provides a visually pleasing result but wrong times. 

This fix adds a new function Planet::getAngularRadiusNoScale() which allows to find accurate RTS times. 

A later improvement could add another flag to "observe scale for RTS times", which may please the audience in a presentation with upscaled objects when numerical results are not important. But not in 26.2.

Fixes #4823  (issue)

### Screenshots (if appropriate):

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system: Windows 11
* Graphics Card: Geforce (irrelevant)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
