### PR TITLE
Fix SC time slider in ViewDialog can be more than currentYear

### DIFF
--- a/src/gui/ViewDialog.cpp
+++ b/src/gui/ViewDialog.cpp
@@ -1721,7 +1721,7 @@ void ViewDialog::populateLists()
 	}
 
 	ui->skyCultureCurrentTimeSpinBox->setMinimum(globalBeginTime);
-	ui->skyCultureCurrentTimeSpinBox->setMaximum(currentYear);
+	ui->skyCultureCurrentTimeSpinBox->setMaximum(currentYear); // The slider maximum is always the current year
 	l->setCurrentItem(l->findItems(app.getSkyCultureMgr().getCurrentSkyCultureNameI18(), Qt::MatchExactly).at(0));    
 	l->blockSignals(false);
 

--- a/src/gui/ViewDialog.cpp
+++ b/src/gui/ViewDialog.cpp
@@ -1652,13 +1652,13 @@ void ViewDialog::populateLists()
 		l->addItem(new SeparatorListWidgetItem(q_("Other"), "Other"));
 	}
 
-	// find the slider limits across all cultures (needed in initSkyCultureTime)
+	// find the earliest real begin year across all cultures (needed in initSkyCultureTime)
 	// ---> evaluate it here so we don't need to iterate over all cultures multiple times.
-	// The "unknown" begin sentinel and the "present/∞" end sentinel are ignored so that cultures
-	// with no defined time range do not stretch the slider to its extremes.
+	// The "unknown" begin sentinel is ignored so that cultures with no defined start do not
+	// stretch the slider to its extreme. The slider maximum is always the current year, since a
+	// culture cannot end in the future (the "present/∞" end sentinel maps to the current year).
 	const int currentYear = QDateTime::currentDateTime().date().year();
 	int globalBeginTime = currentYear;
-	int globalEndTime = currentYear;
 #if (QT_VERSION>=QT_VERSION_CHECK(6,0,0))
 	QMultiMapIterator<QString, QString> cultureRegionIt(cultureRegionMap);
 #else
@@ -1679,11 +1679,6 @@ void ViewDialog::populateLists()
 		if (cultureBeginTime > StelSkyCulture::unknownBeginTime && cultureBeginTime < globalBeginTime)
 		{
 			globalBeginTime = cultureBeginTime;
-		}
-		// Find the latest real end year across all cultures
-		if (cultureEndTime < StelSkyCulture::presentEndTime && cultureEndTime > globalEndTime)
-		{
-			globalEndTime = cultureEndTime;
 		}
 
 		// When region is unknown (non UN-geoscheme), insert item under "other" separator,
@@ -1726,7 +1721,7 @@ void ViewDialog::populateLists()
 	}
 
 	ui->skyCultureCurrentTimeSpinBox->setMinimum(globalBeginTime);
-	ui->skyCultureCurrentTimeSpinBox->setMaximum(globalEndTime);
+	ui->skyCultureCurrentTimeSpinBox->setMaximum(currentYear);
 	l->setCurrentItem(l->findItems(app.getSkyCultureMgr().getCurrentSkyCultureNameI18(), Qt::MatchExactly).at(0));    
 	l->blockSignals(false);
 


### PR DESCRIPTION
When the territory of a sky culture contains a polygon with a date > currentYear and < 9146 (= present), the slider maximum is adjusted to that year. Example: SC author defines a polygon with endYear 3000 -> the slider can go up to 3000.

For various reasons it might be desirable to cap this at the currentYear, so the slider can never go past that.

### Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

### How Has This Been Tested?
Manually on MacOS 26.6.2:

Edit the territory.json of any sky culture by setting the "endTime" of any region to a number > 2026, for example 3000. The slider in ViewDialog should still show 2026.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (header file)
- [ ] I have updated the respective chapter in the Stellarium User Guide
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
