### PR TITLE
Improved sorting in AstroCalc/WUT tool

### DIFF
--- a/src/gui/AstroCalcDialog.cpp
+++ b/src/gui/AstroCalcDialog.cpp
@@ -8105,6 +8105,7 @@ void AstroCalcDialog::calculateWutObjects()
 		}
 
 		initListWUT();
+		ui->wutMatchingObjectsTreeWidget->setSortingEnabled(false);
 		ui->wutMatchingObjectsTreeWidget->showColumn(WUTMagnitude);
 		ui->wutMatchingObjectsTreeWidget->showColumn(WUTAngularSize);		
 		objectsList.clear();
@@ -8693,6 +8694,8 @@ void AstroCalcDialog::calculateWutObjects()
 		enableAngularLimits(enableAngular);
 		core->setJD(JD);
 		adjustWUTColumns();
+		ui->wutMatchingObjectsTreeWidget->setSortingEnabled(true);
+		ui->wutMatchingObjectsTreeWidget->sortByColumn(WUTObjectName, Qt::AscendingOrder);
 		if (!objectsList.isEmpty())
 			ui->saveObjectsButton->setEnabled(true);
 		else

--- a/src/gui/AstroCalcDialog.hpp
+++ b/src/gui/AstroCalcDialog.hpp
@@ -1172,14 +1172,17 @@ private:
 
 		if (column == AstroCalcDialog::WUTObjectName)
 		{
+			int a, b;
+			QString an, ax, bn, bx;
+
 			// minor planets
 			static const QRegularExpression mp("^[(](\\d+)[)]\\s(.+)$");
 			QRegularExpressionMatch mpMatch=mp.match(text(column));
 			QRegularExpressionMatch mpOtherMatch=mp.match(other.text(column));
 			if (mpMatch.hasMatch() && mpOtherMatch.hasMatch())
 			{
-				int a = mpMatch.captured(1).toInt();
-				int b = mpOtherMatch.captured(1).toInt();
+				a = mpMatch.captured(1).toInt();
+				b = mpOtherMatch.captured(1).toInt();
 				return a < b;
 			}
 
@@ -1189,9 +1192,9 @@ private:
 			QRegularExpressionMatch periodicOtherMatch=periodic.match(other.text(column));
 			if (periodicMatch.hasMatch() && periodicOtherMatch.hasMatch())
 			{
-				int apc = periodicMatch.captured(1).toInt();
-				int bpc = periodicOtherMatch.captured(1).toInt();
-				return apc < bpc;
+				a = periodicMatch.captured(1).toInt();
+				b = periodicOtherMatch.captured(1).toInt();
+				return a < b;
 			}
 
 			// deep-sky objects
@@ -1201,17 +1204,17 @@ private:
 			QRegularExpressionMatch dsoOtherMatch=dso.match(other.text(column));
 			if (dsoMatch.hasMatch() && dsoOtherMatch.hasMatch())
 			{
-				QString ap = dsoMatch.captured(1).toLower();
-				QString an = dsoMatch.captured(2);
+				ax = dsoMatch.captured(1).toLower();
+				an = dsoMatch.captured(2);
 				an.replace(rx, "0");
 				an = an.rightJustified(10, '0');
 
-				QString bp = dsoOtherMatch.captured(1).toLower();
-				QString bn = dsoOtherMatch.captured(2);
+				bx = dsoOtherMatch.captured(1).toLower();
+				bn = dsoOtherMatch.captured(2);
 				bn.replace(rx, "0");
 				bn = bn.rightJustified(10, '0');
 
-				return QString("%1 %2").arg(ap, an) < QString("%1 %2").arg(bp, bn);
+				return QString("%1 %2").arg(ax, an) < QString("%1 %2").arg(bx, bn);
 			}
 
 			// HIP-like stars (standard modern designation: CAT XXXXX)
@@ -1220,13 +1223,13 @@ private:
 			QRegularExpressionMatch hipOtherMatch=hip.match(other.text(column));
 			if (hipMatch.hasMatch() && hipOtherMatch.hasMatch())
 			{
-				QString asx = hipMatch.captured(1);
-				QString asn = hipMatch.captured(2).rightJustified(7, '0');
+				ax = hipMatch.captured(1);
+				an = hipMatch.captured(2).rightJustified(7, '0');
 
-				QString bsx = hipOtherMatch.captured(1);
-				QString bsn = hipOtherMatch.captured(2).rightJustified(7, '0');
+				bx = hipOtherMatch.captured(1);
+				bn = hipOtherMatch.captured(2).rightJustified(7, '0');
 
-				return QString("%1 %2").arg(asx, asn) < QString("%1 %2").arg(bsx, bsn);
+				return QString("%1 %2").arg(ax, an) < QString("%1 %2").arg(bx, bn);
 			}
 
 			return StelUtils::naturalLessThan(text(column).toLower(), other.text(column).toLower());

--- a/src/gui/AstroCalcDialog.hpp
+++ b/src/gui/AstroCalcDialog.hpp
@@ -1204,28 +1204,6 @@ private:
 			}
 
 			return StelUtils::naturalLessThan(text(column).toLower(), other.text(column).toLower());
-
-			/*
-			static const QRegularExpression dso("^(\\w+)\\s*(\\d+)\\s*(.*)$");
-			static const QRegularExpression mp("^[(](\\d+)[)]\\s(.+)$");
-			QRegularExpressionMatch dsoMatch=dso.match(text(column));
-			QRegularExpressionMatch mpMatch=mp.match(text(column));
-			QRegularExpressionMatch dsoOtherMatch=dso.match(other.text(column));
-			QRegularExpressionMatch mpOtherMatch=mp.match(other.text(column));
-			int a = 0, b = 0;
-			if (dsoMatch.hasMatch())
-				a = dsoMatch.captured(2).toInt();
-			if (a==0 && mpMatch.hasMatch())
-				a = mpMatch.captured(1).toInt();
-			if (dsoOtherMatch.hasMatch())
-				b = dsoOtherMatch.captured(2).toInt();
-			if (b==0 && mpOtherMatch.hasMatch())
-				b = mpOtherMatch.captured(1).toInt();
-			if (a>0 && b>0)
-				return a < b;
-			else
-				return text(column).toLower() < other.text(column).toLower();
-			*/
 		}
 		else if (column == AstroCalcDialog::WUTMagnitude)
 		{

--- a/src/gui/AstroCalcDialog.hpp
+++ b/src/gui/AstroCalcDialog.hpp
@@ -1203,6 +1203,21 @@ private:
 				return QString("%1 %2").arg(ap, an) < QString("%1 %2").arg(bp, bn);
 			}
 
+			// HIP-like stars (standard modern designation: CAT XXXXX)
+			static const QRegularExpression hip("^(\\w+)\\s(\\d+)\\s*\\w*$");
+			QRegularExpressionMatch hipMatch=hip.match(text(column));
+			QRegularExpressionMatch hipOtherMatch=hip.match(other.text(column));
+			if (hipMatch.hasMatch() && hipOtherMatch.hasMatch())
+			{
+				QString asx = hipMatch.captured(1);
+				QString asn = hipMatch.captured(2).rightJustified(7, '0');
+
+				QString bsx = hipOtherMatch.captured(1);
+				QString bsn = hipOtherMatch.captured(2).rightJustified(7, '0');
+
+				return QString("%1 %2").arg(asx, asn) < QString("%1 %2").arg(bsx, bsn);
+			}
+
 			return StelUtils::naturalLessThan(text(column).toLower(), other.text(column).toLower());
 		}
 		else if (column == AstroCalcDialog::WUTMagnitude)

--- a/src/gui/AstroCalcDialog.hpp
+++ b/src/gui/AstroCalcDialog.hpp
@@ -1183,6 +1183,26 @@ private:
 				return a < b;
 			}
 
+			// deep-sky objects
+			static const QRegularExpression dso("^(\\w+)\\s*([\\d\\-\\+\\.]+)\\s*(.*)$");
+			static const QRegularExpression rx("[\\-\\+\\.]+");
+			QRegularExpressionMatch dsoMatch=dso.match(text(column));
+			QRegularExpressionMatch dsoOtherMatch=dso.match(other.text(column));
+			if (dsoMatch.hasMatch() && dsoOtherMatch.hasMatch())
+			{
+				QString ap = dsoMatch.captured(1).toLower();
+				QString an = dsoMatch.captured(2);
+				an.replace(rx, "0");
+				an = an.rightJustified(10, '0');
+
+				QString bp = dsoOtherMatch.captured(1).toLower();
+				QString bn = dsoOtherMatch.captured(2);
+				bn.replace(rx, "0");
+				bn = bn.rightJustified(10, '0');
+
+				return QString("%1 %2").arg(ap, an) < QString("%1 %2").arg(bp, bn);
+			}
+
 			return StelUtils::naturalLessThan(text(column).toLower(), other.text(column).toLower());
 
 			/*

--- a/src/gui/AstroCalcDialog.hpp
+++ b/src/gui/AstroCalcDialog.hpp
@@ -1172,6 +1172,28 @@ private:
 
 		if (column == AstroCalcDialog::WUTObjectName)
 		{
+			static const QRegularExpression mp("^[(](\\d+)[)]\\s(.+)$");
+			QRegularExpressionMatch mpMatch=mp.match(text(column));
+			QRegularExpressionMatch mpOtherMatch=mp.match(other.text(column));
+			int a = 0, b = 0;
+			bool isMP = false;
+			if (mpMatch.hasMatch())
+			{
+				a = mpMatch.captured(1).toInt();
+				isMP = true;
+			}
+			if (mpOtherMatch.hasMatch())
+			{
+				b = mpOtherMatch.captured(1).toInt();
+				isMP = true;
+			}
+
+			if (isMP) // minor planets
+				return a < b; // compare by MPC numbers
+			else
+				return text(column).toLower() < other.text(column).toLower();
+
+			/*
 			static const QRegularExpression dso("^(\\w+)\\s*(\\d+)\\s*(.*)$");
 			static const QRegularExpression mp("^[(](\\d+)[)]\\s(.+)$");
 			QRegularExpressionMatch dsoMatch=dso.match(text(column));
@@ -1191,6 +1213,7 @@ private:
 				return a < b;
 			else
 				return text(column).toLower() < other.text(column).toLower();
+			*/
 		}
 		else if (column == AstroCalcDialog::WUTMagnitude)
 		{

--- a/src/gui/AstroCalcDialog.hpp
+++ b/src/gui/AstroCalcDialog.hpp
@@ -1183,6 +1183,17 @@ private:
 				return a < b;
 			}
 
+			// periodic comets
+			static const QRegularExpression periodic("^(\\d+)P/([\\w\\-]+)\\s[(](\\d+)[)]$");
+			QRegularExpressionMatch periodicMatch=periodic.match(text(column));
+			QRegularExpressionMatch periodicOtherMatch=periodic.match(other.text(column));
+			if (periodicMatch.hasMatch() && periodicOtherMatch.hasMatch())
+			{
+				int apc = periodicMatch.captured(1).toInt();
+				int bpc = periodicOtherMatch.captured(1).toInt();
+				return apc < bpc;
+			}
+
 			// deep-sky objects
 			static const QRegularExpression dso("^(\\w+)\\s*([\\d\\-\\+\\.]+)\\s*(.*)$");
 			static const QRegularExpression rx("[\\-\\+\\.]+");

--- a/src/gui/AstroCalcDialog.hpp
+++ b/src/gui/AstroCalcDialog.hpp
@@ -1176,26 +1176,14 @@ private:
 			static const QRegularExpression mp("^[(](\\d+)[)]\\s(.+)$");
 			QRegularExpressionMatch mpMatch=mp.match(text(column));
 			QRegularExpressionMatch mpOtherMatch=mp.match(other.text(column));
-
-			int a = 0, b = 0;
-			bool isMP = false;
-
-			// minor planets
-			if (mpMatch.hasMatch())
+			if (mpMatch.hasMatch() && mpOtherMatch.hasMatch())
 			{
-				a = mpMatch.captured(1).toInt();
-				isMP = true;
-			}
-			if (mpOtherMatch.hasMatch())
-			{
-				b = mpOtherMatch.captured(1).toInt();
-				isMP = true;
+				int a = mpMatch.captured(1).toInt();
+				int b = mpOtherMatch.captured(1).toInt();
+				return a < b;
 			}
 
-			if (isMP) // minor planets
-				return a < b; // compare by MPC numbers
-			else
-				return StelUtils::naturalLessThan(text(column).toLower(), other.text(column).toLower());
+			return StelUtils::naturalLessThan(text(column).toLower(), other.text(column).toLower());
 
 			/*
 			static const QRegularExpression dso("^(\\w+)\\s*(\\d+)\\s*(.*)$");

--- a/src/gui/AstroCalcDialog.hpp
+++ b/src/gui/AstroCalcDialog.hpp
@@ -1172,11 +1172,15 @@ private:
 
 		if (column == AstroCalcDialog::WUTObjectName)
 		{
+			// minor planets
 			static const QRegularExpression mp("^[(](\\d+)[)]\\s(.+)$");
 			QRegularExpressionMatch mpMatch=mp.match(text(column));
 			QRegularExpressionMatch mpOtherMatch=mp.match(other.text(column));
+
 			int a = 0, b = 0;
 			bool isMP = false;
+
+			// minor planets
 			if (mpMatch.hasMatch())
 			{
 				a = mpMatch.captured(1).toInt();
@@ -1191,7 +1195,7 @@ private:
 			if (isMP) // minor planets
 				return a < b; // compare by MPC numbers
 			else
-				return text(column).toLower() < other.text(column).toLower();
+				return StelUtils::naturalLessThan(text(column).toLower(), other.text(column).toLower());
 
 			/*
 			static const QRegularExpression dso("^(\\w+)\\s*(\\d+)\\s*(.*)$");


### PR DESCRIPTION
### Description
Fixing and updating sorting rules for AstroCalc/WUT tool.

Added special sorting rules:
- [x] Minor planets
- [x] Periodic comets
- [x] Deep-Sky Objects
- [x] HIP-like stars (standard modern designation: CAT XXXXX)

So, categories with DSO and SSO are completed now, categories with stars are completed partially at the moment.

See #3812 (issue)

### Screenshots (if appropriate):

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
