### PR TITLE
fix: use regionKey() for sky culture region matching to avoid CJK substring issues

### DIFF
--- a/src/gui/SeparatorListWidgetItem.cpp
+++ b/src/gui/SeparatorListWidgetItem.cpp
@@ -14,13 +14,14 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program; if not, see <http://www.gnu.org/licenses/>.
  */
 
 #include "SeparatorListWidgetItem.hpp"
 
-SeparatorListWidgetItem::SeparatorListWidgetItem(const QString &text, QListWidget *parent)
+SeparatorListWidgetItem::SeparatorListWidgetItem(const QString &text, const QString &regionKey, QListWidget *parent)
 	: QListWidgetItem(parent, 1318)
+	, m_regionKey(regionKey)
 {
 	setFlags(Qt::NoItemFlags);
 	setTextAlignment(Qt::AlignCenter);

--- a/src/gui/SeparatorListWidgetItem.hpp
+++ b/src/gui/SeparatorListWidgetItem.hpp
@@ -14,7 +14,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program; if not, see <http://www.gnu.org/licenses/>.
  */
 
 #ifndef SEPARATORLISTWIDGETITEM_HPP
@@ -27,7 +27,14 @@
 class SeparatorListWidgetItem : public QListWidgetItem
 {
 public:
-	SeparatorListWidgetItem(const QString &text, QListWidget *parent=nullptr);
+	//! Constructor with region key for reliable matching
+	SeparatorListWidgetItem(const QString &text, const QString &regionKey, QListWidget *parent=nullptr);
+	
+	//! Get the original (untranslated) region key for matching
+	QString regionKey() const { return m_regionKey; }
+
+private:
+	QString m_regionKey;
 };
 
 #endif // SEPARATORLISTWIDGETITEM_HPP

--- a/src/gui/ViewDialog.cpp
+++ b/src/gui/ViewDialog.cpp
@@ -893,26 +893,19 @@ void ViewDialog::updateHipsText()
 		return;
 	}
 	QJsonObject props = hips->property("properties").toJsonObject();
-	QString html = QString("<h1>%1</h1>
-").arg(props["obs_title"].toString());
+	QString html = QString("<h1>%1</h1>\n").arg(props["obs_title"].toString());
 	if (props.contains("obs_copyright") && props.contains("obs_copyright_url"))
 	{
-		html += QString("<p>Copyright <a href='%2'>%1</a></p>
-")
+		html += QString("<p>Copyright <a href='%2'>%1</a></p>\n")
 				.arg(props["obs_copyright"].toString(), props["obs_copyright_url"].toString());
 	}
-	html += QString("<p>%1</p>
-").arg(props["obs_description"].toString());
-	html += "<h2>" + q_("properties") + "</h2>
-<ul>
-";
+	html += QString("<p>%1</p>\n").arg(props["obs_description"].toString());
+	html += "<h2>" + q_("properties") + "</h2>\n<ul>\n";
 	for (auto iter = props.constBegin(); iter != props.constEnd(); iter++)
 	{
-		html += QString("<li><b>%1</b> %2</li>
-").arg(iter.key(), iter.value().toString());
+		html += QString("<li><b>%1</b> %2</li>\n").arg(iter.key(), iter.value().toString());
 	}
-	html += "</ul>
-";
+	html += "</ul>\n";
 	const auto gui = dynamic_cast<StelGui*>(StelApp::getInstance().getGui());
 	if (gui)
 		ui->surveysTextBrowser->document()->setDefaultStyleSheet(QString(gui->getStelStyle().htmlStyleSheet));

--- a/src/gui/ViewDialog.cpp
+++ b/src/gui/ViewDialog.cpp
@@ -893,19 +893,26 @@ void ViewDialog::updateHipsText()
 		return;
 	}
 	QJsonObject props = hips->property("properties").toJsonObject();
-	QString html = QString("<h1>%1</h1>\n").arg(props["obs_title"].toString());
+	QString html = QString("<h1>%1</h1>
+").arg(props["obs_title"].toString());
 	if (props.contains("obs_copyright") && props.contains("obs_copyright_url"))
 	{
-		html += QString("<p>Copyright <a href='%2'>%1</a></p>\n")
+		html += QString("<p>Copyright <a href='%2'>%1</a></p>
+")
 				.arg(props["obs_copyright"].toString(), props["obs_copyright_url"].toString());
 	}
-	html += QString("<p>%1</p>\n").arg(props["obs_description"].toString());
-	html += "<h2>" + q_("properties") + "</h2>\n<ul>\n";
+	html += QString("<p>%1</p>
+").arg(props["obs_description"].toString());
+	html += "<h2>" + q_("properties") + "</h2>
+<ul>
+";
 	for (auto iter = props.constBegin(); iter != props.constEnd(); iter++)
 	{
-		html += QString("<li><b>%1</b> %2</li>\n").arg(iter.key(), iter.value().toString());
+		html += QString("<li><b>%1</b> %2</li>
+").arg(iter.key(), iter.value().toString());
 	}
-	html += "</ul>\n";
+	html += "</ul>
+";
 	const auto gui = dynamic_cast<StelGui*>(StelApp::getInstance().getGui());
 	if (gui)
 		ui->surveysTextBrowser->document()->setDefaultStyleSheet(QString(gui->getStelStyle().htmlStyleSheet));
@@ -1636,12 +1643,12 @@ void ViewDialog::populateLists()
 	// add regions to list as custom QListWidgetItem
 	for (const auto &region : sortedOccuringRegions)
 	{
-		l->addItem(new SeparatorListWidgetItem(q_(region)));
+		l->addItem(new SeparatorListWidgetItem(q_(region), region));
 	}
 	// oops... the list of regions has unknown region - let's add "other" region for these sky cultures
 	if (occuringRegions.size() > sortedOccuringRegions.size())
 	{
-		l->addItem(new SeparatorListWidgetItem(q_("Other")));
+		l->addItem(new SeparatorListWidgetItem(q_("Other"), "Other"));
 	}
 
 	// find the earliest beginTime of all cultures (needed in initSkyCultureTime)
@@ -1668,8 +1675,41 @@ void ViewDialog::populateLists()
 
 		// When region is unknown (non UN-geoscheme), insert item under "other" separator,
 		// otherwise insert item under respective region separator
-		QString itemName = (l->findItems(q_(cultureRegionIt.value()), Qt::MatchContains).empty()) ? q_("Other") : q_(cultureRegionIt.value());
-		l->insertItem(l->row(l->findItems(itemName, Qt::MatchContains).first()) + 1, item);
+		// When region is unknown (non UN-geoscheme), insert item under "other" separator,
+		// otherwise insert item under respective region separator
+		// Use regionKey() for matching instead of translated text to avoid CJK substring issues
+		SeparatorListWidgetItem* targetSeparator = nullptr;
+		for (int i = 0; i < l->count(); ++i)
+		{
+			SeparatorListWidgetItem* sep = qobject_cast<SeparatorListWidgetItem*>(l->item(i));
+			if (sep && sep->regionKey() == cultureRegionIt.value())
+			{
+				targetSeparator = sep;
+				break;
+			}
+		}
+		if (!targetSeparator)
+		{
+			// Fallback: look for "Other" separator
+			for (int i = 0; i < l->count(); ++i)
+			{
+				SeparatorListWidgetItem* sep = qobject_cast<SeparatorListWidgetItem*>(l->item(i));
+				if (sep && sep->regionKey() == "Other")
+				{
+					targetSeparator = sep;
+					break;
+				}
+			}
+		}
+		if (targetSeparator)
+		{
+			l->insertItem(l->row(targetSeparator) + 1, item);
+		}
+		else
+		{
+			// Fallback: append to end if no separator found
+			l->addItem(item);
+		}
 	}
 
 	ui->skyCultureCurrentTimeSpinBox->setMinimum(globalBeginTime);

--- a/src/gui/ViewDialog.cpp
+++ b/src/gui/ViewDialog.cpp
@@ -1681,7 +1681,7 @@ void ViewDialog::populateLists()
 		SeparatorListWidgetItem* targetSeparator = nullptr;
 		for (int i = 0; i < l->count(); ++i)
 		{
-			SeparatorListWidgetItem* sep = qobject_cast<SeparatorListWidgetItem*>(l->item(i));
+			SeparatorListWidgetItem* sep = dynamic_cast<SeparatorListWidgetItem*>(l->item(i));
 			if (sep && sep->regionKey() == cultureRegionIt.value())
 			{
 				targetSeparator = sep;
@@ -1693,7 +1693,7 @@ void ViewDialog::populateLists()
 			// Fallback: look for "Other" separator
 			for (int i = 0; i < l->count(); ++i)
 			{
-				SeparatorListWidgetItem* sep = qobject_cast<SeparatorListWidgetItem*>(l->item(i));
+				SeparatorListWidgetItem* sep = dynamic_cast<SeparatorListWidgetItem*>(l->item(i));
 				if (sep && sep->regionKey() == "Other")
 				{
 					targetSeparator = sep;


### PR DESCRIPTION
## What this PR does

Fixes incorrect categorization of Indian sky cultures in CJK locales (Chinese, Japanese, Korean).

## Why

In CJK locales, `Qt::MatchContains` creates a substring matching problem:
- "Southern Asia" → "南亚"
- "South-eastern Asia" → "东南亚"

When searching for "南亚" (Southern Asia), Qt also matches "东南亚" (South-eastern Asia) because the latter contains the former as a substring. This causes all Indian sky cultures to be placed under the wrong region separator.

## Solution

Instead of matching against translated strings (which is unreliable), this PR stores the original (untranslated) region key in `SeparatorListWidgetItem` and uses it for matching.

### Changes:
1. **SeparatorListWidgetItem.hpp/cpp**: Added `regionKey` parameter to constructor and `m_regionKey` member with getter
2. **ViewDialog.cpp**: 
   - Pass region key when creating separator items
   - Use `regionKey()` for matching instead of translated text
   - Added fallback to "Other" separator if region not found

This approach is more robust than `MatchExactly` on decorated text because it does not depend on translation strings at all.

## Testing

The fix can be verified by:
1. Switching to a CJK locale (Chinese/Japanese/Korean)
2. Opening Settings → Sky Cultures
3. Verifying that Indian sky cultures appear under "Southern Asia" (南亚/南アジア) instead of "South-eastern Asia" (东南亚/東南アジア)

Fixes #5008