### PR TITLE
Reduce threading

### DIFF
--- a/src/core/modules/SolarSystem.cpp
+++ b/src/core/modules/SolarSystem.cpp
@@ -1798,10 +1798,17 @@ void SolarSystem::computePositions(StelCore *core, double dateJDE, PlanetP obser
 			// ---- Pass 1: first approximation at dateJDE -----------------
 			for (const auto& level : std::as_const(systemPlanetsByLevel))
 			{
-				runLevelParallel(level, [obs, dateJDE](const PlanetP& p)
+				// If level is too small, splitting into threads is pointless and may cause more harm than good.
+				if (level.length() > 100)
+					runLevelParallel(level, [obs, dateJDE](const PlanetP& p)
+					{
+						p->computePosition(obs, dateJDE, Vec3d(0.));
+					});
+				else
 				{
-					p->computePosition(obs, dateJDE, Vec3d(0.));
-				});
+					for (const auto &p: std::as_const(level))
+						p->computePosition(obs, dateJDE, Vec3d(0.));
+				}
 			}
 
 			// Snapshot the observer's heliocentric state *by value* (NOT by
@@ -1835,7 +1842,14 @@ void SolarSystem::computePositions(StelCore *core, double dateJDE, PlanetP obser
 
 			// ---- Pass 2: light-time + aberration correction -------------
 			for (const auto& level : std::as_const(systemPlanetsByLevel))
-				runLevelParallel(level, lightTimeStep);
+				// If level is too small, splitting into threads is pointless and may cause more harm than good.
+				if (level.length() > 100)
+					runLevelParallel(level, lightTimeStep);
+			else
+				{
+					for (const auto& p: std::as_const(level))
+						lightTimeStep(p);
+				}
 
 			// ---- Pass 3: refinement (and rotation element corrections) --
 			// The next call may already do nothing if the time difference to
@@ -1861,7 +1875,14 @@ void SolarSystem::computePositions(StelCore *core, double dateJDE, PlanetP obser
 				else if (p->englishName==L1S("Neptune")) update(dateJDE-lightTimeDays, RotationElements::Neptune);
 			};
 			for (const auto& level : std::as_const(systemPlanetsByLevel))
-				runLevelParallel(level, lightTimeStepWithRotation);
+				// If level is too small, splitting into threads is pointless and may cause more harm than good.
+				if (level.length() > 100)
+					runLevelParallel(level, lightTimeStepWithRotation);
+			else
+				{
+					for (const auto& p: std::as_const(level))
+						lightTimeStepWithRotation(p);
+				}
 
 			computeTransMatrices(dateJDE, observerPlanet->getHeliocentricEclipticPos());
 		}


### PR DESCRIPTION

OK, I have now seen 1 or 2 flickers during many minutes of operation, but am far from knowing what's wrong.  Still, better such occasional flicker than a hanging program as there was real danger before. 

This attempt reduces the occasion for even launching several threads: Only split into threads if the respective SSO group (planets/moons) has more than 100 objects. The 78 moons (or so) will now run on the main thread. I cannot say whether moon computations are involved in the issue which I can hardly see, though. 

The DE4xx computations use a mutex for reading the common ephemeris file. The mutex is essential, removing it has the planets dancing around wildly. I have not seen in their code any other dangerous area so far, but maybe there is something. 

If the problem really is linked to using DE4x, this patch may not really improve the situation, though, as the 8 planets are in the main group of immediate Solar children (Planets, Minor Bodies).

A further rework could then be to separate "8 planets and Earth's Moon"  in one function (which uses VSOP or DE* solutions) that is not multithreaded and "the rest" to be split into the current solution. But not today. A basic mitigation for 26.2 is a recommendation in the FAQ to switch off multithreading if one is affected. The previous solution does not occasionally flicker but hang instead.  The VTune profiler shows other areas of congestion.

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Please include a summary of the change and which issue is fixed. -->
<!--- Please also include relevant motivation and context. -->
<!--- List any dependencies that are required for this change. -->

Fixes #4993 (?)

### Screenshots (if appropriate):

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] (unclear) Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system: Windows 11
* Graphics Card: Geforce 2700

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
