### PR TITLE
Added Tibetan spelling, transliteration and IPA for Tibetan SC

### DIFF
--- a/skycultures/tibetan/description.md
+++ b/skycultures/tibetan/description.md
@@ -328,7 +328,7 @@ We would welcome input from native Tibetan speakers regarding the meanings of th
 
 Alternative figures can be found in the old configuration files. We would welcome verification and corrections from experts in Tibetan astronomy, covering both the identification of the lunar mansions and the review of Tibetan script, transliteration, and IPA.
 
-The *zodiac* and *gyukar* bands have been taken over from Indian tradition. The number of gyukars is given as 28. However, as noted above, the 27-mansion count is equally valid, provided Drozhin and Jizhin are merged. The link "Spica=180°" is also set here for both circles, but should be confirmed.
+The *zodiac* and *gyukar* bands have been taken over from Indian tradition. The number of gyukars is given as 27. However, as noted above, the 28-mansion count is equally valid, provided Drozhin and Jizhin are separated. The link "Spica=180°" is also set here for both circles, but should be confirmed.
 
 #### Further reading
 
@@ -350,7 +350,7 @@ Editura Universit&#x103;&#x163;ii de Vest din Timi&#x15F;oara} (pages 123-136). 
 
 Georg Zotti on May 21, 2019, reworked July-October 2023. *Zodiac* and *Gyukars* added in V25.2. 
 
-Lyu Haocheng [lvhc2016@126.com](mailto:lvhc2016@126.com) supplemented the Tibetan names of the twelve zodiacal signs and the 28 lunar mansions with native script, transliteration, and IPA. Specialist review is still requested.
+Lyu Haocheng [lvhc2016@126.com](mailto:lvhc2016@126.com) supplemented the Tibetan names of the twelve zodiacal signs and the 28 (27) lunar mansions with native script, transliteration, and IPA. Specialist review is still requested.
 
 ## License
 

--- a/skycultures/tibetan/description.md
+++ b/skycultures/tibetan/description.md
@@ -116,6 +116,8 @@ The zodiac is partitioned into 12 figures largely identical to the classical fig
 
 ### The Lunar Mansions
 
+Ancient Indian literature records two traditions regarding the number of lunar mansions: 27 and 28. Tibetan sources similarly preserve both counts. When 27 mansions are enumerated, the two asterisms **Drozhin** (གྲོ་བཞིན) and **Jizhin** (བྱི་བཞིན) are conventionally merged into a single mansion. Thus there is no real contradiction between the 28- and 27-mansion systems. The Kālacakra Tantra states that "Drozhin and Jizhin together occupy the span of a single mansion, without taking up extra space." Several Chinese Buddhist scriptures, such as the *Xiuyao Jing* (Sūtra of Lunar Mansions and Planets) and the *Modengjia Jing* (Mātanga Sūtra), also employ the 27-mansion scheme when describing the relationship between the lunar mansion system and the twelve zodiacal signs.
+
 The Men Tsee Khang emblem shows 27 stick figures for the Lunar mansions arranged in a circle around the central figure. The same figures are also laid out in cement with bright stones connected by black lines in the circular platform which has been erected when the observatory was rebuilt. These 27 *gyukar* figures are described as being equal to the Indian *Nakṣatras* and represent sections of 13°20' longitude along the ecliptic. Actually, one of the *gyukars* consists of 2 asterisms, therefore 28 *lunar asterisms* are named.
 
 However, not much is known of the exact identification of the Tibetan Lunar Stations outside of Tibet. Most literature is Tibetan or Chinese only, and there were no Tibetan star maps available. Also our guides could not explain any of the following to us.
@@ -320,9 +322,13 @@ The star figures for Lunar Mansions in this skyculture are shown as asterisms am
 
 The figures are my own attempt of identification of the Lunar mansion figures. We can be sure about the placement of only those which can also be found in other sky cultures, e.g. Japanese Moon Stations which stem from Chinese tradition. Many stars are rather dim, and the figures in the emblem apparently have to be rotated in arbitrary ways, like *gyukar 3*=Hyades. Others require considerable liberties to accept a topological match. Alternative matches with stars in similar topology arranged in the orientation shown in the emblem (north=outer circle) have been found only in neighboring areas of the sky, making a match rather unlikely. Others appear to have been taken over from Chinese tradition, e.g. Nr. 11. LM21 can be explained only if we accept two separate figures which are not aligned as shown in the concrete figure. Then they represent Chinese constellations *Ox* and *Girl* (which is also Japanese Lunar station *Woman*).
 
-Alternative figures can be found in the old configuration files. We would like to hear from experts of Tibetan astronomy about both confirmed and corrected identification.
+We have supplemented the Tibetan names with native script (Dung dkar Blo bzang 'phrin las, 2002, p. 328), transliteration, and IPA. The "native" field contains the original Tibetan spelling in Tibetan characters. It should be noted that many fonts do not render Tibetan script correctly; we have preserved the correct Unicode codepoints in the file for reference. The "transliteration" follows the Tibetan Pinyin system (Zangyu Hanyu Pinyin Zimu Yinyi Zhuanxie Fa), which is based on the Lhasa pronunciation and adopts a Hanyu Pinyin-like scheme for transcribing Tibetan pronunciation. Several different romanisation systems exist for Tibetan; the scheme adopted here, while close to Hanyu Pinyin, may not be the most intuitive for Western readers. The "sci. translit." field uses the Wylie transliteration system, which is specifically designed for Tibetan orthography and allows a lossless conversion of Tibetan script into Latin letters. It is important to note that Tibetan pronunciation and spelling are not consistent — Tibet has not undergone systematic orthographic reform for over a millennium, and the current spelling reflects Old Tibetan pronunciation. We therefore use Wylie to represent the written form and Tibetan Pinyin to represent the contemporary Lhasa pronunciation.
 
-The *zodiac* and *gyukar* bands have been taken over from Indian tradition. The link "Spica=180°" is also set here for both circles, but should be confirmed. 
+We would welcome input from native Tibetan speakers regarding the meanings of the Tibetan lunar mansion names. So far, we have been able to determine the semantics of only a few, for example མགོ (mgo, go) meaning "head." The Tibetan lunar stations are closely related to both the Indian Nakṣatras and the Chinese lunar mansion traditions, and they share some semantic parallels with both—yet they are not entirely identical to either, each displaying distinctive cultural characteristics. At present, the mansions are identified by their numerical designations; we hope to replace these with their actual semantic names in the future.
+
+Alternative figures can be found in the old configuration files. We would welcome verification and corrections from experts in Tibetan astronomy, covering both the identification of the lunar mansions and the review of Tibetan script, transliteration, and IPA.
+
+The *zodiac* and *gyukar* bands have been taken over from Indian tradition. The number of gyukars is given as 28. However, as noted above, the 27-mansion count is equally valid, provided Drozhin and Jizhin are merged. The link "Spica=180°" is also set here for both circles, but should be confirmed.
 
 #### Further reading
 
@@ -337,10 +343,14 @@ Editura Universit&#x103;&#x163;ii de Vest din Timi&#x15F;oara} (pages 123-136). 
  - [#1]: Burgess, E. (1860). Translation of the Surya-Siddhanta, a Text-Book of Hindu Astronomy. New Haven.
  - [#2]: Cornu, P. (2002). Tibetan Astrology. Boston & London: Shambhala.
  - [#3]: [Reingold, Edward M. and Nachum Dershowitz (2018). Calendrical Calculations: The Ultimate Edition. Cambridge: Cambridge University Press. ](https://dx.doi.org/10.1017/9781107415058)
+ - [#4]: [Suolang, S., Gelang, Nanmujia, & Jilü. (2017). Zangzu chuantong tianwen lical zhong de ershiba xiu tixi yanjiu [A study on the system of the twenty-eight lunar mansions in traditional Tibetan astronomy and calendrical calculations]. *Xizang Daxue Xuebao (Shehui Kexue Ban) / Journal of Tibet University (Social Sciences Edition)*, (4), 57–66](https://doi.org/10.16249/j.cnki.1005-5738.2017.04.009).
+ - [#5]: Dung dkar Blo bzang 'phrin las (Dungkar Lozang Trinlé). (Ed.). (2002). Dung dkar tshig mdzod chen mo [Dung dkar great dictionary of Tibetan studies]. China Tibetology Publishing House.
 
 ## Authors
 
 Georg Zotti on May 21, 2019, reworked July-October 2023. *Zodiac* and *Gyukars* added in V25.2. 
+
+Lyu Haocheng [lvhc2016@126.com](mailto:lvhc2016@126.com) supplemented the Tibetan names of the twelve zodiacal signs and the 28 lunar mansions with native script, transliteration, and IPA. Specialist review is still requested.
 
 ## License
 

--- a/skycultures/tibetan/index.json
+++ b/skycultures/tibetan/index.json
@@ -113,6 +113,7 @@
       "id": "AST tibetan L21",
       "common_name": {"native": "གྲོ་བཞིན།", "transliteration": "gro bzhin", "pronounce": "cho xin", "IPA": "ʈ͡ʂʰo˥˥.ɕĩ˩˨", "english": "LM21", "translators_comments": "Tibetan Lunar Mansion 21"},
       "common_name_of_next_mansion": {"native": "བྱི་བཞིན།", "transliteration": "byi bzhin", "pronounce": "qi xin", "IPA": "t͡ɕʰi˥˥.ɕĩ˩˨", "english": "LM22", "translators_comments": "Tibetan Lunar Mansion 22"},
+      "comments": "In the 28-LM version, the previously combined mansion (Drozhin + Jizhin) is split into two separate LMs: གྲོ་བཞིན། and བྱི་བཞིན།.",
       "lines": [[100064, 100345, 101027, 101123, 100881, 100345, 100310], [102618, 103045, 103005, 102624]]
     },
     {

--- a/skycultures/tibetan/index.json
+++ b/skycultures/tibetan/index.json
@@ -6,155 +6,146 @@
   "asterisms": [
     {
       "id": "AST tibetan L00",
-      "common_name": {"pronounce": "Takar", "english": "LM00", "translators_comments": "Tibetan Lunar Mansion Zero"},
+      "common_name": {"native": "ཐ་སྐར།", "transliteration": "tha skar", "pronounce": "ta gar", "IPA": "tʰa˥˥.ka˥˩", "english": "LM00", "translators_comments": "Tibetan Lunar Mansion Zero"},
       "lines": [[9884, 8903, 8832]]
     },
     {
       "id": "AST tibetan L01",
-      "common_name": {"pronounce": "Dranye", "english": "LM01", "translators_comments": "Tibetan Lunar Mansion 1"},
+      "common_name": {"native": "བྲ་ཉེ།", "transliteration": "bra nye", "pronounce": "cha nyê", "IPA": "ʈ͡ʂʰa˥˥.ȵe˩˨", "english": "LM01", "translators_comments": "Tibetan Lunar Mansion 1"},
       "lines": [[12719, 13061, 13209]]
     },
     {
       "id": "AST tibetan L02",
-      "common_name": {"pronounce": "Mindruk", "english": "LM02", "translators_comments": "Tibetan Lunar Mansion 2"},
+      "common_name": {"native": "སྨིན་དྲུག", "transliteration": "smin drug", "pronounce": "min zhug", "IPA": "mĩ˥˥.ʈ͡ʂuk˥˩", "english": "LM02", "translators_comments": "Tibetan Lunar Mansion 2"},
       "lines": [[17847, 17608, 17702, 17499, 17573, 17531]]
     },
     {
       "id": "AST tibetan L03",
-      "common_name": {"pronounce": "Narma", "english": "LM03", "translators_comments": "Tibetan Lunar Mansion 3"},
+      "common_name": {"native": "སྣར་མ།", "transliteration": "snar ma", "pronounce": "nar ma", "IPA": "naː˥˥.ma˩˨", "english": "LM03", "translators_comments": "Tibetan Lunar Mansion 3"},
       "lines": [[18724, 20205, 20713, 20894, 21421], [20205, 20455, 20648, 20889]]
     },
     {
       "id": "AST tibetan L04",
-      "common_name": {"pronounce": "Go", "english": "LM04", "translators_comments": "Tibetan Lunar Mansion 4"},
+      "common_name": {"native": "མགོ", "transliteration": "mgo", "pronounce": "go", "IPA": "ko˥˥", "english": "LM04", "translators_comments": "Tibetan Lunar Mansion 4"},
       "lines": [[26366, 26207, 26176], [27989, 26727, 27366], [26727, 26311, 25930], [25336, 25930, 24436], [26311, 26237, 26235, 26241]]
     },
     {
       "id": "AST tibetan L05",
-      "common_name": {"pronounce": "Lak", "english": "LM05", "translators_comments": "Tibetan Lunar Mansion 5"},
+      "common_name": {"native": "ལག", "transliteration": "lag", "pronounce": "lag", "IPA": "lak˥˩", "english": "LM05", "translators_comments": "Tibetan Lunar Mansion 5"},
       "lines": [[28614, 27511, 29038, 27913, 29655, 29696, 27661, 28380, 27673]]
     },
     {
       "id": "AST tibetan L06",
-      "common_name": {"pronounce": "Nabso", "english": "LM06", "translators_comments": "Tibetan Lunar Mansion 6"},
+      "common_name": {"native": "ནབས་སོ།", "transliteration": "nabs so", "pronounce": "nab so", "IPA": "nap˥˩.so˥˥", "english": "LM06", "translators_comments": "Tibetan Lunar Mansion 6"},
       "lines": [[30343, 30883, 31681, 32362], [32246, 32921, 34088, 35350], [32921, 30883], [34088, 31681]]
     },
     {
       "id": "AST tibetan L07",
-      "common_name": {"pronounce": "Gyal", "english": "LM07", "translators_comments": "Tibetan Lunar Mansion 7"},
+      "common_name": {"native": "རྒྱལ།", "transliteration": "rgyal", "pronounce": "gyai", "IPA": "cɛː˥˥", "english": "LM07", "translators_comments": "Tibetan Lunar Mansion 7"},
       "lines": [[41822, 41909, 42806, 42911, 41822]]
     },
     {
       "id": "AST tibetan L08",
-      "common_name": {"pronounce": "Kak", "english": "LM08", "translators_comments": "Tibetan Lunar Mansion 8"},
+      "common_name": {"native": "སྐག", "transliteration": "skag", "pronounce": "gag", "IPA": "kak˥˩", "english": "LM08", "translators_comments": "Tibetan Lunar Mansion 8"},
       "lines": [[45336, 47431, 48356, 46390, 42402, 42799, 43109, 43813]]
     },
     {
       "id": "AST tibetan L09",
-      "common_name": {"pronounce": "Chu", "english": "LM09", "translators_comments": "Tibetan Lunar Mansion 9"},
+      "common_name": {"native": "མཆུ།", "transliteration": "mchu", "pronounce": "qu", "IPA": "t͡ɕʰu˥˥", "english": "LM09", "translators_comments": "Tibetan Lunar Mansion 9"},
       "lines": [[49637, 49669], [47508, 49669, 49583, 50583], [47908, 48455, 50335, 50583, 47908]]
     },
     {
       "id": "AST tibetan L10",
-      "common_name": {"pronounce": "Dre", "english": "LM10", "translators_comments": "Tibetan Lunar Mansion 10"},
+      "common_name": {"native": "གྲེ", "transliteration": "gre", "pronounce": "chê", "IPA": "ʈ͡ʂʰe˥˥", "english": "LM10", "translators_comments": "Tibetan Lunar Mansion 10"},
       "lines": [[54872, 54879, 54182, 55434], [54879, 55642, 55434, 55137]]
     },
     {
       "id": "AST tibetan L11",
-      "common_name": {"pronounce": "Wo", "english": "LM11", "translators_comments": "Tibetan Lunar Mansion 11"},
+      "common_name": {"native": "དབོ།", "transliteration": "dbo", "pronounce": "wo", "IPA": "wo˥˥", "english": "LM11", "translators_comments": "Tibetan Lunar Mansion 11"},
       "lines": [[57587, 56633, 55687, 54029, 52980], [55687, 56802], [50066, 51979, 54477, 56280, 57613], [54477, 54204, 51718, 54682, 55598, 53740, 52943], [55598, 57283, 58188], [57283, 55705, 53740], [55705, 55282, 58188]]
     },
     {
       "id": "AST tibetan L12",
-      "common_name": {"pronounce": "Mezhi", "english": "LM12", "translators_comments": "Tibetan Lunar Mansion 12"},
+      "common_name": {"native": "མེ་བཞི།", "transliteration": "me bzhi", "pronounce": "mê xi", "IPA": "me˥˥.ɕi˩˨", "english": "LM12", "translators_comments": "Tibetan Lunar Mansion 12"},
       "lines": [[61359, 59316, 59803, 60965, 61359]]
     },
     {
       "id": "AST tibetan L13",
-      "common_name": {"pronounce": "Nakpa", "english": "LM13", "translators_comments": "Tibetan Lunar Mansion 13"},
+      "common_name": {"native": "ནག་པ།", "transliteration": "nag pa", "pronounce": "nag pa", "IPA": "nak˥˩.pa˥˥", "english": "LM13", "translators_comments": "Tibetan Lunar Mansion 13"},
       "lines": [[65474, 66249]]
     },
     {
       "id": "AST tibetan L14",
-      "common_name": {"pronounce": "Sari", "english": "LM14", "translators_comments": "Tibetan Lunar Mansion 14"},
+      "common_name": {"native": "ས་རི།", "transliteration": "sa ri", "pronounce": "sa ri", "IPA": "sa˥˥.ʐi˩˨", "english": "LM14", "translators_comments": "Tibetan Lunar Mansion 14"},
       "lines": [[69427, 69701, 70755], [69427, 69974]]
     },
     {
       "id": "AST tibetan L15",
-      "common_name": {"pronounce": "Saga", "english": "LM15", "translators_comments": "Tibetan Lunar Mansion 15"},
+      "common_name": {"native": "ས་ག", "transliteration": "sa ga", "pronounce": "sa ga", "IPA": "sa˥˥.ka˩˨", "english": "LM15", "translators_comments": "Tibetan Lunar Mansion 15"},
       "lines": [[76333, 73714, 72622, 74785]]
     },
     {
       "id": "AST tibetan L16",
-      "common_name": {"pronounce": "Lhatsam", "english": "LM16", "translators_comments": "Tibetan Lunar Mansion 16"},
+      "common_name": {"native": "ལྷ་མཚམས།", "transliteration": "lha mtshams", "pronounce": "lha cam", "IPA": "ɬa˥˥.tsʰãː˥˩", "english": "LM16", "translators_comments": "Tibetan Lunar Mansion 16"},
       "lines": [[80763, 80112, 78265], [80112, 78401], [80112, 78820], [80112, 79374], [80112, 80343]]
     },
     {
       "id": "AST tibetan L17",
-      "common_name": {"pronounce": "Nrön", "english": "LM17", "translators_comments": "Tibetan Lunar Mansion 17"},
+      "common_name": {"native": "སྣྲོན།", "transliteration": "snron", "pronounce": "noin", "IPA": "nø̃ː˥˥", "english": "LM17", "translators_comments": "Tibetan Lunar Mansion 17"},
       "lines": [[83196, 81266, 82396]]
     },
     {
       "id": "AST tibetan L18",
-      "common_name": {"pronounce": "Nup", "english": "LM18", "translators_comments": "Tibetan Lunar Mansion 18"},
+      "common_name": {"native": "སྣྲུབས།", "transliteration": "snrubs", "pronounce": "nub", "IPA": "nup˥˩", "english": "LM18", "translators_comments": "Tibetan Lunar Mansion 18"},
       "lines": [[82514, 80945, 82493], [82729, 84143, 86228, 87073, 86670, 85927], [86670, 87261]]
     },
     {
       "id": "AST tibetan L19",
-      "common_name": {"pronounce": "Chutö", "english": "LM19", "translators_comments": "Tibetan Lunar Mansion 19"},
+      "common_name": {"native": "ཆུ་སྟོད།", "transliteration": "chu stod", "pronounce": "qu doi", "IPA": "t͡ɕʰu˥˥.tø˥˩", "english": "LM19", "translators_comments": "Tibetan Lunar Mansion 19"},
       "lines": [[88635, 89931, 90185, 89642]]
     },
     {
       "id": "AST tibetan L20",
-      "common_name": {"pronounce": "Chume", "english": "LM20", "translators_comments": "Tibetan Lunar Mansion 20"},
+      "common_name": {"native": "ཆུ་སྨད།", "transliteration": "chu smad", "pronounce": "qu mai", "IPA": "t͡ɕʰu˥˥.mɛː˩˨", "english": "LM20", "translators_comments": "Tibetan Lunar Mansion 20"},
       "lines": [[93864, 92855, 92041, 93506, 94986, 94114]]
     },
     {
       "id": "AST tibetan L21",
-      "common_name": {"pronounce": "Drozhin", "english": "LM21", "translators_comments": "Tibetan Lunar Mansion 21"},
-      "lines": [[102618, 103045, 103005, 102624], [100064, 100345, 101027, 101123, 100881, 100345, 100310]]
+      "common_name": {"native": "གྲོ་བཞིན།", "transliteration": "gro bzhin", "pronounce": "cho xin", "IPA": "ʈ͡ʂʰo˥˥.ɕĩ˩˨", "english": "LM21", "translators_comments": "Tibetan Lunar Mansion 21"},
+      "lines": [[100064, 100345, 101027, 101123, 100881, 100345, 100310]]
     },
     {
       "id": "AST tibetan L22",
-      "common_name": {"pronounce": "Möndre", "english": "LM22", "translators_comments": "Tibetan Lunar Mansion 22"},
-      "lines": [[104987, 106278]]
+      "common_name": {"native": "བྱི་བཞིན།", "transliteration": "byi bzhin", "pronounce": "qi xin", "IPA": "t͡ɕʰi˥˥.ɕĩ˩˨", "english": "LM22", "translators_comments": "Tibetan Lunar Mansion 22"},
+      "lines": [[102618, 103045, 103005, 102624]]
     },
     {
       "id": "AST tibetan L23",
-      "common_name": {"pronounce": "(Möndru)", "english": "LM23", "translators_comments": "Tibetan Lunar Mansion 23"},
-      "lines": [[109427, 107315, 107348]]
+      "common_name": {"native": "མོན་གྲེ།", "transliteration": "mon gre", "pronounce": "moin zhê", "IPA": "mø̃˥˥.ʈ͡ʂe˩˨", "english": "LM23", "translators_comments": "Tibetan Lunar Mansion 22"},
+      "lines": [[104987, 106278]]
     },
     {
       "id": "AST tibetan L24",
-      "common_name": {"pronounce": "Trumtö", "english": "LM24", "translators_comments": "Tibetan Lunar Mansion 24"},
-      "lines": [[113881, 113963]]
+      "common_name": {"native": "མོན་གྲུ།", "transliteration": "mon gru", "pronounce": "moin zhu", "IPA": "mø̃˥˥.ʈ͡ʂu˩˨", "english": "LM24", "translators_comments": "Tibetan Lunar Mansion 23"},
+      "lines": [[109427, 107315, 107348]]
     },
     {
       "id": "AST tibetan L25",
-      "common_name": {"pronounce": "Trume", "english": "LM25", "translators_comments": "Tibetan Lunar Mansion 25"},
-      "lines": [[677, 1067]]
+      "common_name": {"native": "ཁྲུམས་སྟོད།", "transliteration": "khrums stod", "pronounce": "chum doi", "IPA": "ʈ͡ʂʰũ˥˩.tø˥˩", "english": "LM25", "translators_comments": "Tibetan Lunar Mansion 24"},
+      "lines": [[113881, 113963]]
     },
     {
       "id": "AST tibetan L26",
-      "common_name": {"pronounce": "Namdru", "english": "LM26", "translators_comments": "Tibetan Lunar Mansion 26"},
+      "common_name": {"native": "ཁྲུམས་སྨད།", "transliteration": "khrums smad", "pronounce": "chum mai", "IPA": "ʈ͡ʂʰũ˥˩.mɛː˩˨", "english": "LM26", "translators_comments": "Tibetan Lunar Mansion 25"},
+      "lines": [[677, 1067]]
+    },
+    {
+      "id": "AST tibetan L27",
+      "common_name": {"native": "ནམ་གྲུ།", "transliteration": "nam gru", "pronounce": "nam zhu", "IPA": "nãː˥˥.ʈ͡ʂʰu˩˨", "english": "LM27", "translators_comments": "Tibetan Lunar Mansion 26"},
       "lines": [[5571, 5131, 3693, 3885, 3092, 4889, 2912, 4185], [5571, 5742, 4510, 5544, 4552, 5447, 4436, 4185]]
     }
   ],
   "constellations": [
-    {
-      "id": "CON tibetan Lib",
-      "lines": [[77853, 76333, 74785, 72622, 73714, 76333]],
-      "image": {
-        "file": "illustrations/libra.png",
-        "size": [256, 256],
-        "anchors": [
-          {"pos": [41, 27], "hip": 74785},
-          {"pos": [58, 170], "hip": 77853},
-          {"pos": [224, 107], "hip": 73714}
-        ]
-      },
-      "common_name": {"english": "Libra", "pronounce": "Sangwa"}
-    },
     {
       "id": "CON tibetan Ari",
       "lines": [[13209, 9884, 8903, 8832]],
@@ -167,13 +158,35 @@
           {"pos": [210, 47], "hip": 8832}
         ]
       },
-      "common_name": {"english": "Aries", "pronounce": "Luk"}
+      "common_name": {"english": "Aries", "native": "ལུག", "transliteration": "lug", "pronounce": "lug", "IPA": "luk˥˩"}
     },
     {
-      "id": "CON tibetan Boo",
-      "lines": [[71795, 69673, 72105, 74666, 73555, 71075, 71053, 69673, 67927, 67459]],
-      "common_name": {"english": ""},
-      "comment": "For orientation only. Non-Tibetan!"
+      "id": "CON tibetan Tau",
+      "lines": [[25428, 21881, 20889], [21421, 26451], [20205, 20455], [20205, 18724, 15900], [21421, 20889], [21421, 20894, 20205], [20889, 20648, 20455, 17847]],
+      "image": {
+        "file": "illustrations/taurus.png",
+        "size": [512, 512],
+        "anchors": [
+          {"pos": [13, 92], "hip": 26451},
+          {"pos": [399, 438], "hip": 15900},
+          {"pos": [382, 192], "hip": 17999}
+        ]
+      },
+      "common_name": {"english": "Taurus", "native": "གླང", "transliteration": "glang", "pronounce": "lang", "IPA": "lãː˥˥"}
+    },
+    {
+      "id": "CON tibetan Gem",
+      "lines": [[31681, 34088, 35550, 35350, 32362], [35550, 36962, 37740], [36962, 37826], [36962, 36046, 34693, 36850], [34693, 33018], [34693, 32246, 30883], [32246, 30343, 29655, 28734]],
+      "image": {
+        "file": "illustrations/gemini.png",
+        "size": [256, 256],
+        "anchors": [
+          {"pos": [14, 81], "hip": 37740},
+          {"pos": [117, 252], "hip": 32362},
+          {"pos": [249, 165], "hip": 28734}
+        ]
+      },
+      "common_name": {"english": "Gemini", "native": "འཁྲིག", "transliteration": "'khrig", "pronounce": "chig", "IPA": "ʈ͡ʂʰik˥˩"}
     },
     {
       "id": "CON tibetan Cnc",
@@ -187,7 +200,77 @@
           {"pos": [206, 91], "hip": 40843}
         ]
       },
-      "common_name": {"english": "Cancer", "pronounce": "Karkata"}
+      "common_name": {"english": "Cancer", "native": "ཀརྚ་ཀ", "transliteration": "kar ṭa ka", "pronounce": "gar da ga", "IPA": "ka˥˥.ta˥˥.ka˥˩"}
+    },
+    {
+      "id": "CON tibetan Leo",
+      "lines": [[57632, 54879, 49669, 49583, 50583, 54872, 57632], [50583, 50335, 48455, 47908], [54872, 54879]],
+      "image": {
+        "file": "illustrations/leo.png",
+        "size": [512, 512],
+        "anchors": [
+          {"pos": [69, 411], "hip": 57632},
+          {"pos": [383, 186], "hip": 49669},
+          {"pos": [321, 32], "hip": 47908}
+        ]
+      },
+      "common_name": {"english": "Leo", "native": "སེང་གེ", "transliteration": "seng ge", "pronounce": "sêng gê", "IPA": "sẽː˥˥.ke˩˨"}
+    },
+    {
+      "id": "CON tibetan Vir",
+      "lines": [[57380, 60030, 61941, 65474, 69427, 69701, 71957], [65474, 66249, 68520, 72220], [66249, 63090, 63608], [63090, 61941]],
+      "image": {
+        "file": "illustrations/virgo.png",
+        "size": [512, 512],
+        "anchors": [
+          {"pos": [65, 389], "hip": 72220},
+          {"pos": [454, 57], "hip": 57380},
+          {"pos": [338, 382], "hip": 65474}
+        ]
+      },
+      "common_name": {"english": "Virgo", "native": "བུ་མོ", "transliteration": "bu mo", "pronounce": "pu mo", "IPA": "pʰu˩˨.mo˩˨"}
+    },
+    {
+      "id": "CON tibetan Lib",
+      "lines": [[77853, 76333, 74785, 72622, 73714, 76333]],
+      "image": {
+        "file": "illustrations/libra.png",
+        "size": [256, 256],
+        "anchors": [
+          {"pos": [41, 27], "hip": 74785},
+          {"pos": [58, 170], "hip": 77853},
+          {"pos": [224, 107], "hip": 73714}
+        ]
+      },
+      "common_name": {"english": "Libra", "native": "སྲང", "transliteration": "srang", "pronounce": "sang", "IPA": "sãː˥˥"}
+    },
+    {
+      "id": "CON tibetan Sco",
+      "lines": [[85927, 86670, 87073, 86228, 84143, 82671, 82514, 82396, 81266, 80763, 80112, 78401], [80112, 78265], [80112, 78820]],
+      "image": {
+        "file": "illustrations/scorpius.png",
+        "size": [512, 512],
+        "anchors": [
+          {"pos": [447, 29], "hip": 78820},
+          {"pos": [62, 365], "hip": 85927},
+          {"pos": [217, 462], "hip": 82729}
+        ]
+      },
+      "common_name": {"english": "Scorpius", "native": "སྡིག་པ", "transliteration": "sdig pa", "pronounce": "dig ba", "IPA": "tik˥˩.pa˥˥"}
+    },
+    {
+      "id": "CON tibetan Sgr",
+      "lines": [[89931, 90496], [89642, 90185, 88635, 87072], [88635, 89931, 90185, 93506, 92041, 89931], [92041, 90496, 89341], [93506, 93864, 92855, 92041], [92855, 93085, 93683, 94820, 95168], [93864, 96406, 98688, 98412, 98032, 95347], [98032, 95294]],
+      "image": {
+        "file": "illustrations/sagittarius.png",
+        "size": [512, 512],
+        "anchors": [
+          {"pos": [96, 82], "hip": 95168},
+          {"pos": [307, 492], "hip": 95294},
+          {"pos": [506, 100], "hip": 87072}
+        ]
+      },
+      "common_name": {"english": "Sagittarius", "native": "གཞུ", "transliteration": "gzhu", "pronounce": "xu", "IPA": "ɕu˥˥"}
     },
     {
       "id": "CON tibetan Cap",
@@ -201,7 +284,41 @@
           {"pos": [460, 438], "hip": 102978}
         ]
       },
-      "common_name": {"english": "Capricornus", "pronounce": "Chusin"}
+      "common_name": {"english": "Capricornus", "native": "ཆུ་སྲིན", "transliteration": "chu srin", "pronounce": "qu sin", "IPA": "tɕʰu˥˥.sĩː˥˥"}
+    },
+    {
+      "id": "CON tibetan Aqr",
+      "lines": [[106278, 109074, 110395, 110960, 111497, 112961, 114855, 115438], [109074, 110003, 109139], [110003, 111123, 112716, 113136, 114341], [102618, 106278]],
+      "image": {
+        "file": "illustrations/aquarius.png",
+        "size": [512, 512],
+        "anchors": [
+          {"pos": [144, 464], "hip": 115438},
+          {"pos": [179, 98], "hip": 109074},
+          {"pos": [465, 49], "hip": 102618}
+        ]
+      },
+      "common_name": {"english": "Aquarius", "native": "བུམ་པ", "transliteration": "bum pa", "pronounce": "pum ba", "IPA": "pʰũː˩˨.pa˥˥"}
+    },
+    {
+      "id": "CON tibetan Psc",
+      "lines": [[4889, 5742], [4889, 6193, 5742, 7097, 8198, 9487, 8833, 7884, 7007, 4906, 3760, 1645, 118268, 116771, 116928, 115738, 114971, 115830, 116771]],
+      "image": {
+        "file": "illustrations/pisces.png",
+        "size": [512, 512],
+        "anchors": [
+          {"pos": [24, 104], "hip": 4889},
+          {"pos": [111, 489], "hip": 9487},
+          {"pos": [481, 155], "hip": 114971}
+        ]
+      },
+      "common_name": {"english": "Pisces", "native": "ཉ", "transliteration": "nya", "pronounce": "nya", "IPA": "ȵa˥˥"}
+    },
+    {
+      "id": "CON tibetan Boo",
+      "lines": [[71795, 69673, 72105, 74666, 73555, 71075, 71053, 69673, 67927, 67459]],
+      "common_name": {"english": ""},
+      "comment": "For orientation only. Non-Tibetan!"
     },
     {
       "id": "CON tibetan Cas",
@@ -216,38 +333,10 @@
       "comment": "For orientation only. Non-Tibetan!"
     },
     {
-      "id": "CON tibetan Gem",
-      "lines": [[31681, 34088, 35550, 35350, 32362], [35550, 36962, 37740], [36962, 37826], [36962, 36046, 34693, 36850], [34693, 33018], [34693, 32246, 30883], [32246, 30343, 29655, 28734]],
-      "image": {
-        "file": "illustrations/gemini.png",
-        "size": [256, 256],
-        "anchors": [
-          {"pos": [14, 81], "hip": 37740},
-          {"pos": [117, 252], "hip": 32362},
-          {"pos": [249, 165], "hip": 28734}
-        ]
-      },
-      "common_name": {"english": "Gemini", "pronounce": "Trik"}
-    },
-    {
       "id": "CON tibetan UMa",
       "lines": [[67301, 65378, 62956, 59774, 54061, 53910, 58001, 59774]],
       "common_name": {"english": ""},
       "comment": "For orientation only. Non-Tibetan or names unknown!"
-    },
-    {
-      "id": "CON tibetan Leo",
-      "lines": [[57632, 54879, 49669, 49583, 50583, 54872, 57632], [50583, 50335, 48455, 47908], [54872, 54879]],
-      "image": {
-        "file": "illustrations/leo.png",
-        "size": [512, 512],
-        "anchors": [
-          {"pos": [69, 411], "hip": 57632},
-          {"pos": [383, 186], "hip": 49669},
-          {"pos": [321, 32], "hip": 47908}
-        ]
-      },
-      "common_name": {"english": "Leo", "pronounce": "Senge"}
     },
     {
       "id": "CON tibetan Lyr",
@@ -259,90 +348,6 @@
       "lines": [[11767, 85822, 82080, 77055, 79822, 75097, 72607, 77055]],
       "common_name": {"english": ""},
       "comment": "For orientation only. Non-Tibetan!"
-    },
-    {
-      "id": "CON tibetan Psc",
-      "lines": [[4889, 5742], [4889, 6193, 5742, 7097, 8198, 9487, 8833, 7884, 7007, 4906, 3760, 1645, 118268, 116771, 116928, 115738, 114971, 115830, 116771]],
-      "image": {
-        "file": "illustrations/pisces.png",
-        "size": [512, 512],
-        "anchors": [
-          {"pos": [24, 104], "hip": 4889},
-          {"pos": [111, 489], "hip": 9487},
-          {"pos": [481, 155], "hip": 114971}
-        ]
-      },
-      "common_name": {"english": "Pisces", "pronounce": "Nya"}
-    },
-    {
-      "id": "CON tibetan Sgr",
-      "lines": [[89931, 90496], [89642, 90185, 88635, 87072], [88635, 89931, 90185, 93506, 92041, 89931], [92041, 90496, 89341], [93506, 93864, 92855, 92041], [92855, 93085, 93683, 94820, 95168], [93864, 96406, 98688, 98412, 98032, 95347], [98032, 95294]],
-      "image": {
-        "file": "illustrations/sagittarius.png",
-        "size": [512, 512],
-        "anchors": [
-          {"pos": [96, 82], "hip": 95168},
-          {"pos": [307, 492], "hip": 95294},
-          {"pos": [506, 100], "hip": 87072}
-        ]
-      },
-      "common_name": {"english": "Sagittarius", "pronounce": "Zhu"}
-    },
-    {
-      "id": "CON tibetan Sco",
-      "lines": [[85927, 86670, 87073, 86228, 84143, 82671, 82514, 82396, 81266, 80763, 80112, 78401], [80112, 78265], [80112, 78820]],
-      "image": {
-        "file": "illustrations/scorpius.png",
-        "size": [512, 512],
-        "anchors": [
-          {"pos": [447, 29], "hip": 78820},
-          {"pos": [62, 365], "hip": 85927},
-          {"pos": [217, 462], "hip": 82729}
-        ]
-      },
-      "common_name": {"english": "Scorpius", "pronounce": "Dikpa"}
-    },
-    {
-      "id": "CON tibetan Tau",
-      "lines": [[25428, 21881, 20889], [21421, 26451], [20205, 20455], [20205, 18724, 15900], [21421, 20889], [21421, 20894, 20205], [20889, 20648, 20455, 17847]],
-      "image": {
-        "file": "illustrations/taurus.png",
-        "size": [512, 512],
-        "anchors": [
-          {"pos": [13, 92], "hip": 26451},
-          {"pos": [399, 438], "hip": 15900},
-          {"pos": [382, 192], "hip": 17999}
-        ]
-      },
-      "common_name": {"english": "Taurus", "pronounce": "Lang"}
-    },
-    {
-      "id": "CON tibetan Aqr",
-      "lines": [[106278, 109074, 110395, 110960, 111497, 112961, 114855, 115438], [109074, 110003, 109139], [110003, 111123, 112716, 113136, 114341], [102618, 106278]],
-      "image": {
-        "file": "illustrations/aquarius.png",
-        "size": [512, 512],
-        "anchors": [
-          {"pos": [144, 464], "hip": 115438},
-          {"pos": [179, 98], "hip": 109074},
-          {"pos": [465, 49], "hip": 102618}
-        ]
-      },
-      "common_name": {"english": "Aquarius", "pronounce": "Bumpa"}
-    },
-    {
-      "id": "CON tibetan Vir",
-      "lines": [[57380, 60030, 61941, 65474, 69427, 69701, 71957], [65474, 66249, 68520, 72220], [66249, 63090, 63608], [63090, 61941]],
-      "image": {
-        "file": "illustrations/virgo.png",
-        "size": [512, 512],
-        "anchors": [
-          {"pos": [65, 389], "hip": 72220},
-          {"pos": [454, 57], "hip": 57380},
-          {"pos": [338, 382], "hip": 65474}
-        ]
-      },
-      "common_name": {"english": "Virgo", "pronounce": "Pumo"}
     }
   ],
   "zodiac": { "name": { "english": "Tibetan Zodiac"},
@@ -351,50 +356,53 @@
               "partitions": [ 12, 3, 2, 5],
               "extent": 9,
               "link": { "star": 65474, "offset": 180},
-              "names": [ { "symbol": "\u2648", "pronounce": "Luk",     "english": "Ram"},
-                         { "symbol": "\u2649", "pronounce": "Lang",    "english": "Bull"},
-                         { "symbol": "\u264A", "pronounce": "Trik",    "english": "Twins"},
-                         { "symbol": "\u264B", "pronounce": "Karkata", "english": "Crab"},
-                         { "symbol": "\u264C", "pronounce": "Senge",   "english": "Lion"},
-                         { "symbol": "\u264D", "pronounce": "Pumo",    "english": "Virgin"},
-                         { "symbol": "\u264E", "pronounce": "Sangwa",  "english": "Scales"},
-                         { "symbol": "\u264F", "pronounce": "Dikpa",   "english": "Scorpion"},
-                         { "symbol": "\u2650", "pronounce": "Zhu",     "english": "Archer"},
-                         { "symbol": "\u2651", "pronounce": "Chusin",  "english": "Capricorn"},
-                         { "symbol": "\u2652", "pronounce": "Bumpa",   "english": "Water bearer"},
-                         { "symbol": "\u2653", "pronounce": "Nya",     "english": "Fishes"}]},
-  "lunar_system": { "name": { "pronounce": "Gyukar", "english": "Tib. Nakshatras"},
+              "names": [ { "symbol": "\u2648", "english": "Ram", "native": "ལུག", "transliteration": "lug", "pronounce": "lug", "IPA": "luk˥˩"},
+                         { "symbol": "\u2649", "english": "Bull", "native": "གླང", "transliteration": "glang", "pronounce": "lang", "IPA": "lãː˥˥"},
+                         { "symbol": "\u264A", "english": "Twins", "native": "འཁྲིག", "transliteration": "'khrig", "pronounce": "chig", "IPA": "ʈ͡ʂʰik˥˩"},
+                         { "symbol": "\u264B", "english": "Crab", "native": "ཀརྚ་ཀ", "transliteration": "kar ṭa ka", "pronounce": "gar da ga", "IPA": "ka˥˥.ta˥˥.ka˥˩"},
+                         { "symbol": "\u264C", "english": "Lion", "native": "སེང་གེ", "transliteration": "seng ge", "pronounce": "sêng gê", "IPA": "sẽː˥˥.ke˩˨"},
+                         { "symbol": "\u264D", "english": "Virgin", "native": "བུ་མོ", "transliteration": "bu mo", "pronounce": "pu mo", "IPA": "pʰu˩˨.mo˩˨"},
+                         { "symbol": "\u264E", "english": "Scales", "native": "སྲང", "transliteration": "srang", "pronounce": "sang", "IPA": "sãː˥˥"},
+                         { "symbol": "\u264F", "english": "Scorpion", "native": "སྡིག་པ", "transliteration": "sdig pa", "pronounce": "dig ba", "IPA": "tik˥˩.pa˥˥"},
+                         { "symbol": "\u2650", "english": "Archer", "native": "གཞུ", "transliteration": "gzhu", "pronounce": "xu", "IPA": "ɕu˥˥"},
+                         { "symbol": "\u2651", "english": "Capricorn", "native": "ཆུ་སྲིན", "transliteration": "chu srin", "pronounce": "qu sin", "IPA": "tɕʰu˥˥.sĩː˥˥"},
+                         { "symbol": "\u2652", "english": "Water bearer", "native": "བུམ་པ", "transliteration": "bum pa", "pronounce": "pum ba", "IPA": "pʰũː˩˨.pa˥˥"},
+                         { "symbol": "\u2653", "english": "Fishes", "native": "ཉ", "transliteration": "nya", "pronounce": "nya", "IPA": "ȵa˥˥"}]},
+  "lunar_system": { "name": {"native": "རྒྱུ་སྐར", "transliteration": "rgyu skar", "pronounce": "gyu gar", "english": "Tib. Nakshatras"},
                     "context": "tibetan lunar mansion",
                     "comment" : "Shaped after the Indian nakshatras. Please enhance by Tibetan names and fix if needed!",
-                    "partitions": [ 27],
+                    "partitions": [28],
                     "extent": 5,
-                    "link": { "star": 65474, "offset": 180},
-                    "names": [ 
-                              { "symbol":  "0", "pronounce": "Takar"},
-                              { "symbol":  "1", "pronounce": "Dranye"},
-                              { "symbol":  "2", "pronounce": "Mindruk"},
-                              { "symbol":  "3", "pronounce": "Narma"},
-                              { "symbol":  "4", "pronounce": "Go"},
-                              { "symbol":  "5", "pronounce": "Lak"},
-                              { "symbol":  "6", "pronounce": "Nabso"},
-                              { "symbol":  "7", "pronounce": "Gyal"},
-                              { "symbol":  "8", "pronounce": "Kak"},
-                              { "symbol":  "9", "pronounce": "Chu"},
-                              { "symbol": "10", "pronounce": "Dre"},
-                              { "symbol": "11", "pronounce": "Wo"},
-                              { "symbol": "12", "pronounce": "Mezhi"},
-                              { "symbol": "13", "pronounce": "Nakpa"},
-                              { "symbol": "14", "pronounce": "Sari"},
-                              { "symbol": "15", "pronounce": "Saga"},
-                              { "symbol": "16", "pronounce": "Lhatsam"},
-                              { "symbol": "17", "pronounce": "Nrön"},
-                              { "symbol": "18", "pronounce": "Nup"},
-                              { "symbol": "19", "pronounce": "Chutö"},
-                              { "symbol": "20", "pronounce": "Chume"},
-                              { "symbol": "21", "pronounce": "Drozhin"},
-                              { "symbol": "22", "pronounce": "Möndre"},
-                              { "symbol": "23", "pronounce": "(Möndru)"},
-                              { "symbol": "24", "pronounce": "Trumtö"},
-                              { "symbol": "25", "pronounce": "Trume"},
-                              { "symbol": "26", "pronounce": "Namdru"}]}  
+                    "link": {"star": 65474, "offset": 173.572},
+                    "names": [
+                      {"symbol": "0", "native": "ཐ་སྐར།", "transliteration": "tha skar", "pronounce": "ta gar", "IPA": "tʰa˥˥.ka˥˩"},
+                      {"symbol": "1", "native": "བྲ་ཉེ།", "transliteration": "bra nye", "pronounce": "cha nyê", "IPA": "ʈ͡ʂʰa˥˥.ȵe˩˨"},
+                      {"symbol": "2", "native": "སྨིན་དྲུག", "transliteration": "smin drug", "pronounce": "min zhug", "IPA": "mĩ˥˥.ʈ͡ʂuk˥˩"},
+                      {"symbol": "3", "native": "སྣར་མ།", "transliteration": "snar ma", "pronounce": "nar ma", "IPA": "naː˥˥.ma˩˨"},
+                      {"symbol": "4", "native": "མགོ", "transliteration": "mgo", "pronounce": "go", "IPA": "ko˥˥"},
+                      {"symbol": "5", "native": "ལག", "transliteration": "lag", "pronounce": "lag", "IPA": "lak˥˩"},
+                      {"symbol": "6", "native": "ནབས་སོ།", "transliteration": "nabs so", "pronounce": "nab so", "IPA": "nap˥˩.so˥˥"},
+                      {"symbol": "7", "native": "རྒྱལ།", "transliteration": "rgyal", "pronounce": "gyai", "IPA": "cɛː˥˥"},
+                      {"symbol": "8", "native": "སྐག", "transliteration": "skag", "pronounce": "gag", "IPA": "kak˥˩"},
+                      {"symbol": "9", "native": "མཆུ།", "transliteration": "mchu", "pronounce": "qu", "IPA": "t͡ɕʰu˥˥"},
+                      {"symbol": "10", "native": "གྲེ", "transliteration": "gre", "pronounce": "chê", "IPA": "ʈ͡ʂʰe˥˥"},
+                      {"symbol": "11", "native": "དབོ།", "transliteration": "dbo", "pronounce": "wo", "IPA": "wo˥˥"},
+                      {"symbol": "12", "native": "མེ་བཞི།", "transliteration": "me bzhi", "pronounce": "mê xi", "IPA": "me˥˥.ɕi˩˨"},
+                      {"symbol": "13", "native": "ནག་པ།", "transliteration": "nag pa", "pronounce": "nag pa", "IPA": "nak˥˩.pa˥˥"},
+                      {"symbol": "14", "native": "ས་རི།", "transliteration": "sa ri", "pronounce": "sa ri", "IPA": "sa˥˥.ʐi˩˨"},
+                      {"symbol": "15", "native": "ས་ག", "transliteration": "sa ga", "pronounce": "sa ga", "IPA": "sa˥˥.ka˩˨"},
+                      {"symbol": "16", "native": "ལྷ་མཚམས།", "transliteration": "lha mtshams", "pronounce": "lha cam", "IPA": "ɬa˥˥.tsʰãː˥˩"},
+                      {"symbol": "17", "native": "སྣྲོན།", "transliteration": "snron", "pronounce": "noin", "IPA": "nø̃ː˥˥"},
+                      {"symbol": "18", "native": "སྣྲུབས།", "transliteration": "snrubs", "pronounce": "nub", "IPA": "nup˥˩"},
+                      {"symbol": "19", "native": "ཆུ་སྟོད།", "transliteration": "chu stod", "pronounce": "qu doi", "IPA": "t͡ɕʰu˥˥.tø˥˩"},
+                      {"symbol": "20", "native": "ཆུ་སྨད།", "transliteration": "chu smad", "pronounce": "qu mai", "IPA": "t͡ɕʰu˥˥.mɛː˩˨"},
+                      {"symbol": "21", "native": "གྲོ་བཞིན།", "transliteration": "gro bzhin", "pronounce": "cho xin", "IPA": "ʈ͡ʂʰo˥˥.ɕĩ˩˨"},
+                      {"symbol": "22", "native": "བྱི་བཞིན།", "transliteration": "byi bzhin", "pronounce": "qi xin", "IPA": "t͡ɕʰi˥˥.ɕĩ˩˨"},
+                      {"symbol": "23", "native": "མོན་གྲེ།", "transliteration": "mon gre", "pronounce": "moin zhê", "IPA": "mø̃˥˥.ʈ͡ʂe˩˨"},
+                      {"symbol": "24", "native": "མོན་གྲུ།", "transliteration": "mon gru", "pronounce": "moin zhu", "IPA": "mø̃˥˥.ʈ͡ʂu˩˨"},
+                      {"symbol": "25", "native": "ཁྲུམས་སྟོད།", "transliteration": "khrums stod", "pronounce": "chum doi", "IPA": "ʈ͡ʂʰũ˥˩.tø˥˩"},
+                      {"symbol": "26", "native": "ཁྲུམས་སྨད།", "transliteration": "khrums smad", "pronounce": "chum mai", "IPA": "ʈ͡ʂʰũ˥˩.mɛː˩˨"},
+                      {"symbol": "27", "native": "ནམ་གྲུ།", "transliteration": "nam gru", "pronounce": "nam zhu", "IPA": "nãː˥˥.ʈ͡ʂʰu˩˨"}
+                    ]
+                  }
 }

--- a/skycultures/tibetan/index.json
+++ b/skycultures/tibetan/index.json
@@ -112,36 +112,32 @@
     {
       "id": "AST tibetan L21",
       "common_name": {"native": "གྲོ་བཞིན།", "transliteration": "gro bzhin", "pronounce": "cho xin", "IPA": "ʈ͡ʂʰo˥˥.ɕĩ˩˨", "english": "LM21", "translators_comments": "Tibetan Lunar Mansion 21"},
-      "lines": [[100064, 100345, 101027, 101123, 100881, 100345, 100310]]
+      "common_name_of_next_mansion": {"native": "བྱི་བཞིན།", "transliteration": "byi bzhin", "pronounce": "qi xin", "IPA": "t͡ɕʰi˥˥.ɕĩ˩˨", "english": "LM22", "translators_comments": "Tibetan Lunar Mansion 22"},
+      "lines": [[100064, 100345, 101027, 101123, 100881, 100345, 100310], [102618, 103045, 103005, 102624]]
     },
     {
       "id": "AST tibetan L22",
-      "common_name": {"native": "བྱི་བཞིན།", "transliteration": "byi bzhin", "pronounce": "qi xin", "IPA": "t͡ɕʰi˥˥.ɕĩ˩˨", "english": "LM22", "translators_comments": "Tibetan Lunar Mansion 22"},
-      "lines": [[102618, 103045, 103005, 102624]]
-    },
-    {
-      "id": "AST tibetan L23",
-      "common_name": {"native": "མོན་གྲེ།", "transliteration": "mon gre", "pronounce": "moin zhê", "IPA": "mø̃˥˥.ʈ͡ʂe˩˨", "english": "LM23", "translators_comments": "Tibetan Lunar Mansion 22"},
+      "common_name": {"native": "མོན་གྲེ།", "transliteration": "mon gre", "pronounce": "moin zhê", "IPA": "mø̃˥˥.ʈ͡ʂe˩˨", "english": "LM22", "translators_comments": "Tibetan Lunar Mansion 22"},
       "lines": [[104987, 106278]]
     },
     {
-      "id": "AST tibetan L24",
-      "common_name": {"native": "མོན་གྲུ།", "transliteration": "mon gru", "pronounce": "moin zhu", "IPA": "mø̃˥˥.ʈ͡ʂu˩˨", "english": "LM24", "translators_comments": "Tibetan Lunar Mansion 23"},
+      "id": "AST tibetan L23",
+      "common_name": {"native": "མོན་གྲུ།", "transliteration": "mon gru", "pronounce": "moin zhu", "IPA": "mø̃˥˥.ʈ͡ʂu˩˨", "english": "LM23", "translators_comments": "Tibetan Lunar Mansion 23"},
       "lines": [[109427, 107315, 107348]]
     },
     {
-      "id": "AST tibetan L25",
-      "common_name": {"native": "ཁྲུམས་སྟོད།", "transliteration": "khrums stod", "pronounce": "chum doi", "IPA": "ʈ͡ʂʰũ˥˩.tø˥˩", "english": "LM25", "translators_comments": "Tibetan Lunar Mansion 24"},
+      "id": "AST tibetan L24",
+      "common_name": {"native": "ཁྲུམས་སྟོད།", "transliteration": "khrums stod", "pronounce": "chum doi", "IPA": "ʈ͡ʂʰũ˥˩.tø˥˩", "english": "LM24", "translators_comments": "Tibetan Lunar Mansion 24"},
       "lines": [[113881, 113963]]
     },
     {
-      "id": "AST tibetan L26",
-      "common_name": {"native": "ཁྲུམས་སྨད།", "transliteration": "khrums smad", "pronounce": "chum mai", "IPA": "ʈ͡ʂʰũ˥˩.mɛː˩˨", "english": "LM26", "translators_comments": "Tibetan Lunar Mansion 25"},
+      "id": "AST tibetan L25",
+      "common_name": {"native": "ཁྲུམས་སྨད།", "transliteration": "khrums smad", "pronounce": "chum mai", "IPA": "ʈ͡ʂʰũ˥˩.mɛː˩˨", "english": "LM25", "translators_comments": "Tibetan Lunar Mansion 25"},
       "lines": [[677, 1067]]
     },
     {
-      "id": "AST tibetan L27",
-      "common_name": {"native": "ནམ་གྲུ།", "transliteration": "nam gru", "pronounce": "nam zhu", "IPA": "nãː˥˥.ʈ͡ʂʰu˩˨", "english": "LM27", "translators_comments": "Tibetan Lunar Mansion 26"},
+      "id": "AST tibetan L26",
+      "common_name": {"native": "ནམ་གྲུ།", "transliteration": "nam gru", "pronounce": "nam zhu", "IPA": "nãː˥˥.ʈ͡ʂʰu˩˨", "english": "LM26", "translators_comments": "Tibetan Lunar Mansion 26"},
       "lines": [[5571, 5131, 3693, 3885, 3092, 4889, 2912, 4185], [5571, 5742, 4510, 5544, 4552, 5447, 4436, 4185]]
     }
   ],
@@ -371,9 +367,9 @@
   "lunar_system": { "name": {"native": "རྒྱུ་སྐར", "transliteration": "rgyu skar", "pronounce": "gyu gar", "english": "Tib. Nakshatras"},
                     "context": "tibetan lunar mansion",
                     "comment" : "Shaped after the Indian nakshatras. Please enhance by Tibetan names and fix if needed!",
-                    "partitions": [28],
+                    "partitions": [27],
                     "extent": 5,
-                    "link": {"star": 65474, "offset": 173.572},
+                    "link": {"star": 65474, "offset": 180},
                     "names": [
                       {"symbol": "0", "native": "ཐ་སྐར།", "transliteration": "tha skar", "pronounce": "ta gar", "IPA": "tʰa˥˥.ka˥˩"},
                       {"symbol": "1", "native": "བྲ་ཉེ།", "transliteration": "bra nye", "pronounce": "cha nyê", "IPA": "ʈ͡ʂʰa˥˥.ȵe˩˨"},
@@ -397,12 +393,12 @@
                       {"symbol": "19", "native": "ཆུ་སྟོད།", "transliteration": "chu stod", "pronounce": "qu doi", "IPA": "t͡ɕʰu˥˥.tø˥˩"},
                       {"symbol": "20", "native": "ཆུ་སྨད།", "transliteration": "chu smad", "pronounce": "qu mai", "IPA": "t͡ɕʰu˥˥.mɛː˩˨"},
                       {"symbol": "21", "native": "གྲོ་བཞིན།", "transliteration": "gro bzhin", "pronounce": "cho xin", "IPA": "ʈ͡ʂʰo˥˥.ɕĩ˩˨"},
-                      {"symbol": "22", "native": "བྱི་བཞིན།", "transliteration": "byi bzhin", "pronounce": "qi xin", "IPA": "t͡ɕʰi˥˥.ɕĩ˩˨"},
-                      {"symbol": "23", "native": "མོན་གྲེ།", "transliteration": "mon gre", "pronounce": "moin zhê", "IPA": "mø̃˥˥.ʈ͡ʂe˩˨"},
-                      {"symbol": "24", "native": "མོན་གྲུ།", "transliteration": "mon gru", "pronounce": "moin zhu", "IPA": "mø̃˥˥.ʈ͡ʂu˩˨"},
-                      {"symbol": "25", "native": "ཁྲུམས་སྟོད།", "transliteration": "khrums stod", "pronounce": "chum doi", "IPA": "ʈ͡ʂʰũ˥˩.tø˥˩"},
-                      {"symbol": "26", "native": "ཁྲུམས་སྨད།", "transliteration": "khrums smad", "pronounce": "chum mai", "IPA": "ʈ͡ʂʰũ˥˩.mɛː˩˨"},
-                      {"symbol": "27", "native": "ནམ་གྲུ།", "transliteration": "nam gru", "pronounce": "nam zhu", "IPA": "nãː˥˥.ʈ͡ʂʰu˩˨"}
+                      {"symbol": "22", "native": "མོན་གྲེ།", "transliteration": "mon gre", "pronounce": "moin zhê", "IPA": "mø̃˥˥.ʈ͡ʂe˩˨"},
+                      {"symbol": "23", "native": "མོན་གྲུ།", "transliteration": "mon gru", "pronounce": "moin zhu", "IPA": "mø̃˥˥.ʈ͡ʂu˩˨"},
+                      {"symbol": "24", "native": "ཁྲུམས་སྟོད།", "transliteration": "khrums stod", "pronounce": "chum doi", "IPA": "ʈ͡ʂʰũ˥˩.tø˥˩"},
+                      {"symbol": "25", "native": "ཁྲུམས་སྨད།", "transliteration": "khrums smad", "pronounce": "chum mai", "IPA": "ʈ͡ʂʰũ˥˩.mɛː˩˨"},
+                      {"symbol": "26", "native": "ནམ་གྲུ།", "transliteration": "nam gru", "pronounce": "nam zhu", "IPA": "nãː˥˥.ʈ͡ʂʰu˩˨"},
+                      {"native": "བྱི་བཞིན། (Unused)", "transliteration": "byi bzhin", "pronounce": "qi xin", "IPA": "t͡ɕʰi˥˥.ɕĩ˩˨"}
                     ]
                   }
 }


### PR DESCRIPTION

### Description

This pull request adds the following data for Tibetan sky culture (Tibetan SC):

- Native Tibetan script (native) for asterisms and zodiac signs.
- Pronunciation-based transliteration (Tibetan Pinyin).
- Wylie transliteration (based on spelling).
- IPA.

The zodiac names are taken from reference [5]. The 27/28 lunar mansion names are from the paper cited as [4]. That paper uses a 28‑mansion system (i.e., it splits Drozhin and Jizhin into two separate mansions). Accordingly, I have updated the mansion data in `index.json` to reflect 28 mansions (numbered 0–27). This may differ from the previous 27‑mansion survey by @gzotti .

The `description.md` file has been updated with explanatory notes on the Tibetan script, transliteration, and IPA. The existing "please help us" calls have been kept. I am not certain which transliteration scheme was originally used in the file; I have adopted the Wylie system and Tibetan Pinyin that I am familiar with, but the description text itself remains largely unchanged.

Unfortunately, I have not been able to locate any Tibetan star charts, so I cannot revise the asterism identifications.

I have reviewed the example content related to Tibetan SC in the guide user manual, and I believe it is currently correct and does not require any changes.

Additionally, I noticed that the `class="layout"` attribute on tables in `description.md` triggers an assertion error in the Qt CSS parser (qcssparser.cpp:1491) when running in Debug mode. Only after deleting all 'class=' layout 'occurrences can the test be successful This attribute was present in the original file and was not added by me. It is possible that you did not encounter this issue previously. I didn't remove this 'class=' layout 'occurrences in the pull request I submitted. Please check if there are any issues.

Fixes # (issue)

### Screenshots (if appropriate):

The display of Tibetan letters here is incorrect, I have already reminded in `description.md`.

<img width="647" height="432" alt="image" src="https://github.com/user-attachments/assets/fff2fedf-6a1b-46c5-950f-8d004c2ffd1d" />

The screenshot below shows the 28‑mansion table and the Pleiades star chart from reference [4]:

<img width="424" height="554" alt="image" src="https://github.com/user-attachments/assets/cc97e96e-f937-4f2a-824d-0ed55db9442f" />

<img width="469" height="373" alt="image" src="https://github.com/user-attachments/assets/2108292e-4dfa-4916-8cd4-774799f29808" />

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
- Operating system: Windows 11 (23H2)
- Qt version: 6.5.2 (MSVC 2019, 64-bit)
- Build configuration: Debug
- Compiler: MSVC 2022 (17.6.3)

1. Built Stellarium from source with the `description.md` containing `class="layout"` on `<table>` elements.
2. Launched Stellarium in **Debug** mode and switched to the "Tibetan" sky culture (or refreshed the sky culture).
3. Observed an assertion error popup originating from `qcssparser.cpp:1491` in `Qt6Cored.dll`.
4. Removed **all three** occurrences of `class="layout"` from `<table>` elements in `description.md`, rebuilt, and repeated steps 2–3, verified that the assertion no longer appears.

I cannot confirm whether this issue is environment-specific (e.g., specific Qt version or build configuration). Please test in your environment to ensure no regression.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
