### PR TITLE
Add slant and ground distance to aircraft info panel

### DIFF
--- a/plugins/Planes/src/AircraftObject.cpp
+++ b/plugins/Planes/src/AircraftObject.cpp
@@ -354,10 +354,10 @@ double AircraftObject::getSlantRange(const StelCore* core, const AircraftRecord&
 	if (!core) return 0.0;
 
 	const StelLocation& location = core->getCurrentLocation();
-	const double obsLat = static_cast<double>(location.getLatitude()) * M_PI / 180.0;
-	const double obsLon = static_cast<double>(location.getLongitude()) * M_PI / 180.0;
-	const double tgtLat = record.latitude * M_PI / 180.0;
-	const double tgtLon = record.longitude * M_PI / 180.0;
+	const double obsLat = static_cast<double>(location.getLatitude()) * M_PI_180;
+	const double obsLon = static_cast<double>(location.getLongitude()) * M_PI_180;
+	const double tgtLat = record.latitude * M_PI_180;
+	const double tgtLon = record.longitude * M_PI_180;
 
 	const Vec3d observer = toEcef(obsLat, obsLon, static_cast<double>(location.altitude));
 	const Vec3d aircraft = toEcef(tgtLat, tgtLon, record.altitudeMeters);
@@ -369,17 +369,7 @@ double AircraftObject::getGroundRange(const StelCore* core, const AircraftRecord
 	if (!core) return 0.0;
 
 	const StelLocation& location = core->getCurrentLocation();
-	const double obsLat = static_cast<double>(location.getLatitude()) * M_PI / 180.0;
-	const double obsLon = static_cast<double>(location.getLongitude()) * M_PI / 180.0;
-	const double tgtLat = record.latitude * M_PI / 180.0;
-	const double tgtLon = record.longitude * M_PI / 180.0;
-
-	const double dLat = tgtLat - obsLat;
-	const double dLon = normalizeLongitudeRadians(tgtLon - obsLon);
-
-	const double a = std::sin(dLat / 2.0) * std::sin(dLat / 2.0) + std::cos(obsLat) * std::cos(tgtLat) * std::sin(dLon / 2.0) * std::sin(dLon / 2.0);
-	const double c = 2.0 * std::atan2(std::sqrt(a), std::sqrt(1.0 - a));
-	return kEarthRadiusMeters * c;
+	return location.distanceKm(record.longitude, record.latitude) * 1000.0;
 }
 
 void AircraftObject::draw(StelCore* core, StelPainter* painter, bool drawLabels, int labelMode) const

--- a/plugins/Planes/src/AircraftObject.cpp
+++ b/plugins/Planes/src/AircraftObject.cpp
@@ -201,6 +201,10 @@ QString AircraftObject::getInfoString(const StelCore* core, const InfoStringGrou
 		const bool withTables = StelApp::getInstance().getFlagUseFormattingOutput();
 		// TRANSLATORS: Unit of measure for distance - meters
 		QString m = qc_("m", "distance");
+		// TRANSLATORS: Unit of measure for distance - kilometers
+		QString km = qc_("km", "distance");
+		// TRANSLATORS: Unit of measure for distance - nautical miles
+		QString nmi = qc_("nmi", "distance");
 		// TRANSLATORS: Unit of measure for distance - feets
 		QString ft = qc_("ft", "distance");
 		// TRANSLATORS: Unit of measure for speed - meters per second
@@ -223,6 +227,17 @@ QString AircraftObject::getInfoString(const StelCore* core, const InfoStringGrou
 
 		const QString heading = QString("%1° (%2)").arg(QString::number(normalizeDegrees(currentRecord.trackDegrees), 'f', 0), qc_(headingToCompass(currentRecord.trackDegrees), "compass direction"));
 
+
+		const double slantRangeMeters = getSlantRange(core, currentRecord);
+		const QString slantRange = QString("%1 %2 (%3 %4)").arg(QString::number(slantRangeMeters / 1000.0, 'f', 1), km,
+			QString::number(slantRangeMeters / 1852.0, 'f', 1), nmi);
+
+
+		const double groundRangeMeters = getGroundRange(core, currentRecord);
+		const QString groundRange = QString("%1 %2 (%3 %4)").arg(QString::number(groundRangeMeters / 1000.0, 'f', 1), km,
+			QString::number(groundRangeMeters / 1852.0, 'f', 1), nmi);
+
+
 		const double dataAgeSeconds = getElapsedSeconds();
 		const QString dataAge = QString("%1 %2").arg(QString::number(dataAgeSeconds, 'f', dataAgeSeconds < 10.0 ? 1 : 0), s);
 
@@ -230,6 +245,8 @@ QString AircraftObject::getInfoString(const StelCore* core, const InfoStringGrou
 		{
 			stream << "<table style='margin:0em 0em 0em -0.125em;border-spacing:0px;border:0px;'>";
 			stream << QString("<tr><td>%1:</td><td style='text-align:right;'>%2</td></tr>").arg(q_("Altitude"), altitude);
+			stream << QString("<tr><td>%1:</td><td style='text-align:right;'>%2</td></tr>").arg(q_("Slant Range"), slantRange);
+			stream << QString("<tr><td>%1:</td><td style='text-align:right;'>%2</td></tr>").arg(q_("Ground Range"), groundRange);
 			stream << QString("<tr><td>%1:</td><td style='text-align:right;'>%2</td></tr>").arg(q_("Ground speed"), groundSpeed);
 			stream << QString("<tr><td>%1:</td><td style='text-align:right;'>%2</td></tr>").arg(q_("Vertical rate"), verticalRate);
 			stream << QString("<tr><td>%1:</td><td style='text-align:right;'>%2</td></tr>").arg(q_("Track"), heading);
@@ -239,6 +256,8 @@ QString AircraftObject::getInfoString(const StelCore* core, const InfoStringGrou
 		else
 		{
 			stream << QString("%1: %2<br/>").arg(q_("Altitude"), altitude);
+			stream << QString("%1: %2<br/>").arg(q_("Slant Range"), slantRange);
+			stream << QString("%1: %2<br/>").arg(q_("Ground Range"), groundRange);
 			stream << QString("%1: %2<br/>").arg(q_("Ground speed"), groundSpeed);
 			stream << QString("%1: %2<br/>").arg(q_("Vertical rate"), verticalRate);
 			stream << QString("%1: %2<br/>").arg(q_("Track"), heading);
@@ -328,6 +347,39 @@ float AircraftObject::getScreenRotationDegrees(StelCore* core, const StelProject
 
 	const double angleDeg = std::atan2(dy, dx) * 180.0 / M_PI;
 	return static_cast<float>(angleDeg + kSpriteHeadingOffsetDegrees);
+}
+
+double AircraftObject::getSlantRange(const StelCore* core, const AircraftRecord& record) const
+{
+	if (!core) return 0.0;
+
+	const StelLocation& location = core->getCurrentLocation();
+	const double obsLat = static_cast<double>(location.getLatitude()) * M_PI / 180.0;
+	const double obsLon = static_cast<double>(location.getLongitude()) * M_PI / 180.0;
+	const double tgtLat = record.latitude * M_PI / 180.0;
+	const double tgtLon = record.longitude * M_PI / 180.0;
+
+	const Vec3d observer = toEcef(obsLat, obsLon, static_cast<double>(location.altitude));
+	const Vec3d aircraft = toEcef(tgtLat, tgtLon, record.altitudeMeters);
+	return (aircraft - observer).norm();
+}
+
+double AircraftObject::getGroundRange(const StelCore* core, const AircraftRecord& record) const
+{
+	if (!core) return 0.0;
+
+	const StelLocation& location = core->getCurrentLocation();
+	const double obsLat = static_cast<double>(location.getLatitude()) * M_PI / 180.0;
+	const double obsLon = static_cast<double>(location.getLongitude()) * M_PI / 180.0;
+	const double tgtLat = record.latitude * M_PI / 180.0;
+	const double tgtLon = record.longitude * M_PI / 180.0;
+
+	const double dLat = tgtLat - obsLat;
+	const double dLon = normalizeLongitudeRadians(tgtLon - obsLon);
+
+	const double a = std::sin(dLat / 2.0) * std::sin(dLat / 2.0) + std::cos(obsLat) * std::cos(tgtLat) * std::sin(dLon / 2.0) * std::sin(dLon / 2.0);
+	const double c = 2.0 * std::atan2(std::sqrt(a), std::sqrt(1.0 - a));
+	return kEarthRadiusMeters * c;
 }
 
 void AircraftObject::draw(StelCore* core, StelPainter* painter, bool drawLabels, int labelMode) const

--- a/plugins/Planes/src/AircraftObject.hpp
+++ b/plugins/Planes/src/AircraftObject.hpp
@@ -61,6 +61,8 @@ private:
 	double getElapsedSeconds() const;
 	Vec3d getAltAzPos(const StelCore* core, double elapsedSeconds=0.0) const;
 	float getScreenRotationDegrees(StelCore* core, const StelProjectorP& projector, const Vec3d& currentScreenPos) const;
+	double getSlantRange(const StelCore* core, const AircraftRecord& record) const;
+	double getGroundRange(const StelCore* core, const AircraftRecord& record) const;
 	QString labelText() const;
 	QString displayLabelText(int labelMode) const;
 


### PR DESCRIPTION

### Description
<!--- Please include a summary of the change and which issue is fixed. -->
Adds two new fields to the aircraft info panel:
1. Slant range: the true 3D distance to the aircraft.
2. Ground range: the great-circle distance to the aircraft's ground position.
<img width="401" height="536" alt="slant_and_ground_range" src="https://github.com/user-attachments/assets/06b2093e-71c0-4021-b8d3-9f3bb61b455c" />

<!--- Please also include relevant motivation and context. -->
The planes addon is special and very interesting. I have implemented a requested feature.

Fixes # 5045

### Screenshots (if appropriate):

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I sanity checked the relationship between the two new numbers. For an aircraft nearly overhead, the slant range should be much larger than the ground range. For an aircraft near the horizon, the two values should be much closer together. This is in fact the case.

**Test Configuration**:
* Operating system: Windows 11 Home, 25H2
* Graphics Card: NVIDIA GeForce RTX 5070, Driver Version: 591.86

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x ] I have performed a self-review of my own code
- [x ] I have commented my code, particularly in hard-to-understand areas
- [x ] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x ] Any dependent changes have been merged and published in downstream modules

I didn't touch docs, and there's no test infrastructure for this plugin.