### PR TITLE
Make Lightweight atmosphere model the default

### DIFF
--- a/guide/ch_skylight.tex
+++ b/guide/ch_skylight.tex
@@ -163,7 +163,7 @@ This model \newFeature{26.2} combines a realistic view of the sky as in ShowMySk
 
 The Lightweight model is based on a set of meshes generated from a render of ShowMySky, so its look is just as realistic (at sea level and without any eclipse) as that of ShowMySky, except for the solar aureole, which is a bit simplified.
 
-This model is intended to eventually become the default skylight model when it's proven to be stable enough to replace the Preetham model on all platforms, including the weakest ones.
+This is the default \newFeature{26.3} skylight model that supports the same set of computers as the Preetham model. But if you use a weak laptop on batteries in the field, you may want to switch to Preetham, which is a bit less energy consuming.
 
 \section{Light Pollution}
 

--- a/src/core/modules/LandscapeMgr.cpp
+++ b/src/core/modules/LandscapeMgr.cpp
@@ -66,7 +66,7 @@ constexpr char ATMOSPHERE_ECLIPSE_SIM_QUALITY_CONFIG_KEY[]="landscape/atmosphere
 constexpr char ATMOSPHERE_MODEL_CONF_VAL_PREETHAM[]="preetham";
 constexpr char ATMOSPHERE_MODEL_CONF_VAL_SHOWMYSKY[]="showmysky";
 constexpr char ATMOSPHERE_MODEL_CONF_VAL_LIGHTWEIGHT[]="lightweight";
-constexpr char ATMOSPHERE_MODEL_CONF_VAL_DEFAULT[]="preetham";
+constexpr char ATMOSPHERE_MODEL_CONF_VAL_DEFAULT[]="lightweight";
 }
 
 Cardinals::Cardinals()


### PR DESCRIPTION
So Lightweight atmosphere model has been rather stable for me. I think it can be made the default model.