### PR TITLE
cmake: add OHOS platform detection module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,6 +127,7 @@ ENDIF()
 # Use customized cmake macros
 SET(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/modules)
 INCLUDE(CPM)
+INCLUDE(StellariumPlatform)
 
 # Show platform info
 MESSAGE(STATUS "Platform: ${CMAKE_SYSTEM} (${CMAKE_SYSTEM_PROCESSOR})")

--- a/cmake/modules/StellariumPlatform.cmake
+++ b/cmake/modules/StellariumPlatform.cmake
@@ -1,0 +1,6 @@
+# Centralized platform detection for platform-specific build configuration.
+# The OpenHarmony toolchain identifies the target through CMAKE_SYSTEM_NAME.
+SET(STELLARIUM_PLATFORM_OHOS FALSE)
+IF(CMAKE_SYSTEM_NAME STREQUAL "OHOS")
+     SET(STELLARIUM_PLATFORM_OHOS TRUE)
+ENDIF()


### PR DESCRIPTION
## Summary

Add a small CMake module that exposes `STELLARIUM_PLATFORM_OHOS` when the OpenHarmony toolchain sets `CMAKE_SYSTEM_NAME` to `OHOS`.

This is intentionally limited to platform detection. Follow-up patches will use this flag to make unavailable Qt modules optional, one feature at a time.

## Validation

- Rebased onto current `master` (`a8d81f7fb1`).
- `git diff --check` passes.
- Verified the module with the DevEco CMake 3.28.2 runner.
- A full local configure is not available on this machine because it does not have a desktop Qt SDK installed.

## Scope

No Harmony application code, signing material, generated files, or UI changes are included.