### PR TITLE
Reduce Moon visibility in daylight

### DIFF
--- a/src/core/modules/Planet.cpp
+++ b/src/core/modules/Planet.cpp
@@ -4548,12 +4548,17 @@ void Planet::draw3dModel(StelCore* core, StelProjector::ModelViewTranformP trans
 			static LandscapeMgr* lmgr = GETSTELMODULE(LandscapeMgr);
 			Q_ASSERT(lmgr);
 			const float atmLum=(lmgr->getFlagAtmosphere() ? lmgr->getAtmosphereAverageLuminance() : 0.0f);
+			const float daylightRatio = qBound(0.0f, (log10f(qMax(1.0f, atmLum))-log10f(20.0f))/(log10f(2000.0f)-log10f(20.0f)), 1.0f);
+			const float daylightDimming = daylightRatio*daylightRatio*(3.0f-2.0f*daylightRatio);
+			// Reduce rendered lunar contrast against a bright daytime sky without changing the Moon's magnitude.
+			const float moonContrastFactor = 1.0f - 0.7f*daylightDimming;
+			light.ambient *= moonContrastFactor;
 			if (atmLum<2000.0f && ( eclipseFactor<=0 || eclipseFactor==1.f))
 			{
 				float atmScaling=1.0f - (qMax(1000.0f, atmLum)-1000.0f)*0.001f; // full impact when atmLum<1000.
 				float earthshineFactor=(1.0f-getPhase(ssm->getEarth()->getHeliocentricEclipticPos())); // We really mean the Earth for this! (Try observing from Mars ;-)
 				earthshineFactor*=earthshineFactor*0.15f*atmScaling;
-				light.ambient = Vec3f(earthshineFactor, magFactorGreen*earthshineFactor, magFactorBlue*earthshineFactor);
+				light.ambient = moonContrastFactor*Vec3f(earthshineFactor, magFactorGreen*earthshineFactor, magFactorBlue*earthshineFactor);
 			}
 			const float fov=core->getProjection(transfo)->getFov();
 			float fovFactor=1.3f;
@@ -4563,7 +4568,7 @@ void Planet::draw3dModel(StelCore* core, StelProjector::ModelViewTranformP trans
 				fovFactor -= 0.1f*(5.0f-qMax(2.0f, float(fov/sphereScale)));
 			}
 			// Special case for the Moon. Was 1.6, but this often is too bright.
-			light.diffuse.set(fovFactor,magFactorGreen*fovFactor,magFactorBlue*fovFactor);
+			light.diffuse.set(moonContrastFactor*fovFactor, magFactorGreen*moonContrastFactor*fovFactor, magFactorBlue*moonContrastFactor*fovFactor);
 		}
 
 		// possibly tint sun's color from extinction. This should deliberately cause stronger reddening than for the other objects.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This branch gets rid of the burnt-out Moon in daylight skies. Works equally well in Preetham and ShowMySky. See the screenshot below for a comparison.

Fixes #3067 

### Screenshot:
<img width="2226" height="1122" alt="new_moon_branch" src="https://github.com/user-attachments/assets/94b820a3-d20d-445a-bb42-b7a6cd4774ce" />


### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

**Test Configuration**:
Fedora 44
Qt 6.11.2

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
