### PR TITLE
SCM: fix close/cancel behaviour of Constellation Editor

### DIFF
--- a/plugins/SkyCultureMaker/src/gui/ScmConstellationDialog.cpp
+++ b/plugins/SkyCultureMaker/src/gui/ScmConstellationDialog.cpp
@@ -154,9 +154,15 @@ void ScmConstellationDialog::retranslate()
 
 void ScmConstellationDialog::close()
 {
+	if (constellationBeingEdited != nullptr)
+	{
+		// If we are editing a constellation, we need to show the original one again
+		constellationBeingEdited->isHidden = false;
+	}
 	setVisible(false);
 	maker->setIsLineDrawEnabled(false);
 	maker->setCanCreateConstellations(true);
+	resetDialog();
 }
 
 void ScmConstellationDialog::createDialogContent()
@@ -200,7 +206,7 @@ void ScmConstellationDialog::createDialogContent()
 	ui->tooltipBtn->setToolTip(artworkToolTip);
 
 	connect(ui->saveBtn, &QPushButton::clicked, this, &ScmConstellationDialog::saveConstellation);
-	connect(ui->cancelBtn, &QPushButton::clicked, this, &ScmConstellationDialog::cancel);
+	connect(ui->cancelBtn, &QPushButton::clicked, this, &ScmConstellationDialog::close);
 
 	connect(&StelApp::getInstance(), &StelApp::fontChanged, this, &ScmConstellationDialog::handleFontChanged);
 	connect(&StelApp::getInstance(), &StelApp::guiFontSizeChanged, this, &ScmConstellationDialog::handleFontChanged);
@@ -460,17 +466,6 @@ bool ScmConstellationDialog::canConstellationBeSaved() const
 	return true;
 }
 
-void ScmConstellationDialog::cancel()
-{
-	if (constellationBeingEdited != nullptr)
-	{
-		// If we are editing a constellation, we need to show the original one again
-		constellationBeingEdited->isHidden = false;
-	}
-	resetDialog();
-	ScmConstellationDialog::close();
-}
-
 void ScmConstellationDialog::saveConstellation()
 {
 	if (canConstellationBeSaved())
@@ -498,7 +493,6 @@ void ScmConstellationDialog::saveConstellation()
 		}
 
 		maker->updateSkyCultureDialog();
-		resetDialog();
 		ScmConstellationDialog::close();
 	}
 }

--- a/plugins/SkyCultureMaker/src/gui/ScmConstellationDialog.hpp
+++ b/plugins/SkyCultureMaker/src/gui/ScmConstellationDialog.hpp
@@ -113,11 +113,6 @@ private:
 	void saveConstellation();
 
 	/**
-	 * @brief Resets and closes the dialog.
-	 */
-	void cancel();
-
-	/**
 	 * @brief Updates the state of the artwork.
 	 */
 	void updateArtwork();


### PR DESCRIPTION
This is a fix of the close/cancel behaviour of the SCM Constellation Editor.

The main "bug":
1. Create a constellation and save it
2. Select it and click "Edit". The original constellation disappears and the lines are shown in a different color for editing.
3. Good: Press "Cancel" to close the edit dialog. The original constellation is shown without changes.
4. Bad: Press "X" to close the edit dialog. The original constellation is NOT shown anymore!

There is no reason why pressing "X" or "Cancel" should have different behaviour. I think we wanted the "X" button to be a "hide dialog" feature, where we can continue working after opening again so the current unsaved data is not lost. But this never worked, because opening the edit dialog (either by clicking "Add Constellation" or "Edit") always clears the dialog anyway.

This PR fixes this by using a single close function that makes sure that the original constellation is shown again and that the dialog is properly reset.