### PR TITLE
Add sky HiPS display controls

### DIFF
--- a/guide/ch_surveys.tex
+++ b/guide/ch_surveys.tex
@@ -56,6 +56,21 @@ sources/4/url = file:///D:/Stellarium/hips/hipslist
 sources/size  = 4
 \end{configfile}
 
+\subsection{Finetuning HiPS surveys}
+Sometimes it is useful to alter the rendering of sky HiPS surveys. The
+\indexterm{layer appearance} controls \newFeature{26.3} allow users to adjust
+gamma, saturation, contrast, brightness, opacity, and the displayed color
+channel for each sky survey layer. Opacity is especially useful when displaying
+more than one survey at the same time, or when combining monochrome surveys in
+different color channels.
+
+Users can also invert the colors of a layer, which can be helpful for surveys
+or historical sky maps with a bright background. Optionally, atmospheric
+extinction can be applied to sky HiPS layers, making optical color surveys
+appear more photo-like when shown together with a foreground landscape. The
+layer appearance controls do not apply to planetary HiPS textures.
+
+
 \section{Solar system HiPS survey}
 
 Though not specified in the HiPS standard, Stellarium recognises HiPS surveys

--- a/src/core/StelHips.cpp
+++ b/src/core/StelHips.cpp
@@ -392,7 +392,8 @@ void HipsSurvey::draw(StelPainter* sPainter, double angle, HipsSurvey::DrawCallb
 		aLum = qMin(1.0f, aLum * 2.f);
 		extinctionColor.set(aLum, aLum, aLum);
 
-		const float atmLum = GETSTELMODULE(LandscapeMgr)->getAtmosphereAverageLuminance();
+		const auto landscapeMgr = qobject_cast<LandscapeMgr*>(StelApp::getInstance().getModule("LandscapeMgr"));
+		const float atmLum = landscapeMgr ? landscapeMgr->getAtmosphereAverageLuminance() : 0.f;
 		const float atmFactor = qMax(0.35f, 50.0f * (0.02f - atmLum));
 		extinctionColor *= atmFactor * atmFactor;
 	}

--- a/src/core/StelHips.cpp
+++ b/src/core/StelHips.cpp
@@ -504,7 +504,7 @@ void HipsSurvey::draw(StelPainter* sPainter, double angle, HipsSurvey::DrawCallb
 
 void HipsSurvey::updateProgressBar(int nb, int total)
 {
-	if (nb == total)
+	if (!isVisible() || nb == total)
 	{
 		hideProgressBar();
 		return;

--- a/src/core/StelHips.cpp
+++ b/src/core/StelHips.cpp
@@ -209,8 +209,15 @@ void HipsSurvey::setColorChannel(int value)
 	emit displaySettingsChanged();
 }
 
+void HipsSurvey::setInvertedColors(bool value)
+{
+	if (invertedColors == value) return;
+	invertedColors = value;
+	emit displaySettingsChanged();
+}
+
 void HipsSurvey::setDisplaySettings(float gamma, float saturation, float brightness, float opacity,
-                                    int colorChannel)
+                                    int colorChannel, bool invertedColors)
 {
 	bool changed = false;
 	gamma = qBound(0.1f, gamma, 5.f);
@@ -244,13 +251,18 @@ void HipsSurvey::setDisplaySettings(float gamma, float saturation, float brightn
 		this->colorChannel = colorChannel;
 		changed = true;
 	}
+	if (this->invertedColors != invertedColors)
+	{
+		this->invertedColors = invertedColors;
+		changed = true;
+	}
 	if (changed)
 		emit displaySettingsChanged();
 }
 
 void HipsSurvey::resetDisplaySettings()
 {
-	setDisplaySettings(1.f, 1.f, 1.f, 1.f, ColorChannelRgb);
+	setDisplaySettings(1.f, 1.f, 1.f, 1.f, ColorChannelRgb, false);
 }
 
 bool HipsSurvey::hasDefaultDisplaySettings() const
@@ -259,7 +271,8 @@ bool HipsSurvey::hasDefaultDisplaySettings() const
 	       qFuzzyCompare(saturation, 1.f) &&
 	       qFuzzyCompare(brightness, 1.f) &&
 	       qFuzzyCompare(opacity, 1.f) &&
-	       colorChannel == ColorChannelRgb;
+	       colorChannel == ColorChannelRgb &&
+	       !invertedColors;
 }
 
 void HipsSurvey::hideProgressBar()
@@ -403,7 +416,8 @@ void HipsSurvey::draw(StelPainter* sPainter, double angle, HipsSurvey::DrawCallb
 	if (!planetarySurvey)
 	{
 		sPainter->setTextureDisplayAdjustment(gamma, saturation, brightness,
-		                                      colorChannel, colorChannel != ColorChannelRgb,
+		                                      colorChannel, invertedColors,
+		                                      colorChannel != ColorChannelRgb,
 		                                      fader.getInterstate() * displayOpacity);
 	}
 

--- a/src/core/StelHips.cpp
+++ b/src/core/StelHips.cpp
@@ -21,8 +21,12 @@
 #include "StelApp.hpp"
 #include "StelCore.hpp"
 #include "Planet.hpp"
+#include "RefractionExtinction.hpp"
+#include "LandscapeMgr.hpp"
 #include "StelPainter.hpp"
+#include "StelSkyDrawer.hpp"
 #include "StelTextureMgr.hpp"
+#include "StelToneReproducer.hpp"
 #include "StelUtils.hpp"
 #include "StelProgressController.hpp"
 #include "StelHealpix.hpp"
@@ -165,6 +169,99 @@ void HipsSurvey::setVisible(bool value)
 	emit visibleChanged(value);
 }
 
+void HipsSurvey::setGamma(float value)
+{
+	value = qBound(0.1f, value, 5.f);
+	if (qFuzzyCompare(gamma, value)) return;
+	gamma = value;
+	emit displaySettingsChanged();
+}
+
+void HipsSurvey::setSaturation(float value)
+{
+	value = qBound(0.f, value, 3.f);
+	if (qFuzzyCompare(saturation, value)) return;
+	saturation = value;
+	emit displaySettingsChanged();
+}
+
+void HipsSurvey::setBrightness(float value)
+{
+	value = qBound(0.f, value, 5.f);
+	if (qFuzzyCompare(brightness, value)) return;
+	brightness = value;
+	emit displaySettingsChanged();
+}
+
+void HipsSurvey::setOpacity(float value)
+{
+	value = qBound(0.f, value, 1.f);
+	if (qFuzzyCompare(opacity, value)) return;
+	opacity = value;
+	emit displaySettingsChanged();
+}
+
+void HipsSurvey::setColorChannel(int value)
+{
+	value = qBound(static_cast<int>(ColorChannelRgb), value, static_cast<int>(ColorChannelBlue));
+	if (colorChannel == value) return;
+	colorChannel = value;
+	emit displaySettingsChanged();
+}
+
+void HipsSurvey::setDisplaySettings(float gamma, float saturation, float brightness, float opacity,
+                                    int colorChannel)
+{
+	bool changed = false;
+	gamma = qBound(0.1f, gamma, 5.f);
+	saturation = qBound(0.f, saturation, 3.f);
+	brightness = qBound(0.f, brightness, 5.f);
+	opacity = qBound(0.f, opacity, 1.f);
+	colorChannel = qBound(static_cast<int>(ColorChannelRgb), colorChannel, static_cast<int>(ColorChannelBlue));
+
+	if (!qFuzzyCompare(this->gamma, gamma))
+	{
+		this->gamma = gamma;
+		changed = true;
+	}
+	if (!qFuzzyCompare(this->saturation, saturation))
+	{
+		this->saturation = saturation;
+		changed = true;
+	}
+	if (!qFuzzyCompare(this->brightness, brightness))
+	{
+		this->brightness = brightness;
+		changed = true;
+	}
+	if (!qFuzzyCompare(this->opacity, opacity))
+	{
+		this->opacity = opacity;
+		changed = true;
+	}
+	if (this->colorChannel != colorChannel)
+	{
+		this->colorChannel = colorChannel;
+		changed = true;
+	}
+	if (changed)
+		emit displaySettingsChanged();
+}
+
+void HipsSurvey::resetDisplaySettings()
+{
+	setDisplaySettings(1.f, 1.f, 1.f, 1.f, ColorChannelRgb);
+}
+
+bool HipsSurvey::hasDefaultDisplaySettings() const
+{
+	return qFuzzyCompare(gamma, 1.f) &&
+	       qFuzzyCompare(saturation, 1.f) &&
+	       qFuzzyCompare(brightness, 1.f) &&
+	       qFuzzyCompare(opacity, 1.f) &&
+	       colorChannel == ColorChannelRgb;
+}
+
 void HipsSurvey::hideProgressBar()
 {
 	if (progressBar)
@@ -266,7 +363,7 @@ void HipsSurvey::setHorizonsSurvey(const HipsSurveyP& horizons)
 	if (!horizons) tiles.clear();
 }
 
-void HipsSurvey::draw(StelPainter* sPainter, double angle, HipsSurvey::DrawCallback callback)
+void HipsSurvey::draw(StelPainter* sPainter, double angle, HipsSurvey::DrawCallback callback, bool withAtmosphericExtinction)
 {
 	// We don't draw anything until we get the properties file and the
 	// allsky texture (if available).
@@ -277,10 +374,38 @@ void HipsSurvey::draw(StelPainter* sPainter, double angle, HipsSurvey::DrawCallb
 	if (horizons) gotAllsky &= horizons->getAllsky();
 	if (!gotAllsky) return;
 	if (fader.getInterstate() == 0.0f) return;
-	sPainter->setColor(1, 1, 1, fader.getInterstate());
 
 	// Set the projection.
 	StelCore* core = StelApp::getInstance().getCore();
+	StelSkyDrawer* drawer = core->getSkyDrawer();
+	withAtmosphericExtinction = withAtmosphericExtinction && !planetarySurvey &&
+	                            drawer->getFlagHasAtmosphere() &&
+	                            drawer->getExtinction().getExtinctionCoefficient() >= 0.01f;
+
+	Vec3f extinctionColor(1.0f);
+	if (withAtmosphericExtinction)
+	{
+		const float lum = drawer->surfaceBrightnessToLuminance(12.f);
+		StelToneReproducer* eye = core->getToneReproducer();
+		float aLum = eye->adaptLuminanceScaled(lum);
+		Q_ASSERT(aLum > 0.f);
+		aLum = qMin(1.0f, aLum * 2.f);
+		extinctionColor.set(aLum, aLum, aLum);
+
+		const float atmLum = GETSTELMODULE(LandscapeMgr)->getAtmosphereAverageLuminance();
+		const float atmFactor = qMax(0.35f, 50.0f * (0.02f - atmLum));
+		extinctionColor *= atmFactor * atmFactor;
+	}
+
+	const float displayOpacity = planetarySurvey ? 1.f : opacity;
+	sPainter->setColor(1, 1, 1, fader.getInterstate() * displayOpacity);
+	if (!planetarySurvey)
+	{
+		sPainter->setTextureDisplayAdjustment(gamma, saturation, brightness,
+		                                      colorChannel, colorChannel != ColorChannelRgb,
+		                                      fader.getInterstate() * displayOpacity);
+	}
+
 	StelCore::FrameType frame = StelCore::FrameUninitialized;
 	if (hipsFrame == "galactic")
 		frame = StelCore::FrameGalactic;
@@ -367,9 +492,12 @@ void HipsSurvey::draw(StelPainter* sPainter, double angle, HipsSurvey::DrawCallb
 	const SphericalCap& viewportRegion = sPainter->getProjector()->getBoundingCap();
 	for (int i = 0; i < 12; i++)
 	{
-		drawTile(0, i, drawOrder, splitOrder, outside, viewportRegion, sPainter, obsVelocity, callback);
+		drawTile(0, i, drawOrder, splitOrder, outside, viewportRegion, sPainter, obsVelocity,
+		         callback, withAtmosphericExtinction, extinctionColor);
 	}
 
+	if (!planetarySurvey)
+		sPainter->resetTextureDisplayAdjustment();
 	updateProgressBar(nbLoadedTiles, nbVisibleTiles);
 }
 
@@ -522,7 +650,8 @@ bool HipsSurvey::bindTextures(HipsTile& tile, const int orderMin, Vec2f& texCoor
 
 void HipsSurvey::drawTile(int order, int pix, int drawOrder, int splitOrder, bool outside,
                           const SphericalCap& viewportShape, StelPainter* sPainter,
-                          Vec3d observerVelocity, DrawCallback callback)
+                          Vec3d observerVelocity, DrawCallback callback,
+                          bool withAtmosphericExtinction, const Vec3f& extinctionColor)
 {
 	Vec3d pos;
 	Mat3d mat3;
@@ -534,6 +663,7 @@ void HipsSurvey::drawTile(int order, int pix, int drawOrder, int splitOrder, boo
 	int orderMin = getPropertyInt("hips_order_min", 3);
 	QVector<Vec3d> vertsArray;
 	QVector<Vec2f> texArray;
+	QVector<Vec4f> colorArray;
 	QVector<uint16_t> indicesArray;
 	int nb;
 	Vec4f color = sPainter->getColor();
@@ -599,7 +729,12 @@ void HipsSurvey::drawTile(int order, int pix, int drawOrder, int splitOrder, boo
 
 	// Actually draw the tile, as a single quad.
 	alpha = color[3];
-	if (alpha < 1.0f)
+	if (!planetarySurvey && colorChannel != ColorChannelRgb)
+	{
+		sPainter->setBlending(true, GL_ONE, GL_ONE);
+		sPainter->setColor(color[0], color[1], color[2], alpha);
+	}
+	else if (alpha < 1.0f)
 	{
 		sPainter->setBlending(true);
 		sPainter->setColor(color[0], color[1], color[2], alpha);
@@ -611,9 +746,13 @@ void HipsSurvey::drawTile(int order, int pix, int drawOrder, int splitOrder, boo
 	}
 	sPainter->setCullFace(true);
 	nb = fillArrays(order, pix, drawOrder, splitOrder, outside, sPainter, observerVelocity,
-	                texCoordShift, texCoordScale, vertsArray, texArray, indicesArray);
+	                texCoordShift, texCoordScale, vertsArray, texArray, colorArray, indicesArray,
+	                withAtmosphericExtinction, extinctionColor);
 	if (!callback) {
-		sPainter->setArrays(vertsArray.constData(), texArray.constData());
+		if (withAtmosphericExtinction)
+			sPainter->setArrays(vertsArray.constData(), texArray.constData(), colorArray.constData());
+		else
+			sPainter->setArrays(vertsArray.constData(), texArray.constData());
 		sPainter->drawFromArray(StelPainter::Triangles, nb, 0, true, indicesArray.constData());
 	} else {
 		callback(vertsArray, texArray, indicesArray);
@@ -626,7 +765,8 @@ skip_render:
 		for (int i = 0; i < 4; i++)
 		{
 			drawTile(order + 1, pix * 4 + i, drawOrder, splitOrder, outside,
-			         viewportShape, sPainter, observerVelocity, callback);
+			         viewportShape, sPainter, observerVelocity, callback,
+			         withAtmosphericExtinction, extinctionColor);
 		}
 	}
 	// Restore the painter color.
@@ -636,12 +776,21 @@ skip_render:
 int HipsSurvey::fillArrays(int order, int pix, int drawOrder, int splitOrder,
                            bool outside, StelPainter* sPainter, Vec3d observerVelocity,
                            const Vec2f& texCoordShift, const float texCoordScale,
-                           QVector<Vec3d>& verts, QVector<Vec2f>& tex, QVector<uint16_t>& indices)
+                           QVector<Vec3d>& verts, QVector<Vec2f>& tex, QVector<Vec4f>& colors,
+                           QVector<uint16_t>& indices, bool withAtmosphericExtinction,
+                           const Vec3f& extinctionColor)
 {
 	Q_UNUSED(sPainter)
 	Mat3d mat3;
 	Vec3d pos;
 	Vec2f texPos;
+	StelCore* core = Q_NULLPTR;
+	const Extinction* extinction = Q_NULLPTR;
+	if (withAtmosphericExtinction)
+	{
+		core = StelApp::getInstance().getCore();
+		extinction = &core->getSkyDrawer()->getExtinction();
+	}
 	// First of all, min() limits gridSize to <256, because otherwise squaring it will overflow index type, uint16_t.
 	// But in practice 32 points per side seems already good enough, and getting to 128 points noticeably affects
 	// performance, so the upper limit is lower.
@@ -671,6 +820,24 @@ int HipsSurvey::fillArrays(int order, int pix, int drawOrder, int splitOrder,
 
 			verts << pos;
 			tex << texPos * texCoordScale + texCoordShift;
+			if (withAtmosphericExtinction)
+			{
+				Vec3d altAzPos;
+				if (hipsFrame == "galactic")
+					altAzPos = core->j2000ToAltAz(core->galacticToJ2000(pos), StelCore::RefractionOn);
+				else if (hipsFrame == "equatorial")
+					altAzPos = core->j2000ToAltAz(pos, StelCore::RefractionOn);
+				else
+					altAzPos = core->heliocentricEclipticToAltAz(pos, StelCore::RefractionOn);
+				Q_ASSERT(fabs(altAzPos.normSquared() - 1.0) < 0.001);
+
+				float oneMag = 0.0f;
+				extinction->forward(altAzPos, &oneMag);
+				const float extinctionFactor = std::pow(0.7f, oneMag);
+				colors << Vec4f(extinctionColor[0] * extinctionFactor,
+				                extinctionColor[1] * extinctionFactor,
+				                extinctionColor[2] * extinctionFactor, 1.f);
+			}
 		}
 	}
 	for (uint16_t i = 0; i < gridSize; i++)

--- a/src/core/StelHips.cpp
+++ b/src/core/StelHips.cpp
@@ -413,17 +413,38 @@ void HipsSurvey::draw(StelPainter* sPainter, double angle, HipsSurvey::DrawCallb
 	Vec3f extinctionColor(1.0f);
 	if (withAtmosphericExtinction)
 	{
+		const auto landscapeMgr = qobject_cast<LandscapeMgr*>(StelApp::getInstance().getModule("LandscapeMgr"));
+		const float lightPollutionLum = static_cast<float>(drawer->getLightPollutionLuminance());
+
 		const float lum = drawer->surfaceBrightnessToLuminance(12.f);
 		StelToneReproducer* eye = core->getToneReproducer();
+		const float savedInputScale = eye->getInputScale();
+		const float savedWorldLum = eye->getWorldAdaptationLuminance();
+		float skyDrawerInputScale = 2.45f;
+		if (drawer->getFlagHasAtmosphere() && core->getJD() > 2387627.5)
+		{
+			const float nelm = StelCore::luminanceToNELM(lightPollutionLum);
+			skyDrawerInputScale = 3.3541f * std::exp(-0.404f * (16.5f - 2.f * nelm));
+		}
+		const float neutralInputScale = savedInputScale * (2.45f / qMax(0.0001f, skyDrawerInputScale));
+		eye->setInputScale(neutralInputScale);
+		eye->setWorldAdaptationLuminance(qMax(0.0001f, savedWorldLum - lightPollutionLum));
+
 		float aLum = eye->adaptLuminanceScaled(lum);
+		eye->setWorldAdaptationLuminance(savedWorldLum);
+		eye->setInputScale(savedInputScale);
+
 		Q_ASSERT(aLum > 0.f);
 		aLum = qMin(1.0f, aLum * 2.f);
 		extinctionColor.set(aLum, aLum, aLum);
 
-		const auto landscapeMgr = qobject_cast<LandscapeMgr*>(StelApp::getInstance().getModule("LandscapeMgr"));
-		const float atmLum = landscapeMgr ? landscapeMgr->getAtmosphereAverageLuminance() : 0.f;
-		const float atmFactor = qMax(0.35f, 50.0f * (0.02f - atmLum));
-		extinctionColor *= atmFactor * atmFactor;
+		if (landscapeMgr)
+		{
+			const float atmLum = qMax(0.f, landscapeMgr->getAtmosphereAverageLuminance() - lightPollutionLum);
+			const float modelFactor = landscapeMgr->getAtmosphereModel() == "showmysky" ? 0.2f : 1.f;
+			const float atmFactor = qMax(0.35f, 50.0f * (0.02f - modelFactor * atmLum));
+			extinctionColor *= atmFactor * atmFactor;
+		}
 	}
 
 	const float displayOpacity = planetarySurvey ? 1.f : opacity;

--- a/src/core/StelHips.cpp
+++ b/src/core/StelHips.cpp
@@ -193,6 +193,14 @@ void HipsSurvey::setBrightness(float value)
 	emit displaySettingsChanged();
 }
 
+void HipsSurvey::setContrast(float value)
+{
+	value = qBound(0.f, value, 5.f);
+	if (qFuzzyCompare(contrast, value)) return;
+	contrast = value;
+	emit displaySettingsChanged();
+}
+
 void HipsSurvey::setOpacity(float value)
 {
 	value = qBound(0.f, value, 1.f);
@@ -216,13 +224,14 @@ void HipsSurvey::setInvertedColors(bool value)
 	emit displaySettingsChanged();
 }
 
-void HipsSurvey::setDisplaySettings(float gamma, float saturation, float brightness, float opacity,
-                                    int colorChannel, bool invertedColors)
+void HipsSurvey::setDisplaySettings(float gamma, float saturation, float brightness, float contrast,
+                                    float opacity, int colorChannel, bool invertedColors)
 {
 	bool changed = false;
 	gamma = qBound(0.1f, gamma, 5.f);
 	saturation = qBound(0.f, saturation, 3.f);
 	brightness = qBound(0.f, brightness, 5.f);
+	contrast = qBound(0.f, contrast, 5.f);
 	opacity = qBound(0.f, opacity, 1.f);
 	colorChannel = qBound(static_cast<int>(ColorChannelRgb), colorChannel, static_cast<int>(ColorChannelBlue));
 
@@ -239,6 +248,11 @@ void HipsSurvey::setDisplaySettings(float gamma, float saturation, float brightn
 	if (!qFuzzyCompare(this->brightness, brightness))
 	{
 		this->brightness = brightness;
+		changed = true;
+	}
+	if (!qFuzzyCompare(this->contrast, contrast))
+	{
+		this->contrast = contrast;
 		changed = true;
 	}
 	if (!qFuzzyCompare(this->opacity, opacity))
@@ -262,7 +276,7 @@ void HipsSurvey::setDisplaySettings(float gamma, float saturation, float brightn
 
 void HipsSurvey::resetDisplaySettings()
 {
-	setDisplaySettings(1.f, 1.f, 1.f, 1.f, ColorChannelRgb, false);
+	setDisplaySettings(1.f, 1.f, 1.f, 1.f, 1.f, ColorChannelRgb, false);
 }
 
 bool HipsSurvey::hasDefaultDisplaySettings() const
@@ -270,6 +284,7 @@ bool HipsSurvey::hasDefaultDisplaySettings() const
 	return qFuzzyCompare(gamma, 1.f) &&
 	       qFuzzyCompare(saturation, 1.f) &&
 	       qFuzzyCompare(brightness, 1.f) &&
+	       qFuzzyCompare(contrast, 1.f) &&
 	       qFuzzyCompare(opacity, 1.f) &&
 	       colorChannel == ColorChannelRgb &&
 	       !invertedColors;
@@ -416,7 +431,7 @@ void HipsSurvey::draw(StelPainter* sPainter, double angle, HipsSurvey::DrawCallb
 	if (!planetarySurvey)
 	{
 		sPainter->setTextureDisplayAdjustment(gamma, saturation, brightness,
-		                                      colorChannel, invertedColors,
+		                                      contrast, colorChannel, invertedColors,
 		                                      colorChannel != ColorChannelRgb,
 		                                      fader.getInterstate() * displayOpacity);
 	}

--- a/src/core/StelHips.hpp
+++ b/src/core/StelHips.hpp
@@ -57,6 +57,7 @@ class HipsSurvey : public QObject
 	Q_PROPERTY(float brightness READ getBrightness WRITE setBrightness NOTIFY displaySettingsChanged)
 	Q_PROPERTY(float opacity READ getOpacity WRITE setOpacity NOTIFY displaySettingsChanged)
 	Q_PROPERTY(int colorChannel READ getColorChannel WRITE setColorChannel NOTIFY displaySettingsChanged)
+	Q_PROPERTY(bool invertedColors READ getInvertedColors WRITE setInvertedColors NOTIFY displaySettingsChanged)
 	//! The name of the planet the survey is attached to, or empty if this is a skysurvey.
 	Q_PROPERTY(QString planet MEMBER planet)
 
@@ -132,8 +133,10 @@ public:
 	void setOpacity(float value);
 	int getColorChannel() const { return colorChannel; }
 	void setColorChannel(int value);
+	bool getInvertedColors() const { return invertedColors; }
+	void setInvertedColors(bool value);
 	void setDisplaySettings(float gamma, float saturation, float brightness, float opacity,
-	                        int colorChannel);
+	                        int colorChannel, bool invertedColors);
 	void resetDisplaySettings();
 	bool hasDefaultDisplaySettings() const;
 
@@ -165,6 +168,7 @@ private:
 	float brightness = 1.f;
 	float opacity = 1.f;
 	int colorChannel = ColorChannelRgb;
+	bool invertedColors = false;
 	bool planetarySurvey;
 	QCache<long int, HipsTile> tiles;
 	// reply to the initial download of the properties file and to the

--- a/src/core/StelHips.hpp
+++ b/src/core/StelHips.hpp
@@ -55,6 +55,7 @@ class HipsSurvey : public QObject
 	Q_PROPERTY(float gamma READ getGamma WRITE setGamma NOTIFY displaySettingsChanged)
 	Q_PROPERTY(float saturation READ getSaturation WRITE setSaturation NOTIFY displaySettingsChanged)
 	Q_PROPERTY(float brightness READ getBrightness WRITE setBrightness NOTIFY displaySettingsChanged)
+	Q_PROPERTY(float contrast READ getContrast WRITE setContrast NOTIFY displaySettingsChanged)
 	Q_PROPERTY(float opacity READ getOpacity WRITE setOpacity NOTIFY displaySettingsChanged)
 	Q_PROPERTY(int colorChannel READ getColorChannel WRITE setColorChannel NOTIFY displaySettingsChanged)
 	Q_PROPERTY(bool invertedColors READ getInvertedColors WRITE setInvertedColors NOTIFY displaySettingsChanged)
@@ -129,14 +130,16 @@ public:
 	void setSaturation(float value);
 	float getBrightness() const { return brightness; }
 	void setBrightness(float value);
+	float getContrast() const { return contrast; }
+	void setContrast(float value);
 	float getOpacity() const { return opacity; }
 	void setOpacity(float value);
 	int getColorChannel() const { return colorChannel; }
 	void setColorChannel(int value);
 	bool getInvertedColors() const { return invertedColors; }
 	void setInvertedColors(bool value);
-	void setDisplaySettings(float gamma, float saturation, float brightness, float opacity,
-	                        int colorChannel, bool invertedColors);
+	void setDisplaySettings(float gamma, float saturation, float brightness, float contrast,
+	                        float opacity, int colorChannel, bool invertedColors);
 	void resetDisplaySettings();
 	bool hasDefaultDisplaySettings() const;
 
@@ -166,6 +169,7 @@ private:
 	float gamma = 1.f;
 	float saturation = 1.f;
 	float brightness = 1.f;
+	float contrast = 1.f;
 	float opacity = 1.f;
 	int colorChannel = ColorChannelRgb;
 	bool invertedColors = false;

--- a/src/core/StelHips.hpp
+++ b/src/core/StelHips.hpp
@@ -52,10 +52,24 @@ class HipsSurvey : public QObject
 	Q_PROPERTY(QJsonObject properties MEMBER properties NOTIFY propertiesChanged)
 	Q_PROPERTY(bool isLoading READ isLoading NOTIFY statusChanged)
 	Q_PROPERTY(bool visible READ isVisible WRITE setVisible NOTIFY visibleChanged)
+	Q_PROPERTY(float gamma READ getGamma WRITE setGamma NOTIFY displaySettingsChanged)
+	Q_PROPERTY(float saturation READ getSaturation WRITE setSaturation NOTIFY displaySettingsChanged)
+	Q_PROPERTY(float brightness READ getBrightness WRITE setBrightness NOTIFY displaySettingsChanged)
+	Q_PROPERTY(float opacity READ getOpacity WRITE setOpacity NOTIFY displaySettingsChanged)
+	Q_PROPERTY(int colorChannel READ getColorChannel WRITE setColorChannel NOTIFY displaySettingsChanged)
 	//! The name of the planet the survey is attached to, or empty if this is a skysurvey.
 	Q_PROPERTY(QString planet MEMBER planet)
 
 public:
+	enum ColorChannel
+	{
+		ColorChannelRgb = 0,
+		ColorChannelRed = 1,
+		ColorChannelGreen = 2,
+		ColorChannelBlue = 3,
+	};
+	Q_ENUM(ColorChannel)
+
 	typedef std::function<void(const QVector<Vec3d>& verts, const QVector<Vec2f>& tex,
 	                           const QVector<uint16_t>& indices)> DrawCallback;
 	//! Create a new HipsSurvey from its url.
@@ -85,7 +99,8 @@ public:
 	//!         surveys.  Should be set to 2 pi for sky surveys.
 	//! @param callback if set this will be called for each visible tile, and the callback should do it rendering
 	//!         itself.  If set to Q_NULLPTR, the function will draw the tiles using the default shader.
-	void draw(StelPainter* sPainter, double angle = 2.0 * M_PI, DrawCallback callback = Q_NULLPTR);
+	void draw(StelPainter* sPainter, double angle = 2.0 * M_PI, DrawCallback callback = Q_NULLPTR,
+	          bool withAtmosphericExtinction = false);
 
 	//! Return the source URL of the survey.
 	const QString& getUrl() const {return url;}
@@ -107,6 +122,21 @@ public:
 	void setNormalsSurvey(const HipsSurveyP& normals);
 	void setHorizonsSurvey(const HipsSurveyP& horizons);
 
+	float getGamma() const { return gamma; }
+	void setGamma(float value);
+	float getSaturation() const { return saturation; }
+	void setSaturation(float value);
+	float getBrightness() const { return brightness; }
+	void setBrightness(float value);
+	float getOpacity() const { return opacity; }
+	void setOpacity(float value);
+	int getColorChannel() const { return colorChannel; }
+	void setColorChannel(int value);
+	void setDisplaySettings(float gamma, float saturation, float brightness, float opacity,
+	                        int colorChannel);
+	void resetDisplaySettings();
+	bool hasDefaultDisplaySettings() const;
+
 	//! Parse a hipslist file into a list of surveys.
 	static QList<HipsSurveyP> parseHipslist(const QString& hipslistURL, const QString& data);
 
@@ -114,6 +144,7 @@ signals:
 	void propertiesChanged(void);
 	void statusChanged(void);
 	void visibleChanged(bool);
+	void displaySettingsChanged(void);
 
 private:
 	void checkForPlanetarySurvey();
@@ -129,6 +160,11 @@ private:
 	HipsSurveyP horizons;
 	double releaseDate; // As UTC Julian day.
 	int order = -1;
+	float gamma = 1.f;
+	float saturation = 1.f;
+	float brightness = 1.f;
+	float opacity = 1.f;
+	int colorChannel = ColorChannelRgb;
 	bool planetarySurvey;
 	QCache<long int, HipsTile> tiles;
 	// reply to the initial download of the properties file and to the
@@ -175,13 +211,15 @@ private:
 	bool bindTextures(HipsTile& tile, int orderMin, Vec2f& texCoordShift, float& texCoordScale, bool& tileIsLoaded);
 	// draw a single tile. observerVelocity (in the correct hipsFrame) is necessary for aberration correction. Set to 0 for no aberration correction.
 	void drawTile(int order, int pix, int drawOrder, int splitOrder, bool outside,
-	              const SphericalCap& viewportShape, StelPainter* sPainter, Vec3d observerVelocity, DrawCallback callback);
+	              const SphericalCap& viewportShape, StelPainter* sPainter, Vec3d observerVelocity,
+	              DrawCallback callback, bool withAtmosphericExtinction, const Vec3f& extinctionColor);
 
 	// Fill the array for a given tile.
 	int fillArrays(int order, int pix, int drawOrder, int splitOrder,
 	               bool outside, StelPainter* sPainter, Vec3d observerVelocity,
 	               const Vec2f& texCoordShift, const float texCoordScale,
-	               QVector<Vec3d>& verts, QVector<Vec2f>& tex, QVector<uint16_t>& indices);
+	               QVector<Vec3d>& verts, QVector<Vec2f>& tex, QVector<Vec4f>& colors,
+	               QVector<uint16_t>& indices, bool withAtmosphericExtinction, const Vec3f& extinctionColor);
 
 	void updateProgressBar(int nb, int total);
 };

--- a/src/core/StelPainter.cpp
+++ b/src/core/StelPainter.cpp
@@ -61,6 +61,7 @@ QMutex* StelPainter::globalMutex = new QMutex();
 
 QCache<QByteArray, StringTexture> StelPainter::texCache(TEX_CACHE_LIMIT);
 QOpenGLShaderProgram* StelPainter::texturesShaderProgram=Q_NULLPTR;
+QOpenGLShaderProgram* StelPainter::adjustedTexturesShaderProgram=Q_NULLPTR;
 QOpenGLShaderProgram* StelPainter::textShaderProgram=Q_NULLPTR;
 QOpenGLShaderProgram* StelPainter::basicShaderProgram=Q_NULLPTR;
 QOpenGLShaderProgram* StelPainter::colorShaderProgram=Q_NULLPTR;
@@ -69,6 +70,7 @@ QOpenGLShaderProgram* StelPainter::wideLineShaderProgram=Q_NULLPTR;
 QOpenGLShaderProgram* StelPainter::colorfulWideLineShaderProgram=Q_NULLPTR;
 StelPainter::BasicShaderVars StelPainter::basicShaderVars;
 StelPainter::TexturesShaderVars StelPainter::texturesShaderVars;
+StelPainter::TexturesShaderVars StelPainter::adjustedTexturesShaderVars;
 StelPainter::TextShaderVars StelPainter::textShaderVars;
 StelPainter::BasicShaderVars StelPainter::colorShaderVars;
 StelPainter::TexturesColorShaderVars StelPainter::texturesColorShaderVars;
@@ -120,6 +122,31 @@ void StelPainter::GLState::reset()
 {
 	*this = GLState(gl);
 	apply();
+}
+
+void StelPainter::setTextureDisplayAdjustment(float gamma, float saturation, float brightness,
+                                              int colorChannel, bool premultiplyAlpha, float alpha)
+{
+	textureGamma = qBound(0.1f, gamma, 5.f);
+	textureSaturation = qBound(0.f, saturation, 3.f);
+	textureBrightness = qBound(0.f, brightness, 5.f);
+	textureColorChannel = qBound(0, colorChannel, 3);
+	texturePremultiplyAlpha = premultiplyAlpha;
+	textureAlpha = qBound(0.f, alpha, 1.f);
+}
+
+void StelPainter::resetTextureDisplayAdjustment()
+{
+	setTextureDisplayAdjustment(1.f, 1.f, 1.f, 0, false);
+}
+
+bool StelPainter::hasTextureDisplayAdjustment() const
+{
+	return !qFuzzyCompare(textureGamma, 1.f) ||
+	       !qFuzzyCompare(textureSaturation, 1.f) ||
+	       !qFuzzyCompare(textureBrightness, 1.f) ||
+	       textureColorChannel != 0 ||
+	       texturePremultiplyAlpha;
 }
 
 bool StelPainter::linkProg(QOpenGLShaderProgram* prog, const QString& name)
@@ -2327,6 +2354,62 @@ void main()
 	texturesShaderVars.texColor = texturesShaderProgram->uniformLocation("texColor");
 	texturesShaderVars.texture = texturesShaderProgram->uniformLocation("tex");
 
+	QOpenGLShader adjustedFshader2(QOpenGLShader::Fragment);
+	const auto adjustedFsrc2 =
+		StelOpenGL::globalShaderPrefix(StelOpenGL::FRAGMENT_SHADER) +
+		makeSaturationShader()+
+		"VARYING mediump vec2 texc;\n"
+		"uniform sampler2D tex;\n"
+		"uniform mediump vec4 texColor;\n"
+		"uniform mediump float gamma;\n"
+		"uniform mediump float saturation;\n"
+		"uniform mediump float brightness;\n"
+		"uniform int colorChannel;\n"
+		"uniform int premultiplyAlpha;\n"
+		"void main(void)\n"
+		"{\n"
+		"    mediump vec4 color = texture2D(tex, texc)*texColor;\n"
+		"    color.rgb = max(color.rgb * brightness, vec3(0.0));\n"
+		"    if (saturation != 1.0)\n"
+		"        color.rgb = saturate(color.rgb, saturation);\n"
+		"    if (gamma != 1.0)\n"
+		"        color.rgb = pow(color.rgb, vec3(1.0 / max(gamma, 0.001)));\n"
+		"    if (colorChannel != 0)\n"
+		"    {\n"
+		"        mediump float luma = dot(color.rgb, vec3(0.2126, 0.7152, 0.0722));\n"
+		"        if (colorChannel == 1)\n"
+		"            color.rgb = vec3(luma, 0.0, 0.0);\n"
+		"        else if (colorChannel == 2)\n"
+		"            color.rgb = vec3(0.0, luma, 0.0);\n"
+		"        else\n"
+		"            color.rgb = vec3(0.0, 0.0, luma);\n"
+		"    }\n"
+		"    if (premultiplyAlpha != 0)\n"
+		"    {\n"
+		"        color.rgb *= color.a;\n"
+		"        color.a = 1.0;\n"
+		"    }\n"
+		"    FRAG_COLOR = color;\n"
+		"}\n";
+	adjustedFshader2.compileSourceCode(adjustedFsrc2);
+	if (!adjustedFshader2.log().isEmpty())
+		qWarning().noquote() << "StelPainter: Warnings while compiling adjustedFshader2: " << adjustedFshader2.log();
+
+	adjustedTexturesShaderProgram = new QOpenGLShaderProgram(QOpenGLContext::currentContext());
+	adjustedTexturesShaderProgram->addShader(&vshader2);
+	adjustedTexturesShaderProgram->addShader(&adjustedFshader2);
+	linkProg(adjustedTexturesShaderProgram, "adjustedTexturesShaderProgram");
+	adjustedTexturesShaderVars.projectionMatrix = adjustedTexturesShaderProgram->uniformLocation("projectionMatrix");
+	adjustedTexturesShaderVars.texCoord = adjustedTexturesShaderProgram->attributeLocation("texCoord");
+	adjustedTexturesShaderVars.vertex = adjustedTexturesShaderProgram->attributeLocation("vertex");
+	adjustedTexturesShaderVars.texColor = adjustedTexturesShaderProgram->uniformLocation("texColor");
+	adjustedTexturesShaderVars.texture = adjustedTexturesShaderProgram->uniformLocation("tex");
+	adjustedTexturesShaderVars.gamma = adjustedTexturesShaderProgram->uniformLocation("gamma");
+	adjustedTexturesShaderVars.saturation = adjustedTexturesShaderProgram->uniformLocation("saturation");
+	adjustedTexturesShaderVars.brightness = adjustedTexturesShaderProgram->uniformLocation("brightness");
+	adjustedTexturesShaderVars.colorChannel = adjustedTexturesShaderProgram->uniformLocation("colorChannel");
+	adjustedTexturesShaderVars.premultiplyAlpha = adjustedTexturesShaderProgram->uniformLocation("premultiplyAlpha");
+
 	// Texture shader program + interpolated color per vertex
 	QOpenGLShader vshader4(QOpenGLShader::Vertex);
 	const auto vsrc4 =
@@ -2355,11 +2438,36 @@ void main()
 		"VARYING mediump vec4 outColor;\n"
 		"uniform sampler2D tex;\n"
 		"uniform lowp float saturation;\n"
+		"uniform mediump float gamma;\n"
+		"uniform mediump float brightness;\n"
+		"uniform int colorChannel;\n"
+		"uniform int premultiplyAlpha;\n"
+		"uniform mediump float alpha;\n"
 		"void main(void)\n"
 		"{\n"
-		"    FRAG_COLOR = texture2D(tex, texc)*outColor;\n"
+		"    mediump vec4 color = texture2D(tex, texc)*outColor;\n"
+		"    color.a *= alpha;\n"
+		"    color.rgb = max(color.rgb * brightness, vec3(0.0));\n"
 		"    if (saturation != 1.0)\n"
-		"        FRAG_COLOR.rgb = saturate(FRAG_COLOR.rgb, saturation);\n"
+		"        color.rgb = saturate(color.rgb, saturation);\n"
+		"    if (gamma != 1.0)\n"
+		"        color.rgb = pow(color.rgb, vec3(1.0 / max(gamma, 0.001)));\n"
+		"    if (colorChannel != 0)\n"
+		"    {\n"
+		"        mediump float luma = dot(color.rgb, vec3(0.2126, 0.7152, 0.0722));\n"
+		"        if (colorChannel == 1)\n"
+		"            color.rgb = vec3(luma, 0.0, 0.0);\n"
+		"        else if (colorChannel == 2)\n"
+		"            color.rgb = vec3(0.0, luma, 0.0);\n"
+		"        else\n"
+		"            color.rgb = vec3(0.0, 0.0, luma);\n"
+		"    }\n"
+		"    if (premultiplyAlpha != 0)\n"
+		"    {\n"
+		"        color.rgb *= color.a;\n"
+		"        color.a = 1.0;\n"
+		"    }\n"
+		"    FRAG_COLOR = color;\n"
 		"}\n";
 	fshader4.compileSourceCode(fsrc4);
 	if (!fshader4.log().isEmpty())
@@ -2375,6 +2483,11 @@ void main()
 	texturesColorShaderVars.color = texturesColorShaderProgram->attributeLocation("color");
 	texturesColorShaderVars.texture = texturesColorShaderProgram->uniformLocation("tex");
 	texturesColorShaderVars.saturation = texturesColorShaderProgram->uniformLocation("saturation");
+	texturesColorShaderVars.gamma = texturesColorShaderProgram->uniformLocation("gamma");
+	texturesColorShaderVars.brightness = texturesColorShaderProgram->uniformLocation("brightness");
+	texturesColorShaderVars.colorChannel = texturesColorShaderProgram->uniformLocation("colorChannel");
+	texturesColorShaderVars.premultiplyAlpha = texturesColorShaderProgram->uniformLocation("premultiplyAlpha");
+	texturesColorShaderVars.alpha = texturesColorShaderProgram->uniformLocation("alpha");
 
 	const auto& glInfo = StelMainView::getInstance().getGLInformation();
 	if(glInfo.isCoreProfile && glInfo.isHighGraphicsMode && !glInfo.isGLES)
@@ -2527,6 +2640,8 @@ void StelPainter::deinitGLShaders()
 	colorShaderProgram = Q_NULLPTR;
 	delete texturesShaderProgram;
 	texturesShaderProgram = Q_NULLPTR;
+	delete adjustedTexturesShaderProgram;
+	adjustedTexturesShaderProgram = Q_NULLPTR;
 	delete texturesColorShaderProgram;
 	texturesColorShaderProgram = Q_NULLPTR;
 	delete wideLineShaderProgram;
@@ -2543,6 +2658,15 @@ void StelPainter::setArrays(const Vec3d* vertices, const Vec2f* texCoords, const
 	setVertexPointer(3, GL_DOUBLE, vertices);
 	setTexCoordPointer(2, GL_FLOAT, texCoords);
 	setColorPointer(3, GL_FLOAT, colorArray);
+	setNormalPointer(GL_FLOAT, normalArray);
+}
+
+void StelPainter::setArrays(const Vec3d* vertices, const Vec2f* texCoords, const Vec4f* colorArray, const Vec3f* normalArray)
+{
+	enableClientStates(vertices, texCoords, colorArray, normalArray);
+	setVertexPointer(3, GL_DOUBLE, vertices);
+	setTexCoordPointer(2, GL_FLOAT, texCoords);
+	setColorPointer(4, GL_FLOAT, colorArray);
 	setNormalPointer(GL_FLOAT, normalArray);
 }
 
@@ -2821,7 +2945,9 @@ void StelPainter::drawFromArray(DrawingMode mode, int count, int offset, bool do
 	}
 	else if (texCoordArray.enabled && !colorArray.enabled && !normalArray.enabled && !wideLineMode)
 	{
-		pr = texturesShaderProgram;
+		const bool useAdjustedTextureShader = hasTextureDisplayAdjustment();
+		pr = useAdjustedTextureShader ? adjustedTexturesShaderProgram : texturesShaderProgram;
+		const TexturesShaderVars& shaderVars = useAdjustedTextureShader ? adjustedTexturesShaderVars : texturesShaderVars;
 		pr->bind();
 
 		const auto bufferSize = projectedVertexArray.vertexSizeInBytes()*numberOfVerticesToCopy +
@@ -2833,12 +2959,20 @@ void StelPainter::drawFromArray(DrawingMode mode, int count, int offset, bool do
 		const auto texCoordDataSize = texCoordArray.vertexSizeInBytes()*numberOfVerticesToCopy;
 		verticesVBO->write(texCoordDataOffset, texCoordArray.pointer, texCoordDataSize);
 
-		pr->setAttributeBuffer(texturesShaderVars.vertex, projectedVertexArray.type, 0, projectedVertexArray.size);
-		pr->enableAttributeArray(texturesShaderVars.vertex);
-		pr->setUniformValue(texturesShaderVars.projectionMatrix, qMat);
-		pr->setUniformValue(texturesShaderVars.texColor, currentColor.toQVector());
-		pr->setAttributeBuffer(texturesShaderVars.texCoord, texCoordArray.type, texCoordDataOffset, texCoordArray.size);
-		pr->enableAttributeArray(texturesShaderVars.texCoord);
+		pr->setAttributeBuffer(shaderVars.vertex, projectedVertexArray.type, 0, projectedVertexArray.size);
+		pr->enableAttributeArray(shaderVars.vertex);
+		pr->setUniformValue(shaderVars.projectionMatrix, qMat);
+		pr->setUniformValue(shaderVars.texColor, currentColor.toQVector());
+		if (useAdjustedTextureShader)
+		{
+			pr->setUniformValue(shaderVars.gamma, textureGamma);
+			pr->setUniformValue(shaderVars.saturation, textureSaturation);
+			pr->setUniformValue(shaderVars.brightness, textureBrightness);
+			pr->setUniformValue(shaderVars.colorChannel, textureColorChannel);
+			pr->setUniformValue(shaderVars.premultiplyAlpha, texturePremultiplyAlpha ? 1 : 0);
+		}
+		pr->setAttributeBuffer(shaderVars.texCoord, texCoordArray.type, texCoordDataOffset, texCoordArray.size);
+		pr->enableAttributeArray(shaderVars.texCoord);
 		//pr->setUniformValue(texturesShaderVars.texture, 0);    // use texture unit 0
 	}
 	else if (texCoordArray.enabled && colorArray.enabled && !normalArray.enabled && !wideLineMode)
@@ -2867,7 +3001,12 @@ void StelPainter::drawFromArray(DrawingMode mode, int count, int offset, bool do
 		pr->setAttributeBuffer(texturesColorShaderVars.color, colorArray.type, colorDataOffset, colorArray.size);
 		pr->enableAttributeArray(texturesColorShaderVars.color);
 		//pr->setUniformValue(texturesShaderVars.texture, 0);    // use texture unit 0
-		pr->setUniformValue(texturesColorShaderVars.saturation, saturation);
+		pr->setUniformValue(texturesColorShaderVars.saturation, saturation * textureSaturation);
+		pr->setUniformValue(texturesColorShaderVars.gamma, textureGamma);
+		pr->setUniformValue(texturesColorShaderVars.brightness, textureBrightness);
+		pr->setUniformValue(texturesColorShaderVars.colorChannel, textureColorChannel);
+		pr->setUniformValue(texturesColorShaderVars.premultiplyAlpha, texturePremultiplyAlpha ? 1 : 0);
+		pr->setUniformValue(texturesColorShaderVars.alpha, textureAlpha);
 	}
 	else if (!texCoordArray.enabled && colorArray.enabled && !normalArray.enabled)
 	{
@@ -2997,4 +3136,3 @@ StelPainter::ArrayDesc StelPainter::projectArray(const StelPainter::ArrayDesc& a
 	ret.enabled = array.enabled;
 	return ret;
 }
-

--- a/src/core/StelPainter.cpp
+++ b/src/core/StelPainter.cpp
@@ -125,12 +125,13 @@ void StelPainter::GLState::reset()
 }
 
 void StelPainter::setTextureDisplayAdjustment(float gamma, float saturation, float brightness,
-                                              int colorChannel, bool invertedColors,
+                                              float contrast, int colorChannel, bool invertedColors,
                                               bool premultiplyAlpha, float alpha)
 {
 	textureGamma = qBound(0.1f, gamma, 5.f);
 	textureSaturation = qBound(0.f, saturation, 3.f);
 	textureBrightness = qBound(0.f, brightness, 5.f);
+	textureContrast = qBound(0.f, contrast, 5.f);
 	textureColorChannel = qBound(0, colorChannel, 3);
 	textureInvertedColors = invertedColors;
 	texturePremultiplyAlpha = premultiplyAlpha;
@@ -139,7 +140,7 @@ void StelPainter::setTextureDisplayAdjustment(float gamma, float saturation, flo
 
 void StelPainter::resetTextureDisplayAdjustment()
 {
-	setTextureDisplayAdjustment(1.f, 1.f, 1.f, 0, false, false);
+	setTextureDisplayAdjustment(1.f, 1.f, 1.f, 1.f, 0, false, false);
 }
 
 bool StelPainter::hasTextureDisplayAdjustment() const
@@ -147,6 +148,7 @@ bool StelPainter::hasTextureDisplayAdjustment() const
 	return !qFuzzyCompare(textureGamma, 1.f) ||
 	       !qFuzzyCompare(textureSaturation, 1.f) ||
 	       !qFuzzyCompare(textureBrightness, 1.f) ||
+	       !qFuzzyCompare(textureContrast, 1.f) ||
 	       textureColorChannel != 0 ||
 	       textureInvertedColors ||
 	       texturePremultiplyAlpha;
@@ -2367,6 +2369,7 @@ void main()
 		"uniform mediump float gamma;\n"
 		"uniform mediump float saturation;\n"
 		"uniform mediump float brightness;\n"
+		"uniform mediump float contrast;\n"
 		"uniform int colorChannel;\n"
 		"uniform int invertedColors;\n"
 		"uniform int premultiplyAlpha;\n"
@@ -2374,6 +2377,8 @@ void main()
 		"{\n"
 		"    mediump vec4 color = texture2D(tex, texc)*texColor;\n"
 		"    color.rgb = max(color.rgb * brightness, vec3(0.0));\n"
+		"    if (contrast != 1.0)\n"
+		"        color.rgb = clamp((color.rgb - vec3(0.5)) * contrast + vec3(0.5), vec3(0.0), vec3(1.0));\n"
 		"    if (saturation != 1.0)\n"
 		"        color.rgb = saturate(color.rgb, saturation);\n"
 		"    if (gamma != 1.0)\n"
@@ -2413,6 +2418,7 @@ void main()
 	adjustedTexturesShaderVars.gamma = adjustedTexturesShaderProgram->uniformLocation("gamma");
 	adjustedTexturesShaderVars.saturation = adjustedTexturesShaderProgram->uniformLocation("saturation");
 	adjustedTexturesShaderVars.brightness = adjustedTexturesShaderProgram->uniformLocation("brightness");
+	adjustedTexturesShaderVars.contrast = adjustedTexturesShaderProgram->uniformLocation("contrast");
 	adjustedTexturesShaderVars.colorChannel = adjustedTexturesShaderProgram->uniformLocation("colorChannel");
 	adjustedTexturesShaderVars.invertedColors = adjustedTexturesShaderProgram->uniformLocation("invertedColors");
 	adjustedTexturesShaderVars.premultiplyAlpha = adjustedTexturesShaderProgram->uniformLocation("premultiplyAlpha");
@@ -2444,19 +2450,22 @@ void main()
 		"VARYING mediump vec2 texc;\n"
 		"VARYING mediump vec4 outColor;\n"
 		"uniform sampler2D tex;\n"
-		"uniform lowp float saturation;\n"
-		"uniform mediump float gamma;\n"
-		"uniform mediump float brightness;\n"
-		"uniform int colorChannel;\n"
+	"uniform lowp float saturation;\n"
+	"uniform mediump float gamma;\n"
+	"uniform mediump float brightness;\n"
+	"uniform mediump float contrast;\n"
+	"uniform int colorChannel;\n"
 		"uniform int invertedColors;\n"
 		"uniform int premultiplyAlpha;\n"
 		"uniform mediump float alpha;\n"
 		"void main(void)\n"
 		"{\n"
 		"    mediump vec4 color = texture2D(tex, texc)*outColor;\n"
-		"    color.a *= alpha;\n"
-		"    color.rgb = max(color.rgb * brightness, vec3(0.0));\n"
-		"    if (saturation != 1.0)\n"
+	"    color.a *= alpha;\n"
+	"    color.rgb = max(color.rgb * brightness, vec3(0.0));\n"
+	"    if (contrast != 1.0)\n"
+	"        color.rgb = clamp((color.rgb - vec3(0.5)) * contrast + vec3(0.5), vec3(0.0), vec3(1.0));\n"
+	"    if (saturation != 1.0)\n"
 		"        color.rgb = saturate(color.rgb, saturation);\n"
 		"    if (gamma != 1.0)\n"
 		"        color.rgb = pow(color.rgb, vec3(1.0 / max(gamma, 0.001)));\n"
@@ -2495,6 +2504,7 @@ void main()
 	texturesColorShaderVars.saturation = texturesColorShaderProgram->uniformLocation("saturation");
 	texturesColorShaderVars.gamma = texturesColorShaderProgram->uniformLocation("gamma");
 	texturesColorShaderVars.brightness = texturesColorShaderProgram->uniformLocation("brightness");
+	texturesColorShaderVars.contrast = texturesColorShaderProgram->uniformLocation("contrast");
 	texturesColorShaderVars.colorChannel = texturesColorShaderProgram->uniformLocation("colorChannel");
 	texturesColorShaderVars.invertedColors = texturesColorShaderProgram->uniformLocation("invertedColors");
 	texturesColorShaderVars.premultiplyAlpha = texturesColorShaderProgram->uniformLocation("premultiplyAlpha");
@@ -2979,6 +2989,7 @@ void StelPainter::drawFromArray(DrawingMode mode, int count, int offset, bool do
 			pr->setUniformValue(shaderVars.gamma, textureGamma);
 			pr->setUniformValue(shaderVars.saturation, textureSaturation);
 			pr->setUniformValue(shaderVars.brightness, textureBrightness);
+			pr->setUniformValue(shaderVars.contrast, textureContrast);
 			pr->setUniformValue(shaderVars.colorChannel, textureColorChannel);
 			pr->setUniformValue(shaderVars.invertedColors, textureInvertedColors ? 1 : 0);
 			pr->setUniformValue(shaderVars.premultiplyAlpha, texturePremultiplyAlpha ? 1 : 0);
@@ -3016,6 +3027,7 @@ void StelPainter::drawFromArray(DrawingMode mode, int count, int offset, bool do
 		pr->setUniformValue(texturesColorShaderVars.saturation, saturation * textureSaturation);
 		pr->setUniformValue(texturesColorShaderVars.gamma, textureGamma);
 		pr->setUniformValue(texturesColorShaderVars.brightness, textureBrightness);
+		pr->setUniformValue(texturesColorShaderVars.contrast, textureContrast);
 		pr->setUniformValue(texturesColorShaderVars.colorChannel, textureColorChannel);
 		pr->setUniformValue(texturesColorShaderVars.invertedColors, textureInvertedColors ? 1 : 0);
 		pr->setUniformValue(texturesColorShaderVars.premultiplyAlpha, texturePremultiplyAlpha ? 1 : 0);

--- a/src/core/StelPainter.cpp
+++ b/src/core/StelPainter.cpp
@@ -125,19 +125,21 @@ void StelPainter::GLState::reset()
 }
 
 void StelPainter::setTextureDisplayAdjustment(float gamma, float saturation, float brightness,
-                                              int colorChannel, bool premultiplyAlpha, float alpha)
+                                              int colorChannel, bool invertedColors,
+                                              bool premultiplyAlpha, float alpha)
 {
 	textureGamma = qBound(0.1f, gamma, 5.f);
 	textureSaturation = qBound(0.f, saturation, 3.f);
 	textureBrightness = qBound(0.f, brightness, 5.f);
 	textureColorChannel = qBound(0, colorChannel, 3);
+	textureInvertedColors = invertedColors;
 	texturePremultiplyAlpha = premultiplyAlpha;
 	textureAlpha = qBound(0.f, alpha, 1.f);
 }
 
 void StelPainter::resetTextureDisplayAdjustment()
 {
-	setTextureDisplayAdjustment(1.f, 1.f, 1.f, 0, false);
+	setTextureDisplayAdjustment(1.f, 1.f, 1.f, 0, false, false);
 }
 
 bool StelPainter::hasTextureDisplayAdjustment() const
@@ -146,6 +148,7 @@ bool StelPainter::hasTextureDisplayAdjustment() const
 	       !qFuzzyCompare(textureSaturation, 1.f) ||
 	       !qFuzzyCompare(textureBrightness, 1.f) ||
 	       textureColorChannel != 0 ||
+	       textureInvertedColors ||
 	       texturePremultiplyAlpha;
 }
 
@@ -2365,6 +2368,7 @@ void main()
 		"uniform mediump float saturation;\n"
 		"uniform mediump float brightness;\n"
 		"uniform int colorChannel;\n"
+		"uniform int invertedColors;\n"
 		"uniform int premultiplyAlpha;\n"
 		"void main(void)\n"
 		"{\n"
@@ -2374,6 +2378,8 @@ void main()
 		"        color.rgb = saturate(color.rgb, saturation);\n"
 		"    if (gamma != 1.0)\n"
 		"        color.rgb = pow(color.rgb, vec3(1.0 / max(gamma, 0.001)));\n"
+		"    if (invertedColors != 0)\n"
+		"        color.rgb = vec3(1.0) - clamp(color.rgb, vec3(0.0), vec3(1.0));\n"
 		"    if (colorChannel != 0)\n"
 		"    {\n"
 		"        mediump float luma = dot(color.rgb, vec3(0.2126, 0.7152, 0.0722));\n"
@@ -2408,6 +2414,7 @@ void main()
 	adjustedTexturesShaderVars.saturation = adjustedTexturesShaderProgram->uniformLocation("saturation");
 	adjustedTexturesShaderVars.brightness = adjustedTexturesShaderProgram->uniformLocation("brightness");
 	adjustedTexturesShaderVars.colorChannel = adjustedTexturesShaderProgram->uniformLocation("colorChannel");
+	adjustedTexturesShaderVars.invertedColors = adjustedTexturesShaderProgram->uniformLocation("invertedColors");
 	adjustedTexturesShaderVars.premultiplyAlpha = adjustedTexturesShaderProgram->uniformLocation("premultiplyAlpha");
 
 	// Texture shader program + interpolated color per vertex
@@ -2441,6 +2448,7 @@ void main()
 		"uniform mediump float gamma;\n"
 		"uniform mediump float brightness;\n"
 		"uniform int colorChannel;\n"
+		"uniform int invertedColors;\n"
 		"uniform int premultiplyAlpha;\n"
 		"uniform mediump float alpha;\n"
 		"void main(void)\n"
@@ -2452,6 +2460,8 @@ void main()
 		"        color.rgb = saturate(color.rgb, saturation);\n"
 		"    if (gamma != 1.0)\n"
 		"        color.rgb = pow(color.rgb, vec3(1.0 / max(gamma, 0.001)));\n"
+		"    if (invertedColors != 0)\n"
+		"        color.rgb = vec3(1.0) - clamp(color.rgb, vec3(0.0), vec3(1.0));\n"
 		"    if (colorChannel != 0)\n"
 		"    {\n"
 		"        mediump float luma = dot(color.rgb, vec3(0.2126, 0.7152, 0.0722));\n"
@@ -2486,6 +2496,7 @@ void main()
 	texturesColorShaderVars.gamma = texturesColorShaderProgram->uniformLocation("gamma");
 	texturesColorShaderVars.brightness = texturesColorShaderProgram->uniformLocation("brightness");
 	texturesColorShaderVars.colorChannel = texturesColorShaderProgram->uniformLocation("colorChannel");
+	texturesColorShaderVars.invertedColors = texturesColorShaderProgram->uniformLocation("invertedColors");
 	texturesColorShaderVars.premultiplyAlpha = texturesColorShaderProgram->uniformLocation("premultiplyAlpha");
 	texturesColorShaderVars.alpha = texturesColorShaderProgram->uniformLocation("alpha");
 
@@ -2969,6 +2980,7 @@ void StelPainter::drawFromArray(DrawingMode mode, int count, int offset, bool do
 			pr->setUniformValue(shaderVars.saturation, textureSaturation);
 			pr->setUniformValue(shaderVars.brightness, textureBrightness);
 			pr->setUniformValue(shaderVars.colorChannel, textureColorChannel);
+			pr->setUniformValue(shaderVars.invertedColors, textureInvertedColors ? 1 : 0);
 			pr->setUniformValue(shaderVars.premultiplyAlpha, texturePremultiplyAlpha ? 1 : 0);
 		}
 		pr->setAttributeBuffer(shaderVars.texCoord, texCoordArray.type, texCoordDataOffset, texCoordArray.size);
@@ -3005,6 +3017,7 @@ void StelPainter::drawFromArray(DrawingMode mode, int count, int offset, bool do
 		pr->setUniformValue(texturesColorShaderVars.gamma, textureGamma);
 		pr->setUniformValue(texturesColorShaderVars.brightness, textureBrightness);
 		pr->setUniformValue(texturesColorShaderVars.colorChannel, textureColorChannel);
+		pr->setUniformValue(texturesColorShaderVars.invertedColors, textureInvertedColors ? 1 : 0);
 		pr->setUniformValue(texturesColorShaderVars.premultiplyAlpha, texturePremultiplyAlpha ? 1 : 0);
 		pr->setUniformValue(texturesColorShaderVars.alpha, textureAlpha);
 	}

--- a/src/core/StelPainter.hpp
+++ b/src/core/StelPainter.hpp
@@ -286,6 +286,12 @@ public:
 	//! Sets the color saturation effect value, from 0 (grayscale) to 1 (no effect).
 	void setSaturation(float v) { saturation = v; }
 
+	//! Sets texture color adjustment for subsequent simple textured draws.
+	void setTextureDisplayAdjustment(float gamma, float saturation, float brightness,
+	                                 int colorChannel, bool premultiplyAlpha, float alpha = 1.f);
+	//! Restores neutral texture color adjustment for subsequent simple textured draws.
+	void resetTextureDisplayAdjustment();
+
 	//! Create the OpenGL shaders programs used by the StelPainter.
 	//! This method needs to be called once at init.
 	static void initGLShaders();
@@ -324,6 +330,7 @@ public:
 	//! convenience method that enable and set all the given arrays.
 	//! It is equivalent to calling enableClientStates() and set the array pointer for each array.
 	void setArrays(const Vec3d* vertices, const Vec2f* texCoords=Q_NULLPTR, const Vec3f* colorArray=Q_NULLPTR, const Vec3f* normalArray=Q_NULLPTR);
+	void setArrays(const Vec3d* vertices, const Vec2f* texCoords, const Vec4f* colorArray, const Vec3f* normalArray=Q_NULLPTR);
 	void setArrays(const Vec3f* vertices, const Vec2f* texCoords=Q_NULLPTR, const Vec3f* colorArray=Q_NULLPTR, const Vec3f* normalArray=Q_NULLPTR);
 
 	//! Draws primitives using vertices from the arrays specified by setArrays() or enabled via enableClientStates().
@@ -436,6 +443,13 @@ private:
 	Vec4f currentColor;
 	//! Saturation effect adjustment.
 	float saturation = 1.f;
+	float textureGamma = 1.f;
+	float textureSaturation = 1.f;
+	float textureBrightness = 1.f;
+	int textureColorChannel = 0;
+	bool texturePremultiplyAlpha = false;
+	float textureAlpha = 1.f;
+	bool hasTextureDisplayAdjustment() const;
 
 	static QOpenGLShaderProgram* basicShaderProgram;
 	struct BasicShaderVars {
@@ -465,8 +479,15 @@ private:
 		int vertex;
 		int texColor;
 		int texture;
+		int gamma;
+		int saturation;
+		int brightness;
+		int colorChannel;
+		int premultiplyAlpha;
 	};
 	static TexturesShaderVars texturesShaderVars;
+	static QOpenGLShaderProgram* adjustedTexturesShaderProgram;
+	static TexturesShaderVars adjustedTexturesShaderVars;
 	static QOpenGLShaderProgram* texturesColorShaderProgram;
 	struct TexturesColorShaderVars {
 		int projectionMatrix;
@@ -475,6 +496,11 @@ private:
 		int color;
 		int texture;
 		int saturation;
+		int gamma;
+		int brightness;
+		int colorChannel;
+		int premultiplyAlpha;
+		int alpha;
 	};
 	static TexturesColorShaderVars texturesColorShaderVars;
 
@@ -511,4 +537,3 @@ private:
 };
 
 #endif // STELPAINTER_HPP
-

--- a/src/core/StelPainter.hpp
+++ b/src/core/StelPainter.hpp
@@ -288,7 +288,7 @@ public:
 
 	//! Sets texture color adjustment for subsequent simple textured draws.
 	void setTextureDisplayAdjustment(float gamma, float saturation, float brightness,
-	                                 int colorChannel, bool invertedColors,
+	                                 float contrast, int colorChannel, bool invertedColors,
 	                                 bool premultiplyAlpha, float alpha = 1.f);
 	//! Restores neutral texture color adjustment for subsequent simple textured draws.
 	void resetTextureDisplayAdjustment();
@@ -447,6 +447,7 @@ private:
 	float textureGamma = 1.f;
 	float textureSaturation = 1.f;
 	float textureBrightness = 1.f;
+	float textureContrast = 1.f;
 	int textureColorChannel = 0;
 	bool textureInvertedColors = false;
 	bool texturePremultiplyAlpha = false;
@@ -484,6 +485,7 @@ private:
 		int gamma;
 		int saturation;
 		int brightness;
+		int contrast;
 		int colorChannel;
 		int invertedColors;
 		int premultiplyAlpha;
@@ -501,6 +503,7 @@ private:
 		int saturation;
 		int gamma;
 		int brightness;
+		int contrast;
 		int colorChannel;
 		int invertedColors;
 		int premultiplyAlpha;

--- a/src/core/StelPainter.hpp
+++ b/src/core/StelPainter.hpp
@@ -288,7 +288,8 @@ public:
 
 	//! Sets texture color adjustment for subsequent simple textured draws.
 	void setTextureDisplayAdjustment(float gamma, float saturation, float brightness,
-	                                 int colorChannel, bool premultiplyAlpha, float alpha = 1.f);
+	                                 int colorChannel, bool invertedColors,
+	                                 bool premultiplyAlpha, float alpha = 1.f);
 	//! Restores neutral texture color adjustment for subsequent simple textured draws.
 	void resetTextureDisplayAdjustment();
 
@@ -447,6 +448,7 @@ private:
 	float textureSaturation = 1.f;
 	float textureBrightness = 1.f;
 	int textureColorChannel = 0;
+	bool textureInvertedColors = false;
 	bool texturePremultiplyAlpha = false;
 	float textureAlpha = 1.f;
 	bool hasTextureDisplayAdjustment() const;
@@ -483,6 +485,7 @@ private:
 		int saturation;
 		int brightness;
 		int colorChannel;
+		int invertedColors;
 		int premultiplyAlpha;
 	};
 	static TexturesShaderVars texturesShaderVars;
@@ -499,6 +502,7 @@ private:
 		int gamma;
 		int brightness;
 		int colorChannel;
+		int invertedColors;
 		int premultiplyAlpha;
 		int alpha;
 	};

--- a/src/core/modules/HipsMgr.cpp
+++ b/src/core/modules/HipsMgr.cpp
@@ -92,6 +92,7 @@ HipsMgr::~HipsMgr()
 			conf->setValue("brightness", survey->getBrightness());
 			conf->setValue("opacity", survey->getOpacity());
 			conf->setValue("colorChannel", survey->getColorChannel());
+			conf->setValue("invertedColors", survey->getInvertedColors());
 		}
 		conf->endArray();
 
@@ -224,7 +225,8 @@ void HipsMgr::restoreVisibleSurveys()
 			                           conf->value("saturation", 1.).toFloat(),
 			                           conf->value("brightness", 1.).toFloat(),
 			                           conf->value("opacity", 1.).toFloat(),
-			                           conf->value("colorChannel", HipsSurvey::ColorChannelRgb).toInt());
+			                           conf->value("colorChannel", HipsSurvey::ColorChannelRgb).toInt(),
+			                           conf->value("invertedColors", false).toBool());
 		}
 	}
 	conf->endArray();
@@ -249,6 +251,7 @@ void HipsMgr::saveSurveySettings() const
 		conf->setValue("brightness", survey->getBrightness());
 		conf->setValue("opacity", survey->getOpacity());
 		conf->setValue("colorChannel", survey->getColorChannel());
+		conf->setValue("invertedColors", survey->getInvertedColors());
 	}
 	conf->endArray();
 	conf->endGroup();

--- a/src/core/modules/HipsMgr.cpp
+++ b/src/core/modules/HipsMgr.cpp
@@ -90,6 +90,7 @@ HipsMgr::~HipsMgr()
 			conf->setValue("gamma", survey->getGamma());
 			conf->setValue("saturation", survey->getSaturation());
 			conf->setValue("brightness", survey->getBrightness());
+			conf->setValue("contrast", survey->getContrast());
 			conf->setValue("opacity", survey->getOpacity());
 			conf->setValue("colorChannel", survey->getColorChannel());
 			conf->setValue("invertedColors", survey->getInvertedColors());
@@ -224,6 +225,7 @@ void HipsMgr::restoreVisibleSurveys()
 			survey->setDisplaySettings(conf->value("gamma", 1.).toFloat(),
 			                           conf->value("saturation", 1.).toFloat(),
 			                           conf->value("brightness", 1.).toFloat(),
+			                           conf->value("contrast", 1.).toFloat(),
 			                           conf->value("opacity", 1.).toFloat(),
 			                           conf->value("colorChannel", HipsSurvey::ColorChannelRgb).toInt(),
 			                           conf->value("invertedColors", false).toBool());
@@ -249,6 +251,7 @@ void HipsMgr::saveSurveySettings() const
 		conf->setValue("gamma", survey->getGamma());
 		conf->setValue("saturation", survey->getSaturation());
 		conf->setValue("brightness", survey->getBrightness());
+		conf->setValue("contrast", survey->getContrast());
 		conf->setValue("opacity", survey->getOpacity());
 		conf->setValue("colorChannel", survey->getColorChannel());
 		conf->setValue("invertedColors", survey->getInvertedColors());

--- a/src/core/modules/HipsMgr.cpp
+++ b/src/core/modules/HipsMgr.cpp
@@ -27,6 +27,7 @@
 
 #include <QNetworkReply>
 #include <QSettings>
+#include <QSignalBlocker>
 #include <QTimer>
 
 Q_LOGGING_CATEGORY(HiPS,"stel.HiPS", QtInfoMsg)
@@ -48,6 +49,7 @@ HipsMgr::~HipsMgr()
 		QSettings* conf = StelApp::getInstance().getSettings();
 		conf->beginGroup("hips");
 		conf->setValue("show", getFlagShow());
+		conf->setValue("show_atmospheric_extinction", getFlagShowAtmosphericExtinction());
 
 		// remove 0.18.0 scheme
 		conf->remove("visible");
@@ -75,6 +77,23 @@ HipsMgr::~HipsMgr()
 			}
 			conf->endArray();
 		}
+
+		conf->remove("surveySettings");
+		int settingsIndex = 0;
+		conf->beginWriteArray("surveySettings");
+		for (auto &survey: surveys)
+		{
+			if (survey->isPlanetarySurvey() || survey->hasDefaultDisplaySettings())
+				continue;
+			conf->setArrayIndex(settingsIndex++);
+			conf->setValue("url", survey->getUrl());
+			conf->setValue("gamma", survey->getGamma());
+			conf->setValue("saturation", survey->getSaturation());
+			conf->setValue("brightness", survey->getBrightness());
+			conf->setValue("opacity", survey->getOpacity());
+			conf->setValue("colorChannel", survey->getColorChannel());
+		}
+		conf->endArray();
 
 		conf->endGroup();
 		conf->sync();
@@ -120,6 +139,8 @@ void HipsMgr::loadSources()
 			for (HipsSurveyP &survey: newSurveys)
 			{
 				connect(survey.data(), SIGNAL(propertiesChanged()), this, SIGNAL(surveysChanged()));
+				connect(survey.data(), &HipsSurvey::visibleChanged, this, &HipsMgr::updateActiveSurveys);
+				connect(survey.data(), &HipsSurvey::displaySettingsChanged, this, &HipsMgr::saveSurveySettings);
 				emit gotNewSurvey(survey);
 			}
 			surveys += newSurveys;
@@ -140,6 +161,7 @@ void HipsMgr::init()
 	QSettings* conf = StelApp::getInstance().getSettings();
 	conf->beginGroup("hips");
 	setFlagShow(conf->value("show", false).toBool());
+	flagShowAtmosphericExtinction = conf->value("show_atmospheric_extinction", false).toBool();
 	int size = conf->beginReadArray("surveys");
 	conf->endArray();	
 	conf->endGroup();
@@ -188,6 +210,47 @@ void HipsMgr::restoreVisibleSurveys()
 		}
 	}
 	conf->endArray();
+
+	size = conf->beginReadArray("surveySettings");
+	for (int i = 0; i < size; i++)
+	{
+		conf->setArrayIndex(i);
+		const QString url = conf->value("url").toString();
+		HipsSurveyP survey = getSurveyByUrl(url);
+		if (survey && !survey->isPlanetarySurvey())
+		{
+			const QSignalBlocker blocker(survey.data());
+			survey->setDisplaySettings(conf->value("gamma", 1.).toFloat(),
+			                           conf->value("saturation", 1.).toFloat(),
+			                           conf->value("brightness", 1.).toFloat(),
+			                           conf->value("opacity", 1.).toFloat(),
+			                           conf->value("colorChannel", HipsSurvey::ColorChannelRgb).toInt());
+		}
+	}
+	conf->endArray();
+	conf->endGroup();
+}
+
+void HipsMgr::saveSurveySettings() const
+{
+	QSettings* conf = StelApp::getInstance().getSettings();
+	conf->beginGroup("hips");
+	conf->remove("surveySettings");
+	int settingsIndex = 0;
+	conf->beginWriteArray("surveySettings");
+	for (auto &survey: surveys)
+	{
+		if (survey->isPlanetarySurvey() || survey->hasDefaultDisplaySettings())
+			continue;
+		conf->setArrayIndex(settingsIndex++);
+		conf->setValue("url", survey->getUrl());
+		conf->setValue("gamma", survey->getGamma());
+		conf->setValue("saturation", survey->getSaturation());
+		conf->setValue("brightness", survey->getBrightness());
+		conf->setValue("opacity", survey->getOpacity());
+		conf->setValue("colorChannel", survey->getColorChannel());
+	}
+	conf->endArray();
 	conf->endGroup();
 }
 
@@ -199,20 +262,25 @@ void HipsMgr::draw(StelCore* core)
 {
 	if (!visible) return;
 	StelPainter sPainter(core->getProjection(StelCore::FrameJ2000));
-	for (auto &survey: surveys)
+	for (auto &survey: activeSurveys)
 	{
-		if (survey->isVisible() && survey->planet.isEmpty())
+		if (survey->fader.getInterstate() > 0.f && survey->planet.isEmpty())
 		{
-			survey->draw(&sPainter);
+			survey->draw(&sPainter, 2.0 * M_PI, Q_NULLPTR, flagShowAtmosphericExtinction);
 		}
 	}
 }
 
 void HipsMgr::update(double deltaTime)
 {
-	for (auto &survey: surveys)
+	for (auto it = activeSurveys.begin(); it != activeSurveys.end();)
 	{
+		const auto &survey = *it;
 		survey->fader.update(static_cast<int>(deltaTime * 1000));
+		if (!survey->isVisible() && survey->fader.getInterstate() == 0.f)
+			it = activeSurveys.erase(it);
+		else
+			++it;
 	}
 }
 
@@ -251,5 +319,24 @@ void HipsMgr::setFlagShow(bool b)
 			if (survey->isVisible())
 				survey->hideProgressBar();
 		}
+	}
+}
+
+void HipsMgr::setFlagShowAtmosphericExtinction(bool b)
+{
+	if (flagShowAtmosphericExtinction == b)
+		return;
+	flagShowAtmosphericExtinction = b;
+	StelApp::immediateSave("hips/show_atmospheric_extinction", b);
+	emit flagShowAtmosphericExtinctionChanged(b);
+}
+
+void HipsMgr::updateActiveSurveys()
+{
+	activeSurveys.clear();
+	for (auto &survey: surveys)
+	{
+		if (survey->isVisible() || survey->fader.getInterstate() > 0.f)
+			activeSurveys << survey;
 	}
 }

--- a/src/core/modules/HipsMgr.cpp
+++ b/src/core/modules/HipsMgr.cpp
@@ -264,7 +264,7 @@ void HipsMgr::draw(StelCore* core)
 	StelPainter sPainter(core->getProjection(StelCore::FrameJ2000));
 	for (auto &survey: activeSurveys)
 	{
-		if (survey->fader.getInterstate() > 0.f && survey->planet.isEmpty())
+		if (survey->isVisible() && survey->planet.isEmpty())
 		{
 			survey->draw(&sPainter, 2.0 * M_PI, Q_NULLPTR, flagShowAtmosphericExtinction);
 		}

--- a/src/core/modules/HipsMgr.hpp
+++ b/src/core/modules/HipsMgr.hpp
@@ -45,6 +45,7 @@ class HipsMgr : public StelModule
 			MEMBER surveys
 			NOTIFY surveysChanged)
 	Q_PROPERTY(bool flagShow READ getFlagShow WRITE setFlagShow NOTIFY showChanged)
+	Q_PROPERTY(bool flagShowAtmosphericExtinction READ getFlagShowAtmosphericExtinction WRITE setFlagShowAtmosphericExtinction NOTIFY flagShowAtmosphericExtinctionChanged)
 	Q_PROPERTY(State state READ getState NOTIFY stateChanged)
 	Q_PROPERTY(bool loaded READ isLoaded NOTIFY stateChanged)
 
@@ -75,6 +76,7 @@ public:
 
 signals:
 	void showChanged(bool value) const;
+	void flagShowAtmosphericExtinctionChanged(bool value) const;
 	void surveysChanged() const;
 	void stateChanged(State value) const;
 	//! Emitted when a new survey has been loaded.
@@ -89,14 +91,20 @@ public slots:
 	bool getFlagShow(void) const;
 	//! Set whether the surveys are displayed.
 	void setFlagShow(bool b);
+	bool getFlagShowAtmosphericExtinction(void) const { return flagShowAtmosphericExtinction; }
+	void setFlagShowAtmosphericExtinction(bool b);
 
 private slots:
 	// after loading survey list from network, restore the visible surveys from config.ini.
 	void restoreVisibleSurveys();
+	void saveSurveySettings() const;
+	void updateActiveSurveys();
 
 private:
 	QList<HipsSurveyP> surveys;
+	QList<HipsSurveyP> activeSurveys;
 	bool visible = true;
+	bool flagShowAtmosphericExtinction = false;
 	State state = Created;
 	//! Used internally to keep track of the loading state.
 	int nbSourcesLoaded = 0;

--- a/src/gui/ViewDialog.cpp
+++ b/src/gui/ViewDialog.cpp
@@ -58,6 +58,7 @@
 #include <QFile>
 #include <QFileInfo>
 #include <QSettings>
+#include <QSignalBlocker>
 #include <QTimer>
 #include <QDialog>
 #include <QStringList>
@@ -745,9 +746,23 @@ void ViewDialog::createDialogContent()
 	connect(ui->surveyTypeComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(updateHips()));
 	connect(ui->stackListWidget, SIGNAL(currentItemChanged(QListWidgetItem *, QListWidgetItem *)), this, SLOT(updateHips()));
 	connect(ui->surveysTreeWidget, &QTreeWidget::currentItemChanged, this, &ViewDialog::updateHipsText, Qt::QueuedConnection);
+	connect(ui->surveysTreeWidget, &QTreeWidget::currentItemChanged, this, &ViewDialog::updateHipsControls, Qt::QueuedConnection);
 	connect(ui->surveysTreeWidget, &QTreeWidget::itemChanged, this, &ViewDialog::hipsListItemChanged);
 	connect(ui->surveysFilter, &QLineEdit::textChanged, this, &ViewDialog::filterSurveys);
 	connect(ui->listOnlyEnabledSurveys, &QCheckBox::toggled, this, &ViewDialog::filterSurveys);
+	connect(ui->hipsGammaDoubleSpinBox, QOverload<double>::of(&QDoubleSpinBox::valueChanged),
+	        this, &ViewDialog::hipsDisplaySettingsChanged);
+	connect(ui->hipsSaturationDoubleSpinBox, QOverload<double>::of(&QDoubleSpinBox::valueChanged),
+	        this, &ViewDialog::hipsDisplaySettingsChanged);
+	connect(ui->hipsBrightnessDoubleSpinBox, QOverload<double>::of(&QDoubleSpinBox::valueChanged),
+	        this, &ViewDialog::hipsDisplaySettingsChanged);
+	connect(ui->hipsOpacityDoubleSpinBox, QOverload<double>::of(&QDoubleSpinBox::valueChanged),
+	        this, &ViewDialog::hipsDisplaySettingsChanged);
+	connect(ui->hipsColorChannelComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged),
+	        this, &ViewDialog::hipsDisplaySettingsChanged);
+	connect(ui->hipsResetPushButton, &QPushButton::clicked, this, &ViewDialog::resetSelectedHipsDisplaySettings);
+	connect(ui->hipsResetAllPushButton, &QPushButton::clicked, this, &ViewDialog::resetAllHipsDisplaySettings);
+	connectBoolProperty(ui->hipsAtmosphericExtinctionCheckBox, "HipsMgr.flagShowAtmosphericExtinction");
 	updateHips();
 
 	updateTabBarListWidgetWidth();
@@ -894,12 +909,103 @@ void ViewDialog::updateHipsText()
 	ui->surveysTextBrowser->setHtml(html);
 }
 
+HipsSurveyP ViewDialog::currentSkyHips() const
+{
+	const auto currentItem = ui->surveysTreeWidget->currentItem();
+	if (!currentItem || currentItem->data(0, HipsRole::ItemType).toInt() != HipsItemType::Survey)
+		return HipsSurveyP(Q_NULLPTR);
+
+	const auto hipsmgr = qobject_cast<HipsMgr*>(StelApp::getInstance().getModule("HipsMgr"));
+	const auto hips = hipsmgr->getSurveyByUrl(currentItem->data(0, HipsRole::URL).toString());
+	if (!hips || hips->isPlanetarySurvey())
+		return HipsSurveyP(Q_NULLPTR);
+	return hips;
+}
+
+void ViewDialog::updateHipsControls()
+{
+	const auto hips = currentSkyHips();
+	bool hasSkySurvey = false;
+	const auto hipsmgr = qobject_cast<HipsMgr*>(StelApp::getInstance().getModule("HipsMgr"));
+	const QList<HipsSurveyP> hipslist = hipsmgr->property("surveys").value<QList<HipsSurveyP>>();
+	for (auto &survey: hipslist)
+	{
+		if (!survey->isPlanetarySurvey())
+		{
+			hasSkySurvey = true;
+			break;
+		}
+	}
+
+	const QSignalBlocker gammaBlocker(ui->hipsGammaDoubleSpinBox);
+	const QSignalBlocker saturationBlocker(ui->hipsSaturationDoubleSpinBox);
+	const QSignalBlocker brightnessBlocker(ui->hipsBrightnessDoubleSpinBox);
+	const QSignalBlocker opacityBlocker(ui->hipsOpacityDoubleSpinBox);
+	const QSignalBlocker colorChannelBlocker(ui->hipsColorChannelComboBox);
+
+	ui->hipsGammaDoubleSpinBox->setValue(hips ? hips->getGamma() : 1.);
+	ui->hipsSaturationDoubleSpinBox->setValue(hips ? hips->getSaturation() : 1.);
+	ui->hipsBrightnessDoubleSpinBox->setValue(hips ? hips->getBrightness() : 1.);
+	ui->hipsOpacityDoubleSpinBox->setValue(hips ? hips->getOpacity() : 1.);
+	ui->hipsColorChannelComboBox->setCurrentIndex(hips ? hips->getColorChannel() : HipsSurvey::ColorChannelRgb);
+
+	const bool enableSelectedControls = static_cast<bool>(hips);
+	ui->hipsSettingsGroupBox->setEnabled(enableSelectedControls || hasSkySurvey);
+	ui->hipsGammaLabel->setEnabled(enableSelectedControls);
+	ui->hipsGammaDoubleSpinBox->setEnabled(enableSelectedControls);
+	ui->hipsSaturationLabel->setEnabled(enableSelectedControls);
+	ui->hipsSaturationDoubleSpinBox->setEnabled(enableSelectedControls);
+	ui->hipsBrightnessLabel->setEnabled(enableSelectedControls);
+	ui->hipsBrightnessDoubleSpinBox->setEnabled(enableSelectedControls);
+	ui->hipsOpacityLabel->setEnabled(enableSelectedControls);
+	ui->hipsOpacityDoubleSpinBox->setEnabled(enableSelectedControls);
+	ui->hipsColorChannelLabel->setEnabled(enableSelectedControls);
+	ui->hipsColorChannelComboBox->setEnabled(enableSelectedControls);
+	ui->hipsResetPushButton->setEnabled(enableSelectedControls);
+	ui->hipsResetAllPushButton->setEnabled(hasSkySurvey);
+}
+
+void ViewDialog::hipsDisplaySettingsChanged()
+{
+	const auto hips = currentSkyHips();
+	if (!hips)
+		return;
+
+	hips->setDisplaySettings(static_cast<float>(ui->hipsGammaDoubleSpinBox->value()),
+	                         static_cast<float>(ui->hipsSaturationDoubleSpinBox->value()),
+	                         static_cast<float>(ui->hipsBrightnessDoubleSpinBox->value()),
+	                         static_cast<float>(ui->hipsOpacityDoubleSpinBox->value()),
+	                         ui->hipsColorChannelComboBox->currentIndex());
+}
+
+void ViewDialog::resetSelectedHipsDisplaySettings()
+{
+	const auto hips = currentSkyHips();
+	if (!hips)
+		return;
+	hips->resetDisplaySettings();
+	updateHipsControls();
+}
+
+void ViewDialog::resetAllHipsDisplaySettings()
+{
+	const auto hipsmgr = qobject_cast<HipsMgr*>(StelApp::getInstance().getModule("HipsMgr"));
+	const QList<HipsSurveyP> hipslist = hipsmgr->property("surveys").value<QList<HipsSurveyP>>();
+	for (auto &hips: hipslist)
+	{
+		if (!hips->isPlanetarySurvey())
+			hips->resetDisplaySettings();
+	}
+	updateHipsControls();
+}
+
 void ViewDialog::clearHips()
 {
 	ui->surveysTreeWidget->clear();
 	planetarySurveys.clear();
 	surveysInTheList.clear();
 	selectedSurveyType.clear();
+	updateHipsControls();
 }
 
 void ViewDialog::updateHips()
@@ -1049,6 +1155,7 @@ void ViewDialog::updateHips()
 
 	l->blockSignals(false);
 	filterSurveys();
+	updateHipsControls();
 }
 
 void ViewDialog::populateHipsGroups()

--- a/src/gui/ViewDialog.cpp
+++ b/src/gui/ViewDialog.cpp
@@ -756,6 +756,8 @@ void ViewDialog::createDialogContent()
 	        this, &ViewDialog::hipsDisplaySettingsChanged);
 	connect(ui->hipsBrightnessDoubleSpinBox, QOverload<double>::of(&QDoubleSpinBox::valueChanged),
 	        this, &ViewDialog::hipsDisplaySettingsChanged);
+	connect(ui->hipsContrastDoubleSpinBox, QOverload<double>::of(&QDoubleSpinBox::valueChanged),
+	        this, &ViewDialog::hipsDisplaySettingsChanged);
 	connect(ui->hipsOpacityDoubleSpinBox, QOverload<double>::of(&QDoubleSpinBox::valueChanged),
 	        this, &ViewDialog::hipsDisplaySettingsChanged);
 	connect(ui->hipsColorChannelComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged),
@@ -941,6 +943,7 @@ void ViewDialog::updateHipsControls()
 	const QSignalBlocker gammaBlocker(ui->hipsGammaDoubleSpinBox);
 	const QSignalBlocker saturationBlocker(ui->hipsSaturationDoubleSpinBox);
 	const QSignalBlocker brightnessBlocker(ui->hipsBrightnessDoubleSpinBox);
+	const QSignalBlocker contrastBlocker(ui->hipsContrastDoubleSpinBox);
 	const QSignalBlocker opacityBlocker(ui->hipsOpacityDoubleSpinBox);
 	const QSignalBlocker colorChannelBlocker(ui->hipsColorChannelComboBox);
 	const QSignalBlocker invertedColorsBlocker(ui->hipsInvertedColorsCheckBox);
@@ -948,6 +951,7 @@ void ViewDialog::updateHipsControls()
 	ui->hipsGammaDoubleSpinBox->setValue(hips ? hips->getGamma() : 1.);
 	ui->hipsSaturationDoubleSpinBox->setValue(hips ? hips->getSaturation() : 1.);
 	ui->hipsBrightnessDoubleSpinBox->setValue(hips ? hips->getBrightness() : 1.);
+	ui->hipsContrastDoubleSpinBox->setValue(hips ? hips->getContrast() : 1.);
 	ui->hipsOpacityDoubleSpinBox->setValue(hips ? hips->getOpacity() : 1.);
 	ui->hipsColorChannelComboBox->setCurrentIndex(hips ? hips->getColorChannel() : HipsSurvey::ColorChannelRgb);
 	ui->hipsInvertedColorsCheckBox->setChecked(hips ? hips->getInvertedColors() : false);
@@ -960,6 +964,8 @@ void ViewDialog::updateHipsControls()
 	ui->hipsSaturationDoubleSpinBox->setEnabled(enableSelectedControls);
 	ui->hipsBrightnessLabel->setEnabled(enableSelectedControls);
 	ui->hipsBrightnessDoubleSpinBox->setEnabled(enableSelectedControls);
+	ui->hipsContrastLabel->setEnabled(enableSelectedControls);
+	ui->hipsContrastDoubleSpinBox->setEnabled(enableSelectedControls);
 	ui->hipsOpacityLabel->setEnabled(enableSelectedControls);
 	ui->hipsOpacityDoubleSpinBox->setEnabled(enableSelectedControls);
 	ui->hipsColorChannelLabel->setEnabled(enableSelectedControls);
@@ -978,6 +984,7 @@ void ViewDialog::hipsDisplaySettingsChanged()
 	hips->setDisplaySettings(static_cast<float>(ui->hipsGammaDoubleSpinBox->value()),
 	                         static_cast<float>(ui->hipsSaturationDoubleSpinBox->value()),
 	                         static_cast<float>(ui->hipsBrightnessDoubleSpinBox->value()),
+	                         static_cast<float>(ui->hipsContrastDoubleSpinBox->value()),
 	                         static_cast<float>(ui->hipsOpacityDoubleSpinBox->value()),
 	                         ui->hipsColorChannelComboBox->currentIndex(),
 	                         ui->hipsInvertedColorsCheckBox->isChecked());

--- a/src/gui/ViewDialog.cpp
+++ b/src/gui/ViewDialog.cpp
@@ -760,6 +760,7 @@ void ViewDialog::createDialogContent()
 	        this, &ViewDialog::hipsDisplaySettingsChanged);
 	connect(ui->hipsColorChannelComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged),
 	        this, &ViewDialog::hipsDisplaySettingsChanged);
+	connect(ui->hipsInvertedColorsCheckBox, &QCheckBox::toggled, this, &ViewDialog::hipsDisplaySettingsChanged);
 	connect(ui->hipsResetPushButton, &QPushButton::clicked, this, &ViewDialog::resetSelectedHipsDisplaySettings);
 	connect(ui->hipsResetAllPushButton, &QPushButton::clicked, this, &ViewDialog::resetAllHipsDisplaySettings);
 	connectBoolProperty(ui->hipsAtmosphericExtinctionCheckBox, "HipsMgr.flagShowAtmosphericExtinction");
@@ -942,12 +943,14 @@ void ViewDialog::updateHipsControls()
 	const QSignalBlocker brightnessBlocker(ui->hipsBrightnessDoubleSpinBox);
 	const QSignalBlocker opacityBlocker(ui->hipsOpacityDoubleSpinBox);
 	const QSignalBlocker colorChannelBlocker(ui->hipsColorChannelComboBox);
+	const QSignalBlocker invertedColorsBlocker(ui->hipsInvertedColorsCheckBox);
 
 	ui->hipsGammaDoubleSpinBox->setValue(hips ? hips->getGamma() : 1.);
 	ui->hipsSaturationDoubleSpinBox->setValue(hips ? hips->getSaturation() : 1.);
 	ui->hipsBrightnessDoubleSpinBox->setValue(hips ? hips->getBrightness() : 1.);
 	ui->hipsOpacityDoubleSpinBox->setValue(hips ? hips->getOpacity() : 1.);
 	ui->hipsColorChannelComboBox->setCurrentIndex(hips ? hips->getColorChannel() : HipsSurvey::ColorChannelRgb);
+	ui->hipsInvertedColorsCheckBox->setChecked(hips ? hips->getInvertedColors() : false);
 
 	const bool enableSelectedControls = static_cast<bool>(hips);
 	ui->hipsSettingsGroupBox->setEnabled(enableSelectedControls || hasSkySurvey);
@@ -961,6 +964,7 @@ void ViewDialog::updateHipsControls()
 	ui->hipsOpacityDoubleSpinBox->setEnabled(enableSelectedControls);
 	ui->hipsColorChannelLabel->setEnabled(enableSelectedControls);
 	ui->hipsColorChannelComboBox->setEnabled(enableSelectedControls);
+	ui->hipsInvertedColorsCheckBox->setEnabled(enableSelectedControls);
 	ui->hipsResetPushButton->setEnabled(enableSelectedControls);
 	ui->hipsResetAllPushButton->setEnabled(hasSkySurvey);
 }
@@ -975,7 +979,8 @@ void ViewDialog::hipsDisplaySettingsChanged()
 	                         static_cast<float>(ui->hipsSaturationDoubleSpinBox->value()),
 	                         static_cast<float>(ui->hipsBrightnessDoubleSpinBox->value()),
 	                         static_cast<float>(ui->hipsOpacityDoubleSpinBox->value()),
-	                         ui->hipsColorChannelComboBox->currentIndex());
+	                         ui->hipsColorChannelComboBox->currentIndex(),
+	                         ui->hipsInvertedColorsCheckBox->isChecked());
 }
 
 void ViewDialog::resetSelectedHipsDisplaySettings()

--- a/src/gui/ViewDialog.hpp
+++ b/src/gui/ViewDialog.hpp
@@ -21,6 +21,7 @@
 #define VIEWDIALOG_HPP
 
 #include "StelDialog.hpp"
+#include "StelHips.hpp"
 
 #include <QObject>
 #include <QTimer>
@@ -114,8 +115,12 @@ private slots:
 	void clearHips();
 	void updateHips();
 	void updateHipsText();
+	void updateHipsControls();
 	void filterSurveys();
 	void hipsListItemChanged(QTreeWidgetItem* item);
+	void hipsDisplaySettingsChanged();
+	void resetSelectedHipsDisplaySettings();
+	void resetAllHipsDisplaySettings();
 	void populateHipsGroups();
 	void toggleHipsDialog();
 
@@ -126,6 +131,7 @@ private slots:
 	void setDisplayFormatForSpins(bool flagDecimalDegrees);
 
 private:
+	HipsSurveyP currentSkyHips() const;
 	void updateSurveyFilteredState(QTreeWidgetItem& item, const QString& filterPattern) const;
 	void connectGroupBox(class QGroupBox* groupBox, const QString& actionId);
 	void updateSkyCultureText();

--- a/src/gui/viewDialog.ui
+++ b/src/gui/viewDialog.ui
@@ -6749,13 +6749,39 @@
               </widget>
              </item>
              <item row="2" column="0">
+              <widget class="QLabel" name="hipsContrastLabel">
+               <property name="text">
+                <string>Contrast:</string>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="1">
+              <widget class="QDoubleSpinBox" name="hipsContrastDoubleSpinBox">
+               <property name="decimals">
+                <number>2</number>
+               </property>
+               <property name="minimum">
+                <double>0.000000000000000</double>
+               </property>
+               <property name="maximum">
+                <double>5.000000000000000</double>
+               </property>
+               <property name="singleStep">
+                <double>0.100000000000000</double>
+               </property>
+               <property name="value">
+                <double>1.000000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="2">
               <widget class="QLabel" name="hipsColorChannelLabel">
                <property name="text">
                 <string>Color channel:</string>
                </property>
               </widget>
              </item>
-             <item row="2" column="1">
+             <item row="2" column="3">
               <widget class="QComboBox" name="hipsColorChannelComboBox">
                <item>
                 <property name="text">
@@ -6779,7 +6805,7 @@
                </item>
               </widget>
              </item>
-             <item row="2" column="2" colspan="2">
+             <item row="3" column="0" colspan="2">
               <widget class="QCheckBox" name="hipsInvertedColorsCheckBox">
                <property name="text">
                 <string>Invert colors</string>

--- a/src/gui/viewDialog.ui
+++ b/src/gui/viewDialog.ui
@@ -6623,6 +6623,186 @@
             </column>
            </widget>
           </item>
+          <item row="3" column="0" colspan="2">
+           <widget class="QGroupBox" name="hipsSettingsGroupBox">
+            <property name="title">
+             <string>Layer appearance</string>
+            </property>
+            <layout class="QGridLayout" name="gridLayout_hipsSettings">
+             <property name="leftMargin">
+              <number>3</number>
+             </property>
+             <property name="topMargin">
+              <number>3</number>
+             </property>
+             <property name="rightMargin">
+              <number>3</number>
+             </property>
+             <property name="bottomMargin">
+              <number>3</number>
+             </property>
+             <property name="spacing">
+              <number>3</number>
+             </property>
+             <item row="0" column="0">
+              <widget class="QLabel" name="hipsGammaLabel">
+               <property name="text">
+                <string>Gamma:</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="1">
+              <widget class="QDoubleSpinBox" name="hipsGammaDoubleSpinBox">
+               <property name="decimals">
+                <number>2</number>
+               </property>
+               <property name="minimum">
+                <double>0.100000000000000</double>
+               </property>
+               <property name="maximum">
+                <double>5.000000000000000</double>
+               </property>
+               <property name="singleStep">
+                <double>0.100000000000000</double>
+               </property>
+               <property name="value">
+                <double>1.000000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="0">
+              <widget class="QLabel" name="hipsSaturationLabel">
+               <property name="text">
+                <string>Saturation:</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="1">
+              <widget class="QDoubleSpinBox" name="hipsSaturationDoubleSpinBox">
+               <property name="decimals">
+                <number>2</number>
+               </property>
+               <property name="minimum">
+                <double>0.000000000000000</double>
+               </property>
+               <property name="maximum">
+                <double>3.000000000000000</double>
+               </property>
+               <property name="singleStep">
+                <double>0.100000000000000</double>
+               </property>
+               <property name="value">
+                <double>1.000000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="0">
+              <widget class="QLabel" name="hipsBrightnessLabel">
+               <property name="text">
+                <string>Brightness:</string>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="1">
+              <widget class="QDoubleSpinBox" name="hipsBrightnessDoubleSpinBox">
+               <property name="decimals">
+                <number>2</number>
+               </property>
+               <property name="minimum">
+                <double>0.000000000000000</double>
+               </property>
+               <property name="maximum">
+                <double>5.000000000000000</double>
+               </property>
+               <property name="singleStep">
+                <double>0.100000000000000</double>
+               </property>
+               <property name="value">
+                <double>1.000000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="3" column="0">
+              <widget class="QLabel" name="hipsOpacityLabel">
+               <property name="text">
+                <string>Opacity:</string>
+               </property>
+              </widget>
+             </item>
+             <item row="3" column="1">
+              <widget class="QDoubleSpinBox" name="hipsOpacityDoubleSpinBox">
+               <property name="decimals">
+                <number>2</number>
+               </property>
+               <property name="minimum">
+                <double>0.000000000000000</double>
+               </property>
+               <property name="maximum">
+                <double>1.000000000000000</double>
+               </property>
+               <property name="singleStep">
+                <double>0.050000000000000</double>
+               </property>
+               <property name="value">
+                <double>1.000000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="4" column="0">
+              <widget class="QLabel" name="hipsColorChannelLabel">
+               <property name="text">
+                <string>Color channel:</string>
+               </property>
+              </widget>
+             </item>
+             <item row="4" column="1">
+              <widget class="QComboBox" name="hipsColorChannelComboBox">
+               <item>
+                <property name="text">
+                 <string>RGB</string>
+                </property>
+               </item>
+               <item>
+                <property name="text">
+                 <string>Red</string>
+                </property>
+               </item>
+               <item>
+                <property name="text">
+                 <string>Green</string>
+                </property>
+               </item>
+               <item>
+                <property name="text">
+                 <string>Blue</string>
+                </property>
+               </item>
+              </widget>
+             </item>
+             <item row="5" column="0" colspan="2">
+              <widget class="QCheckBox" name="hipsAtmosphericExtinctionCheckBox">
+               <property name="text">
+                <string>Show atmospheric extinction</string>
+               </property>
+              </widget>
+             </item>
+             <item row="6" column="0">
+              <widget class="QPushButton" name="hipsResetPushButton">
+               <property name="text">
+                <string>Reset</string>
+               </property>
+              </widget>
+             </item>
+             <item row="6" column="1">
+              <widget class="QPushButton" name="hipsResetAllPushButton">
+               <property name="text">
+                <string>Reset all</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
          </layout>
         </widget>
        </widget>

--- a/src/gui/viewDialog.ui
+++ b/src/gui/viewDialog.ui
@@ -6578,7 +6578,7 @@
           <property name="spacing">
            <number>3</number>
           </property>
-          <item row="0" column="2" rowspan="3">
+          <item row="0" column="2" rowspan="4">
            <widget class="QTextBrowser" name="surveysTextBrowser">
             <property name="openExternalLinks">
              <bool>true</bool>

--- a/src/gui/viewDialog.ui
+++ b/src/gui/viewDialog.ui
@@ -6780,20 +6780,27 @@
               </widget>
              </item>
              <item row="2" column="2" colspan="2">
+              <widget class="QCheckBox" name="hipsInvertedColorsCheckBox">
+               <property name="text">
+                <string>Invert colors</string>
+               </property>
+              </widget>
+             </item>
+             <item row="3" column="2" colspan="2">
               <widget class="QCheckBox" name="hipsAtmosphericExtinctionCheckBox">
                <property name="text">
                 <string>Show atmospheric extinction</string>
                </property>
               </widget>
              </item>
-             <item row="3" column="0" colspan="2">
+             <item row="4" column="0" colspan="2">
               <widget class="QPushButton" name="hipsResetPushButton">
                <property name="text">
                 <string>Reset</string>
                </property>
               </widget>
              </item>
-             <item row="3" column="2" colspan="2">
+             <item row="4" column="2" colspan="2">
               <widget class="QPushButton" name="hipsResetAllPushButton">
                <property name="text">
                 <string>Reset all</string>

--- a/src/gui/viewDialog.ui
+++ b/src/gui/viewDialog.ui
@@ -6696,14 +6696,14 @@
                </property>
               </widget>
              </item>
-             <item row="2" column="0">
+             <item row="0" column="2">
               <widget class="QLabel" name="hipsBrightnessLabel">
                <property name="text">
                 <string>Brightness:</string>
                </property>
               </widget>
              </item>
-             <item row="2" column="1">
+             <item row="0" column="3">
               <widget class="QDoubleSpinBox" name="hipsBrightnessDoubleSpinBox">
                <property name="decimals">
                 <number>2</number>
@@ -6722,14 +6722,14 @@
                </property>
               </widget>
              </item>
-             <item row="3" column="0">
+             <item row="1" column="2">
               <widget class="QLabel" name="hipsOpacityLabel">
                <property name="text">
                 <string>Opacity:</string>
                </property>
               </widget>
              </item>
-             <item row="3" column="1">
+             <item row="1" column="3">
               <widget class="QDoubleSpinBox" name="hipsOpacityDoubleSpinBox">
                <property name="decimals">
                 <number>2</number>
@@ -6748,14 +6748,14 @@
                </property>
               </widget>
              </item>
-             <item row="4" column="0">
+             <item row="2" column="0">
               <widget class="QLabel" name="hipsColorChannelLabel">
                <property name="text">
                 <string>Color channel:</string>
                </property>
               </widget>
              </item>
-             <item row="4" column="1">
+             <item row="2" column="1">
               <widget class="QComboBox" name="hipsColorChannelComboBox">
                <item>
                 <property name="text">
@@ -6779,21 +6779,21 @@
                </item>
               </widget>
              </item>
-             <item row="5" column="0" colspan="2">
+             <item row="2" column="2" colspan="2">
               <widget class="QCheckBox" name="hipsAtmosphericExtinctionCheckBox">
                <property name="text">
                 <string>Show atmospheric extinction</string>
                </property>
               </widget>
              </item>
-             <item row="6" column="0">
+             <item row="3" column="0" colspan="2">
               <widget class="QPushButton" name="hipsResetPushButton">
                <property name="text">
                 <string>Reset</string>
                </property>
               </widget>
              </item>
-             <item row="6" column="1">
+             <item row="3" column="2" colspan="2">
               <widget class="QPushButton" name="hipsResetAllPushButton">
                <property name="text">
                 <string>Reset all</string>


### PR DESCRIPTION
This branch adds a few display controls for the HiPS surveys, with buttons to reset either the selected survey, or all surveys, to default values. 

It lets users set:

- Gamma
- Saturation
- Contrast
- Brightness
- Opacity (helps when showing several surveys simultaneously)
- Color channel (RGB/R/G/B)
- Inversion of color
- As a bonus, optional atmospheric extinction was added (also making it sensitive to atmospheric light distribution such as twilight, moonlight, light pollution) using the same logic as the TOAST survey. It gives optical surveys a prettier look together with landscapes.

Display control settings are saved between sessions and only reset when pressing the button `Reset`.

Do test it thoroughly if this is good enough to merge. I've generated the code with AI (Codex).

Fixes #4259

### Screenshots:
Mellinger + Constellation survey:
<img width="2560" height="1366" alt="stellarium-001" src="https://github.com/user-attachments/assets/931a3582-f803-4e54-a264-8df05478ce6f" />

Milky Way arch with extinction effect:
<img width="2560" height="1366" alt="stellarium-002" src="https://github.com/user-attachments/assets/e8fab5b4-b98a-4203-b46e-c7242e4e73ac" />

With red channel only:
<img width="1565" height="987" alt="Skärmbild_20260702_200752" src="https://github.com/user-attachments/assets/dd8dac52-da1e-4380-b748-03ed48366e46" />


### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] This change requires a documentation update
- [ ] Housekeeping


**Test Configuration**:
Fedora 44
Qt 6.11.1

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
