### PR TITLE
Fix link error when --as-needed linker flag set

### DIFF
--- a/plugins/TelescopeControl/src/gui/CMakeLists.txt
+++ b/plugins/TelescopeControl/src/gui/CMakeLists.txt
@@ -31,6 +31,7 @@ target_link_libraries(TelescopeControl_gui
     Qt${QT_VERSION_MAJOR}::Network
     Qt${QT_VERSION_MAJOR}::Gui
     Qt${QT_VERSION_MAJOR}::OpenGL
+    Qt${QT_VERSION_MAJOR}::SerialPort
     TelescopeControl_common
     )
 


### PR DESCRIPTION
### Description

In Gentoo Linux ([https://bugs.gentoo.org/980281](https://bugs.gentoo.org/980281)), the build fails at the final link step, not during compilation:

plugins/TelescopeControl/src/gui/libTelescopeControl_gui.a(TelescopeConfigurationDialog.cpp.o): undefined reference to `QSerialPortInfo::availablePorts()'
collect2: error: ld returned 1 exit status

TelescopeConfigurationDialog.cpp (in the TelescopeControl plugin's GUI sub-library) uses QSerialPortInfo, but plugins/TelescopeControl/src/gui/CMakeLists.txt never links Qt::SerialPort for that target; it only links Core, Network, Gui, OpenGL, and TelescopeControl_common.

The parent target, TelescopeControl-static, does link Qt::SerialPort; but it does so before it links the gui sub-library in the CMakeLists.txt (two separate TARGET_LINK_LIBRARIES calls, SerialPort first). That ordering flows straight through into the final executable's link command: libQt6SerialPort.so appears on the link line before libTelescopeControl_gui.a.

Combined with Gentoo's default -Wl,--as-needed linker flag, this is fatal: ld processes the command line left-to-right, and when it reaches libQt6SerialPort.so no prior object yet needs its symbols, so --as-needed drops it. By the time libTelescopeControl_gui.a is processed and needs QSerialPortInfo, the linker has already passed over (and discarded) the one library that provides it.

### Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system: Gentoo Linux
* Graphics Card:  Intel Corporation CoffeeLake-H GT2 [UHD Graphics 630]

## Checklist:
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
