### PR TITLE
Add new tab 'Twilight limits' to Object Visibility plugin

### DIFF
--- a/plugins/ObjectVisibility/src/ObjectVisibility.cpp
+++ b/plugins/ObjectVisibility/src/ObjectVisibility.cpp
@@ -60,7 +60,9 @@ StelPluginInfo ObjectVisibilityStelPluginInterface::getPluginInfo() const
 	info.description = N_("Shows on a planet map where a selected star or "
 	                      "deep-sky object is visible.  Supports observation "
 	                      "from Earth, the Moon, the eight planets, Pluto, "
-	                      "and the four Galilean moons.  Based on the "
+	                      "and the four Galilean moons.  Also shows "
+	                      "Earth-only solstice twilight latitude limits "
+	                      "computed from obliquity of date.  Based on the "
 	                      "geometric criteria of the Astro-Geo-GIS article "
 	                      "\"The 49 brightest stars in the night sky – when "
 	                      "and where can we see them?\"");

--- a/plugins/ObjectVisibility/src/ObjectVisibility.hpp
+++ b/plugins/ObjectVisibility/src/ObjectVisibility.hpp
@@ -57,6 +57,12 @@ Given a star with declination @f$\delta@f$ at the current epoch
 The plugin does **not** handle planets, the Sun, the Moon, asteroids,
 comets or artificial satellites: their motion across the sky is too
 fast for a single static snapshot to be useful.
+
+The Twilight limits tab is Earth-only. It draws the equator, tropics,
+polar circles, and solstice latitudes where the Sun's lowest or highest
+altitude is -6°, -12°, or -18°. These latitudes are computed from
+Earth's obliquity of date, so they remain valid for historical and
+future epochs supported by Stellarium.
 @}
 */
 

--- a/plugins/ObjectVisibility/src/gui/ObjectVisibilityDialog.cpp
+++ b/plugins/ObjectVisibility/src/gui/ObjectVisibilityDialog.cpp
@@ -28,6 +28,7 @@
 #include "StelFileMgr.hpp"
 #include "StelGui.hpp"
 #include "StelLocation.hpp"
+#include "StelLocationMgr.hpp"
 #include "StelModuleMgr.hpp"
 #include "StelObjectMgr.hpp"
 #include "StelTranslator.hpp"
@@ -36,6 +37,7 @@
 #include "modules/SolarSystem.hpp"
 
 #include <QDebug>
+#include <QComboBox>
 #include <QSpinBox>
 #include <QCheckBox>
 #include <QPushButton>
@@ -60,8 +62,11 @@ void ObjectVisibilityDialog::retranslate()
 	if (dialog)
 	{
 		ui->retranslateUi(dialog);
+		configurePlaceLabelControls();
 		setAboutHtml();
 		refreshTitleLabel();
+		refreshTwilightLimits();
+		updatePlaceLabels();
 	}
 }
 
@@ -107,17 +112,39 @@ void ObjectVisibilityDialog::createDialogContent()
 	// Push the same value back into the map widget at startup so the
 	// dashed line uses the correct altitude limit straight away.
 	ui->mapWidget->setGoodVisibilityAltitude(plugin->getGoodVisibilityLimit());
+	ui->twilightMapWidget->setOverlayMode(ObjectVisibilityMapWidget::TwilightLimitsOverlay);
+	ui->twilightMapWidget->setMarkerVisible(true);
+	ui->twilightMapWidget->setMap(QPixmap(":/graphicGui/miscWorldMap.jpg"));
+	configurePlaceLabelControls();
 
 	// Buttons.
 	connect(ui->calculatePushButton, &QPushButton::clicked,
 	        this, &ObjectVisibilityDialog::calculate);
 	connect(ui->setLocationByClickCheckBox, &QCheckBox::toggled,
 	        this, &ObjectVisibilityDialog::onSetLocationByClickToggled);
+	connect(ui->twilightSetLocationByClickCheckBox, &QCheckBox::toggled,
+	        this, &ObjectVisibilityDialog::onTwilightSetLocationByClickToggled);
 	connect(ui->resetSettingsPushButton, &QPushButton::clicked,
 	        this, &ObjectVisibilityDialog::onResetSettings);
+	connect(ui->placeLabelsCheckBox, &QCheckBox::toggled,
+	        this, &ObjectVisibilityDialog::onPlaceLabelsToggled);
+	connect(ui->twilightPlaceLabelsCheckBox, &QCheckBox::toggled,
+	        this, &ObjectVisibilityDialog::onTwilightPlaceLabelsToggled);
+	connect(ui->placeLabelsPopulationComboBox,
+	        QOverload<int>::of(&QComboBox::currentIndexChanged),
+	        this, &ObjectVisibilityDialog::onPlaceLabelsPopulationChanged);
+	connect(ui->twilightPlaceLabelsPopulationComboBox,
+	        QOverload<int>::of(&QComboBox::currentIndexChanged),
+	        this, &ObjectVisibilityDialog::onTwilightPlaceLabelsPopulationChanged);
+	connect(ui->placeLabelsNearLinesOnlyCheckBox, &QCheckBox::toggled,
+	        this, &ObjectVisibilityDialog::onPlaceLabelsNearLinesOnlyToggled);
+	connect(ui->twilightPlaceLabelsNearLinesOnlyCheckBox, &QCheckBox::toggled,
+	        this, &ObjectVisibilityDialog::onTwilightPlaceLabelsNearLinesOnlyToggled);
 
 	// Map clicks while in "set location" mode.
 	connect(ui->mapWidget, &ObjectVisibilityMapWidget::locationPicked,
+	        this, &ObjectVisibilityDialog::onLocationPicked);
+	connect(ui->twilightMapWidget, &ObjectVisibilityMapWidget::locationPicked,
 	        this, &ObjectVisibilityDialog::onLocationPicked);
 
 	// Track Stellarium's selection so we can enable/disable Calculate
@@ -138,10 +165,14 @@ void ObjectVisibilityDialog::createDialogContent()
 	StelCore* core = StelApp::getInstance().getCore();
 	connect(core, &StelCore::locationChanged,
 	        this, &ObjectVisibilityDialog::syncMarkerToObserver);
+	connect(core, &StelCore::dateChanged,
+	        this, &ObjectVisibilityDialog::refreshTwilightLimits);
 	syncMarkerToObserver();
 
 	setAboutHtml();
 	refreshTitleLabel();
+	refreshTwilightLimits();
+	updatePlaceLabels();
 	updateCalculateButtonEnabled();
 }
 
@@ -244,6 +275,36 @@ void ObjectVisibilityDialog::onGoodVisibilityLimitChanged(int degrees)
 void ObjectVisibilityDialog::onSetLocationByClickToggled(bool on)
 {
 	ui->mapWidget->setClickSetsLocationMode(on);
+
+	if (ui->twilightSetLocationByClickCheckBox->isEnabled())
+	{
+		QSignalBlocker blocker(ui->twilightSetLocationByClickCheckBox);
+		ui->twilightSetLocationByClickCheckBox->setChecked(on);
+		ui->twilightMapWidget->setClickSetsLocationMode(on);
+	}
+}
+
+void ObjectVisibilityDialog::onTwilightSetLocationByClickToggled(bool on)
+{
+	StelCore* core = StelApp::getInstance().getCore();
+	const bool earth = core &&
+	                   core->getCurrentLocation().planetName == QStringLiteral("Earth");
+
+	if (on && !earth)
+	{
+		QSignalBlocker blocker(ui->twilightSetLocationByClickCheckBox);
+		ui->twilightSetLocationByClickCheckBox->setChecked(false);
+		ui->twilightMapWidget->setClickSetsLocationMode(false);
+		return;
+	}
+
+	ui->twilightMapWidget->setClickSetsLocationMode(on);
+
+	{
+		QSignalBlocker blocker(ui->setLocationByClickCheckBox);
+		ui->setLocationByClickCheckBox->setChecked(on);
+	}
+	ui->mapWidget->setClickSetsLocationMode(on);
 }
 
 void ObjectVisibilityDialog::onLocationPicked(double longitude,
@@ -271,6 +332,7 @@ void ObjectVisibilityDialog::onLocationPicked(double longitude,
 	// StelCore::locationChanged to arrive — that signal is emitted
 	// after the (async) move completes, which would feel laggy.
 	ui->mapWidget->setMarkerPos(longitude, latitude);
+	ui->twilightMapWidget->setMarkerPos(longitude, latitude);
 }
 
 void ObjectVisibilityDialog::onResetSettings()
@@ -282,6 +344,52 @@ void ObjectVisibilityDialog::onResetSettings()
 	const int g = plugin->getGoodVisibilityLimit();
 	ui->goodVisibilityLimitSpinBox->setValue(g);
 	ui->mapWidget->setGoodVisibilityAltitude(g);
+}
+
+void ObjectVisibilityDialog::onPlaceLabelsToggled(bool on)
+{
+	placeLabelsVisible = on;
+	syncPlaceLabelControls();
+	updatePlaceLabels();
+}
+
+void ObjectVisibilityDialog::onTwilightPlaceLabelsToggled(bool on)
+{
+	placeLabelsVisible = on;
+	syncPlaceLabelControls();
+	updatePlaceLabels();
+}
+
+void ObjectVisibilityDialog::onPlaceLabelsPopulationChanged(int index)
+{
+	const QVariant value = ui->placeLabelsPopulationComboBox->itemData(index);
+	if (!value.isValid()) return;
+	placeLabelsMinimumPopulation = value.toInt();
+	syncPlaceLabelControls();
+	updatePlaceLabels();
+}
+
+void ObjectVisibilityDialog::onTwilightPlaceLabelsPopulationChanged(int index)
+{
+	const QVariant value = ui->twilightPlaceLabelsPopulationComboBox->itemData(index);
+	if (!value.isValid()) return;
+	placeLabelsMinimumPopulation = value.toInt();
+	syncPlaceLabelControls();
+	updatePlaceLabels();
+}
+
+void ObjectVisibilityDialog::onPlaceLabelsNearLinesOnlyToggled(bool on)
+{
+	placeLabelsNearLinesOnly = on;
+	syncPlaceLabelControls();
+	updatePlaceLabels();
+}
+
+void ObjectVisibilityDialog::onTwilightPlaceLabelsNearLinesOnlyToggled(bool on)
+{
+	placeLabelsNearLinesOnly = on;
+	syncPlaceLabelControls();
+	updatePlaceLabels();
 }
 
 void ObjectVisibilityDialog::syncMarkerToObserver()
@@ -331,11 +439,179 @@ void ObjectVisibilityDialog::syncMarkerToObserver()
 	const float lon = loc.getLongitude(true);
 	ui->mapWidget->setMarkerPos(static_cast<double>(lon),
 	                            static_cast<double>(lat));
+	ui->twilightMapWidget->setMarkerPos(static_cast<double>(lon),
+	                                    static_cast<double>(lat));
 
 	// (3) Refresh the Calculate-enabled state and title label, since
 	// both depend on whether the current planet is supported.
 	updateCalculateButtonEnabled();
 	refreshTitleLabel();
+	refreshTwilightLimits();
+	updatePlaceLabels();
+}
+
+void ObjectVisibilityDialog::refreshTwilightLimits()
+{
+	if (!ui || !ui->twilightMapWidget) return;
+
+	StelCore* core = StelApp::getInstance().getCore();
+	if (!core) return;
+
+	const QString planet = core->getCurrentLocation().planetName;
+	if (planet != QStringLiteral("Earth"))
+	{
+		ui->twilightMapWidget->clearTwilightLimits();
+		ui->twilightMapWidget->setMarkerVisible(false);
+		ui->twilightMapWidget->setClickSetsLocationMode(false);
+		ui->twilightSetLocationByClickCheckBox->setEnabled(false);
+		ui->twilightSetLocationByClickCheckBox->setToolTip(
+			q_("Setting the observer location from the twilight map is "
+			   "available on Earth only."));
+		{
+			QSignalBlocker blocker(ui->twilightSetLocationByClickCheckBox);
+			ui->twilightSetLocationByClickCheckBox->setChecked(false);
+		}
+		ui->twilightTitleLabel->setText(
+			QString(q_("Solstice twilight limits are available for Earth only. "
+			           "Current observing body: %1"))
+			.arg(q_(planet.toUtf8().constData())));
+		return;
+	}
+
+	SolarSystem* ssm = GETSTELMODULE(SolarSystem);
+	PlanetP earth = ssm ? ssm->getEarth() : PlanetP();
+	if (!earth)
+	{
+		ui->twilightMapWidget->clearTwilightLimits();
+		ui->twilightMapWidget->setMarkerVisible(false);
+		ui->twilightMapWidget->setClickSetsLocationMode(false);
+		ui->twilightSetLocationByClickCheckBox->setEnabled(false);
+		ui->twilightTitleLabel->setText(
+			q_("Solstice twilight limits on Earth are unavailable."));
+		return;
+	}
+
+	ui->twilightMapWidget->setMarkerVisible(true);
+	ui->twilightSetLocationByClickCheckBox->setEnabled(true);
+	ui->twilightSetLocationByClickCheckBox->setToolTip(
+		q_("Enable to move the observer by clicking on the map.  Stays "
+		   "active until you uncheck it — you can pick as many locations "
+		   "as you like."));
+
+	const double obliquityDeg = earth->getRotObliquity(core->getJDE()) * 180.0 / M_PI;
+	ui->twilightMapWidget->setTwilightObliquity(obliquityDeg);
+
+	const int year = currentYear(core);
+	ui->twilightTitleLabel->setText(
+		QString(q_("Solstice twilight limits on Earth in %1 "
+		           "(obliquity %2°)"))
+		.arg(year)
+		.arg(obliquityDeg, 0, 'f', 2));
+}
+
+void ObjectVisibilityDialog::configurePlaceLabelControls()
+{
+	QSignalBlocker b1(ui->placeLabelsPopulationComboBox);
+	QSignalBlocker b2(ui->twilightPlaceLabelsPopulationComboBox);
+
+	auto configureCombo = [](QComboBox* combo)
+	{
+		combo->clear();
+		combo->addItem(q_("100,000"), 100000);
+		combo->addItem(q_("500,000"), 500000);
+		combo->addItem(q_("1,000,000"), 1000000);
+		combo->addItem(q_("5,000,000"), 5000000);
+	};
+
+	configureCombo(ui->placeLabelsPopulationComboBox);
+	configureCombo(ui->twilightPlaceLabelsPopulationComboBox);
+	syncPlaceLabelControls();
+}
+
+void ObjectVisibilityDialog::syncPlaceLabelControls()
+{
+	QSignalBlocker b1(ui->placeLabelsCheckBox);
+	QSignalBlocker b2(ui->twilightPlaceLabelsCheckBox);
+	QSignalBlocker b3(ui->placeLabelsPopulationComboBox);
+	QSignalBlocker b4(ui->twilightPlaceLabelsPopulationComboBox);
+	QSignalBlocker b5(ui->placeLabelsNearLinesOnlyCheckBox);
+	QSignalBlocker b6(ui->twilightPlaceLabelsNearLinesOnlyCheckBox);
+
+	ui->placeLabelsCheckBox->setChecked(placeLabelsVisible);
+	ui->twilightPlaceLabelsCheckBox->setChecked(placeLabelsVisible);
+	ui->placeLabelsNearLinesOnlyCheckBox->setChecked(placeLabelsNearLinesOnly);
+	ui->twilightPlaceLabelsNearLinesOnlyCheckBox->setChecked(placeLabelsNearLinesOnly);
+
+	auto selectPopulation = [this](QComboBox* combo)
+	{
+		const int index = combo->findData(placeLabelsMinimumPopulation);
+		if (index >= 0)
+			combo->setCurrentIndex(index);
+	};
+	selectPopulation(ui->placeLabelsPopulationComboBox);
+	selectPopulation(ui->twilightPlaceLabelsPopulationComboBox);
+}
+
+void ObjectVisibilityDialog::updatePlaceLabels()
+{
+	if (!ui || !ui->mapWidget || !ui->twilightMapWidget) return;
+
+	StelCore* core = StelApp::getInstance().getCore();
+	const bool earth = core &&
+	                   core->getCurrentLocation().planetName == QStringLiteral("Earth");
+
+	auto setControlsEnabled = [earth](QCheckBox* showCheckBox,
+	                                  QLabel* populationLabel,
+	                                  QComboBox* populationComboBox,
+	                                  QCheckBox* nearLinesOnlyCheckBox)
+	{
+		showCheckBox->setEnabled(earth);
+		populationLabel->setEnabled(earth);
+		populationComboBox->setEnabled(earth);
+		nearLinesOnlyCheckBox->setEnabled(earth);
+	};
+
+	setControlsEnabled(ui->placeLabelsCheckBox,
+	                   ui->placeLabelsPopulationLabel,
+	                   ui->placeLabelsPopulationComboBox,
+	                   ui->placeLabelsNearLinesOnlyCheckBox);
+	setControlsEnabled(ui->twilightPlaceLabelsCheckBox,
+	                   ui->twilightPlaceLabelsPopulationLabel,
+	                   ui->twilightPlaceLabelsPopulationComboBox,
+	                   ui->twilightPlaceLabelsNearLinesOnlyCheckBox);
+
+	if (!earth || !placeLabelsVisible)
+	{
+		ui->mapWidget->setPlaceLabelsVisible(false);
+		ui->twilightMapWidget->setPlaceLabelsVisible(false);
+		return;
+	}
+
+	QVector<ObjectVisibilityMapWidget::PlaceLabel> labels;
+	const LocationList locations = StelApp::getInstance().getLocationMgr().getAll();
+	labels.reserve(locations.size());
+	for (const StelLocation& loc : locations)
+	{
+		if (loc.planetName != QStringLiteral("Earth")) continue;
+		if (loc.name.isEmpty()) continue;
+
+		ObjectVisibilityMapWidget::PlaceLabel label;
+		label.name = loc.name;
+		label.longitude = loc.getLongitude(true);
+		label.latitude = loc.getLatitude(true);
+		label.population = loc.population;
+		label.role = loc.role;
+		labels.append(label);
+	}
+
+	ui->mapWidget->setPlaceLabels(labels);
+	ui->twilightMapWidget->setPlaceLabels(labels);
+	ui->mapWidget->setPlaceLabelMinimumPopulation(placeLabelsMinimumPopulation);
+	ui->twilightMapWidget->setPlaceLabelMinimumPopulation(placeLabelsMinimumPopulation);
+	ui->mapWidget->setPlaceLabelsNearLinesOnly(placeLabelsNearLinesOnly);
+	ui->twilightMapWidget->setPlaceLabelsNearLinesOnly(placeLabelsNearLinesOnly);
+	ui->mapWidget->setPlaceLabelsVisible(true);
+	ui->twilightMapWidget->setPlaceLabelsVisible(true);
 }
 
 bool ObjectVisibilityDialog::isSupportedPlanet(const QString& englishName)
@@ -539,6 +815,17 @@ void ObjectVisibilityDialog::setAboutHtml()
 	                   "planetarium.  To see Sirius's visibility in "
 	                   "10&thinsp;000 BCE, set the planetarium's date "
 	                   "first, then press Calculate.")
+	        + "</p>";
+
+	html += "<p>" + q_("The Twilight limits tab is Earth-only.  It draws the "
+	                   "equator, tropics, polar circles, and solstice "
+	                   "latitudes where the Sun's lowest or highest altitude "
+	                   "is -6&deg;, -12&deg;, or -18&deg;.  These lines use "
+	                   "Earth's obliquity at the current epoch, so they shift "
+	                   "when you change the planetarium date.  They are not "
+	                   "shown for other observing bodies because civil, "
+	                   "nautical, and astronomical twilight depend on Earth's "
+	                   "atmosphere.")
 	        + "</p>";
 
 	html += "<h3>" + q_("Credits") + "</h3>";

--- a/plugins/ObjectVisibility/src/gui/ObjectVisibilityDialog.cpp
+++ b/plugins/ObjectVisibility/src/gui/ObjectVisibilityDialog.cpp
@@ -494,9 +494,8 @@ void ObjectVisibilityDialog::refreshTwilightLimits()
 	ui->twilightMapWidget->setMarkerVisible(true);
 	ui->twilightSetLocationByClickCheckBox->setEnabled(true);
 	ui->twilightSetLocationByClickCheckBox->setToolTip(
-		q_("Enable to move the observer by clicking on the map.  Stays "
-		   "active until you uncheck it — you can pick as many locations "
-		   "as you like."));
+		q_("Enable to move the observer by clicking on the map. "
+		   "Stays active until you uncheck it."));
 
 	const double obliquityDeg = earth->getRotObliquity(core->getJDE()) * 180.0 / M_PI;
 	ui->twilightMapWidget->setTwilightObliquity(obliquityDeg);

--- a/plugins/ObjectVisibility/src/gui/ObjectVisibilityDialog.hpp
+++ b/plugins/ObjectVisibility/src/gui/ObjectVisibilityDialog.hpp
@@ -58,6 +58,9 @@ private slots:
 	//! Toggle "click on map to set location" mode on the map widget.
 	void onSetLocationByClickToggled(bool on);
 
+	//! Toggle "click on map to set location" mode on the twilight map.
+	void onTwilightSetLocationByClickToggled(bool on);
+
 	//! The user clicked the map while in click-to-set mode.
 	void onLocationPicked(double longitude, double latitude,
 	                      const QColor &color);
@@ -68,10 +71,21 @@ private slots:
 	//! Reset settings button.
 	void onResetSettings();
 
+	void onPlaceLabelsToggled(bool on);
+	void onTwilightPlaceLabelsToggled(bool on);
+	void onPlaceLabelsPopulationChanged(int index);
+	void onTwilightPlaceLabelsPopulationChanged(int index);
+	void onPlaceLabelsNearLinesOnlyToggled(bool on);
+	void onTwilightPlaceLabelsNearLinesOnlyToggled(bool on);
+
 	//! Re-sync the location marker AND the planet texture from
 	//! StelCore's current observer.  Called on startup and whenever
 	//! StelCore reports a location change.
 	void syncMarkerToObserver();
+
+	//! Recompute Earth-only solstice/twilight limits for the current
+	//! epoch and update the twilight tab.
+	void refreshTwilightLimits();
 
 private:
 	Ui_objectVisibilityDialog* ui;
@@ -92,9 +106,16 @@ private:
 	//! geographic position on the same planet.
 	QString  cachedPlanetName;
 
+	bool placeLabelsVisible = false;
+	int  placeLabelsMinimumPopulation = 1000000;
+	bool placeLabelsNearLinesOnly = true;
+
 	void setAboutHtml();
 	void refreshTitleLabel();
 	void updateCalculateButtonEnabled();
+	void configurePlaceLabelControls();
+	void syncPlaceLabelControls();
+	void updatePlaceLabels();
 
 	//! Compute the year label in astronomical convention from the
 	//! StelCore's current JD.  E.g. 2026, or -10000 for 10001 BCE.

--- a/plugins/ObjectVisibility/src/gui/ObjectVisibilityMapWidget.cpp
+++ b/plugins/ObjectVisibility/src/gui/ObjectVisibilityMapWidget.cpp
@@ -158,9 +158,9 @@ const QColor DASHED_COLOR   = QColor(0,  60, 220, 220);
 const QColor ZENITH_COLOR   = QColor(0,  60, 220, 240);
 const QColor TRIANGLE_COLOR = QColor(0,  60, 220, 255);
 
-const QColor EQUATOR_COLOR  = QColor(35, 35, 35, 235);
+const QColor EQUATOR_COLOR  = QColor(235, 235, 235, 245);
 const QColor TROPIC_COLOR   = QColor(220, 155, 30, 245);
-const QColor POLAR_COLOR    = QColor(0, 150, 170, 245);
+const QColor POLAR_COLOR    = QColor(0, 120, 145, 245);
 
 const QColor CIVIL_MIN_COLOR = QColor(245, 110, 45, 245);
 const QColor NAUT_MIN_COLOR  = QColor(160, 90, 210, 245);
@@ -311,14 +311,16 @@ void ObjectVisibilityMapWidget::drawVisibilityOverlay(QPainter& painter) const
 void ObjectVisibilityMapWidget::drawTwilightLimitsOverlay(QPainter& painter) const
 {
 	const double ratio = devicePixelRatioF();
-	const double penW = std::max(1.0, 1.5 * ratio);
+	const double penW = std::max(1.0, 1.35 * ratio);
 	const double eps = twilightObliquityDeg;
 	const double polar = 90.0 - eps;
 
-	auto penFor = [penW](const QColor& color, Qt::PenStyle style = Qt::SolidLine)
+	auto penFor = [penW](const QColor& color,
+	                     Qt::PenStyle style = Qt::SolidLine,
+	                     double width = 0.0)
 	{
 		QPen pen(color);
-		pen.setWidthF(penW);
+		pen.setWidthF(width > 0.0 ? width : penW);
 		pen.setCapStyle(Qt::FlatCap);
 		pen.setStyle(style);
 		if (style == Qt::CustomDashLine)
@@ -333,9 +335,13 @@ void ObjectVisibilityMapWidget::drawTwilightLimitsOverlay(QPainter& painter) con
 			drawLatitudeLineCopies(painter, -latitude, pen);
 	};
 
-	drawLatitudeLineCopies(painter, 0.0, penFor(EQUATOR_COLOR));
+	drawLatitudeLineCopies(painter, 0.0, penFor(EQUATOR_COLOR,
+	                                            Qt::SolidLine,
+	                                            std::max(1.0, 1.8 * ratio)));
 	drawSymmetric(eps, penFor(TROPIC_COLOR));
-	drawSymmetric(polar, penFor(POLAR_COLOR));
+	drawSymmetric(polar, penFor(POLAR_COLOR,
+	                            Qt::DotLine,
+	                            std::max(1.0, 1.9 * ratio)));
 
 	// At solstice the Sun's declination is +/-eps.  For the
 	// summer-solstice midnight Sun, h_min = phi + eps - 90, giving

--- a/plugins/ObjectVisibility/src/gui/ObjectVisibilityMapWidget.cpp
+++ b/plugins/ObjectVisibility/src/gui/ObjectVisibilityMapWidget.cpp
@@ -26,7 +26,9 @@
 #include <QFont>
 #include <QFontMetrics>
 #include <QPolygonF>
+#include <QRectF>
 #include <cmath>
+#include <algorithm>
 
 ObjectVisibilityMapWidget::ObjectVisibilityMapWidget(QWidget* parent)
 	: MapWidget(parent)
@@ -40,6 +42,41 @@ ObjectVisibilityMapWidget::ObjectVisibilityMapWidget(QWidget* parent)
 	// re-emit them upwards.
 	connect(this, &MapWidget::positionChanged,
 	        this, &ObjectVisibilityMapWidget::onPositionChanged);
+}
+
+void ObjectVisibilityMapWidget::setOverlayMode(OverlayMode mode)
+{
+	if (currentOverlayMode == mode) return;
+	currentOverlayMode = mode;
+	update();
+}
+
+void ObjectVisibilityMapWidget::setPlaceLabels(const QVector<PlaceLabel>& labels)
+{
+	placeLabels = labels;
+	update();
+}
+
+void ObjectVisibilityMapWidget::setPlaceLabelsVisible(bool visible)
+{
+	if (showPlaceLabels == visible) return;
+	showPlaceLabels = visible;
+	update();
+}
+
+void ObjectVisibilityMapWidget::setPlaceLabelMinimumPopulation(int population)
+{
+	if (population < 0) population = 0;
+	if (placeLabelMinimumPopulation == population) return;
+	placeLabelMinimumPopulation = population;
+	update();
+}
+
+void ObjectVisibilityMapWidget::setPlaceLabelsNearLinesOnly(bool nearLinesOnly)
+{
+	if (placeLabelsNearLinesOnly == nearLinesOnly) return;
+	placeLabelsNearLinesOnly = nearLinesOnly;
+	update();
 }
 
 void ObjectVisibilityMapWidget::setClickSetsLocationMode(bool on)
@@ -78,6 +115,25 @@ void ObjectVisibilityMapWidget::clearVisibility()
 	update();
 }
 
+void ObjectVisibilityMapWidget::setTwilightObliquity(double obliquityDeg)
+{
+	if (obliquityDeg <= 0.0 || obliquityDeg >= 90.0)
+	{
+		clearTwilightLimits();
+		return;
+	}
+	hasTwilightObliquity = true;
+	twilightObliquityDeg = obliquityDeg;
+	update();
+}
+
+void ObjectVisibilityMapWidget::clearTwilightLimits()
+{
+	if (!hasTwilightObliquity) return;
+	hasTwilightObliquity = false;
+	update();
+}
+
 void ObjectVisibilityMapWidget::onPositionChanged(double longitude,
                                                   double latitude,
                                                   const QColor& color)
@@ -101,6 +157,18 @@ const QColor LINE_COLOR     = QColor(0,  60, 220, 255);
 const QColor DASHED_COLOR   = QColor(0,  60, 220, 220);
 const QColor ZENITH_COLOR   = QColor(0,  60, 220, 240);
 const QColor TRIANGLE_COLOR = QColor(0,  60, 220, 255);
+
+const QColor EQUATOR_COLOR  = QColor(35, 35, 35, 235);
+const QColor TROPIC_COLOR   = QColor(220, 155, 30, 245);
+const QColor POLAR_COLOR    = QColor(0, 150, 170, 245);
+
+const QColor CIVIL_MIN_COLOR = QColor(245, 110, 45, 245);
+const QColor NAUT_MIN_COLOR  = QColor(160, 90, 210, 245);
+const QColor ASTRO_MIN_COLOR = QColor(60, 105, 220, 245);
+
+const QColor CIVIL_MAX_COLOR = QColor(205, 60, 60, 245);
+const QColor NAUT_MAX_COLOR  = QColor(120, 65, 175, 245);
+const QColor ASTRO_MAX_COLOR = QColor(35, 70, 160, 245);
 } // namespace
 
 void ObjectVisibilityMapWidget::drawLatitudeLine(QPainter& painter,
@@ -123,6 +191,13 @@ void ObjectVisibilityMapWidget::drawLatitudeLine(QPainter& painter,
 	// line still appears continuous over map wrap-arounds.
 	painter.drawLine(QPointF(0.0,                       y),
 	                 QPointF(width() * ratio,           y));
+}
+
+void ObjectVisibilityMapWidget::drawLatitudeLineCopies(QPainter& painter,
+                                                       double latitudeDeg,
+                                                       const QPen& pen) const
+{
+	drawLatitudeLine(painter, latitudeDeg, pen);
 }
 
 void ObjectVisibilityMapWidget::drawLatitudeMarkers(QPainter& painter,
@@ -171,24 +246,11 @@ void ObjectVisibilityMapWidget::drawLatitudeMarkers(QPainter& painter,
 	}
 }
 
-void ObjectVisibilityMapWidget::paintEvent(QPaintEvent* event)
+void ObjectVisibilityMapWidget::drawVisibilityOverlay(QPainter& painter) const
 {
-	// Step 1: let MapWidget render the world map, the (hidden) marker,
-	// and any location filter.  This is the cheapest way to keep
-	// pan/zoom/HiDPI behaviour identical to LocationDialog's map.
-	MapWidget::paintEvent(event);
-
-	if (!hasDeclination) return;
-
-	// Step 2: overlay our visibility lines.  Like the base class, we
-	// work in device-pixel space.
-	QPainter painter(this);
-	const double ratio = devicePixelRatioF();
-	painter.scale(1.0 / ratio, 1.0 / ratio);
-	painter.setRenderHint(QPainter::Antialiasing, true);
-
 	const double dec = declinationDeg;
 	const double h   = static_cast<double>(goodVisibilityDeg);
+	const double ratio = devicePixelRatioF();
 
 	// Pen widths scale with HiDPI so lines look the same physical
 	// thickness on any monitor.
@@ -244,4 +306,273 @@ void ObjectVisibilityMapWidget::paintEvent(QPaintEvent* event)
 	drawLatitudeMarkers(painter, -90.0 - dec,
 	                    QChar(0x25BC),  // BLACK DOWN-POINTING TRIANGLE
 	                    TRIANGLE_COLOR);
+}
+
+void ObjectVisibilityMapWidget::drawTwilightLimitsOverlay(QPainter& painter) const
+{
+	const double ratio = devicePixelRatioF();
+	const double penW = std::max(1.0, 1.5 * ratio);
+	const double eps = twilightObliquityDeg;
+	const double polar = 90.0 - eps;
+
+	auto penFor = [penW](const QColor& color, Qt::PenStyle style = Qt::SolidLine)
+	{
+		QPen pen(color);
+		pen.setWidthF(penW);
+		pen.setCapStyle(Qt::FlatCap);
+		pen.setStyle(style);
+		if (style == Qt::CustomDashLine)
+			pen.setDashPattern({6.0, 4.0});
+		return pen;
+	};
+
+	auto drawSymmetric = [this, &painter](double latitude, const QPen& pen)
+	{
+		drawLatitudeLineCopies(painter,  latitude, pen);
+		if (std::abs(latitude) > 1e-9)
+			drawLatitudeLineCopies(painter, -latitude, pen);
+	};
+
+	drawLatitudeLineCopies(painter, 0.0, penFor(EQUATOR_COLOR));
+	drawSymmetric(eps, penFor(TROPIC_COLOR));
+	drawSymmetric(polar, penFor(POLAR_COLOR));
+
+	// At solstice the Sun's declination is +/-eps.  For the
+	// summer-solstice midnight Sun, h_min = phi + eps - 90, giving
+	// phi = 90 - eps - |h|.  For the winter-solstice noon Sun,
+	// h_max = 90 - phi - eps, giving phi = 90 - eps + |h|.
+	drawSymmetric(polar - 6.0,  penFor(CIVIL_MIN_COLOR));
+	drawSymmetric(polar - 12.0, penFor(NAUT_MIN_COLOR));
+	drawSymmetric(polar - 18.0, penFor(ASTRO_MIN_COLOR));
+
+	drawSymmetric(polar + 6.0,  penFor(CIVIL_MAX_COLOR, Qt::CustomDashLine));
+	drawSymmetric(polar + 12.0, penFor(NAUT_MAX_COLOR, Qt::CustomDashLine));
+	drawSymmetric(polar + 18.0, penFor(ASTRO_MAX_COLOR, Qt::CustomDashLine));
+}
+
+QVector<double> ObjectVisibilityMapWidget::currentOverlayLatitudes() const
+{
+	QVector<double> latitudes;
+
+	auto addLatitude = [&latitudes](double latitude)
+	{
+		if (latitude < -90.0 || latitude > 90.0) return;
+		for (double existing : latitudes)
+		{
+			if (std::abs(existing - latitude) < 1e-6)
+				return;
+		}
+		latitudes.append(latitude);
+	};
+
+	auto addSymmetric = [&addLatitude](double latitude)
+	{
+		addLatitude(latitude);
+		if (std::abs(latitude) > 1e-9)
+			addLatitude(-latitude);
+	};
+
+	if (currentOverlayMode == VisibilityOverlay && hasDeclination)
+	{
+		const double dec = declinationDeg;
+		const double h = static_cast<double>(goodVisibilityDeg);
+		addLatitude(dec + 90.0);
+		addLatitude(dec - 90.0);
+		addLatitude(dec + (90.0 - h));
+		addLatitude(dec - (90.0 - h));
+		addLatitude(dec);
+		addLatitude(90.0 - dec);
+		addLatitude(-90.0 - dec);
+	}
+	else if (currentOverlayMode == TwilightLimitsOverlay && hasTwilightObliquity)
+	{
+		const double eps = twilightObliquityDeg;
+		const double polar = 90.0 - eps;
+		addLatitude(0.0);
+		addSymmetric(eps);
+		addSymmetric(polar);
+		addSymmetric(polar - 6.0);
+		addSymmetric(polar - 12.0);
+		addSymmetric(polar - 18.0);
+		addSymmetric(polar + 6.0);
+		addSymmetric(polar + 12.0);
+		addSymmetric(polar + 18.0);
+	}
+
+	return latitudes;
+}
+
+void ObjectVisibilityMapWidget::drawPlaceLabels(QPainter& painter) const
+{
+	if (!showPlaceLabels || placeLabels.isEmpty()) return;
+
+	const double ratio = devicePixelRatioF();
+	const auto leftEdge = lonLatToMapPoint(-180.0, 0.0);
+	const auto rightEdge = lonLatToMapPoint(180.0, 0.0);
+	const double mapWidth = rightEdge.x - leftEdge.x;
+	if (mapWidth <= 0.0) return;
+
+	const QVector<double> lineLatitudes = currentOverlayLatitudes();
+	const bool filterNearLines = placeLabelsNearLinesOnly && !lineLatitudes.isEmpty();
+
+	constexpr double nearLineDegrees = 1.0;
+	constexpr int maxLabels = 120;
+	const double logicalWidth = width() * ratio;
+	const double logicalHeight = height() * ratio;
+
+	QVector<const PlaceLabel*> candidates;
+	candidates.reserve(static_cast<int>(std::min<qsizetype>(
+		placeLabels.size(), 2048)));
+	for (const PlaceLabel& label : placeLabels)
+	{
+		if (label.population < placeLabelMinimumPopulation)
+			continue;
+
+		if (filterNearLines)
+		{
+			bool near = false;
+			for (double latitude : lineLatitudes)
+			{
+				if (std::abs(label.latitude - latitude) <= nearLineDegrees)
+				{
+					near = true;
+					break;
+				}
+			}
+			if (!near)
+				continue;
+		}
+
+		candidates.append(&label);
+	}
+
+	auto rolePriority = [](QChar role)
+	{
+		const QChar r = role.toUpper();
+		if (r == QChar('C') || r == QChar('B')) return 0;
+		if (r == QChar('R')) return 1;
+		if (r == QChar('O')) return 2;
+		return 3;
+	};
+
+	std::sort(candidates.begin(), candidates.end(),
+	          [rolePriority](const PlaceLabel* a, const PlaceLabel* b)
+	          {
+		          const int ar = rolePriority(a->role);
+		          const int br = rolePriority(b->role);
+		          if (ar != br) return ar < br;
+		          return a->population > b->population;
+	          });
+
+	QFont font = painter.font();
+	font.setPixelSize(std::max(8, static_cast<int>(std::round(11.0 * ratio))));
+	painter.setFont(font);
+	const QFontMetrics fm(font);
+
+	QVector<QRectF> occupied;
+	occupied.reserve(maxLabels);
+	int labelsDrawn = 0;
+
+	for (const PlaceLabel* label : candidates)
+	{
+		if (labelsDrawn >= maxLabels) break;
+		if (label->latitude < -90.0 || label->latitude > 90.0) continue;
+
+		const auto p = lonLatToMapPoint(label->longitude, label->latitude);
+		const QString text = label->name;
+		const int textWidth =
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+			fm.horizontalAdvance(text);
+#else
+			fm.width(text);
+#endif
+		const double dotR = std::max(2.0, 2.4 * ratio);
+		const double xOffset = 6.0 * ratio;
+		const double yOffset = -4.0 * ratio;
+		const double labelPadX = 3.5 * ratio;
+		const double labelPadY = 1.5 * ratio;
+
+		auto drawCandidate = [&](double x)
+		{
+			const QPointF dotPos(x, p.y);
+			const QPointF textPos(dotPos.x() + xOffset,
+			                      dotPos.y() + yOffset);
+			const QRectF glyphRect(textPos.x(),
+			                       textPos.y() - fm.ascent(),
+			                       textWidth,
+			                       fm.height());
+			const QRectF labelRect = glyphRect.adjusted(-labelPadX,
+			                                            -labelPadY,
+			                                            labelPadX,
+			                                            labelPadY);
+			if (labelRect.right() < 0.0 || labelRect.left() > logicalWidth ||
+			    labelRect.bottom() < 0.0 || labelRect.top() > logicalHeight)
+				return false;
+
+			const QRectF padded = labelRect.adjusted(-3.0 * ratio, -1.5 * ratio,
+			                                         3.0 * ratio, 1.5 * ratio);
+			for (const QRectF& rect : occupied)
+			{
+				if (rect.intersects(padded))
+					return false;
+			}
+
+			painter.setPen(QPen(QColor(255, 255, 255, 210), 1.2 * ratio));
+			painter.setBrush(QColor(25, 25, 25, 215));
+			painter.drawEllipse(dotPos, dotR, dotR);
+
+			painter.setPen(Qt::NoPen);
+			painter.setBrush(QColor(255, 255, 255, 188));
+			painter.drawRoundedRect(labelRect, 2.0 * ratio, 2.0 * ratio);
+			painter.setPen(QColor(15, 15, 15, 245));
+			painter.drawText(textPos, text);
+
+			occupied.append(padded);
+			++labelsDrawn;
+			return true;
+		};
+
+		bool drawnThisPlace = false;
+		for (double x = p.x; x < logicalWidth + mapWidth; x += mapWidth)
+		{
+			if (drawnThisPlace) break;
+			if (x < -mapWidth) continue;
+			drawnThisPlace = drawCandidate(x);
+		}
+
+		for (double x = p.x - mapWidth; x > -mapWidth; x -= mapWidth)
+		{
+			if (drawnThisPlace) break;
+			drawnThisPlace = drawCandidate(x);
+		}
+	}
+}
+
+void ObjectVisibilityMapWidget::paintEvent(QPaintEvent* event)
+{
+	// Step 1: let MapWidget render the world map, the marker, and any
+	// location filter.  This is the cheapest way to keep pan/zoom/HiDPI
+	// behaviour identical to LocationDialog's map.
+	MapWidget::paintEvent(event);
+
+	// Step 2: overlay our latitude lines.  Like the base class, we
+	// work in device-pixel space.
+	QPainter painter(this);
+	const double ratio = devicePixelRatioF();
+	painter.scale(1.0 / ratio, 1.0 / ratio);
+	painter.setRenderHint(QPainter::Antialiasing, true);
+
+	switch (currentOverlayMode)
+	{
+	case VisibilityOverlay:
+		if (hasDeclination)
+			drawVisibilityOverlay(painter);
+		break;
+	case TwilightLimitsOverlay:
+		if (hasTwilightObliquity)
+			drawTwilightLimitsOverlay(painter);
+		break;
+	}
+
+	drawPlaceLabels(painter);
 }

--- a/plugins/ObjectVisibility/src/gui/ObjectVisibilityMapWidget.hpp
+++ b/plugins/ObjectVisibility/src/gui/ObjectVisibilityMapWidget.hpp
@@ -23,12 +23,17 @@
 
 #include "MapWidget.hpp"
 
+#include <QString>
+#include <QVector>
+
 //! A MapWidget subclass that:
 //!  1. Optionally gates emission of positionChanged() through a "click
 //!     to set location" mode.  Outside of that mode, the user can pan
 //!     and zoom freely without ever moving the observer.
 //!  2. Overlays "visibility lines" on top of the map, computed from
 //!     the declination of a star/DSO.
+//!  3. Optionally overlays Earth-only twilight/solstice latitude
+//!     limits, computed from Earth's obliquity of date.
 //!
 //! All five line types are simply parallels of geographic latitude:
 //!   - limit-of-visibility:   phi = dec +/- 90
@@ -46,6 +51,29 @@ class ObjectVisibilityMapWidget : public MapWidget
 
 public:
 	explicit ObjectVisibilityMapWidget(QWidget *parent = nullptr);
+
+	enum OverlayMode
+	{
+		VisibilityOverlay,
+		TwilightLimitsOverlay
+	};
+
+	void setOverlayMode(OverlayMode mode);
+	OverlayMode overlayMode() const { return currentOverlayMode; }
+
+	struct PlaceLabel
+	{
+		QString name;
+		double longitude = 0.0;
+		double latitude = 0.0;
+		int population = 0;
+		QChar role;
+	};
+
+	void setPlaceLabels(const QVector<PlaceLabel>& labels);
+	void setPlaceLabelsVisible(bool visible);
+	void setPlaceLabelMinimumPopulation(int population);
+	void setPlaceLabelsNearLinesOnly(bool nearLinesOnly);
 
 	//! Enable/disable "click on map to set observer location" mode.
 	//! In normal mode, clicks on the map do nothing (panning/zooming
@@ -65,6 +93,13 @@ public:
 	//! Hide all visibility lines (e.g. when no object is selected).
 	void clearVisibility();
 
+	//! Set Earth obliquity of date (degrees) and draw the twilight
+	//! solstice limits. Pass a value outside (0, 90) to clear.
+	void setTwilightObliquity(double obliquityDeg);
+
+	//! Hide all twilight/solstice limit lines.
+	void clearTwilightLimits();
+
 signals:
 	//! Forwarded to the dialog when the user clicked on the map and we
 	//! were in click-to-set mode.  Mirrors MapWidget::positionChanged.
@@ -79,14 +114,29 @@ private slots:
 private:
 	void drawLatitudeLine(QPainter& painter, double latitudeDeg,
 	                      const QPen& pen) const;
+	void drawLatitudeLineCopies(QPainter& painter, double latitudeDeg,
+	                            const QPen& pen) const;
 	void drawLatitudeMarkers(QPainter& painter, double latitudeDeg,
 	                         const QChar& marker, const QColor& color) const;
+	void drawVisibilityOverlay(QPainter& painter) const;
+	void drawTwilightLimitsOverlay(QPainter& painter) const;
+	void drawPlaceLabels(QPainter& painter) const;
+	QVector<double> currentOverlayLatitudes() const;
 
+	OverlayMode currentOverlayMode = VisibilityOverlay;
 	bool   clickToSetMode = false;
 
 	bool   hasDeclination = false;
 	double declinationDeg = 0.0;
 	int    goodVisibilityDeg = 5;
+
+	bool   hasTwilightObliquity = false;
+	double twilightObliquityDeg = 0.0;
+
+	QVector<PlaceLabel> placeLabels;
+	bool showPlaceLabels = false;
+	int placeLabelMinimumPopulation = 1000000;
+	bool placeLabelsNearLinesOnly = true;
 };
 
 #endif // OBJECTVISIBILITYMAPWIDGET_HPP

--- a/plugins/ObjectVisibility/src/gui/objectVisibilityDialog.ui
+++ b/plugins/ObjectVisibility/src/gui/objectVisibilityDialog.ui
@@ -113,9 +113,9 @@
           <property name="bottomMargin">
            <number>6</number>
           </property>
-          <property name="horizontalSpacing">
-           <number>12</number>
-          </property>
+	          <property name="horizontalSpacing">
+	           <number>6</number>
+	          </property>
           <property name="verticalSpacing">
            <number>4</number>
           </property>
@@ -466,8 +466,21 @@
 	            </property>
 	           </widget>
 	          </item>
-	          <item row="0" column="2" colspan="2">
-	           <widget class="QLabel" name="twilightLegendHeaderLowest">
+	          <item row="0" column="2" rowspan="4">
+	           <spacer name="twilightLegendSpacerReferenceLowest">
+	            <property name="orientation">
+	             <enum>Qt::Horizontal</enum>
+	            </property>
+	            <property name="sizeHint" stdset="0">
+	             <size>
+	              <width>24</width>
+	              <height>10</height>
+	             </size>
+	            </property>
+	           </spacer>
+	          </item>
+	          <item row="0" column="3" colspan="2">
+		           <widget class="QLabel" name="twilightLegendHeaderLowest">
 	            <property name="styleSheet">
 	             <string notr="true">font-weight: bold;</string>
 	            </property>
@@ -476,8 +489,21 @@
 	            </property>
 	           </widget>
 	          </item>
-	          <item row="0" column="4" colspan="2">
-	           <widget class="QLabel" name="twilightLegendHeaderHighest">
+	          <item row="0" column="5" rowspan="4">
+	           <spacer name="twilightLegendSpacerLowestHighest">
+	            <property name="orientation">
+	             <enum>Qt::Horizontal</enum>
+	            </property>
+	            <property name="sizeHint" stdset="0">
+	             <size>
+	              <width>24</width>
+	              <height>10</height>
+	             </size>
+	            </property>
+	           </spacer>
+	          </item>
+	          <item row="0" column="6" colspan="2">
+		           <widget class="QLabel" name="twilightLegendHeaderHighest">
 	            <property name="styleSheet">
 	             <string notr="true">font-weight: bold;</string>
 	            </property>
@@ -538,7 +564,7 @@
 	           </widget>
 	          </item>
 
-	          <item row="1" column="2">
+	          <item row="1" column="3">
 	           <widget class="QLabel" name="twilightLegendSwatchCivilMin">
 	            <property name="styleSheet">
 	             <string notr="true">color: rgb(245,110,45); font-weight: bold; font-family: monospace;</string>
@@ -548,14 +574,14 @@
 	            </property>
 	           </widget>
 	          </item>
-	          <item row="1" column="3">
+	          <item row="1" column="4">
 	           <widget class="QLabel" name="twilightLegendTextCivilMin">
 	            <property name="text">
 	             <string>-6° civil</string>
 	            </property>
 	           </widget>
 	          </item>
-	          <item row="1" column="4">
+	          <item row="1" column="6">
 	           <widget class="QLabel" name="twilightLegendSwatchCivilMax">
 	            <property name="styleSheet">
 	             <string notr="true">color: rgb(205,60,60); font-weight: bold; font-family: monospace;</string>
@@ -565,7 +591,7 @@
 	            </property>
 	           </widget>
 	          </item>
-	          <item row="1" column="5">
+	          <item row="1" column="7">
 	           <widget class="QLabel" name="twilightLegendTextCivilMax">
 	            <property name="text">
 	             <string>-6° civil</string>
@@ -573,7 +599,7 @@
 	           </widget>
 	          </item>
 
-	          <item row="2" column="2">
+	          <item row="2" column="3">
 	           <widget class="QLabel" name="twilightLegendSwatchNautMin">
 	            <property name="styleSheet">
 	             <string notr="true">color: rgb(160,90,210); font-weight: bold; font-family: monospace;</string>
@@ -583,14 +609,14 @@
 	            </property>
 	           </widget>
 	          </item>
-	          <item row="2" column="3">
+	          <item row="2" column="4">
 	           <widget class="QLabel" name="twilightLegendTextNautMin">
 	            <property name="text">
 	             <string>-12° nautical</string>
 	            </property>
 	           </widget>
 	          </item>
-	          <item row="2" column="4">
+	          <item row="2" column="6">
 	           <widget class="QLabel" name="twilightLegendSwatchNautMax">
 	            <property name="styleSheet">
 	             <string notr="true">color: rgb(120,65,175); font-weight: bold; font-family: monospace;</string>
@@ -600,7 +626,7 @@
 	            </property>
 	           </widget>
 	          </item>
-	          <item row="2" column="5">
+	          <item row="2" column="7">
 	           <widget class="QLabel" name="twilightLegendTextNautMax">
 	            <property name="text">
 	             <string>-12° nautical</string>
@@ -608,7 +634,7 @@
 	           </widget>
 	          </item>
 
-	          <item row="3" column="2">
+	          <item row="3" column="3">
 	           <widget class="QLabel" name="twilightLegendSwatchAstroMin">
 	            <property name="styleSheet">
 	             <string notr="true">color: rgb(60,105,220); font-weight: bold; font-family: monospace;</string>
@@ -618,14 +644,14 @@
 	            </property>
 	           </widget>
 	          </item>
-	          <item row="3" column="3">
+	          <item row="3" column="4">
 	           <widget class="QLabel" name="twilightLegendTextAstroMin">
 	            <property name="text">
 	             <string>-18° astronomical</string>
 	            </property>
 	           </widget>
 	          </item>
-	          <item row="3" column="4">
+	          <item row="3" column="6">
 	           <widget class="QLabel" name="twilightLegendSwatchAstroMax">
 	            <property name="styleSheet">
 	             <string notr="true">color: rgb(35,70,160); font-weight: bold; font-family: monospace;</string>
@@ -635,7 +661,7 @@
 	            </property>
 	           </widget>
 	          </item>
-	          <item row="3" column="5">
+	          <item row="3" column="7">
 	           <widget class="QLabel" name="twilightLegendTextAstroMax">
 	            <property name="text">
 	             <string>-18° astronomical</string>

--- a/plugins/ObjectVisibility/src/gui/objectVisibilityDialog.ui
+++ b/plugins/ObjectVisibility/src/gui/objectVisibilityDialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>820</width>
-    <height>620</height>
+    <width>760</width>
+    <height>560</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -84,8 +84,8 @@
          </property>
          <property name="minimumSize">
           <size>
-           <width>400</width>
-           <height>200</height>
+             <width>360</width>
+             <height>180</height>
           </size>
          </property>
         </widget>
@@ -242,112 +242,139 @@
         </widget>
        </item>
 
-       <!-- Controls row -->
+       <!-- Controls -->
        <item>
-        <layout class="QHBoxLayout" name="controlsLayout">
+        <layout class="QVBoxLayout" name="controlsLayout">
          <property name="spacing">
-          <number>8</number>
+          <number>4</number>
          </property>
          <item>
-          <widget class="QPushButton" name="calculatePushButton">
-           <property name="text">
-            <string>Calculate</string>
+          <layout class="QHBoxLayout" name="visibilityControlsTopLayout">
+           <property name="spacing">
+            <number>6</number>
            </property>
-           <property name="toolTip">
-            <string>Compute visibility for the selected object.</string>
-           </property>
-          </widget>
+           <item>
+            <widget class="QPushButton" name="calculatePushButton">
+             <property name="text">
+              <string>Calculate</string>
+             </property>
+             <property name="toolTip">
+              <string>Compute visibility for the selected object.</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="Line" name="ctrlSep1">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="goodVisibilityLabel">
+             <property name="text">
+              <string>Good visibility:</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QSpinBox" name="goodVisibilityLimitSpinBox">
+             <property name="suffix">
+              <string>°</string>
+             </property>
+             <property name="minimum">
+              <number>1</number>
+             </property>
+             <property name="maximum">
+              <number>89</number>
+             </property>
+             <property name="value">
+              <number>5</number>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="resetSettingsPushButton">
+             <property name="text">
+              <string>Reset</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="ctrlSpacer">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>10</width>
+               <height>10</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
          </item>
          <item>
-          <widget class="Line" name="ctrlSep1">
-           <property name="orientation">
-            <enum>Qt::Vertical</enum>
+          <layout class="QHBoxLayout" name="visibilityControlsBottomLayout">
+           <property name="spacing">
+            <number>6</number>
            </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLabel" name="goodVisibilityLabel">
-           <property name="text">
-            <string>Good visibility above the horizon:</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QSpinBox" name="goodVisibilityLimitSpinBox">
-           <property name="suffix">
-            <string>°</string>
-           </property>
-           <property name="minimum">
-            <number>1</number>
-           </property>
-           <property name="maximum">
-            <number>89</number>
-           </property>
-           <property name="value">
-            <number>5</number>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <spacer name="ctrlSpacer">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>10</width>
-             <height>10</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item>
-          <widget class="QCheckBox" name="setLocationByClickCheckBox">
-           <property name="text">
-            <string>Set location by clicking on the map</string>
-           </property>
-           <property name="toolTip">
-            <string>Enable to move the observer by clicking on the map.  Stays active until you uncheck it — you can pick as many locations as you like.</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="Line" name="ctrlSep2">
-           <property name="orientation">
-            <enum>Qt::Vertical</enum>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QCheckBox" name="placeLabelsCheckBox">
-           <property name="text">
-            <string>Show place labels</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLabel" name="placeLabelsPopulationLabel">
-           <property name="text">
-            <string>Minimum population:</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QComboBox" name="placeLabelsPopulationComboBox"/>
-         </item>
-         <item>
-          <widget class="QCheckBox" name="placeLabelsNearLinesOnlyCheckBox">
-           <property name="text">
-            <string>Near lines only</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QPushButton" name="resetSettingsPushButton">
-           <property name="text">
-            <string>Reset settings</string>
-           </property>
-          </widget>
+           <item>
+            <widget class="QCheckBox" name="setLocationByClickCheckBox">
+             <property name="text">
+              <string>Set location by map click</string>
+             </property>
+             <property name="toolTip">
+              <string>Enable to move the observer by clicking on the map. Stays active until you uncheck it.</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="Line" name="ctrlSep2">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QCheckBox" name="placeLabelsCheckBox">
+             <property name="text">
+              <string>Places</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="placeLabelsPopulationLabel">
+             <property name="text">
+              <string>Min. population:</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QComboBox" name="placeLabelsPopulationComboBox"/>
+           </item>
+           <item>
+            <widget class="QCheckBox" name="placeLabelsNearLinesOnlyCheckBox">
+             <property name="text">
+              <string>Near lines</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="placeLabelSpacer">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>10</width>
+               <height>10</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
          </item>
         </layout>
        </item>
@@ -396,8 +423,8 @@
          </property>
          <property name="minimumSize">
           <size>
-           <width>400</width>
-           <height>200</height>
+             <width>360</width>
+             <height>180</height>
           </size>
          </property>
         </widget>
@@ -405,7 +432,7 @@
        <item>
         <widget class="QGroupBox" name="twilightLegendGroupBox">
          <property name="title">
-          <string>Key of solstice twilight limits</string>
+          <string>Solstice twilight limits</string>
          </property>
          <property name="styleSheet">
           <string notr="true">QGroupBox#twilightLegendGroupBox { background-color: white; color: black; } QGroupBox#twilightLegendGroupBox QLabel { background-color: transparent; color: black; }</string>
@@ -426,226 +453,276 @@
           <property name="horizontalSpacing">
            <number>12</number>
           </property>
-          <property name="verticalSpacing">
-           <number>4</number>
-          </property>
-          <item row="0" column="0">
-           <widget class="QLabel" name="twilightLegendSwatchEquator">
-            <property name="styleSheet">
-             <string notr="true">color: rgb(35,35,35); font-weight: bold; font-family: monospace;</string>
+	          <property name="verticalSpacing">
+	           <number>4</number>
+	          </property>
+	          <item row="0" column="0" colspan="2">
+	           <widget class="QLabel" name="twilightLegendHeaderReference">
+	            <property name="styleSheet">
+	             <string notr="true">font-weight: bold;</string>
+	            </property>
+	            <property name="text">
+	             <string>Reference lines</string>
+	            </property>
+	           </widget>
+	          </item>
+	          <item row="0" column="2" colspan="2">
+	           <widget class="QLabel" name="twilightLegendHeaderLowest">
+	            <property name="styleSheet">
+	             <string notr="true">font-weight: bold;</string>
+	            </property>
+	            <property name="text">
+	             <string>Lowest Sun</string>
+	            </property>
+	           </widget>
+	          </item>
+	          <item row="0" column="4" colspan="2">
+	           <widget class="QLabel" name="twilightLegendHeaderHighest">
+	            <property name="styleSheet">
+	             <string notr="true">font-weight: bold;</string>
+	            </property>
+	            <property name="text">
+	             <string>Highest Sun</string>
+	            </property>
+	           </widget>
+	          </item>
+	          <item row="1" column="0">
+	           <widget class="QLabel" name="twilightLegendSwatchEquator">
+	            <property name="styleSheet">
+	             <string notr="true">color: rgb(230,230,230); font-weight: bold; font-family: monospace;</string>
             </property>
             <property name="text">
              <string notr="true">────</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QLabel" name="twilightLegendTextEquator">
-            <property name="text">
-             <string>Equator</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="2">
-           <widget class="QLabel" name="twilightLegendSwatchTropic">
-            <property name="styleSheet">
-             <string notr="true">color: rgb(220,155,30); font-weight: bold; font-family: monospace;</string>
-            </property>
-            <property name="text">
-             <string notr="true">────</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="3">
-           <widget class="QLabel" name="twilightLegendTextTropic">
-            <property name="text">
-             <string>Tropics</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="4">
-           <widget class="QLabel" name="twilightLegendSwatchPolar">
-            <property name="styleSheet">
-             <string notr="true">color: rgb(0,150,170); font-weight: bold; font-family: monospace;</string>
-            </property>
+	            </property>
+	           </widget>
+	          </item>
+	          <item row="1" column="1">
+	           <widget class="QLabel" name="twilightLegendTextEquator">
+	            <property name="text">
+	             <string>Equator</string>
+	            </property>
+	           </widget>
+	          </item>
+	          <item row="2" column="0">
+	           <widget class="QLabel" name="twilightLegendSwatchTropic">
+	            <property name="styleSheet">
+	             <string notr="true">color: rgb(220,155,30); font-weight: bold; font-family: monospace;</string>
+	            </property>
             <property name="text">
              <string notr="true">────</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="5">
-           <widget class="QLabel" name="twilightLegendTextPolar">
+	            </property>
+	           </widget>
+	          </item>
+	          <item row="2" column="1">
+	           <widget class="QLabel" name="twilightLegendTextTropic">
+	            <property name="text">
+	             <string>Tropics</string>
+	            </property>
+	           </widget>
+	          </item>
+	          <item row="3" column="0">
+	           <widget class="QLabel" name="twilightLegendSwatchPolar">
+	            <property name="styleSheet">
+	             <string notr="true">color: rgb(0,120,145); font-weight: bold; font-family: monospace;</string>
+	            </property>
             <property name="text">
-             <string>Polar circles</string>
-            </property>
-           </widget>
-          </item>
+             <string notr="true">· · ·</string>
+	            </property>
+	           </widget>
+	          </item>
+	          <item row="3" column="1">
+	           <widget class="QLabel" name="twilightLegendTextPolar">
+	            <property name="text">
+	             <string>Polar circles</string>
+	            </property>
+	           </widget>
+	          </item>
 
-          <item row="1" column="0">
-           <widget class="QLabel" name="twilightLegendSwatchCivilMin">
-            <property name="styleSheet">
-             <string notr="true">color: rgb(245,110,45); font-weight: bold; font-family: monospace;</string>
-            </property>
+	          <item row="1" column="2">
+	           <widget class="QLabel" name="twilightLegendSwatchCivilMin">
+	            <property name="styleSheet">
+	             <string notr="true">color: rgb(245,110,45); font-weight: bold; font-family: monospace;</string>
+	            </property>
             <property name="text">
              <string notr="true">────</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1" colspan="2">
-           <widget class="QLabel" name="twilightLegendTextCivilMin">
-            <property name="text">
-             <string>Lowest Sun altitude at solstice: -6° (civil twilight)</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="3">
-           <widget class="QLabel" name="twilightLegendSwatchCivilMax">
-            <property name="styleSheet">
-             <string notr="true">color: rgb(205,60,60); font-weight: bold; font-family: monospace;</string>
-            </property>
+	            </property>
+	           </widget>
+	          </item>
+	          <item row="1" column="3">
+	           <widget class="QLabel" name="twilightLegendTextCivilMin">
+	            <property name="text">
+	             <string>-6° civil</string>
+	            </property>
+	           </widget>
+	          </item>
+	          <item row="1" column="4">
+	           <widget class="QLabel" name="twilightLegendSwatchCivilMax">
+	            <property name="styleSheet">
+	             <string notr="true">color: rgb(205,60,60); font-weight: bold; font-family: monospace;</string>
+	            </property>
             <property name="text">
              <string notr="true">- - -</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="4" colspan="2">
-           <widget class="QLabel" name="twilightLegendTextCivilMax">
-            <property name="text">
-             <string>Highest Sun altitude at solstice: -6° (civil twilight)</string>
-            </property>
-           </widget>
-          </item>
+	            </property>
+	           </widget>
+	          </item>
+	          <item row="1" column="5">
+	           <widget class="QLabel" name="twilightLegendTextCivilMax">
+	            <property name="text">
+	             <string>-6° civil</string>
+	            </property>
+	           </widget>
+	          </item>
 
-          <item row="2" column="0">
-           <widget class="QLabel" name="twilightLegendSwatchNautMin">
-            <property name="styleSheet">
-             <string notr="true">color: rgb(160,90,210); font-weight: bold; font-family: monospace;</string>
-            </property>
+	          <item row="2" column="2">
+	           <widget class="QLabel" name="twilightLegendSwatchNautMin">
+	            <property name="styleSheet">
+	             <string notr="true">color: rgb(160,90,210); font-weight: bold; font-family: monospace;</string>
+	            </property>
             <property name="text">
              <string notr="true">────</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1" colspan="2">
-           <widget class="QLabel" name="twilightLegendTextNautMin">
-            <property name="text">
-             <string>Lowest Sun altitude at solstice: -12° (nautical twilight)</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="3">
-           <widget class="QLabel" name="twilightLegendSwatchNautMax">
-            <property name="styleSheet">
-             <string notr="true">color: rgb(120,65,175); font-weight: bold; font-family: monospace;</string>
-            </property>
+	            </property>
+	           </widget>
+	          </item>
+	          <item row="2" column="3">
+	           <widget class="QLabel" name="twilightLegendTextNautMin">
+	            <property name="text">
+	             <string>-12° nautical</string>
+	            </property>
+	           </widget>
+	          </item>
+	          <item row="2" column="4">
+	           <widget class="QLabel" name="twilightLegendSwatchNautMax">
+	            <property name="styleSheet">
+	             <string notr="true">color: rgb(120,65,175); font-weight: bold; font-family: monospace;</string>
+	            </property>
             <property name="text">
              <string notr="true">- - -</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="4" colspan="2">
-           <widget class="QLabel" name="twilightLegendTextNautMax">
-            <property name="text">
-             <string>Highest Sun altitude at solstice: -12° (nautical twilight)</string>
-            </property>
-           </widget>
-          </item>
+	            </property>
+	           </widget>
+	          </item>
+	          <item row="2" column="5">
+	           <widget class="QLabel" name="twilightLegendTextNautMax">
+	            <property name="text">
+	             <string>-12° nautical</string>
+	            </property>
+	           </widget>
+	          </item>
 
-          <item row="3" column="0">
-           <widget class="QLabel" name="twilightLegendSwatchAstroMin">
-            <property name="styleSheet">
-             <string notr="true">color: rgb(60,105,220); font-weight: bold; font-family: monospace;</string>
-            </property>
+	          <item row="3" column="2">
+	           <widget class="QLabel" name="twilightLegendSwatchAstroMin">
+	            <property name="styleSheet">
+	             <string notr="true">color: rgb(60,105,220); font-weight: bold; font-family: monospace;</string>
+	            </property>
             <property name="text">
              <string notr="true">────</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="1" colspan="2">
-           <widget class="QLabel" name="twilightLegendTextAstroMin">
-            <property name="text">
-             <string>Lowest Sun altitude at solstice: -18° (astronomical twilight)</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="3">
-           <widget class="QLabel" name="twilightLegendSwatchAstroMax">
-            <property name="styleSheet">
-             <string notr="true">color: rgb(35,70,160); font-weight: bold; font-family: monospace;</string>
-            </property>
+	            </property>
+	           </widget>
+	          </item>
+	          <item row="3" column="3">
+	           <widget class="QLabel" name="twilightLegendTextAstroMin">
+	            <property name="text">
+	             <string>-18° astronomical</string>
+	            </property>
+	           </widget>
+	          </item>
+	          <item row="3" column="4">
+	           <widget class="QLabel" name="twilightLegendSwatchAstroMax">
+	            <property name="styleSheet">
+	             <string notr="true">color: rgb(35,70,160); font-weight: bold; font-family: monospace;</string>
+	            </property>
             <property name="text">
              <string notr="true">- - -</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="4" colspan="2">
-           <widget class="QLabel" name="twilightLegendTextAstroMax">
-            <property name="text">
-             <string>Highest Sun altitude at solstice: -18° (astronomical twilight)</string>
-            </property>
-           </widget>
-          </item>
+	            </property>
+	           </widget>
+	          </item>
+	          <item row="3" column="5">
+	           <widget class="QLabel" name="twilightLegendTextAstroMax">
+	            <property name="text">
+	             <string>-18° astronomical</string>
+	            </property>
+	           </widget>
+	          </item>
          </layout>
         </widget>
        </item>
        <item>
-        <layout class="QHBoxLayout" name="twilightControlsLayout">
+        <layout class="QVBoxLayout" name="twilightControlsLayout">
          <property name="spacing">
-          <number>8</number>
+          <number>4</number>
          </property>
          <item>
-          <spacer name="twilightCtrlSpacer">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
+          <layout class="QHBoxLayout" name="twilightControlsTopLayout">
+           <property name="spacing">
+            <number>6</number>
            </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>10</width>
-             <height>10</height>
-            </size>
-           </property>
-          </spacer>
+           <item>
+            <widget class="QCheckBox" name="twilightSetLocationByClickCheckBox">
+             <property name="text">
+              <string>Set location by map click</string>
+             </property>
+             <property name="toolTip">
+              <string>Enable to move the observer by clicking on the map. Available on Earth only.</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="twilightCtrlSpacer">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>10</width>
+               <height>10</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
          </item>
          <item>
-          <widget class="QCheckBox" name="twilightSetLocationByClickCheckBox">
-           <property name="text">
-            <string>Set location by clicking on the map</string>
+          <layout class="QHBoxLayout" name="twilightControlsBottomLayout">
+           <property name="spacing">
+            <number>6</number>
            </property>
-           <property name="toolTip">
-            <string>Enable to move the observer by clicking on the map. Available on Earth only.</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="Line" name="twilightCtrlSep1">
-           <property name="orientation">
-            <enum>Qt::Vertical</enum>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QCheckBox" name="twilightPlaceLabelsCheckBox">
-           <property name="text">
-            <string>Show place labels</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLabel" name="twilightPlaceLabelsPopulationLabel">
-           <property name="text">
-            <string>Minimum population:</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QComboBox" name="twilightPlaceLabelsPopulationComboBox"/>
-         </item>
-         <item>
-          <widget class="QCheckBox" name="twilightPlaceLabelsNearLinesOnlyCheckBox">
-           <property name="text">
-            <string>Near lines only</string>
-           </property>
-          </widget>
+           <item>
+            <widget class="QCheckBox" name="twilightPlaceLabelsCheckBox">
+             <property name="text">
+              <string>Places</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="twilightPlaceLabelsPopulationLabel">
+             <property name="text">
+              <string>Min. population:</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QComboBox" name="twilightPlaceLabelsPopulationComboBox"/>
+           </item>
+           <item>
+            <widget class="QCheckBox" name="twilightPlaceLabelsNearLinesOnlyCheckBox">
+             <property name="text">
+              <string>Near lines</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="twilightPlaceLabelSpacer">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>10</width>
+               <height>10</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
          </item>
         </layout>
        </item>

--- a/plugins/ObjectVisibility/src/gui/objectVisibilityDialog.ui
+++ b/plugins/ObjectVisibility/src/gui/objectVisibilityDialog.ui
@@ -312,9 +312,338 @@
           </widget>
          </item>
          <item>
+          <widget class="Line" name="ctrlSep2">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="placeLabelsCheckBox">
+           <property name="text">
+            <string>Show place labels</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="placeLabelsPopulationLabel">
+           <property name="text">
+            <string>Minimum population:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="placeLabelsPopulationComboBox"/>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="placeLabelsNearLinesOnlyCheckBox">
+           <property name="text">
+            <string>Near lines only</string>
+           </property>
+          </widget>
+         </item>
+         <item>
           <widget class="QPushButton" name="resetSettingsPushButton">
            <property name="text">
             <string>Reset settings</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+     </layout>
+     </widget>
+     <widget class="QWidget" name="twilightLimitsTab">
+      <attribute name="title">
+       <string>Twilight limits</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="twilightLimitsTabLayout">
+       <property name="spacing">
+        <number>6</number>
+       </property>
+       <property name="leftMargin">
+        <number>8</number>
+       </property>
+       <property name="topMargin">
+        <number>8</number>
+       </property>
+       <property name="rightMargin">
+        <number>8</number>
+       </property>
+       <property name="bottomMargin">
+        <number>8</number>
+       </property>
+       <item>
+        <widget class="QLabel" name="twilightTitleLabel">
+         <property name="text">
+          <string>Solstice twilight limits on Earth</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+         <property name="styleSheet">
+          <string notr="true">font-weight: bold; font-size: 14px;</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="ObjectVisibilityMapWidget" name="twilightMapWidget" native="true">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+           <horstretch>1</horstretch>
+           <verstretch>1</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>400</width>
+           <height>200</height>
+          </size>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="twilightLegendGroupBox">
+         <property name="title">
+          <string>Key of solstice twilight limits</string>
+         </property>
+         <property name="styleSheet">
+          <string notr="true">QGroupBox#twilightLegendGroupBox { background-color: white; color: black; } QGroupBox#twilightLegendGroupBox QLabel { background-color: transparent; color: black; }</string>
+         </property>
+         <layout class="QGridLayout" name="twilightLegendGridLayout">
+          <property name="leftMargin">
+           <number>8</number>
+          </property>
+          <property name="topMargin">
+           <number>6</number>
+          </property>
+          <property name="rightMargin">
+           <number>8</number>
+          </property>
+          <property name="bottomMargin">
+           <number>6</number>
+          </property>
+          <property name="horizontalSpacing">
+           <number>12</number>
+          </property>
+          <property name="verticalSpacing">
+           <number>4</number>
+          </property>
+          <item row="0" column="0">
+           <widget class="QLabel" name="twilightLegendSwatchEquator">
+            <property name="styleSheet">
+             <string notr="true">color: rgb(35,35,35); font-weight: bold; font-family: monospace;</string>
+            </property>
+            <property name="text">
+             <string notr="true">────</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QLabel" name="twilightLegendTextEquator">
+            <property name="text">
+             <string>Equator</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="2">
+           <widget class="QLabel" name="twilightLegendSwatchTropic">
+            <property name="styleSheet">
+             <string notr="true">color: rgb(220,155,30); font-weight: bold; font-family: monospace;</string>
+            </property>
+            <property name="text">
+             <string notr="true">────</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="3">
+           <widget class="QLabel" name="twilightLegendTextTropic">
+            <property name="text">
+             <string>Tropics</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="4">
+           <widget class="QLabel" name="twilightLegendSwatchPolar">
+            <property name="styleSheet">
+             <string notr="true">color: rgb(0,150,170); font-weight: bold; font-family: monospace;</string>
+            </property>
+            <property name="text">
+             <string notr="true">────</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="5">
+           <widget class="QLabel" name="twilightLegendTextPolar">
+            <property name="text">
+             <string>Polar circles</string>
+            </property>
+           </widget>
+          </item>
+
+          <item row="1" column="0">
+           <widget class="QLabel" name="twilightLegendSwatchCivilMin">
+            <property name="styleSheet">
+             <string notr="true">color: rgb(245,110,45); font-weight: bold; font-family: monospace;</string>
+            </property>
+            <property name="text">
+             <string notr="true">────</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1" colspan="2">
+           <widget class="QLabel" name="twilightLegendTextCivilMin">
+            <property name="text">
+             <string>Lowest Sun altitude at solstice: -6° (civil twilight)</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="3">
+           <widget class="QLabel" name="twilightLegendSwatchCivilMax">
+            <property name="styleSheet">
+             <string notr="true">color: rgb(205,60,60); font-weight: bold; font-family: monospace;</string>
+            </property>
+            <property name="text">
+             <string notr="true">- - -</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="4" colspan="2">
+           <widget class="QLabel" name="twilightLegendTextCivilMax">
+            <property name="text">
+             <string>Highest Sun altitude at solstice: -6° (civil twilight)</string>
+            </property>
+           </widget>
+          </item>
+
+          <item row="2" column="0">
+           <widget class="QLabel" name="twilightLegendSwatchNautMin">
+            <property name="styleSheet">
+             <string notr="true">color: rgb(160,90,210); font-weight: bold; font-family: monospace;</string>
+            </property>
+            <property name="text">
+             <string notr="true">────</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1" colspan="2">
+           <widget class="QLabel" name="twilightLegendTextNautMin">
+            <property name="text">
+             <string>Lowest Sun altitude at solstice: -12° (nautical twilight)</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="3">
+           <widget class="QLabel" name="twilightLegendSwatchNautMax">
+            <property name="styleSheet">
+             <string notr="true">color: rgb(120,65,175); font-weight: bold; font-family: monospace;</string>
+            </property>
+            <property name="text">
+             <string notr="true">- - -</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="4" colspan="2">
+           <widget class="QLabel" name="twilightLegendTextNautMax">
+            <property name="text">
+             <string>Highest Sun altitude at solstice: -12° (nautical twilight)</string>
+            </property>
+           </widget>
+          </item>
+
+          <item row="3" column="0">
+           <widget class="QLabel" name="twilightLegendSwatchAstroMin">
+            <property name="styleSheet">
+             <string notr="true">color: rgb(60,105,220); font-weight: bold; font-family: monospace;</string>
+            </property>
+            <property name="text">
+             <string notr="true">────</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1" colspan="2">
+           <widget class="QLabel" name="twilightLegendTextAstroMin">
+            <property name="text">
+             <string>Lowest Sun altitude at solstice: -18° (astronomical twilight)</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="3">
+           <widget class="QLabel" name="twilightLegendSwatchAstroMax">
+            <property name="styleSheet">
+             <string notr="true">color: rgb(35,70,160); font-weight: bold; font-family: monospace;</string>
+            </property>
+            <property name="text">
+             <string notr="true">- - -</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="4" colspan="2">
+           <widget class="QLabel" name="twilightLegendTextAstroMax">
+            <property name="text">
+             <string>Highest Sun altitude at solstice: -18° (astronomical twilight)</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="twilightControlsLayout">
+         <property name="spacing">
+          <number>8</number>
+         </property>
+         <item>
+          <spacer name="twilightCtrlSpacer">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>10</width>
+             <height>10</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="twilightSetLocationByClickCheckBox">
+           <property name="text">
+            <string>Set location by clicking on the map</string>
+           </property>
+           <property name="toolTip">
+            <string>Enable to move the observer by clicking on the map. Available on Earth only.</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="Line" name="twilightCtrlSep1">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="twilightPlaceLabelsCheckBox">
+           <property name="text">
+            <string>Show place labels</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="twilightPlaceLabelsPopulationLabel">
+           <property name="text">
+            <string>Minimum population:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="twilightPlaceLabelsPopulationComboBox"/>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="twilightPlaceLabelsNearLinesOnlyCheckBox">
+           <property name="text">
+            <string>Near lines only</string>
            </property>
           </widget>
          </item>


### PR DESCRIPTION
This branch adds a new tab to the Object Visibility plug-in; Twilight limits. It shows lines of latitude for the twilight stage limits during summer and winter solstices. For example, if someone is interested in showing the line of limit of the civil twilight in northern hemisphere summer solstice, the line is drawn on the map. Equator, tropic lines and polar circles are also drawn, as are limits of maximum solar altitude during winter solstice (think Longyearbyen, Svalbard during winter solstice with Sun reaching maximum -11.6 degrees). These lines are dashed.

We calculate according to the epoch of the planetarium, meaning we can follow e.g. the polar circle movement across millennia.

Another improvement to the plug-in, is location labels, called from Stellarium's own location database. We filter by population and avoid clutter when zooming out. This applies to both tabs.

Code was generated by AI (Codex). If this is interesting and worth merging, please test it thoroughly. Suggestions for improvement most welcome!

### Screenshots:
<img width="1528" height="1041" alt="bild" src="https://github.com/user-attachments/assets/bca6d5ae-82cc-4514-9caa-23953a89bbfb" />

<img width="1398" height="999" alt="bild" src="https://github.com/user-attachments/assets/0cb64248-a1db-4634-8a31-ac5609422917" />

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] This change requires a documentation update
- [ ] Housekeeping

**Test Configuration**:
Fedora 44
Qt 6.11.1

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
