### PR TITLE
Set desktop file name for the application

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -188,6 +188,7 @@ int main(int argc, char **argv)
 	QCoreApplication::setApplicationVersion(StelUtils::getApplicationPublicVersion());
 	QCoreApplication::setOrganizationDomain("stellarium.org");
 	QCoreApplication::setOrganizationName("stellarium");
+	QGuiApplication::setDesktopFileName("org.stellarium.Stellarium");
 
 	QCoreApplication::setAttribute(Qt::AA_CompressHighFrequencyEvents);
 	// Support high DPI pixmaps and fonts


### PR DESCRIPTION
### Description
This ensures that the XDG toplevel app ID matches with the desktop file name, so Wayland compositors could match the window with the application and show the appropriate icon for them.

Without this change, the app ID is `org.stellarium.stellarium`, but the desktop file is called as [`org.stellarium.Stellarium`](https://github.com/Stellarium/stellarium/blob/a5e0caf9b1a18738087d88035380f56d63c0da9b/data/org.stellarium.Stellarium.desktop).

References:
- https://github.com/qt/qtbase/blob/bf1ae5862807ec2b9a411506d59ccd566937a4c7/src/plugins/platforms/wayland/qwaylandwindow.cpp#L152C20-L177
- https://wayland.app/protocols/xdg-shell#xdg_toplevel:request:set_app_id

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?
Run Stellarium in a Wayland environment (e.g. in GNOME), and check the icon on the dock.

## Checklist:
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
