### PR TITLE
TelescopeControl: add TCP transport for LX200 protocol

### DIFF
--- a/plugins/TelescopeControl/src/Lx200/Lx200Connection.cpp
+++ b/plugins/TelescopeControl/src/Lx200/Lx200Connection.cpp
@@ -7,6 +7,8 @@ It also contains sample server classes (dummy, Meade LX200).
 Author and Copyright of this file and of the stellarium telescope library:
 Johannes Gajdosik, 2006
 
+TCP transport support added by Rumen Bogdanovski, 2026.
+
 This library is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License
 as published by the Free Software Foundation; either version 2
@@ -31,7 +33,8 @@ Foundation, Inc., 51 Franklin Street, Suite 500, Boston, MA  02110-1335, USA.
 #include <cmath>
 
 
-Lx200Connection::Lx200Connection(Server &server, const char *serial_device) : SerialPort(server, serial_device)
+template <class Transport>
+void Lx200ConnectionImpl<Transport>::initTiming(void)
 {
 	time_between_commands = 0;
 	next_send_time = GetNow();
@@ -42,16 +45,17 @@ Lx200Connection::Lx200Connection(Server &server, const char *serial_device) : Se
 //! Resets the connection.
 //! Removes all commands in the queue without executing them and
 //! cleans both the read and the write buffers.
-void Lx200Connection::resetCommunication(void)
+template <class Transport>
+void Lx200ConnectionImpl<Transport>::resetCommunication(void)
 {
 	while (!command_list.empty())
 	{
 		delete command_list.front();
 		command_list.pop_front();
 	}
-	
-	read_buff_end = read_buff;
-	write_buff_end = write_buff;
+
+	this->read_buff_end = this->read_buff;
+	this->write_buff_end = this->write_buff;
 	#ifdef DEBUG4
 	*log_file << Now() << "Lx200Connection::resetCommunication" << StelUtils::getEndLineChar();
 	#endif
@@ -60,13 +64,14 @@ void Lx200Connection::resetCommunication(void)
 	next_send_time = GetNow() + 10000000;
 	read_timeout_endtime = 0x7FFFFFFFFFFFFFFFLL;
 	goto_commands_queued = 0;
-	static_cast<TelescopeClientDirectLx200&>(server).communicationResetReceived();
+	static_cast<TelescopeClientDirectLx200&>(this->server).communicationResetReceived();
 }
 
 //! Commands the telescope to slew to the given right ascension and declination.
 //! Converts the coordinates and queues the necessary sequence of Lx200Command
 //! objects to perform the slew.
-void Lx200Connection::sendGoto(unsigned int ra_int, int dec_int)
+template <class Transport>
+void Lx200ConnectionImpl<Transport>::sendGoto(unsigned int ra_int, int dec_int)
 {
 	if (goto_commands_queued <= 1)
 	{
@@ -84,10 +89,10 @@ void Lx200Connection::sendGoto(unsigned int ra_int, int dec_int)
 		int ra = static_cast<int>(std::floor(0.5 + ra_int * (86400.0/4294967296.0)));
 		if (ra >= 86400)
 			ra -= 86400;
-		sendCommand(new Lx200CommandStopSlew(server));
-		sendCommand(new Lx200CommandSetSelectedRa(server, ra));
-		sendCommand(new Lx200CommandSetSelectedDec(server, dec));
-		sendCommand(new Lx200CommandGotoSelected(server));
+		sendCommand(new Lx200CommandStopSlew(this->server));
+		sendCommand(new Lx200CommandSetSelectedRa(this->server, ra));
+		sendCommand(new Lx200CommandSetSelectedDec(this->server, dec));
+		sendCommand(new Lx200CommandGotoSelected(this->server));
 		goto_commands_queued++;
 	}
 	else
@@ -98,7 +103,8 @@ void Lx200Connection::sendGoto(unsigned int ra_int, int dec_int)
 	}
 }
 
-void Lx200Connection::sendSync(unsigned int ra_int, int dec_int)
+template <class Transport>
+void Lx200ConnectionImpl<Transport>::sendSync(unsigned int ra_int, int dec_int)
 {
 	if (goto_commands_queued <= 1)
 	{
@@ -116,10 +122,10 @@ void Lx200Connection::sendSync(unsigned int ra_int, int dec_int)
 		int ra = static_cast<int>(std::floor(0.5 + ra_int * (86400.0/4294967296.0)));
 		if (ra >= 86400)
 			ra -= 86400;
-		sendCommand(new Lx200CommandStopSlew(server));
-		sendCommand(new Lx200CommandSetSelectedRa(server, ra));
-		sendCommand(new Lx200CommandSetSelectedDec(server, dec));
-		sendCommand(new Lx200CommandSyncSelected(server));
+		sendCommand(new Lx200CommandStopSlew(this->server));
+		sendCommand(new Lx200CommandSetSelectedRa(this->server, ra));
+		sendCommand(new Lx200CommandSetSelectedDec(this->server, dec));
+		sendCommand(new Lx200CommandSyncSelected(this->server));
 		goto_commands_queued++;
 	}
 	else
@@ -131,15 +137,16 @@ void Lx200Connection::sendSync(unsigned int ra_int, int dec_int)
 }
 
 
-bool Lx200Connection::writeFrontCommandToBuffer(void)
+template <class Transport>
+bool Lx200ConnectionImpl<Transport>::writeFrontCommandToBuffer(void)
 {
 	if(command_list.empty())
 	{
 		return false;
 	}
-	
+
 	const long long int now = GetNow();
-	if (now < next_send_time) 
+	if (now < next_send_time)
 	{
 #ifdef DEBUG4
 		/*
@@ -150,8 +157,8 @@ bool Lx200Connection::writeFrontCommandToBuffer(void)
 #endif
 		return false;
 	}
-	
-	const bool rval = command_list.front()->writeCommandToBuffer(write_buff_end, write_buff+sizeof(write_buff));
+
+	const bool rval = command_list.front()->writeCommandToBuffer(this->write_buff_end, this->write_buff+sizeof(this->write_buff));
 	if (rval)
 	{
 		next_send_time = now;
@@ -181,32 +188,34 @@ bool Lx200Connection::writeFrontCommandToBuffer(void)
 			  << StelUtils::getEndLineChar();
 		#endif
 	}
-	
+
 	return rval;
 }
 
-void Lx200Connection::dataReceived(const char *&p, const char *read_buff_end)
+template <class Transport>
+void Lx200ConnectionImpl<Transport>::dataReceived(const char *&p, const char *read_buff_end)
 {
-	if (isClosed())
+	if (this->isClosed())
 	{
 		*log_file << Now() << "Lx200Connection::dataReceived: strange: fd is closed" << StelUtils::getEndLineChar();
 	}
 	else if (command_list.empty())
 	{
-		if (GetNow() < next_send_time)
-		{
-			// just ignore
-			p = read_buff_end;
-		}
-		else
-		{
-			#ifdef DEBUG4
-			*log_file << Now()
-			          << "Lx200Connection::dataReceived: error: command_list is empty"
-				  << StelUtils::getEndLineChar();
-			#endif
-			resetCommunication();
-		}
+		// No command is waiting for an answer. The LX200 protocol is strictly
+		// request/response, so any bytes arriving here are leftovers from a
+		// command that was already discarded - typically the answer to a
+		// position query that was dropped by sendAbort(). Ignore them instead
+		// of forcing a full communication reset: the reset imposes a multi-
+		// second pause before the next command is sent, which is long enough
+		// for a networked LX200 server to hit its read timeout and close the
+		// connection. A genuine desync is still caught later, when the answer
+		// to an actual queued command fails to parse.
+		#ifdef DEBUG4
+		*log_file << Now()
+		          << "Lx200Connection::dataReceived: ignoring unexpected data (command_list is empty)"
+			  << StelUtils::getEndLineChar();
+		#endif
+		p = read_buff_end;
 	}
 	else if (command_list.front()->needsNoAnswer())
 	{
@@ -260,9 +269,10 @@ void Lx200Connection::dataReceived(const char *&p, const char *read_buff_end)
 	}
 }
 
-void Lx200Connection::prepareSelectFds(fd_set &read_fds,
-                                       fd_set &write_fds,
-                                       int &fd_max)
+template <class Transport>
+void Lx200ConnectionImpl<Transport>::prepareSelectFds(fd_set &read_fds,
+                                                      fd_set &write_fds,
+                                                      int &fd_max)
 {
 	// if some telegram is delayed try to queue it now:
 	flushCommandList();
@@ -292,10 +302,11 @@ void Lx200Connection::prepareSelectFds(fd_set &read_fds,
 			resetCommunication();
 		}
 	}
-	SerialPort::prepareSelectFds(read_fds, write_fds, fd_max);
+	Transport::prepareSelectFds(read_fds, write_fds, fd_max);
 }
 
-void Lx200Connection::flushCommandList(void)
+template <class Transport>
+void Lx200ConnectionImpl<Transport>::flushCommandList(void)
 {
 	if (!command_list.empty())
 	{
@@ -332,7 +343,8 @@ void Lx200Connection::flushCommandList(void)
 	}
 }
 
-void Lx200Connection::sendCommand(Lx200Command *command)
+template <class Transport>
+void Lx200ConnectionImpl<Transport>::sendCommand(Lx200Command *command)
 {
 	if (command)
 	{
@@ -350,7 +362,8 @@ void Lx200Connection::sendCommand(Lx200Command *command)
 	}
 }
 
-void Lx200Connection::sendAbort()
+template <class Transport>
+void Lx200ConnectionImpl<Transport>::sendAbort()
 {
 #ifdef DEBUG4
 	*log_file << Now()
@@ -364,10 +377,14 @@ void Lx200Connection::sendAbort()
 		command_list.pop_front();
 	}
 
-	read_buff_end = read_buff;
-	write_buff_end = write_buff;
-	command_list.push_back(new Lx200CommandStopSlew(server));
+	this->read_buff_end = this->read_buff;
+	this->write_buff_end = this->write_buff;
+	command_list.push_back(new Lx200CommandStopSlew(this->server));
 	flushCommandList();
 	//*log_file << Now() << "Lx200Connection::sendAbort() end"
 	//          << StelUtils::getEndLineChar();
 }
+
+// Explicitly instantiate the two transports we support: serial and TCP/IP.
+template class Lx200ConnectionImpl<SerialPort>;
+template class Lx200ConnectionImpl<TcpConnection>;

--- a/plugins/TelescopeControl/src/Lx200/Lx200Connection.hpp
+++ b/plugins/TelescopeControl/src/Lx200/Lx200Connection.hpp
@@ -7,6 +7,8 @@ It also contains sample server classes (dummy, Meade LX200).
 Author and Copyright of this file and of the stellarium telescope library:
 Johannes Gajdosik, 2006
 
+TCP transport support added by Rumen Bogdanovski, 2026.
+
 This library is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License
 as published by the Free Software Foundation; either version 2
@@ -26,27 +28,58 @@ Foundation, Inc., 51 Franklin Street, Suite 500, Boston, MA  02110-1335, USA.
 #define LX200CONNECTION_HPP
 
 #include "common/SerialPort.hpp"
+#include "common/TcpConnection.hpp"
 
 #include <list>
 
 class Lx200Command;
+class Server;
 
-//! Serial port connection to a Meade LX200 or a compatible telescope.
-class Lx200Connection : public SerialPort
+//! Transport-independent interface to a Meade LX200 (or compatible) telescope.
+//!
+//! The Meade LX200 ASCII protocol can be spoken either over a serial port or
+//! over a TCP/IP connection. TelescopeClientDirectLx200 talks to the telescope
+//! through this interface without needing to know which transport is in use.
+class Lx200Connection
 {
 public:
-	Lx200Connection(Server &server, const char *serial_device);
-	void sendGoto(unsigned int ra_int, int dec_int);
-	void sendSync(unsigned int ra_int, int dec_int);
-	void sendCommand(Lx200Command * command);
+	virtual ~Lx200Connection() {}
+	virtual void sendGoto(unsigned int ra_int, int dec_int) = 0;
+	virtual void sendSync(unsigned int ra_int, int dec_int) = 0;
+	virtual void sendCommand(Lx200Command *command) = 0;
 	//! Delete pending commands and send abort signal.
-	void sendAbort();
+	virtual void sendAbort() = 0;
+	//! Returns true if the underlying connection is closed.
+	virtual bool isClosed(void) const = 0;
+};
+
+//! Implements the Meade LX200 command protocol on top of an arbitrary
+//! transport (@p Transport must be a Connection: either SerialPort or
+//! TcpConnection). All the protocol logic lives here and is shared between the
+//! serial and the network variants; only the transport differs.
+template <class Transport>
+class Lx200ConnectionImpl : public Transport, public Lx200Connection
+{
+public:
+	template <class... TransportArgs>
+	Lx200ConnectionImpl(Server &server, TransportArgs... transport_args)
+		: Transport(server, transport_args...)
+	{
+		initTiming();
+	}
+
+	void sendGoto(unsigned int ra_int, int dec_int) override;
+	void sendSync(unsigned int ra_int, int dec_int) override;
+	void sendCommand(Lx200Command *command) override;
+	void sendAbort() override;
+	bool isClosed(void) const override {return Transport::isClosed();}
 	void setTimeBetweenCommands(long long int micro_seconds)
 	{
 		time_between_commands = micro_seconds;
 	}
-	
+
 private:
+	void initTiming(void);
 	//! Parses read buffer data received from the telescope.
 	void dataReceived(const char *&p, const char *read_buff_end) override;
 	//! Not implemented, as this is not a connection to a client.
@@ -59,13 +92,29 @@ private:
 	//! as many commands as possible, until it reaches a command that
 	//! requires an answer.
 	void flushCommandList(void);
-	
+
 private:
 	std::list<Lx200Command*> command_list;
 	long long int time_between_commands;
 	long long int next_send_time;
 	long long int read_timeout_endtime;
 	int goto_commands_queued;
+};
+
+//! Serial port connection to a Meade LX200 or a compatible telescope.
+class Lx200SerialConnection : public Lx200ConnectionImpl<SerialPort>
+{
+public:
+	Lx200SerialConnection(Server &server, const char *serial_device)
+		: Lx200ConnectionImpl<SerialPort>(server, serial_device) {}
+};
+
+//! TCP/IP connection to a Meade LX200 or a compatible telescope.
+class Lx200TcpConnection : public Lx200ConnectionImpl<TcpConnection>
+{
+public:
+	Lx200TcpConnection(Server &server, const char *host, int port)
+		: Lx200ConnectionImpl<TcpConnection>(server, host, port) {}
 };
 
 #endif // LX200CONNECTION_HPP

--- a/plugins/TelescopeControl/src/Lx200/TelescopeClientDirectLx200.cpp
+++ b/plugins/TelescopeControl/src/Lx200/TelescopeClientDirectLx200.cpp
@@ -50,51 +50,89 @@ TelescopeClientDirectLx200::TelescopeClientDirectLx200 (const QString &name, con
 	, next_pos_time(0)
 {
 	interpolatedPosition.reset();
-	
-	//Extract parameters
-	//Format: "serial_port_name:time_delay"
-	static const QRegularExpression paramRx("^([^:]*):(\\d+)$");
-	QRegularExpressionMatch paramMatch=paramRx.match(parameters);
+
+	//Extract parameters. Two formats are accepted:
+	// Serial:  "serial_port_name:time_delay"          e.g. "/dev/ttyS0:500000"
+	// Network: "host_name:tcp_port:time_delay"        e.g. "192.168.1.5:4030:500000"
+	//The network form (LX200 protocol over TCP) is distinguished by having
+	//two colons instead of one.
+	static const QRegularExpression tcpParamRx("^([^:]+):(\\d+):(\\d+)$");
+	static const QRegularExpression serialParamRx("^([^:]*):(\\d+)$");
+	QRegularExpressionMatch tcpMatch = tcpParamRx.match(parameters);
+
 	QString serialDeviceName;
-	if (paramMatch.hasMatch())
+	QString hostName;
+	int tcpPort = 0;
+	bool useNetwork = false;
+
+	if (tcpMatch.hasMatch())
 	{
-		// This RegExp only matches valid integers
-		serialDeviceName = paramMatch.captured(1).trimmed();
-		time_delay       = paramMatch.captured(2).toInt();
+		useNetwork = true;
+		hostName   = tcpMatch.captured(1).trimmed();
+		tcpPort    = tcpMatch.captured(2).toInt();
+		time_delay = tcpMatch.captured(3).toInt();
 	}
 	else
 	{
-		qCWarning(Telescopes) << "ERROR creating TelescopeClientDirectLx200: invalid parameters.";
-		return;
+		QRegularExpressionMatch serialMatch = serialParamRx.match(parameters);
+		if (serialMatch.hasMatch())
+		{
+			// This RegExp only matches valid integers
+			serialDeviceName = serialMatch.captured(1).trimmed();
+			time_delay       = serialMatch.captured(2).toInt();
+		}
+		else
+		{
+			qCWarning(Telescopes) << "ERROR creating TelescopeClientDirectLx200: invalid parameters.";
+			return;
+		}
 	}
-	
-	qCDebug(Telescopes) << "TelescopeClientDirectLx200 parameters: port, time_delay:" << serialDeviceName << time_delay;
-	
+
+	if (useNetwork)
+		qCDebug(Telescopes) << "TelescopeClientDirectLx200 parameters: host, port, time_delay:" << hostName << tcpPort << time_delay;
+	else
+		qCDebug(Telescopes) << "TelescopeClientDirectLx200 parameters: port, time_delay:" << serialDeviceName << time_delay;
+
 	//Validation: Time delay
 	if (time_delay <= 0 || time_delay > 10000000)
 	{
 		qCWarning(Telescopes) << "ERROR creating TelescopeClientDirectLx200: time_delay not valid (should be less than 10000000)";
 		return;
 	}
-	
+
 	//end_of_timeout = -0x8000000000000000LL;
-	
-	#ifdef Q_OS_WIN
-	if(serialDeviceName.right(serialDeviceName.size() - 3).toInt() > 9)
-		serialDeviceName = "\\\\.\\" + serialDeviceName;//"\\.\COMxx", not sure if it will work
-	#endif //Q_OS_WIN
-	
+
 	//Try to establish a connection to the telescope
-	lx200 = new Lx200Connection(*this, qPrintable(serialDeviceName));
-	if (lx200->isClosed())
+	if (useNetwork)
 	{
-		qCWarning(Telescopes) << "ERROR creating TelescopeClientDirectLx200: cannot open serial device" << serialDeviceName;
-		return;
+		Lx200TcpConnection *connection = new Lx200TcpConnection(*this, qPrintable(hostName), tcpPort);
+		lx200 = connection;
+		if (connection->isClosed())
+		{
+			qCWarning(Telescopes) << "ERROR creating TelescopeClientDirectLx200: cannot connect to" << hostName << "port" << tcpPort;
+			return;
+		}
+		// lx200 will be deleted in the destructor of Server
+		addConnection(connection);
 	}
-	
-	// lx200 will be deleted in the destructor of Server
-	// TODO: GZ2024: Server destructor is empty. Who deletes lx200 in version 24.2? Someone please clarify and fix documentation, then delete this note.
-	addConnection(lx200);
+	else
+	{
+		#ifdef Q_OS_WIN
+		if(serialDeviceName.right(serialDeviceName.size() - 3).toInt() > 9)
+			serialDeviceName = "\\\\.\\" + serialDeviceName;//"\\.\COMxx", not sure if it will work
+		#endif //Q_OS_WIN
+
+		Lx200SerialConnection *connection = new Lx200SerialConnection(*this, qPrintable(serialDeviceName));
+		lx200 = connection;
+		if (connection->isClosed())
+		{
+			qCWarning(Telescopes) << "ERROR creating TelescopeClientDirectLx200: cannot open serial device" << serialDeviceName;
+			return;
+		}
+		// lx200 will be deleted in the destructor of Server
+		// TODO: GZ2024: Server destructor is empty. Who deletes lx200 in version 24.2? Someone please clarify and fix documentation, then delete this note.
+		addConnection(connection);
+	}
 	
 	long_format_used = false; // unknown
 	last_ra = 0;
@@ -157,6 +195,15 @@ void TelescopeClientDirectLx200::telescopeAbortSlew()
 	if (!isConnected())
 		return;
 	lx200->sendAbort();
+
+	// sendAbort() discards every queued command, including any position query
+	// that was in flight. That would leave queue_get_position stuck false and
+	// stop the position polling entirely. Re-arm it, but with a short delay so
+	// that answers to the discarded queries can arrive and be ignored before
+	// the next query is sent. Without this the client goes silent and a
+	// networked LX200 server drops the connection on its read timeout.
+	queue_get_position = true;
+	next_pos_time = GetNow() + 500000; // 0.5 s
 }
 
 void TelescopeClientDirectLx200::gotoReceived(unsigned int ra_int, int dec_int)
@@ -199,11 +246,11 @@ void TelescopeClientDirectLx200::communicationResetReceived(void)
 	*log_file << Now() << "TelescopeClientDirectLx200::communicationResetReceived" << StelUtils::getEndLineChar();
 #endif
 
-	if (answers_received)
-	{
-		closeAcceptedConnections();
-		answers_received = false;
-	}
+	// A protocol-level reset (e.g. a timeout while waiting for an answer)
+	// must not tear down the transport itself: the serial path never did
+	// (closeAcceptedConnections() only touches TCP sockets), so neither
+	// should the TCP path. We simply re-synchronise and keep the link open.
+	answers_received = false;
 }
 
 //! Called in Lx200CommandGetRa and Lx200CommandGetDec.
@@ -242,6 +289,8 @@ void TelescopeClientDirectLx200::decReceived(unsigned int dec_int)
 
 void TelescopeClientDirectLx200::step(long long int timeout_micros)
 {
+	if (!lx200 || lx200->isClosed())
+		return;
 	long long int now = GetNow();
 	if (queue_get_position && now >= next_pos_time)
 	{
@@ -255,12 +304,12 @@ void TelescopeClientDirectLx200::step(long long int timeout_micros)
 
 bool TelescopeClientDirectLx200::isConnected(void) const
 {
-	return (!lx200->isClosed());//TODO
+	return (lx200 && !lx200->isClosed());//TODO
 }
 
 bool TelescopeClientDirectLx200::isInitialized(void) const
 {
-	return (!lx200->isClosed());
+	return (lx200 && !lx200->isClosed());
 }
 
 //Merged from Connection::sendPosition() and TelescopeTCP::performReading()

--- a/plugins/TelescopeControl/src/TelescopeControl.cpp
+++ b/plugins/TelescopeControl/src/TelescopeControl.cpp
@@ -846,9 +846,10 @@ void TelescopeControl::loadTelescopes()
 
 		if (connectionType == ConnectionInternal)
 		{
-			//Serial port and device model
+			//Device model and either a serial port or a network host
 			deviceModelName = telescope.value("device_model").toString();
 			portSerial = telescope.value("serial_port").toString();
+			hostName = telescope.value("host_name").toString();
 
 			if(deviceModelName.isEmpty())
 			{
@@ -866,9 +867,11 @@ void TelescopeControl::loadTelescopes()
 				continue;
 			}
 
-			if(portSerial.isEmpty())
+			//A directly connected telescope needs either a serial port or a
+			//network host (LX200-compatible protocol over TCP/IP).
+			if(portSerial.isEmpty() && hostName.isEmpty())
 			{
-                                qCWarning(Telescopes) << "[TelescopeControl] Unable to load telescope: No valid serial port specified at slot" << key;
+                                qCWarning(Telescopes) << "[TelescopeControl] Unable to load telescope: No valid serial port or host name specified at slot" << key;
 				map.remove(key);
 				continue;
 			}
@@ -995,7 +998,12 @@ void TelescopeControl::loadTelescopes()
 				{
 					addLogAtSlot(slot);
 					logAtSlot(slot);
-					if(!startClientAtSlot(slot, connectionType, name, equinox, QString(), 0, delay, internalCircles, deviceModelName, portSerial))
+					//Serial connections pass the serial port; network connections
+					//(LX200 over TCP) pass the host name and TCP port instead.
+					bool clientStarted = portSerial.isEmpty()
+						? startClientAtSlot(slot, connectionType, name, equinox, hostName, portTCP, delay, internalCircles, deviceModelName, QString())
+						: startClientAtSlot(slot, connectionType, name, equinox, QString(), 0, delay, internalCircles, deviceModelName, portSerial);
+					if(!clientStarted)
 					{
                                                 qCDebug(Telescopes) << "[TelescopeControl] Unable to create a telescope client at slot" << slot;
 						//Unnecessary due to if-else construction;
@@ -1084,9 +1092,20 @@ bool TelescopeControl::addTelescopeAtSlot(int slot, ConnectionType connectionTyp
 			return false;
 		telescope.insert("device_model", deviceModelName);
 
-		if (portSerial.isEmpty())
+		if (!portSerial.isEmpty())
+		{
+			// Directly connected through a serial port
+			telescope.insert("serial_port", portSerial);
+		}
+		else if (!host.isEmpty() && isValidPort(portTCP))
+		{
+			// Directly connected over TCP/IP (e.g. LX200 protocol over the network)
+			telescope.insert("host_name", host);
+		}
+		else
+		{
 			return false;
-		telescope.insert("serial_port", portSerial);
+		}
 	}
 
 	if (connectionType != ConnectionVirtual)
@@ -1234,7 +1253,12 @@ bool TelescopeControl::startTelescopeAtSlot(int slot)
 		{
 			addLogAtSlot(slot);
 			logAtSlot(slot);
-			if (startClientAtSlot(slot, connectionType, name, equinox, QString(), 0, delay, circles, deviceModelName, portSerial))
+			//Serial connections pass the serial port; network connections
+			//(LX200 over TCP) pass the host name and TCP port instead.
+			bool clientStarted = portSerial.isEmpty()
+				? startClientAtSlot(slot, connectionType, name, equinox, host, portTCP, delay, circles, deviceModelName, QString())
+				: startClientAtSlot(slot, connectionType, name, equinox, QString(), 0, delay, circles, deviceModelName, portSerial);
+			if (clientStarted)
 			{
 				emit clientConnected(slot, name);
 				return true;
@@ -1399,8 +1423,14 @@ bool TelescopeControl::startClientAtSlot(int slotNumber, ConnectionType connecti
 		break;
 
 	case ConnectionInternal:
-		if(!deviceModelName.isEmpty() && !portSerial.isEmpty())
-			initString = QString("%1:%2:%3:%4:%5").arg(name, deviceModels[deviceModelName].server, equinox, portSerial, QString::number(delay));
+		if(!deviceModelName.isEmpty())
+		{
+			if(!portSerial.isEmpty())
+				initString = QString("%1:%2:%3:%4:%5").arg(name, deviceModels[deviceModelName].server, equinox, portSerial, QString::number(delay));
+			else if(!host.isEmpty() && isValidPort(portTCP))
+				// Device protocol (e.g. LX200) spoken directly over TCP/IP
+				initString = QString("%1:%2:%3:%4:%5:%6").arg(name, deviceModels[deviceModelName].server, equinox, host, QString::number(portTCP), QString::number(delay));
+		}
 		break;
 
 	case ConnectionLocal:

--- a/plugins/TelescopeControl/src/common/CMakeLists.txt
+++ b/plugins/TelescopeControl/src/common/CMakeLists.txt
@@ -21,6 +21,8 @@ add_library(TelescopeControl_common STATIC
     Connection.cpp
     SerialPort.hpp
     SerialPort.cpp
+    TcpConnection.hpp
+    TcpConnection.cpp
     InterpolatedPosition.hpp
     InterpolatedPosition.cpp
     ${TelescopeControl_ASCOM_common_SRC}

--- a/plugins/TelescopeControl/src/common/Server.cpp
+++ b/plugins/TelescopeControl/src/common/Server.cpp
@@ -69,21 +69,17 @@ void Server::step(long long int timeout_micros)
 	const int select_rc = select(fd_max+1, &read_fds, &write_fds, nullptr, &tv);
 	if (select_rc > 0)
 	{
-		auto it = socket_list.begin();
-		while (it != socket_list.end())
+		// Note: a connection that has become closed is intentionally NOT
+		// deleted here. A device client (e.g. TelescopeClientDirectLx200)
+		// keeps a pointer to its connection for its whole lifetime; deleting
+		// the object here would leave that pointer dangling and cause a
+		// use-after-free (e.g. a crash after a TCP connection drops). Closed
+		// connections stay in the list (their prepareSelectFds()/
+		// handleSelectFds() become no-ops once the socket is invalid) and are
+		// freed when the Server itself is destroyed.
+		for (auto* socket : socket_list)
 		{
-			(*it)->handleSelectFds(read_fds, write_fds);
-			if ((*it)->isClosed())
-			{
-				auto tmp = it;
-				it++;
-				delete (*tmp);
-				socket_list.erase(tmp);
-			}
-			else
-			{
-				it++;
-			}
+			socket->handleSelectFds(read_fds, write_fds);
 		}
 	}
 }

--- a/plugins/TelescopeControl/src/common/TcpConnection.cpp
+++ b/plugins/TelescopeControl/src/common/TcpConnection.cpp
@@ -1,0 +1,146 @@
+/*
+The stellarium telescope library helps building
+telescope server programs, that can communicate with stellarium
+by means of the stellarium TCP telescope protocol.
+It also contains sample server classes (dummy, Meade LX200).
+
+Author and Copyright of this file:
+Rumen Bogdanovski, 2026
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Suite 500, Boston, MA  02110-1335, USA.
+*/
+
+#include "TcpConnection.hpp"
+#include "LogFile.hpp"
+#include "StelUtils.hpp"
+
+#ifdef Q_OS_WIN
+  #include <ws2tcpip.h> // getaddrinfo, freeaddrinfo
+#else
+  #include <netdb.h>    // getaddrinfo, freeaddrinfo
+#endif
+
+#include <cstring> // memset
+#include <string>
+
+namespace
+{
+//! Number of seconds we are willing to wait for the connection to be
+//! established before giving up.
+const int CONNECT_TIMEOUT_SECONDS = 5;
+
+#ifdef Q_OS_WIN
+//! Make sure the Windows Sockets library is initialised before we use it.
+//! WSAStartup() is reference counted, so this cooperates with Qt (which
+//! initialises WinSock too) and the matching WSACleanup() is intentionally
+//! omitted for the lifetime of the process.
+void ensureWinSock(void)
+{
+	static bool initialised = false;
+	if (!initialised)
+	{
+		WSADATA wsa_data;
+		WSAStartup(MAKEWORD(2, 2), &wsa_data);
+		initialised = true;
+	}
+}
+#endif
+} // anonymous namespace
+
+TcpConnection::TcpConnection(Server &server, const char *host, int port)
+	: Connection(server, INVALID_SOCKET)
+{
+#ifdef Q_OS_WIN
+	ensureWinSock();
+#endif
+
+	struct addrinfo hints;
+	memset(&hints, 0, sizeof(hints));
+	hints.ai_family   = AF_UNSPEC;   // allow both IPv4 and IPv6
+	hints.ai_socktype = SOCK_STREAM; // TCP
+
+	const std::string port_string = std::to_string(port);
+	struct addrinfo *address_list = nullptr;
+	const int gai_rc = getaddrinfo(host, port_string.c_str(), &hints, &address_list);
+	if (gai_rc != 0 || address_list == nullptr)
+	{
+		*log_file << Now() << "TcpConnection::TcpConnection(" << host << ':' << port << "): "
+		             "cannot resolve host: " << gai_strerror(gai_rc) << StelUtils::getEndLineChar();
+		return;
+	}
+
+	// Try each resolved address in turn until one connects.
+	for (struct addrinfo *ai = address_list; ai != nullptr; ai = ai->ai_next)
+	{
+		const SOCKET sock = socket(ai->ai_family, ai->ai_socktype, ai->ai_protocol);
+		if (IS_INVALID_SOCKET(sock))
+			continue;
+
+		if (SETNONBLOCK(sock) < 0)
+		{
+			close(sock);
+			continue;
+		}
+
+		const int connect_rc = connect(sock, ai->ai_addr, static_cast<SOCKLEN_T>(ai->ai_addrlen));
+		bool connected = (connect_rc == 0);
+		if (!connected)
+		{
+#ifdef Q_OS_WIN
+			const bool in_progress = (ERRNO == WSAEWOULDBLOCK || ERRNO == WSAEINPROGRESS);
+#else
+			const bool in_progress = (ERRNO == EINPROGRESS || ERRNO == EAGAIN || ERRNO == EINTR);
+#endif
+			if (in_progress)
+			{
+				// Non-blocking connect in progress: wait (with a timeout) for
+				// the socket to become writable, then verify it really connected.
+				fd_set write_fds;
+				FD_ZERO(&write_fds);
+				FD_SET(sock, &write_fds);
+				struct timeval tv;
+				tv.tv_sec  = CONNECT_TIMEOUT_SECONDS;
+				tv.tv_usec = 0;
+				const int select_rc = select(static_cast<int>(sock) + 1, nullptr, &write_fds, nullptr, &tv);
+				if (select_rc > 0 && FD_ISSET(sock, &write_fds))
+				{
+					int so_error = 0;
+					SOCKLEN_T len = sizeof(so_error);
+					if (getsockopt(sock, SOL_SOCKET, SO_ERROR,
+					               reinterpret_cast<char *>(&so_error), &len) == 0 && so_error == 0)
+						connected = true;
+				}
+			}
+		}
+
+		if (connected)
+		{
+			fd = sock;
+			break;
+		}
+
+		close(sock);
+	}
+
+	freeaddrinfo(address_list);
+
+	if (IS_INVALID_SOCKET(fd))
+	{
+		// Note: after a non-blocking connect ERRNO is not a reliable indicator
+		// of the failure reason, so we do not print it here.
+		*log_file << Now() << "TcpConnection::TcpConnection(" << host << ':' << port << "): "
+		             "cannot connect to host" << StelUtils::getEndLineChar();
+	}
+}

--- a/plugins/TelescopeControl/src/common/TcpConnection.hpp
+++ b/plugins/TelescopeControl/src/common/TcpConnection.hpp
@@ -1,0 +1,53 @@
+/*
+The stellarium telescope library helps building
+telescope server programs, that can communicate with stellarium
+by means of the stellarium TCP telescope protocol.
+It also contains sample server classes (dummy, Meade LX200).
+
+Author and Copyright of this file:
+Rumen Bogdanovski, 2026
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Suite 500, Boston, MA  02110-1335, USA.
+*/
+
+#ifndef TCPCONNECTION_HPP
+#define TCPCONNECTION_HPP
+
+#include "Connection.hpp"
+
+//! Outgoing TCP/IP client connection to a device that speaks an ASCII
+//! telescope protocol (such as a Meade LX200 exposed over a network bridge).
+//!
+//! Unlike Connection, whose constructor wraps an already-accepted socket,
+//! TcpConnection actively resolves @p host and connects to @p port. Once
+//! connected it reuses all of Connection's cross-platform, select()-based
+//! reading and writing. The socket is switched to non-blocking mode, but the
+//! initial connection attempt is performed synchronously (with a timeout) so
+//! that isClosed() reflects the real connection state right after construction,
+//! mirroring the behaviour of SerialPort.
+class TcpConnection : public Connection
+{
+public:
+	//! @param host host name or IPv4/IPv6 address of the telescope.
+	//! @param port TCP port the telescope is listening on.
+	TcpConnection(Server &server, const char *host, int port);
+
+private:
+	//! An ASCII protocol runs on top of this connection, so allow the
+	//! DEBUG5 logging in Connection to dump the traffic as text.
+	bool isAsciiConnection(void) const override {return true;}
+};
+
+#endif // TCPCONNECTION_HPP

--- a/plugins/TelescopeControl/src/gui/TelescopeConfigurationDialog.cpp
+++ b/plugins/TelescopeControl/src/gui/TelescopeConfigurationDialog.cpp
@@ -174,9 +174,12 @@ void TelescopeConfigurationDialog::createDialogContent()
 
 	connect(ui->comboBoxDeviceModel, SIGNAL(currentIndexChanged(int)), this, SLOT(deviceModelSelected(int)));
 
+	connect(ui->radioButtonNetworkConnection, SIGNAL(toggled(bool)), this, SLOT(toggleDeviceConnectionMedium(bool)));
+
 	// Setting validators
 	ui->lineEditTelescopeName->setValidator(telescopeNameValidator);
 	ui->lineEditHostName->setValidator(hostNameValidator);
+	ui->lineEditDeviceHost->setValidator(hostNameValidator);
 	ui->lineEditCircleList->setValidator(circleListValidator);
 	ui->comboSerialPort->setValidator(serialPortValidator);
 
@@ -321,13 +324,27 @@ void TelescopeConfigurationDialog::initExistingTelescopeConfiguration(int slot)
 		else
 			ui->comboBoxDeviceModel->setCurrentIndex(index);
 
-		// Initialize the serial port value
+		// A directly-connected device uses either a serial port or a network
+		// (TCP/IP) connection. An empty serial port with a host name stored
+		// means the LX200 protocol is spoken over TCP.
+		if (serialPortName.isEmpty() && !host.isEmpty())
+		{
+			ui->radioButtonNetworkConnection->setChecked(true);
+			ui->lineEditDeviceHost->setText(host);
+			ui->spinBoxDevicePort->setValue(portTCP);
+		}
+		else
+		{
+			ui->radioButtonSerialConnection->setChecked(true);
+			// Initialize the serial port value
 #if (QT_VERSION>=QT_VERSION_CHECK(5,14,0))
-		emit ui->comboSerialPort->textActivated(serialPortName);
+			emit ui->comboSerialPort->textActivated(serialPortName);
 #else
-		ui->comboSerialPort->activated(serialPortName);
+			ui->comboSerialPort->activated(serialPortName);
 #endif
-		ui->comboSerialPort->setEditText(serialPortName);
+			ui->comboSerialPort->setEditText(serialPortName);
+		}
+		updateDeviceConnectionMediumState();
 	}
 	else if (connectionType == TelescopeControl::ConnectionRemote)
 	{
@@ -413,6 +430,10 @@ void TelescopeConfigurationDialog::toggleTypeLocal(bool isChecked)
 		ui->lineEditHostName->setText("localhost");
 		ui->spinBoxTCPPort->setValue(DEFAULT_TCP_PORT_FOR_SLOT(configuredSlot));
 
+		// Default a directly-connected device to the serial port medium
+		ui->radioButtonSerialConnection->setChecked(true);
+		updateDeviceConnectionMediumState();
+
 		ui->groupBoxDeviceSettings->show();
 
 		ui->scrollArea->ensureWidgetVisible(ui->groupBoxTelescopeProperties);
@@ -421,6 +442,38 @@ void TelescopeConfigurationDialog::toggleTypeLocal(bool isChecked)
 	{
 		ui->groupBoxDeviceSettings->hide();
 	}
+}
+
+bool TelescopeConfigurationDialog::currentDeviceModelSupportsNetwork() const
+{
+	const QString deviceModelName = ui->comboBoxDeviceModel->currentText();
+	// Only the LX200 (or compatible) protocol is supported over TCP/IP so far.
+	return telescopeManager->getDeviceModels().value(deviceModelName).server == QLatin1String("TelescopeServerLx200");
+}
+
+void TelescopeConfigurationDialog::updateDeviceConnectionMediumState()
+{
+	const bool networkSupported = currentDeviceModelSupportsNetwork();
+	ui->radioButtonNetworkConnection->setEnabled(networkSupported);
+	// If the selected device model cannot be reached over the network, fall
+	// back to the serial port medium.
+	if (!networkSupported && ui->radioButtonNetworkConnection->isChecked())
+		ui->radioButtonSerialConnection->setChecked(true);
+
+	const bool network = networkSupported && ui->radioButtonNetworkConnection->isChecked();
+
+	ui->labelSerialPort->setVisible(!network);
+	ui->comboSerialPort->setVisible(!network);
+	ui->labelDeviceHost->setVisible(network);
+	ui->lineEditDeviceHost->setVisible(network);
+	ui->labelDevicePort->setVisible(network);
+	ui->spinBoxDevicePort->setVisible(network);
+}
+
+void TelescopeConfigurationDialog::toggleDeviceConnectionMedium(bool networkChecked)
+{
+	Q_UNUSED(networkChecked)
+	updateDeviceConnectionMediumState();
 }
 
 void TelescopeConfigurationDialog::toggleTypeConnection(bool isChecked)
@@ -525,11 +578,26 @@ void TelescopeConfigurationDialog::buttonSavePressed()
 	TelescopeControl::ConnectionType type = TelescopeControl::ConnectionNA;
 	if (ui->radioButtonTelescopeLocal->isChecked())
 	{
-		// Read the serial port
-		QString serialPortName = ui->comboSerialPort->currentText();
 		type = TelescopeControl::ConnectionInternal;
-		telescopeManager->addTelescopeAtSlot(configuredSlot, type, name, equinox, host, portTCP, delay,
-		  connectAtStartup, circles, ui->comboBoxDeviceModel->currentText(), serialPortName);
+		if (ui->radioButtonNetworkConnection->isChecked() && currentDeviceModelSupportsNetwork())
+		{
+			// Directly connected over TCP/IP (LX200 protocol over the network)
+			QString deviceHost = ui->lineEditDeviceHost->text().trimmed();
+			if (deviceHost.isEmpty())
+				return;
+			int devicePort = ui->spinBoxDevicePort->value();
+			// Pass an empty serial port so the slot is stored/started as a
+			// network connection.
+			telescopeManager->addTelescopeAtSlot(configuredSlot, type, name, equinox, deviceHost, devicePort, delay,
+			  connectAtStartup, circles, ui->comboBoxDeviceModel->currentText(), QString());
+		}
+		else
+		{
+			// Read the serial port
+			QString serialPortName = ui->comboSerialPort->currentText();
+			telescopeManager->addTelescopeAtSlot(configuredSlot, type, name, equinox, host, portTCP, delay,
+			  connectAtStartup, circles, ui->comboBoxDeviceModel->currentText(), serialPortName);
+		}
 	}
 	else if (ui->radioButtonTelescopeConnection->isChecked())
 	{
@@ -586,4 +654,7 @@ void TelescopeConfigurationDialog::deviceModelSelected(int modelIndex)
 	  q_(telescopeManager->getDeviceModels().value(deviceModelName).description));
 	ui->doubleSpinBoxTelescopeDelay->setValue(
 	  SECONDS_FROM_MICROSECONDS(telescopeManager->getDeviceModels().value(deviceModelName).defaultDelay));
+
+	// The serial/network choice depends on the selected device model
+	updateDeviceConnectionMediumState();
 }

--- a/plugins/TelescopeControl/src/gui/TelescopeConfigurationDialog.hpp
+++ b/plugins/TelescopeControl/src/gui/TelescopeConfigurationDialog.hpp
@@ -62,6 +62,8 @@ private:
 	QStringList* listSerialPorts();
 	void initConfigurationDialog();
 	void populateToolTips();
+	bool currentDeviceModelSupportsNetwork() const;
+	void updateDeviceConnectionMediumState();
 	
 private slots:
 	void buttonSavePressed();
@@ -79,6 +81,9 @@ private slots:
 	#endif
 	
 	void deviceModelSelected(int modelIndex);
+
+	//! Toggle between a serial and a network (TCP/IP) connection.
+	void toggleDeviceConnectionMedium(bool networkChecked);
 
 
 signals:

--- a/plugins/TelescopeControl/src/gui/TelescopeDialog.cpp
+++ b/plugins/TelescopeControl/src/gui/TelescopeDialog.cpp
@@ -367,7 +367,7 @@ void TelescopeDialog::setAboutText()
 	helpPage += "</li>";
 	helpPage += "<li>";
 	// TRANSLATORS: The text between braces is the text of an HTML link.
-	helpPage += q_("<b>local, Stellarium</b> means a DIRECT connection to the telescope (see {above});").replace(a_rx, "<a href=\"#usingthisplugin\">\\1</a>");
+	helpPage += q_("<b>direct, Stellarium</b> means a DIRECT connection to the telescope (see {above});").replace(a_rx, "<a href=\"#usingthisplugin\">\\1</a>");
 	helpPage += "</li>";
 	helpPage += "<li>" + q_("<b>local, external</b> means an INDIRECT connection to a program running on the same computer;") + "</li>";
 	helpPage += "<li>" + q_("<b>remote, unknown</b> means an INDIRECT connection over a network to a remote machine.") + "</li></ul></li></ul>";
@@ -382,7 +382,7 @@ void TelescopeDialog::setAboutText()
 	helpPage += q_("The topmost field represents the choice between the two types of connections (see {above}):").replace(a_rx, "<a href=\"#usingthisplugin\">\\1</a>");
 	helpPage += "</p>";
 	helpPage += "<p><b>" + q_("Telescope controlled by:") + "</b></p><ul>";
-	helpPage += "<li>" + q_("<b>Stellarium, directly through a serial port</b> is the DIRECT case. LX200-compatible mounts can alternatively be connected directly over a TCP/IP network (see {Device settings}).").replace(a_rx, "<a href=\"#device_settings\">\\1</a>") + "</li>";
+	helpPage += "<li>" + q_("<b>Stellarium, directly (serial port or network)</b> is the DIRECT case. LX200-compatible mounts can be connected either through a serial port or over a TCP/IP network (see {Device settings}).").replace(a_rx, "<a href=\"#device_settings\">\\1</a>") + "</li>";
 	helpPage += "<li>" + q_("<b>External software or a remote computer</b> is the INDIRECT case") + "</li>";
 	helpPage += "<li>";
 	// TRANSLATORS: The text between braces is the text of an HTML link.
@@ -576,7 +576,7 @@ QString TelescopeDialog::getTypeLabel(TelescopeControl::ConnectionType type)
 {
 	static const QMap<TelescopeControl::ConnectionType, QString>map={
 		// TRANSLATORS: Telescope connection type
-		{ TelescopeControl::ConnectionInternal, N_("local, Stellarium")},
+		{ TelescopeControl::ConnectionInternal, N_("direct, Stellarium")},
 		// TRANSLATORS: Telescope connection type
 		{ TelescopeControl::ConnectionLocal, N_("local, external")},
 		// TRANSLATORS: Telescope connection type

--- a/plugins/TelescopeControl/src/gui/TelescopeDialog.cpp
+++ b/plugins/TelescopeControl/src/gui/TelescopeDialog.cpp
@@ -278,9 +278,10 @@ void TelescopeDialog::setAboutText()
 	aboutPage += "<tr><td>Gion Kunz &lt;gion.kunz@gmail.com&gt; (" + q_("ASCOM Telescope Client") + ")</td></tr>";
 	aboutPage += "<tr><td>Petr Kubánek (" + q_("RTS2 support") + ")</td></tr>";
 	aboutPage += "<tr><td>Alessandro Siniscalchi &lt;asiniscalchi@gmail.com&gt; (" + q_("INDI Telescope Client") + ")</td></tr>";
-	aboutPage += "<tr><td rowspan=3><strong>" + q_("Contributors") + ":</strong></td><td>Alexander Wolf</td></tr>";
+	aboutPage += "<tr><td rowspan=4><strong>" + q_("Contributors") + ":</strong></td><td>Alexander Wolf</td></tr>";
 	aboutPage += "<tr><td>Michael Heinz</td></tr>";
 	aboutPage += "<tr><td>Alexandros Kosiaris</td></tr>";
+	aboutPage += "<tr><td>Rumen Bogdanovski &lt;rumenastro@gmail.com&gt; (" + q_("LX200 telescope control over TCP/IP") + ")</td></tr>";
 	aboutPage += "</table>";
 
 	aboutPage += "<p>" + q_("This plug-in is based on and reuses a lot of code under the GNU General Public License:") + "</p><ul>";
@@ -381,7 +382,7 @@ void TelescopeDialog::setAboutText()
 	helpPage += q_("The topmost field represents the choice between the two types of connections (see {above}):").replace(a_rx, "<a href=\"#usingthisplugin\">\\1</a>");
 	helpPage += "</p>";
 	helpPage += "<p><b>" + q_("Telescope controlled by:") + "</b></p><ul>";
-	helpPage += "<li>" + q_("<b>Stellarium, directly through a serial port</b> is the DIRECT case") + "</li>";
+	helpPage += "<li>" + q_("<b>Stellarium, directly through a serial port</b> is the DIRECT case. LX200-compatible mounts can alternatively be connected directly over a TCP/IP network (see {Device settings}).").replace(a_rx, "<a href=\"#device_settings\">\\1</a>") + "</li>";
 	helpPage += "<li>" + q_("<b>External software or a remote computer</b> is the INDIRECT case") + "</li>";
 	helpPage += "<li>";
 	// TRANSLATORS: The text between braces is the text of an HTML link.
@@ -402,6 +403,10 @@ void TelescopeDialog::setAboutText()
 	// TRANSLATORS: The text between braces is the text of an HTML link.
 	helpPage += q_("This section is active only for DIRECT connections (see {above}).").replace(a_rx, "<a href=\"#usingthisplugin\">\\1</a>");
 	helpPage += "</p>";
+	helpPage += "<p>";
+	// TRANSLATORS: The text between braces is the text of an HTML link.
+	helpPage += q_("<b>Connection</b> selects how Stellarium reaches the telescope. Choose <b>Serial port</b> for a device attached through a serial or USB cable. For LX200-compatible mounts you can instead choose <b>Network (TCP)</b> to talk to the telescope over TCP/IP - for example a Wi-Fi/Ethernet adapter or a software bridge that exposes the Meade LX200 protocol on a network port.");
+	helpPage += "</p>";
 	helpPage += "<p>" + q_("<b>Serial port</b> sets the serial port used by the telescope.") + "</p>";
 	helpPage += "<p>" + q_("There is a pop-up box that suggests some default values:") + "</p><ul>";
 	helpPage += "<li>" + q_("On Windows, serial ports COM1 to COM10;") + "</li>";
@@ -414,6 +419,7 @@ void TelescopeDialog::setAboutText()
 	// TRANSLATORS: The text between braces is the text of an HTML link.
 	helpPage += q_("<b>Device model</b>: see {Supported devices} below.").replace(a_rx, "<a href=\"#devices\">\\1</a>");
 	helpPage += "</p>";
+	helpPage += "<p>" + q_("When <b>Network (TCP)</b> is selected, the <b>Serial port</b> field is replaced by <b>Host</b> and <b>Port</b> fields: enter the host name or IP address of the telescope (or of the computer running the LX200 network bridge) and the TCP port it is listening on. The <b>Network (TCP)</b> option is available only for LX200-compatible device models.") + "</p>";
 	helpPage += "<p><a href=\"#top\"><small>[" + q_("Back to top") + "]</small></a></p>";
 
 	helpPage += "<h4><a name=\"connection_settings\" />" + q_("Connection settings") + "</h4>";
@@ -480,6 +486,7 @@ void TelescopeDialog::setAboutText()
 	// TRANSLATORS: The text between braces is the text of an HTML link.
 	helpPage += q_("All devices listed in the {'Device model' list} are convenience definitions using one of the two built-in interfaces: the Meade LX200 (the Meade Autostar controller) interface and the Celestron NexStar interface.").replace(a_rx, "<a href=\"#device_settings\">\\1</a>");
 	helpPage += "</p>";
+	helpPage += "<p>" + q_("Devices using the Meade LX200 interface can be connected either through a serial/USB port or over a TCP/IP network. Devices using the Celestron NexStar interface are connected through a serial/USB port only.") + "</p>";
 	helpPage += "<p>" + q_("The device list contains the following:") + "</p><dl>";
 	helpPage += "<dt><b>Celestron NexStar (compatible)</b></dt><dd>" + q_("Any device using the NexStar interface.") + "</dd>";
 	helpPage += "<dt><b>Losmandy G-11</b></dt><dd>" + q_("A computerized telescope mount made by Losmandy (Meade LX-200/Autostar interface).") + "</dd>";

--- a/plugins/TelescopeControl/src/gui/telescopeConfigurationDialog.ui
+++ b/plugins/TelescopeControl/src/gui/telescopeConfigurationDialog.ui
@@ -93,7 +93,7 @@
          <string>A telescope connected to this computer via a serial port and controlled directly by Stellarium.</string>
         </property>
         <property name="text">
-         <string>Stellarium, directly through a serial port</string>
+         <string>Stellarium, directly (serial port or network)</string>
         </property>
         <property name="checked">
          <bool>true</bool>

--- a/plugins/TelescopeControl/src/gui/telescopeConfigurationDialog.ui
+++ b/plugins/TelescopeControl/src/gui/telescopeConfigurationDialog.ui
@@ -435,6 +435,62 @@
            <number>0</number>
           </property>
           <item>
+           <layout class="QHBoxLayout" name="horizontalLayoutConnectionMedium">
+            <item>
+             <widget class="QLabel" name="labelConnectionMedium">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>0</width>
+                <height>24</height>
+               </size>
+              </property>
+              <property name="text">
+               <string>Connection:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QRadioButton" name="radioButtonSerialConnection">
+              <property name="text">
+               <string>Serial port</string>
+              </property>
+              <property name="checked">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QRadioButton" name="radioButtonNetworkConnection">
+              <property name="toolTip">
+               <string>Communicate with the telescope using the LX200 protocol over a TCP/IP network connection</string>
+              </property>
+              <property name="text">
+               <string>Network (TCP)</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacerConnectionMedium">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
+          <item>
            <layout class="QHBoxLayout" name="horizontalLayoutSerialPort">
             <item>
              <widget class="QLabel" name="labelSerialPort">
@@ -459,6 +515,59 @@
              <widget class="QComboBox" name="comboSerialPort">
               <property name="editable">
                <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayoutDeviceNetwork">
+            <item>
+             <widget class="QLabel" name="labelDeviceHost">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>0</width>
+                <height>24</height>
+               </size>
+              </property>
+              <property name="text">
+               <string>Host:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLineEdit" name="lineEditDeviceHost">
+              <property name="toolTip">
+               <string>Host name or IP address of the telescope</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="labelDevicePort">
+              <property name="text">
+               <string>Port:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QSpinBox" name="spinBoxDevicePort">
+              <property name="toolTip">
+               <string>TCP port the telescope is listening on</string>
+              </property>
+              <property name="minimum">
+               <number>1</number>
+              </property>
+              <property name="maximum">
+               <number>65535</number>
+              </property>
+              <property name="value">
+               <number>4030</number>
               </property>
              </widget>
             </item>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR adds new feature - ability to connect to LX200 mounts over TCP/IP

### Description
Lately there are LX200 mounts that can be accessed over WIFI (TCP/IP) like ML Astro SAL33, ZWO AM3/5/7 and basically all OnStep nased mounts. So adding this functionality is a nice addition to Stellarium. Also indigo_mount_agent offers LX200 translation layer over TCP and all indigo mounts can be accessed via the common LX200 commands. TCP or Serial connection can be chosen when the telescope is created or modified. The current serial transport is unchanged TCP/IP is added as an alternative. Plugin help page is updated accordingly.

Fixes # (issue)

### Screenshots (if appropriate):
<img width="2430" height="1346" alt="Screenshot From 2026-07-04 14-05-57" src="https://github.com/user-attachments/assets/82e97f75-9387-4623-9185-af9eed9d6783" />

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested with OnStepX mount and INDIGO lx200 server.
Slew/sync/abort/ connect disconnect all work as expected.

**Test Configuration**:
* Operating system: Ububtu 
* Graphics Card: AMD Radeon

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules