### PR TITLE
Nova light curve continuity

### DIFF
--- a/plugins/Novae/src/Nova.cpp
+++ b/plugins/Novae/src/Nova.cpp
@@ -265,7 +265,8 @@ float Nova::getVMagnitude(const StelCore* core) const
 		float step;
 		float d2 = maxMagnitude+2.f;
 		float d3 = maxMagnitude+3.f;
-		float d6 = maxMagnitude+6.f;		
+		float d6 = maxMagnitude+6.f;
+		float d9 = maxMagnitude+9.f;
 
 		if (deltaJD>0 && deltaJD<=t2)
 		{
@@ -275,24 +276,27 @@ float Nova::getVMagnitude(const StelCore* core) const
 
 		if (deltaJD>t2 && deltaJD<=t3)
 		{
-			step = 3.f/t3;
+			step = 1.f/(t3-t2);
 			vmag = d2 + step*(deltaJD-t2);
 		}
 
 		if (deltaJD>t3 && deltaJD<=t6)
 		{
-			step = 6.f/t6;
+			step = 3.f/(t6-t3);
 			vmag = d3 + step*(deltaJD-t3);
 		}
 
 		if (deltaJD>t6 && deltaJD<=t9)
 		{
-			step = 9.f/t9;
+			step = 3.f/(t9-t6);
 			vmag = d6 + step*(deltaJD-t6);
 		}
 
 		if (deltaJD>t9)
-			vmag = minMagnitude;
+		{
+			step = 9.f/t9;
+			vmag = d9 + step*(deltaJD-t9);
+		}
 	}
 	else
 	{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Nova::getVMagnitude is modified to produce a more continuous light curve.

### Description
<!--- Please include a summary of the change and which issue is fixed. -->
<!--- Please also include relevant motivation and context. -->
The previous implementation had unintended step changes in magnitude t3=30 and t6=100 days after peak for a type "NA" nova with default light curve parameters. A step change t9=400 days after peak appeared intentional, but I considered it undesirable.
This change corrects the interpolations and adds an extrapolation so that the magnitude before and after t2, t3, t6, and t9 has the expected values and is continuous.
<!--- List any dependencies that are required for this change. -->

Fixes # (issue)

### Screenshots (if appropriate):

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
In the application, I searched for Nova Lupi 2025, which is listed in novae.json as type "NA," peaking on JD 2460847.248765 (2025-06-20 17:58 UTC) at magnitude 4.741.
With no atmosphere, I verified that its magnitude was close to these values at both 17:30 and 18:30 UTC on these dates:
2025-06-30, magnitude 6.74;
2025-07-20, magnitude 7.74;
2025-09-28, magnitude 10.74;
2026-07-25, magnitude 13.74.

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system: Ubuntu 24.04
* Graphics Card: Intel HD 4600

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
