### PR TITLE
Remove references to core.getSkyLanguage and core.setSkyLanguage

### DIFF
--- a/scripts/save_state.inc
+++ b/scripts/save_state.inc
@@ -31,7 +31,7 @@
 //    * Fix to work under stellarium 0.19
 //    * Add change log, version, and author list to header
 // 2026-06-29   Nicolas Martignoni (martignoni)
-//    * Remove reference to core.getSkyLanguage and core.setSkyLanguage (removed in Stellarium 26.3)
+//    * Remove reference to core.getSkyLanguage and core.setSkyLanguage (removed in Stellarium 25.3)
 
 // declare a global variable to store saved state
 var savedStates = new Array();

--- a/scripts/save_state.inc
+++ b/scripts/save_state.inc
@@ -1,11 +1,12 @@
 //
 // Name:        Save and restore display state
-// Version:     0.22.3
+// Version:     0.22.4
 // License:     Public Domain
 // Authors:     Matthew Gates (matthewg42) (Original author)
 //              Alexander Wolf (alex-w)
 //              Georg Zotti (gzotti)
 //              Brian W. Mulligan (astrobit)
+//              Nicolas Martignoni (martignoni)
 // Description: Provide functions for saving and restoring state (view settings etc.)
 //              for use in other scripts via the include feature.  A state is 
 //              associated with some string identifier.  This is arbitrary.  You can 
@@ -29,6 +30,8 @@
 // 2019-08-14   Brian W. Mulligan (astrobit)
 //    * Fix to work under stellarium 0.19
 //    * Add change log, version, and author list to header
+// 2026-06-29   Nicolas Martignoni (martignoni)
+//    * Remove reference to core.getSkyLanguage and core.setSkyLanguage (removed in Stellarium 26.3)
 
 // declare a global variable to store saved state
 var savedStates = new Array();
@@ -103,7 +106,6 @@ function saveState(stateName)
 	savedStates[stateName]["DecAngle"] = core.getViewDecAngle();
 
 	savedStates[stateName]["AppLanguage"] = core.getAppLanguage();
-	savedStates[stateName]["SkyLanguage"] = core.getSkyLanguage();
 
 	core.debug("saveState() - state saved with ID: " + stateName);
 }
@@ -196,7 +198,6 @@ function restoreState(stateName, options)
 	core.setDiskViewport(savedStates[stateName]["DiskViewport"]);
 	core.setObserverLocation(savedStates[stateName]["ObserverLocation"]);
 	core.setAppLanguage(savedStates[stateName]["AppLanguage"]);
-	core.setSkyLanguage(savedStates[stateName]["SkyLanguage"]);
 
 	// optional restoration options...
 	if (!options["time"])


### PR DESCRIPTION
### Description
Core.getSkyLanguage and core.setSkyLanguage were removed from Stellarium 25.3 and later.

Fixes #5012.

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] Housekeeping

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system: macOS Sequoia 15.7.7
* Graphics Card: Radeon Pro 580X 8 Go

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
