### PR TITLE
TelescopeControl: fix segmenation fault for INDI/INDIGO drivers witho…

### DIFF
--- a/plugins/TelescopeControl/src/INDI/INDIConnection.cpp
+++ b/plugins/TelescopeControl/src/INDI/INDIConnection.cpp
@@ -166,8 +166,11 @@ void INDIConnection::unParkTelescope()
 		return;
 	}
 
+	// Some drivers (e.g. INDIGO's LX200/RainbowAstro emulation) expose the
+	// TELESCOPE_PARK property with only a single "PARK" item and no "UNPARK"
+	// item - must be null-checked before dereferencing.
 	auto park = switchVector.findWidgetByName("PARK");
-	if (park->s == ISS_ON)
+	if (park && park->s == ISS_ON)
 	{
 		park->setState(ISS_OFF);
 		sendNewSwitch(switchVector);
@@ -175,7 +178,7 @@ void INDIConnection::unParkTelescope()
 
 	// The telescope will work without running command below, but I use it to avoid undefined state for parking property.
 	auto unpark = switchVector.findWidgetByName("UNPARK");
-	if (unpark->s == ISS_OFF)
+	if (unpark && unpark->s == ISS_OFF)
 	{
 		unpark->setState(ISS_ON);
 		sendNewSwitch(switchVector);
@@ -199,14 +202,14 @@ void INDIConnection::parkTelescope()
 	}
 
 	auto park = switchVector.findWidgetByName("PARK");
-	if (park->s == ISS_OFF)
+	if (park && park->s == ISS_OFF)
 	{
 		park->setState(ISS_ON);
 		sendNewSwitch(switchVector);
 	}
 
 	auto unpark = switchVector.findWidgetByName("UNPARK");
-	if (unpark->s == ISS_ON)
+	if (unpark && unpark->s == ISS_ON)
 	{
 		unpark->setState(ISS_OFF);
 		sendNewSwitch(switchVector);


### PR DESCRIPTION
…ut UNPARK item

<!--- Provide a general summary of your changes in the Title above -->

Fixes segfault with some INDIGO/INDI drivers missing UNPARK capability

### Description
Some drivers (e.g. INDIGO's LX200/RainbowAstro) expose the TELESCOPE_PARK property with only a single "PARK" item and no "UNPARK" item - must be null-checked before dereferencing. Otherwise stellarium crashes.

Fixes # (issue)

### Screenshots (if appropriate):

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?
Yes i tested it against drivers with and without unpark - all ok!

**Test Configuration**:
* Operating system: <Name, version number>
* Graphics Card: <Manufacturer (likely Intel, NVidia, AMD?), Model (HD, Geforce, Radeon..., with model number), driver version?>

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation (header file)
- [] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
