### PR TITLE
Protect the whole jpl_pleph with the mutex

### DIFF
--- a/src/core/planetsephems/jpleph.cpp
+++ b/src/core/planetsephems/jpleph.cpp
@@ -151,6 +151,8 @@ double DLL_FUNC jpl_get_double(const void *ephem, const int value)
 int DLL_FUNC jpl_pleph(void *ephem, const double et, const int ntarg,
                       const int ncent, double rrd[], const int calc_velocity)
 {
+    QMutexLocker locker(&mutex);
+
     struct jpl_eph_data *eph = static_cast<struct jpl_eph_data *>(ephem);
     double pv[13][6]={{0.}};/* pv is the position/velocity array
                              NUMBERED FROM ZERO: 0=Mercury,1=Venus,...
@@ -588,8 +590,6 @@ static unsigned int dimension(const unsigned int idx)
 int DLL_FUNC jpl_state(void *ephem, const double et, const int list[14],
                           double pv[][6], double nut[4], const int bary)
 {
-	QMutexLocker locker(&mutex);
-
 	struct jpl_eph_data *eph = static_cast<struct jpl_eph_data *>(ephem);
 	unsigned i, j, n_intervals;
 	double *buf = eph->cache;


### PR DESCRIPTION
While `jpl_state()` is not thread-safe, the use of the whole `jpl_eph_data` isn't thread-safe either, and it's accessed by `jpl_ephem()`.

Although `jpl_ephem()` is called from `GetDe440Coor`, `GetDe441Coor`, etc., these functions aren't used concurrently, so there's no issue with protecting `jpl_ephem()` itself by a global JPL mutex.

The `jpl_state()` itself is only ever used from `jpl_ephem()`, so it doesn't really need any additional protection.

Fixes #4993
