### PR TITLE
Fix saving/retrieving stored main window size on scaled screens

### DIFF
--- a/src/StelMainView.cpp
+++ b/src/StelMainView.cpp
@@ -1624,21 +1624,14 @@ void StelMainView::moveEvent(QMoveEvent * event)
 	//const QPoint &pos=event->pos(); // top-left of drawing area
 	const QPoint &pos=frameGeometry().topLeft(); // including frame!
 
-	// We use the glWidget instead of the event, as we want the screen that shows most of the widget.
-	QWindow* win = glWidget->windowHandle();
-	if(win)
-	{
-		stelApp->setDevicePixelsPerPixel(win->devicePixelRatio());
-	}
-	else
-		qWarning() << "Cannot get window handle (to set device pixel ratio). (uncritical)";
-
 	if (StelApp::isInitialized())
 	{
-		qDebug() << "saving position with devicePixelRatio=" << devicePixelRatio();
+		const qreal dpp = devicePixelRatio();
+		stelApp->setDevicePixelsPerPixel(dpp);
+		qDebug() << "saving position with devicePixelRatio =" << dpp;
 
-		StelApp::immediateSave("video/screen_x", int(std::lround(pos.x()*devicePixelRatio())));
-		StelApp::immediateSave("video/screen_y", int(std::lround(pos.y()*devicePixelRatio())));
+		StelApp::immediateSave("video/screen_x", int(std::lround(pos.x()*dpp)));
+		StelApp::immediateSave("video/screen_y", int(std::lround(pos.y()*dpp)));
 	}
 }
 

--- a/src/StelMainView.cpp
+++ b/src/StelMainView.cpp
@@ -727,7 +727,6 @@ void StelMainView::resizeEvent(QResizeEvent* event)
 			guiItem->setGeometry(QRectF(0.0,0.0,sz.width(),sz.height()));
 		if (StelApp::isInitialized()  && !isFullScreen())
 		{
-			qDebug() << "saving size with devicePixelRatio=" << devicePixelRatio();
 			StelApp::immediateSave("video/screen_w", int(std::lround(sz.width() *devicePixelRatio())));
 			StelApp::immediateSave("video/screen_h", int(std::lround(sz.height()*devicePixelRatio())));
 		}
@@ -1621,14 +1620,12 @@ bool StelMainView::needsMaxFPS() const
 
 void StelMainView::moveEvent(QMoveEvent * event)
 {
-	//const QPoint &pos=event->pos(); // top-left of drawing area
-	const QPoint &pos=frameGeometry().topLeft(); // including frame!
+	const QPoint &pos=frameGeometry().topLeft(); // including frame! (Original event->pos() returns top-left of drawing area)
 
 	if (StelApp::isInitialized())
 	{
 		const qreal dpp = devicePixelRatio();
 		stelApp->setDevicePixelsPerPixel(dpp);
-		qDebug() << "saving position with devicePixelRatio =" << dpp;
 
 		StelApp::immediateSave("video/screen_x", int(std::lround(pos.x()*dpp)));
 		StelApp::immediateSave("video/screen_y", int(std::lround(pos.y()*dpp)));

--- a/src/StelMainView.cpp
+++ b/src/StelMainView.cpp
@@ -718,6 +718,16 @@ StelMainView::StelMainView(QSettings* settings)
 
 void StelMainView::resizeEvent(QResizeEvent* event)
 {
+	qreal devicePixelRatio=1.0;
+	// We use the glWidget instead of the event, as we want the screen that shows most of the widget.
+	QWindow* win = glWidget->windowHandle();
+	if(win)
+	{
+		devicePixelRatio=win->devicePixelRatio();
+	}
+	else
+		qCritical() << "resizeEvent: CANNOT GET WINDOW HANDLE! --> CANNOT SET devicePixelRatio";
+
 	if(scene())
 	{
 		const QSize& sz = event->size();
@@ -727,8 +737,9 @@ void StelMainView::resizeEvent(QResizeEvent* event)
 			guiItem->setGeometry(QRectF(0.0,0.0,sz.width(),sz.height()));
 		if (StelApp::isInitialized()  && !isFullScreen())
 		{
-			StelApp::immediateSave("video/screen_w", sz.width());
-			StelApp::immediateSave("video/screen_h", sz.height());
+			qDebug() << "saving size with devicePixelRatio=" << devicePixelRatio;
+			StelApp::immediateSave("video/screen_w", sz.width() *devicePixelRatio);
+			StelApp::immediateSave("video/screen_h", sz.height()*devicePixelRatio);
 		}
 		emit sizeChanged(sz);
 	}
@@ -1621,18 +1632,24 @@ bool StelMainView::needsMaxFPS() const
 void StelMainView::moveEvent(QMoveEvent * event)
 {
 	const QPoint &pos=event->pos();
+	qreal devicePixelRatio=1.0;
 
 	// We use the glWidget instead of the event, as we want the screen that shows most of the widget.
 	QWindow* win = glWidget->windowHandle();
 	if(win)
 	{
-		stelApp->setDevicePixelsPerPixel(win->devicePixelRatio());
+		devicePixelRatio=win->devicePixelRatio();
+		stelApp->setDevicePixelsPerPixel(devicePixelRatio);
 	}
+	else
+		qCritical() << "moveEvent: CANNOT GET WINDOW HANDLE! --> CANNOT SET devicePixelRatio";
 
 	if (StelApp::isInitialized())
 	{
-		StelApp::immediateSave("video/screen_x", pos.x());
-		StelApp::immediateSave("video/screen_y", pos.y());
+		qDebug() << "saving position with devicePixelRatio=" << devicePixelRatio;
+
+		StelApp::immediateSave("video/screen_x", pos.x()*devicePixelRatio);
+		StelApp::immediateSave("video/screen_y", pos.y()*devicePixelRatio);
 	}
 }
 

--- a/src/StelMainView.cpp
+++ b/src/StelMainView.cpp
@@ -718,16 +718,6 @@ StelMainView::StelMainView(QSettings* settings)
 
 void StelMainView::resizeEvent(QResizeEvent* event)
 {
-	qreal devicePixelRatio=1.0;
-	// We use the glWidget instead of the event, as we want the screen that shows most of the widget.
-	QWindow* win = glWidget->windowHandle();
-	if(win)
-	{
-		devicePixelRatio=win->devicePixelRatio();
-	}
-	else
-		qCritical() << "resizeEvent: CANNOT GET WINDOW HANDLE! --> CANNOT SET devicePixelRatio";
-
 	if(scene())
 	{
 		const QSize& sz = event->size();
@@ -737,9 +727,9 @@ void StelMainView::resizeEvent(QResizeEvent* event)
 			guiItem->setGeometry(QRectF(0.0,0.0,sz.width(),sz.height()));
 		if (StelApp::isInitialized()  && !isFullScreen())
 		{
-			qDebug() << "saving size with devicePixelRatio=" << devicePixelRatio;
-			StelApp::immediateSave("video/screen_w", sz.width() *devicePixelRatio);
-			StelApp::immediateSave("video/screen_h", sz.height()*devicePixelRatio);
+			qDebug() << "saving size with devicePixelRatio=" << devicePixelRatio();
+			StelApp::immediateSave("video/screen_w", int(std::lround(sz.width() *devicePixelRatio())));
+			StelApp::immediateSave("video/screen_h", int(std::lround(sz.height()*devicePixelRatio())));
 		}
 		emit sizeChanged(sz);
 	}
@@ -1631,25 +1621,24 @@ bool StelMainView::needsMaxFPS() const
 
 void StelMainView::moveEvent(QMoveEvent * event)
 {
-	const QPoint &pos=event->pos();
-	qreal devicePixelRatio=1.0;
+	//const QPoint &pos=event->pos(); // top-left of drawing area
+	const QPoint &pos=frameGeometry().topLeft(); // including frame!
 
 	// We use the glWidget instead of the event, as we want the screen that shows most of the widget.
 	QWindow* win = glWidget->windowHandle();
 	if(win)
 	{
-		devicePixelRatio=win->devicePixelRatio();
-		stelApp->setDevicePixelsPerPixel(devicePixelRatio);
+		stelApp->setDevicePixelsPerPixel(win->devicePixelRatio());
 	}
 	else
-		qCritical() << "moveEvent: CANNOT GET WINDOW HANDLE! --> CANNOT SET devicePixelRatio";
+		qWarning() << "Cannot get window handle (to set device pixel ratio). (uncritical)";
 
 	if (StelApp::isInitialized())
 	{
-		qDebug() << "saving position with devicePixelRatio=" << devicePixelRatio;
+		qDebug() << "saving position with devicePixelRatio=" << devicePixelRatio();
 
-		StelApp::immediateSave("video/screen_x", pos.x()*devicePixelRatio);
-		StelApp::immediateSave("video/screen_y", pos.y()*devicePixelRatio);
+		StelApp::immediateSave("video/screen_x", int(std::lround(pos.x()*devicePixelRatio())));
+		StelApp::immediateSave("video/screen_y", int(std::lround(pos.y()*devicePixelRatio())));
 	}
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -476,6 +476,11 @@ int main(int argc, char **argv)
 	const auto qscreen = qApp->screens().at(screen);
 	const QRect screenGeom = qscreen->geometry();
 
+	qDebug() << "Reading \"video/screen_w\" =" << confSettings->value("video/screen_w").toString() << "as" << confSettings->value("video/screen_w", 0).toInt();
+	qDebug() << "ScreenGeom.width() =" << screenGeom.width();
+	qDebug() << "Reading \"video/screen_h\" =" << confSettings->value("video/screen_h").toString() << "as" << confSettings->value("video/screen_h", 0).toInt();
+	qDebug() << "ScreenGeom.height() =" << screenGeom.height();
+
 	const auto virtSize = QSize(confSettings->value("video/screen_w", screenGeom.width()).toInt(),
 								confSettings->value("video/screen_h", screenGeom.height()).toInt());
 //#ifdef Q_OS_WIN

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -476,21 +476,11 @@ int main(int argc, char **argv)
 	const auto qscreen = qApp->screens().at(screen);
 	const QRect screenGeom = qscreen->geometry();
 
-	qDebug() << "Reading \"video/screen_w\" =" << confSettings->value("video/screen_w").toString() << "as" << confSettings->value("video/screen_w", 0).toInt();
-	qDebug() << "ScreenGeom.width() =" << screenGeom.width();
-	qDebug() << "Reading \"video/screen_h\" =" << confSettings->value("video/screen_h").toString() << "as" << confSettings->value("video/screen_h", 0).toInt();
-	qDebug() << "ScreenGeom.height() =" << screenGeom.height();
-
 	const auto virtSize = QSize(confSettings->value("video/screen_w", screenGeom.width()).toInt(),
 								confSettings->value("video/screen_h", screenGeom.height()).toInt());
-//#ifdef Q_OS_WIN
-//	const auto size = QSize(std::lround(virtSize.width()),
-//				    std::lround(virtSize.height()));
-//#else
 	const auto pixelRatio = qscreen->devicePixelRatio();
 	const auto size = QSize(std::lround(virtSize.width()/pixelRatio),
 				    std::lround(virtSize.height()/pixelRatio));
-//#endif
 	mainWin.resize(size);
 
 	const bool fullscreen = confSettings->value("video/fullscreen", true).toBool();
@@ -508,13 +498,8 @@ int main(int argc, char **argv)
 	{
 		const int x = confSettings->value("video/screen_x", 0).toInt();
 		const int y = confSettings->value("video/screen_y", 0).toInt();
-//#ifdef Q_OS_WIN
-//		mainWin.move(screenGeom.x() + x,
-//			     screenGeom.y() + y);
-//#else
 		mainWin.move(screenGeom.x() + x/pixelRatio,
 			     screenGeom.y() + y/pixelRatio);
-//#endif
 	}
 
 	mainWin.show();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -478,14 +478,14 @@ int main(int argc, char **argv)
 
 	const auto virtSize = QSize(confSettings->value("video/screen_w", screenGeom.width()).toInt(),
 								confSettings->value("video/screen_h", screenGeom.height()).toInt());
-#ifdef Q_OS_WIN
-	const auto size = QSize(std::lround(virtSize.width()),
-				    std::lround(virtSize.height()));
-#else
+//#ifdef Q_OS_WIN
+//	const auto size = QSize(std::lround(virtSize.width()),
+//				    std::lround(virtSize.height()));
+//#else
 	const auto pixelRatio = qscreen->devicePixelRatio();
 	const auto size = QSize(std::lround(virtSize.width()/pixelRatio),
 				    std::lround(virtSize.height()/pixelRatio));
-#endif
+//#endif
 	mainWin.resize(size);
 
 	const bool fullscreen = confSettings->value("video/fullscreen", true).toBool();
@@ -503,13 +503,13 @@ int main(int argc, char **argv)
 	{
 		const int x = confSettings->value("video/screen_x", 0).toInt();
 		const int y = confSettings->value("video/screen_y", 0).toInt();
-#ifdef Q_OS_WIN
-		mainWin.move(screenGeom.x() + x,
-			     screenGeom.y() + y);
-#else
+//#ifdef Q_OS_WIN
+//		mainWin.move(screenGeom.x() + x,
+//			     screenGeom.y() + y);
+//#else
 		mainWin.move(screenGeom.x() + x/pixelRatio,
 			     screenGeom.y() + y/pixelRatio);
-#endif
+//#endif
 	}
 
 	mainWin.show();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
A problem at loading window size has been reported for 26.1 and 26.2 that shows only on hiDPI screens and when using the old-fashioned manual "store settings".

### Description
<!--- Please include a summary of the change and which issue is fixed. -->
<!--- Please also include relevant motivation and context. -->
<!--- List any dependencies that are required for this change. -->

Fixes #5074 (issue)

### Screenshots (if appropriate):

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Test Configuration**:
* Operating system: Win11 24H2
* Graphics Card: Geforce 2070

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
