### PR TITLE
Improve two first tabs of Object Visibility plug-in

### DIFF
--- a/plugins/ObjectVisibility/src/ObjectVisibility.cpp
+++ b/plugins/ObjectVisibility/src/ObjectVisibility.cpp
@@ -101,6 +101,7 @@ ObjectVisibility::ObjectVisibility()
 	, placeLabelsVisible(false)
 	, placeLabelsMinimumPopulation(1000000)
 	, placeLabelsNearLinesOnly(true)
+	, visibilityAutoCompute(false)
 	, syncMaps(false)
 	, conf(nullptr)
 #ifndef NO_GUI
@@ -206,12 +207,15 @@ void ObjectVisibility::loadSettings()
 		conf->value("place_labels_minimum_population", 1000000).toInt());
 	const bool labelsNearLinesOnly =
 		conf->value("place_labels_near_lines_only", true).toBool();
+	const bool autoCompute =
+		conf->value("visibility_auto_compute", false).toBool();
 	const bool mapsSynced = conf->value("sync_maps", false).toBool();
 	conf->endGroup();
 	setGoodVisibilityLimit(std::clamp(v, 1, 89));
 	setPlaceLabelsVisible(labelsVisible);
 	setPlaceLabelsMinimumPopulation(minPopulation);
 	setPlaceLabelsNearLinesOnly(labelsNearLinesOnly);
+	setVisibilityAutoCompute(autoCompute);
 	setSyncMaps(mapsSynced);
 }
 
@@ -224,6 +228,7 @@ void ObjectVisibility::restoreDefaultSettings()
 	conf->setValue("place_labels_visible", false);
 	conf->setValue("place_labels_minimum_population", 1000000);
 	conf->setValue("place_labels_near_lines_only", true);
+	conf->setValue("visibility_auto_compute", false);
 	conf->setValue("sync_maps", false);
 	conf->endGroup();
 	loadSettings();
@@ -286,6 +291,20 @@ void ObjectVisibility::setPlaceLabelsNearLinesOnly(bool nearLinesOnly)
 		conf->beginGroup("ObjectVisibility");
 		conf->setValue("place_labels_near_lines_only",
 		               placeLabelsNearLinesOnly);
+		conf->endGroup();
+	}
+}
+
+void ObjectVisibility::setVisibilityAutoCompute(bool enabled)
+{
+	if (enabled == visibilityAutoCompute)
+		return;
+	visibilityAutoCompute = enabled;
+
+	if (conf)
+	{
+		conf->beginGroup("ObjectVisibility");
+		conf->setValue("visibility_auto_compute", visibilityAutoCompute);
 		conf->endGroup();
 	}
 }

--- a/plugins/ObjectVisibility/src/ObjectVisibility.hpp
+++ b/plugins/ObjectVisibility/src/ObjectVisibility.hpp
@@ -103,6 +103,7 @@ public:
 	bool getPlaceLabelsVisible() const { return placeLabelsVisible; }
 	int getPlaceLabelsMinimumPopulation() const { return placeLabelsMinimumPopulation; }
 	bool getPlaceLabelsNearLinesOnly() const { return placeLabelsNearLinesOnly; }
+	bool getVisibilityAutoCompute() const { return visibilityAutoCompute; }
 	bool getSyncMaps() const { return syncMaps; }
 
 signals:
@@ -113,6 +114,7 @@ public slots:
 	void setPlaceLabelsVisible(bool visible);
 	void setPlaceLabelsMinimumPopulation(int population);
 	void setPlaceLabelsNearLinesOnly(bool nearLinesOnly);
+	void setVisibilityAutoCompute(bool enabled);
 	void setSyncMaps(bool enabled);
 
 private:
@@ -120,6 +122,7 @@ private:
 	bool placeLabelsVisible;
 	int placeLabelsMinimumPopulation;
 	bool placeLabelsNearLinesOnly;
+	bool visibilityAutoCompute;
 	bool syncMaps;
 	QSettings* conf;
 

--- a/plugins/ObjectVisibility/src/gui/ObjectVisibilityDialog.cpp
+++ b/plugins/ObjectVisibility/src/gui/ObjectVisibilityDialog.cpp
@@ -284,9 +284,10 @@ void ObjectVisibilityDialog::updateCalculateButtonEnabled()
 	StelCore* core = StelApp::getInstance().getCore();
 	const QString planet = core->getCurrentLocation().planetName;
 	const bool planetOk = isSupportedPlanet(planet);
+	const bool autoCalculate = ui->visibilityAutoComputeCheckBox->isChecked();
 
 	const bool acceptable = typeOk && planetOk;
-	ui->calculatePushButton->setEnabled(acceptable);
+	ui->calculatePushButton->setEnabled(acceptable && !autoCalculate);
 
 	QString tip;
 	if (!typeOk)
@@ -296,8 +297,10 @@ void ObjectVisibilityDialog::updateCalculateButtonEnabled()
 		         "Moon, the eight planets, Pluto and the four Galilean "
 		         "moons.  The current observing body (%1) is not "
 		         "supported.").arg(planet);
+	else if (autoCalculate)
+		tip = q_("Turn off Calculate automatically to use this button.");
 	else
-		tip = q_("Compute visibility for the selected object.");
+		tip = q_("Calculate visibility for the selected object.");
 	ui->calculatePushButton->setToolTip(tip);
 }
 

--- a/plugins/ObjectVisibility/src/gui/ObjectVisibilityDialog.cpp
+++ b/plugins/ObjectVisibility/src/gui/ObjectVisibilityDialog.cpp
@@ -79,8 +79,12 @@ void ObjectVisibilityDialog::setVisible(bool visible)
 {
 	StelDialog::setVisible(visible);
 	updateTwilightMapTimerState();
+	if (visible && isAutoVisibilityTabActive())
+		refreshVisibility();
 	if (visible && isLiveTwilightMapTabActive())
 		scheduleTwilightMapRefresh();
+	if (visible && isDailyTwilightLimitsTabActive())
+		refreshTwilightLimits();
 }
 
 //
@@ -96,6 +100,8 @@ void ObjectVisibilityDialog::createDialogContent()
 	placeLabelsMinimumPopulation = plugin->getPlaceLabelsMinimumPopulation();
 	placeLabelsNearLinesOnly = plugin->getPlaceLabelsNearLinesOnly();
 	syncMaps = plugin->getSyncMaps();
+	ui->visibilityAutoComputeCheckBox->setChecked(
+		plugin->getVisibilityAutoCompute());
 
 	// Standard kinetic scrolling for the About browser.
 	kineticScrollingList << ui->aboutTextBrowser;
@@ -169,12 +175,16 @@ void ObjectVisibilityDialog::createDialogContent()
 	        this, &ObjectVisibilityDialog::onTwilightPlaceLabelsNearLinesOnlyToggled);
 	connect(ui->twilightMapPlaceLabelsNearLinesOnlyCheckBox, &QCheckBox::toggled,
 	        this, &ObjectVisibilityDialog::onLiveTwilightPlaceLabelsNearLinesOnlyToggled);
+	connect(ui->visibilityAutoComputeCheckBox, &QCheckBox::toggled,
+	        this, &ObjectVisibilityDialog::onVisibilityAutoComputeToggled);
 	connect(ui->syncMapsCheckBox, &QCheckBox::toggled,
 	        this, &ObjectVisibilityDialog::onSyncMapsToggled);
 	connect(ui->twilightSyncMapsCheckBox, &QCheckBox::toggled,
 	        this, &ObjectVisibilityDialog::onSyncMapsToggled);
 	connect(ui->twilightMapSyncMapsCheckBox, &QCheckBox::toggled,
 	        this, &ObjectVisibilityDialog::onSyncMapsToggled);
+	connect(ui->twilightComputeDailyCheckBox, &QCheckBox::toggled,
+	        this, &ObjectVisibilityDialog::onTwilightComputeDailyToggled);
 	connect(ui->tabs, &QTabWidget::currentChanged,
 	        this, &ObjectVisibilityDialog::onTabChanged);
 
@@ -211,13 +221,15 @@ void ObjectVisibilityDialog::createDialogContent()
 	connect(core, &StelCore::locationChanged,
 	        this, &ObjectVisibilityDialog::syncMarkerToObserver);
 	connect(core, &StelCore::dateChanged,
+	        this, &ObjectVisibilityDialog::refreshVisibility);
+	connect(core, &StelCore::dateChanged,
 	        this, &ObjectVisibilityDialog::refreshTwilightLimits);
 	connect(core, &StelCore::dateChanged,
 	        this, &ObjectVisibilityDialog::scheduleTwilightMapRefresh);
 	twilightMapTimer = new QTimer(this);
 	twilightMapTimer->setInterval(1000);
 	connect(twilightMapTimer, &QTimer::timeout,
-	        this, qOverload<>(&ObjectVisibilityDialog::refreshTwilightMap));
+	        this, &ObjectVisibilityDialog::onTwilightTimerTimeout);
 	updateTwilightMapTimerState();
 	syncMarkerToObserver();
 
@@ -246,6 +258,11 @@ bool ObjectVisibilityDialog::isAcceptableType(const QString& type)
 void ObjectVisibilityDialog::onSelectedObjectChanged()
 {
 	updateCalculateButtonEnabled();
+	if (isAutoVisibilityTabActive())
+	{
+		refreshVisibility();
+		return;
+	}
 	// In the pre-Calculate state, the label depends on what's
 	// selected — refresh it so the user gets immediate feedback
 	// about whether the new selection is acceptable.  Once
@@ -286,13 +303,17 @@ void ObjectVisibilityDialog::updateCalculateButtonEnabled()
 
 void ObjectVisibilityDialog::calculate()
 {
-	StelObjectMgr* objMgr = GETSTELMODULE(StelObjectMgr);
-	if (!objMgr || objMgr->getSelectedObject().isEmpty())
-		return;
+	calculateObject(currentSelectedVisibilityObject());
+}
 
-	const StelObjectP sel = objMgr->getSelectedObject().first();
-	if (!isAcceptableType(sel->getType()))
-		return;
+bool ObjectVisibilityDialog::calculateObject(const StelObjectP& sel)
+{
+	if (!sel || !isAcceptableType(sel->getType()))
+		return false;
+
+	StelCore* core = StelApp::getInstance().getCore();
+	if (!core || !isSupportedPlanet(core->getCurrentLocation().planetName))
+		return false;
 
 	// Remember which object we computed for, so the title label can
 	// be refreshed on retranslate without re-running the geometry.
@@ -306,7 +327,6 @@ void ObjectVisibilityDialog::calculate()
 	if (lockedObjectNameI18n.isEmpty())
 		lockedObjectNameI18n = lockedObjectId;
 
-	StelCore* core = StelApp::getInstance().getCore();
 	// getEquinoxEquatorialPos() returns the equatorial coordinates at
 	// the *current* equinox (date), which is exactly what the spec requires:
 	// precession and (where applicable) proper motion are folded in,
@@ -318,6 +338,19 @@ void ObjectVisibilityDialog::calculate()
 
 	ui->mapWidget->setDeclination(decDeg);
 	refreshTitleLabel();
+	return true;
+}
+
+StelObjectP ObjectVisibilityDialog::currentSelectedVisibilityObject() const
+{
+	StelObjectMgr* objMgr = GETSTELMODULE(StelObjectMgr);
+	if (!objMgr || objMgr->getSelectedObject().isEmpty())
+		return StelObjectP();
+
+	const StelObjectP sel = objMgr->getSelectedObject().first();
+	if (!sel || !isAcceptableType(sel->getType()))
+		return StelObjectP();
+	return sel;
 }
 
 void ObjectVisibilityDialog::onGoodVisibilityLimitChanged(int degrees)
@@ -434,6 +467,8 @@ void ObjectVisibilityDialog::onResetSettings()
 	placeLabelsMinimumPopulation = plugin->getPlaceLabelsMinimumPopulation();
 	placeLabelsNearLinesOnly = plugin->getPlaceLabelsNearLinesOnly();
 	syncMaps = plugin->getSyncMaps();
+	ui->visibilityAutoComputeCheckBox->setChecked(
+		plugin->getVisibilityAutoCompute());
 	syncPlaceLabelControls();
 	syncMapControls();
 	updatePlaceLabels();
@@ -517,6 +552,15 @@ void ObjectVisibilityDialog::onLiveTwilightPlaceLabelsNearLinesOnlyToggled(bool 
 	updatePlaceLabels();
 }
 
+void ObjectVisibilityDialog::onVisibilityAutoComputeToggled(bool on)
+{
+	plugin->setVisibilityAutoCompute(on);
+	if (on)
+		refreshVisibility();
+	updateCalculateButtonEnabled();
+	updateTwilightMapTimerState();
+}
+
 void ObjectVisibilityDialog::onSyncMapsToggled(bool on)
 {
 	syncMaps = on;
@@ -548,6 +592,14 @@ void ObjectVisibilityDialog::onSyncMapsToggled(bool on)
 	applyingMapSync = false;
 }
 
+void ObjectVisibilityDialog::onTwilightComputeDailyToggled(bool on)
+{
+	Q_UNUSED(on);
+	lastTwilightLimitsJd = 0.0;
+	refreshTwilightLimits();
+	updateTwilightMapTimerState();
+}
+
 void ObjectVisibilityDialog::onMapViewChanged(double centerLongitude,
                                               double centerLatitude,
                                               double zoom)
@@ -575,8 +627,12 @@ void ObjectVisibilityDialog::onTabChanged(int index)
 {
 	Q_UNUSED(index);
 	updateTwilightMapTimerState();
+	if (isAutoVisibilityTabActive())
+		refreshVisibility();
 	if (isLiveTwilightMapTabActive())
 		scheduleTwilightMapRefresh();
+	if (isDailyTwilightLimitsTabActive())
+		refreshTwilightLimits();
 }
 
 void ObjectVisibilityDialog::syncMarkerToObserver()
@@ -673,16 +729,31 @@ void ObjectVisibilityDialog::refreshTwilightLimits()
 
 	SolarSystem* ssm = GETSTELMODULE(SolarSystem);
 	PlanetP earth = ssm ? ssm->getEarth() : PlanetP();
-	if (!earth)
+	PlanetP sun = ssm ? ssm->getSun() : PlanetP();
+	const bool computeDaily = ui->twilightComputeDailyCheckBox->isChecked();
+	if (computeDaily && !isDailyTwilightLimitsTabActive())
+		return;
+	if (!earth || (computeDaily && !sun))
 	{
 		ui->twilightMapWidget->clearTwilightLimits();
 		ui->twilightMapWidget->setMarkerVisible(false);
 		ui->twilightMapWidget->setClickSetsLocationMode(false);
 		ui->twilightSetLocationByClickCheckBox->setEnabled(false);
 		ui->twilightTitleLabel->setText(
-			q_("Solstice twilight limits on Earth are unavailable."));
+			q_("Twilight limits on Earth are unavailable."));
 		return;
 	}
+
+	const double jd = core->getJD();
+	if (computeDaily &&
+	    lastTwilightLimitsJd > 0.0 &&
+	    twilightLimitsCachedPlanet == planet &&
+	    twilightLimitsCachedDaily == computeDaily &&
+	    std::abs(jd - lastTwilightLimitsJd) < 0.20 / 86400.0)
+		return;
+	lastTwilightLimitsJd = jd;
+	twilightLimitsCachedPlanet = planet;
+	twilightLimitsCachedDaily = computeDaily;
 
 	ui->twilightMapWidget->setMarkerVisible(true);
 	ui->twilightSetLocationByClickCheckBox->setEnabled(true);
@@ -691,14 +762,34 @@ void ObjectVisibilityDialog::refreshTwilightLimits()
 		   "Stays active until you uncheck it."));
 
 	const double obliquityDeg = earth->getRotObliquity(core->getJDE()) * 180.0 / M_PI;
-	ui->twilightMapWidget->setTwilightObliquity(obliquityDeg);
-
 	const int year = currentYear(core);
-	ui->twilightTitleLabel->setText(
-		QString(q_("Solstice twilight limits on Earth in %1 "
-		           "(obliquity %2°)"))
-		.arg(year)
-		.arg(obliquityDeg, 0, 'f', 2));
+	if (computeDaily)
+	{
+		double ra = 0.0;
+		double dec = 0.0;
+		StelUtils::rectToSphe(&ra, &dec, sun->getEquinoxEquatorialPos(core));
+		Q_UNUSED(ra);
+		const double sunDeclinationDeg = dec * 180.0 / M_PI;
+		ui->twilightMapWidget->setTwilightLimits(
+			obliquityDeg, sunDeclinationDeg, true);
+		ui->twilightLegendGroupBox->setTitle(q_("Daily twilight limits"));
+		ui->twilightTitleLabel->setText(
+			QString(q_("Daily twilight limits on Earth in %1 "
+			           "(solar declination %2°, obliquity %3°)"))
+			.arg(year)
+			.arg(sunDeclinationDeg, 0, 'f', 2)
+			.arg(obliquityDeg, 0, 'f', 2));
+	}
+	else
+	{
+		ui->twilightMapWidget->setTwilightObliquity(obliquityDeg);
+		ui->twilightLegendGroupBox->setTitle(q_("Solstice twilight limits"));
+		ui->twilightTitleLabel->setText(
+			QString(q_("Solstice twilight limits on Earth in %1 "
+			           "(obliquity %2°)"))
+			.arg(year)
+			.arg(obliquityDeg, 0, 'f', 2));
+	}
 }
 
 void ObjectVisibilityDialog::refreshTwilightMap()
@@ -735,6 +826,31 @@ void ObjectVisibilityDialog::refreshTwilightMapNow()
 
 	twilightMapRefreshPending = false;
 	refreshTwilightMap(true);
+}
+
+void ObjectVisibilityDialog::onTwilightTimerTimeout()
+{
+	if (isAutoVisibilityTabActive())
+		refreshVisibility();
+	if (isDailyTwilightLimitsTabActive())
+		refreshTwilightLimits();
+	refreshTwilightMap();
+}
+
+void ObjectVisibilityDialog::refreshVisibility()
+{
+	if (!isAutoVisibilityTabActive())
+		return;
+
+	const StelObjectP sel = currentSelectedVisibilityObject();
+	if (calculateObject(sel))
+		return;
+
+	lockedObjectId.clear();
+	lockedObjectType.clear();
+	lockedObjectNameI18n.clear();
+	ui->mapWidget->clearVisibility();
+	refreshTitleLabel();
 }
 
 void ObjectVisibilityDialog::refreshTwilightMap(bool force)
@@ -878,11 +994,27 @@ bool ObjectVisibilityDialog::isLiveTwilightMapTabActive() const
 	       ui->tabs->currentWidget() == ui->twilightMapTab;
 }
 
+bool ObjectVisibilityDialog::isAutoVisibilityTabActive() const
+{
+	return dialog && ui && twilightMapTimer && visible() &&
+	       ui->tabs->currentWidget() == ui->visibilityTab &&
+	       ui->visibilityAutoComputeCheckBox->isChecked();
+}
+
+bool ObjectVisibilityDialog::isDailyTwilightLimitsTabActive() const
+{
+	return dialog && ui && twilightMapTimer && visible() &&
+	       ui->tabs->currentWidget() == ui->twilightLimitsTab &&
+	       ui->twilightComputeDailyCheckBox->isChecked();
+}
+
 void ObjectVisibilityDialog::updateTwilightMapTimerState()
 {
 	if (!twilightMapTimer) return;
 
-	if (isLiveTwilightMapTabActive())
+	if (isAutoVisibilityTabActive() ||
+	    isLiveTwilightMapTabActive() ||
+	    isDailyTwilightLimitsTabActive())
 	{
 		if (!twilightMapTimer->isActive())
 			twilightMapTimer->start();

--- a/plugins/ObjectVisibility/src/gui/ObjectVisibilityDialog.hpp
+++ b/plugins/ObjectVisibility/src/gui/ObjectVisibilityDialog.hpp
@@ -22,6 +22,7 @@
 #define OBJECTVISIBILITYDIALOG_HPP
 
 #include "StelDialog.hpp"
+#include "StelObjectType.hpp"
 #include <QString>
 
 class Ui_objectVisibilityDialog;
@@ -85,7 +86,9 @@ private slots:
 	void onPlaceLabelsNearLinesOnlyToggled(bool on);
 	void onTwilightPlaceLabelsNearLinesOnlyToggled(bool on);
 	void onLiveTwilightPlaceLabelsNearLinesOnlyToggled(bool on);
+	void onVisibilityAutoComputeToggled(bool on);
 	void onSyncMapsToggled(bool on);
+	void onTwilightComputeDailyToggled(bool on);
 	void onMapViewChanged(double centerLongitude, double centerLatitude,
 	                      double zoom);
 	void onTabChanged(int index);
@@ -108,6 +111,11 @@ private slots:
 
 	//! Run the queued forced refresh.
 	void refreshTwilightMapNow();
+	void onTwilightTimerTimeout();
+
+	//! Recompute first-tab visibility from the current selection when
+	//! automatic mode is active.
+	void refreshVisibility();
 
 private:
 	Ui_objectVisibilityDialog* ui;
@@ -129,6 +137,9 @@ private:
 	QString  cachedPlanetName;
 
 	QTimer* twilightMapTimer = nullptr;
+	double  lastTwilightLimitsJd = 0.0;
+	QString twilightLimitsCachedPlanet;
+	bool    twilightLimitsCachedDaily = false;
 	double  lastTwilightMapJd = 0.0;
 	QString twilightMapCachedPlanet;
 	bool    twilightMapRefreshPending = false;
@@ -146,8 +157,12 @@ private:
 	void syncPlaceLabelControls();
 	void updatePlaceLabels();
 	void syncMapControls();
+	bool isAutoVisibilityTabActive() const;
 	bool isLiveTwilightMapTabActive() const;
+	bool isDailyTwilightLimitsTabActive() const;
 	void updateTwilightMapTimerState();
+	bool calculateObject(const StelObjectP& object);
+	StelObjectP currentSelectedVisibilityObject() const;
 
 	//! Compute the year label in astronomical convention from the
 	//! StelCore's current JD.  E.g. 2026, or -10000 for 10001 BCE.

--- a/plugins/ObjectVisibility/src/gui/ObjectVisibilityMapWidget.cpp
+++ b/plugins/ObjectVisibility/src/gui/ObjectVisibilityMapWidget.cpp
@@ -125,13 +125,37 @@ void ObjectVisibilityMapWidget::clearVisibility()
 
 void ObjectVisibilityMapWidget::setTwilightObliquity(double obliquityDeg)
 {
+	setTwilightLimits(obliquityDeg, 0.0, false);
+}
+
+void ObjectVisibilityMapWidget::setTwilightLimits(double obliquityDeg,
+                                                  double sunDeclinationDeg,
+                                                  bool computeDaily)
+{
 	if (obliquityDeg <= 0.0 || obliquityDeg >= 90.0)
 	{
 		clearTwilightLimits();
 		return;
 	}
+	if (computeDaily &&
+	    (sunDeclinationDeg < -90.0 || sunDeclinationDeg > 90.0))
+	{
+		clearTwilightLimits();
+		return;
+	}
+
+	const bool unchanged = hasTwilightObliquity &&
+		qFuzzyCompare(twilightObliquityDeg, obliquityDeg) &&
+		twilightLimitsComputeDaily == computeDaily &&
+		(!computeDaily ||
+		 qFuzzyCompare(twilightSunDeclinationDeg, sunDeclinationDeg));
+	if (unchanged)
+		return;
+
 	hasTwilightObliquity = true;
 	twilightObliquityDeg = obliquityDeg;
+	twilightSunDeclinationDeg = sunDeclinationDeg;
+	twilightLimitsComputeDaily = computeDaily;
 	update();
 }
 
@@ -139,6 +163,8 @@ void ObjectVisibilityMapWidget::clearTwilightLimits()
 {
 	if (!hasTwilightObliquity) return;
 	hasTwilightObliquity = false;
+	twilightSunDeclinationDeg = 0.0;
+	twilightLimitsComputeDaily = false;
 	update();
 }
 
@@ -429,6 +455,36 @@ void ObjectVisibilityMapWidget::drawTwilightLimitsOverlay(QPainter& painter) con
 	drawSymmetric(polar, penFor(POLAR_COLOR,
 	                            Qt::DotLine,
 	                            std::max(1.0, 1.9 * ratio)));
+
+	if (twilightLimitsComputeDaily)
+	{
+		const double dec = twilightSunDeclinationDeg;
+		auto drawLowest = [this, &painter, &penFor, dec]
+		                  (double altitudeDeg, const QColor& color)
+		{
+			const double distance = 90.0 + altitudeDeg;
+			const QPen pen = penFor(color);
+			drawLatitudeLineCopies(painter, -dec + distance, pen);
+			drawLatitudeLineCopies(painter, -dec - distance, pen);
+		};
+		auto drawHighest = [this, &painter, &penFor, dec]
+		                   (double altitudeDeg, const QColor& color)
+		{
+			const double distance = 90.0 - altitudeDeg;
+			const QPen pen = penFor(color, Qt::CustomDashLine);
+			drawLatitudeLineCopies(painter, dec + distance, pen);
+			drawLatitudeLineCopies(painter, dec - distance, pen);
+		};
+
+		drawLowest(-6.0,  CIVIL_MIN_COLOR);
+		drawLowest(-12.0, NAUT_MIN_COLOR);
+		drawLowest(-18.0, ASTRO_MIN_COLOR);
+
+		drawHighest(-6.0,  CIVIL_MAX_COLOR);
+		drawHighest(-12.0, NAUT_MAX_COLOR);
+		drawHighest(-18.0, ASTRO_MAX_COLOR);
+		return;
+	}
 
 	// At solstice the Sun's declination is +/-eps.  For the
 	// summer-solstice midnight Sun, h_min = phi + eps - 90, giving
@@ -1042,12 +1098,37 @@ QVector<double> ObjectVisibilityMapWidget::currentOverlayLatitudes() const
 		addLatitude(0.0);
 		addSymmetric(eps);
 		addSymmetric(polar);
-		addSymmetric(polar - 6.0);
-		addSymmetric(polar - 12.0);
-		addSymmetric(polar - 18.0);
-		addSymmetric(polar + 6.0);
-		addSymmetric(polar + 12.0);
-		addSymmetric(polar + 18.0);
+		if (twilightLimitsComputeDaily)
+		{
+			const double dec = twilightSunDeclinationDeg;
+			auto addLowest = [&addLatitude, dec](double altitudeDeg)
+			{
+				const double distance = 90.0 + altitudeDeg;
+				addLatitude(-dec + distance);
+				addLatitude(-dec - distance);
+			};
+			auto addHighest = [&addLatitude, dec](double altitudeDeg)
+			{
+				const double distance = 90.0 - altitudeDeg;
+				addLatitude(dec + distance);
+				addLatitude(dec - distance);
+			};
+			addLowest(-6.0);
+			addLowest(-12.0);
+			addLowest(-18.0);
+			addHighest(-6.0);
+			addHighest(-12.0);
+			addHighest(-18.0);
+		}
+		else
+		{
+			addSymmetric(polar - 6.0);
+			addSymmetric(polar - 12.0);
+			addSymmetric(polar - 18.0);
+			addSymmetric(polar + 6.0);
+			addSymmetric(polar + 12.0);
+			addSymmetric(polar + 18.0);
+		}
 	}
 
 	return latitudes;

--- a/plugins/ObjectVisibility/src/gui/ObjectVisibilityMapWidget.hpp
+++ b/plugins/ObjectVisibility/src/gui/ObjectVisibilityMapWidget.hpp
@@ -102,6 +102,12 @@ public:
 	//! solstice limits. Pass a value outside (0, 90) to clear.
 	void setTwilightObliquity(double obliquityDeg);
 
+	//! Set Earth obliquity and optional current solar declination for
+	//! twilight limits. When computeDaily is true, twilight altitude
+	//! lines use sunDeclinationDeg instead of the solstice extrema.
+	void setTwilightLimits(double obliquityDeg, double sunDeclinationDeg,
+	                       bool computeDaily);
+
 	//! Hide all twilight/solstice limit lines.
 	void clearTwilightLimits();
 
@@ -175,6 +181,8 @@ private:
 
 	bool   hasTwilightObliquity = false;
 	double twilightObliquityDeg = 0.0;
+	double twilightSunDeclinationDeg = 0.0;
+	bool   twilightLimitsComputeDaily = false;
 
 	bool   hasTwilightMap = false;
 	double twilightSunLongitudeDeg = 0.0;

--- a/plugins/ObjectVisibility/src/gui/objectVisibilityDialog.ui
+++ b/plugins/ObjectVisibility/src/gui/objectVisibilityDialog.ui
@@ -264,6 +264,16 @@
             </widget>
            </item>
            <item>
+            <widget class="QCheckBox" name="visibilityAutoComputeCheckBox">
+             <property name="toolTip">
+              <string>Automatically compute visibility for the selected star or deep-sky object and keep it updated while this tab is open.</string>
+             </property>
+             <property name="text">
+              <string>Compute automatically</string>
+             </property>
+            </widget>
+           </item>
+           <item>
             <widget class="Line" name="ctrlSep1">
              <property name="orientation">
               <enum>Qt::Vertical</enum>
@@ -772,6 +782,23 @@
              </property>
              <property name="text">
               <string>Sync maps</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="Line" name="twilightCtrlSepComputeDaily">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QCheckBox" name="twilightComputeDailyCheckBox">
+             <property name="toolTip">
+              <string>Compute twilight limits from the Sun's current position instead of the solstice extrema.</string>
+             </property>
+             <property name="text">
+              <string>Compute daily</string>
              </property>
             </widget>
            </item>

--- a/plugins/ObjectVisibility/src/gui/objectVisibilityDialog.ui
+++ b/plugins/ObjectVisibility/src/gui/objectVisibilityDialog.ui
@@ -259,17 +259,17 @@
               <string>Calculate</string>
              </property>
              <property name="toolTip">
-              <string>Compute visibility for the selected object.</string>
+              <string>Calculate visibility for the selected object.</string>
              </property>
             </widget>
            </item>
            <item>
             <widget class="QCheckBox" name="visibilityAutoComputeCheckBox">
              <property name="toolTip">
-              <string>Automatically compute visibility for the selected star or deep-sky object and keep it updated while this tab is open.</string>
+              <string>Automatically calculate visibility for the selected star or deep-sky object and keep it updated while this tab is open.</string>
              </property>
              <property name="text">
-              <string>Compute automatically</string>
+              <string>Calculate automatically</string>
              </property>
             </widget>
            </item>


### PR DESCRIPTION
Small but useful change to the Object Visibility plug-in; we let users compute twilight limits for the current day (dynamically changes if the user scrolls through dates, really useful for northern observers such as myself), and let users compute stellar visibility automatically by selecting a star, and also compute the visibility limits automatically at the epoch displayed in the planetarium (also dynamically changes if the user changes date).

This feature is enabled by selecting `Compute daily` and `Compute automatically` respectively.


### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

**Test Configuration**:
Qt 6.11.1
Fedora 44

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
