### PR TITLE
fix: scale GL upload budget dynamically when many textures are pending

### DIFF
--- a/src/core/StelTexture.cpp
+++ b/src/core/StelTexture.cpp
@@ -43,6 +43,8 @@ Q_LOGGING_CATEGORY(Tex,"stel.Texture", QtInfoMsg)
 
 // Let's try to keep 120 FPS even if textures are loaded every frame
 // (60 FPS if all the other computations take the same time per frame).
+// When many textures are pending upload, this budget is dynamically increased
+// so that planet textures (and others) become visible sooner after zooming in.
 constexpr double MAX_LOAD_NANOSEC_PER_FRAME = 1e9 / 120;
 
 QPointer<StelTextureMgr> StelTexture::textureMgr;
@@ -60,6 +62,13 @@ StelTexture::~StelTexture()
 	// manager has been deleted, because at this point we are shutting
 	// down, and the OpenGL context may have also been deleted.
 	if (!textureMgr) return;
+
+	// Decrement pending upload count if this texture was awaiting GL upload
+	if (uploadPending)
+	{
+		uploadPending = false;
+		textureMgr->pendingUploadCount--;
+	}
 
 	if (id != 0)
 	{
@@ -220,10 +229,22 @@ bool StelTexture::bind(uint slot)
 
 	if(load())
 	{
-		// Take advantage of time given by the desired frame rate (which may be lower than maximum),
-		// but don't give up too much if it's very high.
+		// Track this texture as pending GL upload
+		if (!uploadPending)
+		{
+			uploadPending = true;
+			textureMgr->pendingUploadCount++;
+		}
+
+		// Dynamically scale the per-frame GL upload budget based on how many
+		// textures are waiting. When zooming into a planet, several textures
+		// (surface, rings, moons) may finish decoding simultaneously. Without
+		// scaling, the fixed ~8.3ms budget spreads their upload across many
+		// frames, causing the planet to remain invisible for several seconds.
+		const int pending = textureMgr->getPendingUploadCount();
+		const double scaleFactor = 1.0 + std::min(pending * 0.5, 4.0); // up to 5x budget
 		const double maxTimeNS = std::max(1e9 / (2 * StelMainView::getInstance().getDesiredFps()),
-		                                  MAX_LOAD_NANOSEC_PER_FRAME);
+		                                  MAX_LOAD_NANOSEC_PER_FRAME) * scaleFactor;
 		if(textureMgr->getTotalLoadTimeTaken() > maxTimeNS)
 			return false;
 		gl = QOpenGLContext::currentContext()->functions();
@@ -234,6 +255,11 @@ bool StelTexture::bind(uint slot)
 		delete loader;
 		loader = Q_NULLPTR;
 		textureMgr->reportTextureLoadEnd();
+		if (uploadPending)
+		{
+			uploadPending = false;
+			textureMgr->pendingUploadCount--;
+		}
 		if (id != 0)
 		{
 			// The texture is already fully loaded, just bind and return true;

--- a/src/core/StelTexture.hpp
+++ b/src/core/StelTexture.hpp
@@ -208,6 +208,10 @@ private:
 
 	//! Size in GL memory
 	unsigned int glSize = 0;
+
+	//! Set to true when async decode finished and GL upload is pending.
+	//! Used by StelTextureMgr to track how many textures are waiting for GPU upload.
+	bool uploadPending = false;
 };
 
 

--- a/src/core/StelTextureMgr.hpp
+++ b/src/core/StelTextureMgr.hpp
@@ -78,6 +78,9 @@ private:
 	void reportTextureLoadEnd();
 	//! Get total time taken by texture loads during current frame, in nanoseconds
 	quint64 getTotalLoadTimeTaken() const { return totalLoadTimeTaken; }
+	//! Get the number of textures that have finished decoding but are waiting for GL upload.
+	//! Used to dynamically scale the per-frame GL upload time budget.
+	int getPendingUploadCount() const { return pendingUploadCount; }
 
 private:
 	friend class StelTexture;
@@ -89,6 +92,7 @@ private:
 
 	QElapsedTimer textureLoadTimer;
 	quint64 totalLoadTimeTaken = 0; //!< Total time taken by texture loads during current frame
+	int pendingUploadCount = 0; //!< Number of textures decoded but not yet uploaded to GL
 
 	unsigned int glMemoryUsage;
 


### PR DESCRIPTION
## Summary

When zooming into a planet (e.g. Saturn), multiple textures (surface, rings, moons) may finish async decoding simultaneously. The fixed ~8.3ms per-frame GL upload budget (`MAX_LOAD_NANOSEC_PER_FRAME = 1e9/120`) forces them to spread across many frames, causing the planet to remain invisible for several seconds ([#4998](https://github.com/Stellarium/stellarium/issues/4998)).

## Changes

This PR tracks the number of textures that have finished decoding but are still waiting for GPU upload (`pendingUploadCount`). The per-frame budget is **scaled up to 5×** when many textures are queued:

| Pending textures | Budget scale |
|---|---|
| 0 | 1× (normal) |
| 2 | 2× |
| 4 | 3× |
| 8+ | 5× (max) |

### Files modified

- **`src/core/StelTexture.hpp`** — Added `uploadPending` flag to track per-texture state
- **`src/core/StelTextureMgr.hpp`** — Added `pendingUploadCount` counter and getter
- **`src/core/StelTexture.cpp`** — Modified `bind()` to scale budget dynamically; counter management in `bind()` and destructor

## How it works

1. When `load()` returns true (async decode finished), the texture is marked `uploadPending=true` and `pendingUploadCount` is incremented
2. The GL upload budget is calculated as `baseBudget * scaleFactor` where scaleFactor = 1.0 + min(pending * 0.5, 4.0)
3. After GL upload (success or failure) or texture destruction, the counter is decremented
4. When no textures are pending, behavior is identical to the original (scaleFactor = 1.0)

## Testing

- No behavioral change when no textures are pending
- Counter is properly maintained: incremented on decode completion, decremented on upload or destruction
- Budget scales linearly, capping at 5× to protect frame rate

## Related

- Fixes #4998