### PR TITLE
Fix SCM overwriting existing SC changes illustration names

### DIFF
--- a/plugins/SkyCultureMaker/src/ScmConstellation.cpp
+++ b/plugins/SkyCultureMaker/src/ScmConstellation.cpp
@@ -205,8 +205,13 @@ bool scm::ScmConstellation::saveArtwork(const QString &directory)
 		return true; // Not an error just a warning
 	}
 
-	QString filename = id.split(" ").back(); // Last part of id as usually used as the illustrations name
-	QString filepath = directory + QDir::separator() + filename + ".png"; // Write every illustrations as png
+	QString filename = artwork.getSourceImageFileName();
+	if (filename.isEmpty())
+	{
+		// Fall back to the last part of the id, as usually used as the illustrations name
+		filename = id.split(" ").back() + ".png";
+	}
+	QString filepath = directory + QDir::separator() + filename; // Keep the original file name when available
 	artworkPath      = filepath;
 	return artwork.save(filepath);
 }

--- a/plugins/SkyCultureMaker/src/ScmConstellationArtwork.cpp
+++ b/plugins/SkyCultureMaker/src/ScmConstellationArtwork.cpp
@@ -185,6 +185,16 @@ const QImage &scm::ScmConstellationArtwork::getArtwork() const
 	return artwork;
 }
 
+void scm::ScmConstellationArtwork::setSourceImageFileName(const QString &fileName)
+{
+	sourceImageFileName = fileName;
+}
+
+const QString &scm::ScmConstellationArtwork::getSourceImageFileName() const
+{
+	return sourceImageFileName;
+}
+
 bool scm::ScmConstellationArtwork::getHasArt() const
 {
 	return hasArt;

--- a/plugins/SkyCultureMaker/src/ScmConstellationArtwork.hpp
+++ b/plugins/SkyCultureMaker/src/ScmConstellationArtwork.hpp
@@ -83,6 +83,19 @@ public:
 	const QImage &getArtwork() const;
 
 	/**
+	 * @brief Sets the original file name (with extension) the artwork was loaded from.
+	 *
+	 * When set, this name is reused on export so an existing illustration keeps its
+	 * original file name instead of being renamed after the constellation id.
+	 */
+	void setSourceImageFileName(const QString &fileName);
+
+	/**
+	 * @brief Gets the original file name the artwork was loaded from, or an empty string.
+	 */
+	const QString &getSourceImageFileName() const;
+
+	/**
 	 * @brief Get the indicator if the artwork contains art.
 	 * 
 	 * @return true Contains art.
@@ -146,6 +159,9 @@ private:
 
 	/// Holds the the artwork.
 	QImage artwork;
+
+	/// Original illustration file name (with extension) if loaded from disk; empty otherwise.
+	QString sourceImageFileName;
 
 	/// Holds the artwork as texture to draw.
 	StelTextureSP artTexture;

--- a/plugins/SkyCultureMaker/src/ScmSCLoader.cpp
+++ b/plugins/SkyCultureMaker/src/ScmSCLoader.cpp
@@ -33,6 +33,7 @@
 #include <QDebug>
 #include <QFile>
 #include <QFileDialog>
+#include <QFileInfo>
 #include <QImage>
 #include <QJsonArray>
 #include <QJsonDocument>
@@ -224,6 +225,7 @@ void ScmSCLoader::parseIndexJsonConstellations(const QJsonArray &constellationsA
 			anchors[a].hip         = aObj["hip"].toInt();
 		}
 		scm::ScmConstellationArtwork artwork(anchors, image);
+		artwork.setSourceImageFileName(QFileInfo(imgFile).fileName());
 		artwork.setupArt();
 		constellation.setArtwork(artwork);
 	}


### PR DESCRIPTION
When loading and then overwriting an existing SC, even the illustrations that stayed the same lost their original names and were renamed to "001.png", "002.png", etc. This PR fixes this issue by keeping their original names.

I have kept this PR small on purpose so its easier to review. There will be a follow-up PR that introduces a backup mechanism for overwrites.

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?
Manually by loading and overwriting SCs.

**Test Configuration**:
* Operating system: MacOS 26.6.2
* Graphics Card: Apple M3 Pro

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
